### PR TITLE
db migrations: add empty down() method into AbstractMigration

### DIFF
--- a/packages/framework/src/Migrations/Version20151210115739.php
+++ b/packages/framework/src/Migrations/Version20151210115739.php
@@ -20,12 +20,4 @@ class Version20151210115739 extends AbstractMigration
             RENAME COLUMN visible TO calculated_visibility';
         $this->sql($sql);
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20151230012022.php
+++ b/packages/framework/src/Migrations/Version20151230012022.php
@@ -20,12 +20,4 @@ class Version20151230012022 extends AbstractMigration
             'CREATE TABLE cron_modules (module_id VARCHAR(255) NOT NULL, scheduled BOOLEAN NOT NULL, PRIMARY KEY(module_id));',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20151231104800.php
+++ b/packages/framework/src/Migrations/Version20151231104800.php
@@ -20,12 +20,4 @@ class Version20151231104800 extends AbstractMigration
             'ALTER TABLE cron_modules ADD suspended BOOLEAN NOT NULL DEFAULT FALSE;',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160105140120.php
+++ b/packages/framework/src/Migrations/Version20160105140120.php
@@ -20,12 +20,4 @@ class Version20160105140120 extends AbstractMigration
             ALTER name SET NOT NULL;';
         $this->sql($sql);
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160108183213.php
+++ b/packages/framework/src/Migrations/Version20160108183213.php
@@ -20,12 +20,4 @@ class Version20160108183213 extends AbstractMigration
             (id SERIAL NOT NULL, name TEXT NOT NULL, code TEXT NOT NULL, PRIMARY KEY(id));';
         $this->sql($sql);
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160113151330.php
+++ b/packages/framework/src/Migrations/Version20160113151330.php
@@ -20,12 +20,4 @@ class Version20160113151330 extends AbstractMigration
             ADD COLUMN placement TEXT NOT NULL';
         $this->sql($sql);
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160129122637.php
+++ b/packages/framework/src/Migrations/Version20160129122637.php
@@ -44,12 +44,4 @@ class Version20160129122637 extends AbstractMigration implements ContainerAwareI
             END
             $$ LANGUAGE plpgsql IMMUTABLE;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160314174500.php
+++ b/packages/framework/src/Migrations/Version20160314174500.php
@@ -18,12 +18,4 @@ class Version20160314174500 extends AbstractMigration
     {
         $this->sql('ALTER TABLE adverts ALTER type SET NOT NULL;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160322180746.php
+++ b/packages/framework/src/Migrations/Version20160322180746.php
@@ -39,12 +39,4 @@ class Version20160322180746 extends AbstractMigration
         $this->sql('ALTER SEQUENCE availabilities_translations_id_seq RENAME TO availability_translations_id_seq');
         $this->sql('ALTER SEQUENCE parameter_titles_translations_id_seq RENAME TO parameter_translations_id_seq');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160419131007.php
+++ b/packages/framework/src/Migrations/Version20160419131007.php
@@ -19,12 +19,4 @@ class Version20160419131007 extends AbstractMigration
         $this->sql('ALTER TABLE products ADD ordering_priority INT NOT NULL DEFAULT 0;');
         $this->sql('ALTER TABLE products ALTER ordering_priority DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160420165146.php
+++ b/packages/framework/src/Migrations/Version20160420165146.php
@@ -18,12 +18,4 @@ class Version20160420165146 extends AbstractMigration
     {
         $this->sql('ALTER TABLE category_domains ADD COLUMN description TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160422164530.php
+++ b/packages/framework/src/Migrations/Version20160422164530.php
@@ -18,12 +18,4 @@ class Version20160422164530 extends AbstractMigration
     {
         $this->sql('ALTER TABLE products ALTER availability_id DROP NOT NULL;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160425173252.php
+++ b/packages/framework/src/Migrations/Version20160425173252.php
@@ -18,12 +18,4 @@ class Version20160425173252 extends AbstractMigration
     {
         $this->sql('ALTER TABLE product_domains ADD COLUMN short_description TEXT DEFAULT NULL;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160503132106.php
+++ b/packages/framework/src/Migrations/Version20160503132106.php
@@ -19,12 +19,4 @@ class Version20160503132106 extends AbstractMigration
         $this->sql('ALTER TABLE flags ADD visible BOOLEAN NOT NULL DEFAULT TRUE;');
         $this->sql('ALTER TABLE flags ALTER visible DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160503140649.php
+++ b/packages/framework/src/Migrations/Version20160503140649.php
@@ -19,12 +19,4 @@ class Version20160503140649 extends AbstractMigration
         $this->sql('ALTER TABLE parameter_titles ADD visible BOOLEAN NOT NULL DEFAULT TRUE;');
         $this->sql('ALTER TABLE parameter_titles ALTER visible DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160512152113.php
+++ b/packages/framework/src/Migrations/Version20160512152113.php
@@ -82,12 +82,4 @@ class Version20160512152113 extends AbstractMigration implements ContainerAwareI
         );
         $this->sql('CREATE INDEX IDX_E52FFDEEE76AA954 ON orders (delivery_country_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160531080553.php
+++ b/packages/framework/src/Migrations/Version20160531080553.php
@@ -22,12 +22,4 @@ class Version20160531080553 extends AbstractMigration
             (\'feedNameToContinue\', 0, NULL, \'string\')
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160601124500.php
+++ b/packages/framework/src/Migrations/Version20160601124500.php
@@ -30,12 +30,4 @@ class Version20160601124500 extends AbstractMigration
         $this->sql('ALTER TABLE brand_translations ADD CONSTRAINT FK_B018D342C2AC5D3 FOREIGN KEY (translatable_id) 
             REFERENCES brands (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160627173212.php
+++ b/packages/framework/src/Migrations/Version20160627173212.php
@@ -18,12 +18,4 @@ class Version20160627173212 extends AbstractMigration
     {
         $this->sql('CREATE TABLE newsletter_subscribers (email VARCHAR(255) NOT NULL, PRIMARY KEY(email));');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160715100000.php
+++ b/packages/framework/src/Migrations/Version20160715100000.php
@@ -18,12 +18,4 @@ class Version20160715100000 extends AbstractMigration
     {
         $this->sql('ALTER TABLE setting_values ALTER type TYPE VARCHAR(8)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160717105120.php
+++ b/packages/framework/src/Migrations/Version20160717105120.php
@@ -19,12 +19,4 @@ class Version20160717105120 extends AbstractMigration
         $this->sql('ALTER TABLE articles ADD hidden BOOLEAN NOT NULL DEFAULT FALSE;');
         $this->sql('ALTER TABLE articles ALTER hidden DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160717144201.php
+++ b/packages/framework/src/Migrations/Version20160717144201.php
@@ -19,12 +19,4 @@ class Version20160717144201 extends AbstractMigration
         $this->sql('ALTER TABLE slider_items ADD hidden BOOLEAN NOT NULL DEFAULT FALSE;');
         $this->sql('ALTER TABLE slider_items ALTER hidden DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160805142110.php
+++ b/packages/framework/src/Migrations/Version20160805142110.php
@@ -22,12 +22,4 @@ class Version20160805142110 extends AbstractMigration
         $this->sql('ALTER TABLE product_domains ADD zbozi_cpc NUMERIC(16, 2) DEFAULT NULL');
         $this->sql('ALTER TABLE product_domains ADD zbozi_cpc_search NUMERIC(16, 2) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160828201247.php
+++ b/packages/framework/src/Migrations/Version20160828201247.php
@@ -25,12 +25,4 @@ class Version20160828201247 extends AbstractMigration implements ContainerAwareI
             ', ['domainId' => $domainId]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160902125810.php
+++ b/packages/framework/src/Migrations/Version20160902125810.php
@@ -25,12 +25,4 @@ class Version20160902125810 extends AbstractMigration implements ContainerAwareI
             ', ['domainId' => $domainId]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20160902145842.php
+++ b/packages/framework/src/Migrations/Version20160902145842.php
@@ -25,12 +25,4 @@ class Version20160902145842 extends AbstractMigration implements ContainerAwareI
             ', ['domainId' => $domainId]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161010151719.php
+++ b/packages/framework/src/Migrations/Version20161010151719.php
@@ -24,12 +24,4 @@ class Version20161010151719 extends AbstractMigration
                 CONSTRAINT FK_BEF48445A76ED395 FOREIGN KEY (user_id)
                     REFERENCES users (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161013090245.php
+++ b/packages/framework/src/Migrations/Version20161013090245.php
@@ -32,12 +32,4 @@ class Version20161013090245 extends AbstractMigration
         ');
         $this->sql('ALTER TABLE orders DROP delivery_contact_person');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161111124254.php
+++ b/packages/framework/src/Migrations/Version20161111124254.php
@@ -18,12 +18,4 @@ class Version20161111124254 extends AbstractMigration
     {
         $this->sql('ALTER TABLE cart_items RENAME COLUMN session_id TO cart_identifier');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161124152029.php
+++ b/packages/framework/src/Migrations/Version20161124152029.php
@@ -25,12 +25,4 @@ class Version20161124152029 extends AbstractMigration
             ADD PRIMARY KEY (product_id, domain_id)
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161124154622.php
+++ b/packages/framework/src/Migrations/Version20161124154622.php
@@ -19,12 +19,4 @@ class Version20161124154622 extends AbstractMigration
         $this->sql('ALTER TABLE products_top ADD position INT NOT NULL DEFAULT 0');
         $this->sql('ALTER TABLE products_top ALTER position DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161125140534.php
+++ b/packages/framework/src/Migrations/Version20161125140534.php
@@ -31,12 +31,4 @@ class Version20161125140534 extends AbstractMigration
                 CONSTRAINT FK_20AA436212469DE2 FOREIGN KEY (category_id)
                     REFERENCES categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161207135225.php
+++ b/packages/framework/src/Migrations/Version20161207135225.php
@@ -46,12 +46,4 @@ class Version20161207135225 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20161207144725.php
+++ b/packages/framework/src/Migrations/Version20161207144725.php
@@ -35,12 +35,4 @@ class Version20161207144725 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170207091754.php
+++ b/packages/framework/src/Migrations/Version20170207091754.php
@@ -19,12 +19,4 @@ class Version20170207091754 extends AbstractMigration
         $this->sql('ALTER TABLE category_domains ADD seo_title TEXT DEFAULT NULL');
         $this->sql('ALTER TABLE category_domains ADD seo_meta_description TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170228101522.php
+++ b/packages/framework/src/Migrations/Version20170228101522.php
@@ -18,12 +18,4 @@ class Version20170228101522 extends AbstractMigration
     {
         $this->sql('CREATE INDEX IDX_C52F9B1F12469DE2115F0EE5 ON product_category_domains (category_id, domain_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170329131658.php
+++ b/packages/framework/src/Migrations/Version20170329131658.php
@@ -20,12 +20,4 @@ class Version20170329131658 extends AbstractMigration
         $this->sql('ALTER TABLE cron_modules RENAME COLUMN module_id TO service_id');
         $this->sql('ALTER TABLE cron_modules ADD PRIMARY KEY (service_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170418094333.php
+++ b/packages/framework/src/Migrations/Version20170418094333.php
@@ -29,12 +29,4 @@ class Version20170418094333 extends AbstractMigration
                     REFERENCES currencies (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170530101845.php
+++ b/packages/framework/src/Migrations/Version20170530101845.php
@@ -37,12 +37,4 @@ class Version20170530101845 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170627144556.php
+++ b/packages/framework/src/Migrations/Version20170627144556.php
@@ -24,14 +24,6 @@ class Version20170627144556 extends AbstractMigration
         $this->sql('UPDATE product_domains SET short_description = short_description');
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function replaceProductDomainFulltextTriggerOnProduct()
     {
         $this->sql('

--- a/packages/framework/src/Migrations/Version20170629163629.php
+++ b/packages/framework/src/Migrations/Version20170629163629.php
@@ -18,12 +18,4 @@ class Version20170629163629 extends AbstractMigration
     {
         $this->sql('ALTER TABLE product_accessories ALTER "position" SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170703131941.php
+++ b/packages/framework/src/Migrations/Version20170703131941.php
@@ -44,12 +44,4 @@ class Version20170703131941 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170710111348.php
+++ b/packages/framework/src/Migrations/Version20170710111348.php
@@ -18,12 +18,4 @@ class Version20170710111348 extends AbstractMigration
     {
         $this->sql('ALTER TABLE product_domains ADD seo_h1 TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170710120313.php
+++ b/packages/framework/src/Migrations/Version20170710120313.php
@@ -18,12 +18,4 @@ class Version20170710120313 extends AbstractMigration
     {
         $this->sql('ALTER TABLE category_domains ADD seo_h1 TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170710120408.php
+++ b/packages/framework/src/Migrations/Version20170710120408.php
@@ -18,12 +18,4 @@ class Version20170710120408 extends AbstractMigration
     {
         $this->sql('ALTER TABLE articles ADD seo_h1 TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170728120619.php
+++ b/packages/framework/src/Migrations/Version20170728120619.php
@@ -19,12 +19,4 @@ class Version20170728120619 extends AbstractMigration
         $this->sql('ALTER TABLE cart_items ADD added_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT now()');
         $this->sql('ALTER TABLE cart_items ALTER added_at DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170801093853.php
+++ b/packages/framework/src/Migrations/Version20170801093853.php
@@ -23,12 +23,4 @@ class Version20170801093853 extends AbstractMigration
             'ALTER TABLE parameter_translations RENAME CONSTRAINT parameter_titles_translations_pkey TO parameters_translations_pkey',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170802141735.php
+++ b/packages/framework/src/Migrations/Version20170802141735.php
@@ -26,12 +26,4 @@ class Version20170802141735 extends AbstractMigration
             )',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20170807084807.php
+++ b/packages/framework/src/Migrations/Version20170807084807.php
@@ -70,12 +70,4 @@ class Version20170807084807 extends AbstractMigration
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20171005091354.php
+++ b/packages/framework/src/Migrations/Version20171005091354.php
@@ -78,12 +78,4 @@ class Version20171005091354 extends AbstractMigration
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180206151021.php
+++ b/packages/framework/src/Migrations/Version20180206151021.php
@@ -23,12 +23,4 @@ class Version20180206151021 extends AbstractMigration
                 created_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT \'1970-01-01 00:00:00\' NOT NULL');
         $this->sql('COMMENT ON COLUMN newsletter_subscribers.created_at IS \'(DC2Type:datetime_immutable)\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180214070314.php
+++ b/packages/framework/src/Migrations/Version20180214070314.php
@@ -25,12 +25,4 @@ class Version20180214070314 extends AbstractMigration implements ContainerAwareI
             ', ['domainId' => $domainId]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180216091004.php
+++ b/packages/framework/src/Migrations/Version20180216091004.php
@@ -46,12 +46,4 @@ class Version20180216091004 extends AbstractMigration implements ContainerAwareI
         $this->sql('ALTER TABLE newsletter_subscribers ALTER COLUMN domain_id SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX newsletter_subscribers_uni ON newsletter_subscribers (email, domain_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180216091409.php
+++ b/packages/framework/src/Migrations/Version20180216091409.php
@@ -27,12 +27,4 @@ class Version20180216091409 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180301081843.php
+++ b/packages/framework/src/Migrations/Version20180301081843.php
@@ -27,12 +27,4 @@ class Version20180301081843 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180306094316.php
+++ b/packages/framework/src/Migrations/Version20180306094316.php
@@ -27,12 +27,4 @@ class Version20180306094316 extends AbstractMigration
             )');
         $this->sql('CREATE UNIQUE INDEX UNIQ_C84FBB18D1B862B8 ON personal_data_access_request (hash)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180409055551.php
+++ b/packages/framework/src/Migrations/Version20180409055551.php
@@ -37,12 +37,4 @@ class Version20180409055551 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180409100239.php
+++ b/packages/framework/src/Migrations/Version20180409100239.php
@@ -20,12 +20,4 @@ class Version20180409100239 extends AbstractMigration
         $this->sql('UPDATE personal_data_access_request SET type = :type', ['type' => 'display']);
         $this->sql('ALTER TABLE personal_data_access_request ALTER COLUMN type SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180411124519.php
+++ b/packages/framework/src/Migrations/Version20180411124519.php
@@ -18,12 +18,4 @@ class Version20180411124519 extends AbstractMigration
     {
         $this->sql('ALTER TABLE countries ADD code VARCHAR(2) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180413102110.php
+++ b/packages/framework/src/Migrations/Version20180413102110.php
@@ -18,12 +18,4 @@ class Version20180413102110 extends AbstractMigration
     {
         $this->sql('DROP TABLE plugin_data_values');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180530113304.php
+++ b/packages/framework/src/Migrations/Version20180530113304.php
@@ -21,12 +21,4 @@ class Version20180530113304 extends AbstractMigration
         $this->sql('ALTER TABLE brand_domains ADD PRIMARY KEY (id)');
         $this->sql('CREATE UNIQUE INDEX brand_domain ON brand_domains (brand_id, domain_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180530131622.php
+++ b/packages/framework/src/Migrations/Version20180530131622.php
@@ -21,12 +21,4 @@ class Version20180530131622 extends AbstractMigration
         $this->sql('ALTER TABLE product_domains ADD PRIMARY KEY (id)');
         $this->sql('CREATE UNIQUE INDEX product_domain ON product_domains (product_id, domain_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180531141640.php
+++ b/packages/framework/src/Migrations/Version20180531141640.php
@@ -24,12 +24,4 @@ class Version20180531141640 extends AbstractMigration
         $this->sql('ALTER TABLE category_domains RENAME COLUMN hidden TO enabled');
         $this->sql('UPDATE category_domains SET enabled = NOT enabled');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180531231229.php
+++ b/packages/framework/src/Migrations/Version20180531231229.php
@@ -39,12 +39,4 @@ class Version20180531231229 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135339.php
+++ b/packages/framework/src/Migrations/Version20180603135339.php
@@ -39,12 +39,4 @@ class Version20180603135339 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135340.php
+++ b/packages/framework/src/Migrations/Version20180603135340.php
@@ -30,14 +30,6 @@ class Version20180603135340 extends AbstractMigration
         $this->createProductDomainFulltextTriggerOnProductDomain();
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function createGetDomainIdsByLocaleFunction(): void
     {
         $this->sql('CREATE OR REPLACE FUNCTION get_domain_ids_by_locale(locale text) RETURNS SETOF integer AS $$

--- a/packages/framework/src/Migrations/Version20180603135341.php
+++ b/packages/framework/src/Migrations/Version20180603135341.php
@@ -73,12 +73,4 @@ class Version20180603135341 extends AbstractMigration implements ContainerAwareI
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135342.php
+++ b/packages/framework/src/Migrations/Version20180603135342.php
@@ -51,12 +51,4 @@ class Version20180603135342 extends AbstractMigration
             'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'defaultDomainCurrencyId\', 1, 2, \'integer\')',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135343.php
+++ b/packages/framework/src/Migrations/Version20180603135343.php
@@ -37,12 +37,4 @@ class Version20180603135343 extends AbstractMigration
             'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'defaultVatId\', 0, 1, \'integer\')',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135344.php
+++ b/packages/framework/src/Migrations/Version20180603135344.php
@@ -28,12 +28,4 @@ class Version20180603135344 extends AbstractMigration
             'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'defaultUnitId\', 0, null, \'integer\')',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135345.php
+++ b/packages/framework/src/Migrations/Version20180603135345.php
@@ -29,12 +29,4 @@ class Version20180603135345 extends AbstractMigration
         );
         $this->sql('ALTER SEQUENCE category_domains_id_seq RESTART WITH 2');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135346.php
+++ b/packages/framework/src/Migrations/Version20180603135346.php
@@ -39,12 +39,4 @@ class Version20180603135346 extends AbstractMigration
             'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'defaultPricingGroupId\', 1, 1, \'integer\')',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180603135347.php
+++ b/packages/framework/src/Migrations/Version20180603135347.php
@@ -25,14 +25,6 @@ class Version20180603135347 extends AbstractMigration
     }
 
     /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
-    /**
      * @param string $mailTemplateName
      * @param string $sendMail
      */

--- a/packages/framework/src/Migrations/Version20180702111015.php
+++ b/packages/framework/src/Migrations/Version20180702111015.php
@@ -33,12 +33,4 @@ class Version20180702111015 extends AbstractMigration
 
         $this->sql('ALTER SEQUENCE administrators_id_seq RESTART WITH 3');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180702111016.php
+++ b/packages/framework/src/Migrations/Version20180702111016.php
@@ -28,12 +28,4 @@ class Version20180702111016 extends AbstractMigration
             . '(\'productStockCalculations\')',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180702111017.php
+++ b/packages/framework/src/Migrations/Version20180702111017.php
@@ -38,12 +38,4 @@ class Version20180702111017 extends AbstractMigration
             EXECUTE PROCEDURE set_main_variant_price_recalculation_by_product_visibility();
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180702111018.php
+++ b/packages/framework/src/Migrations/Version20180702111018.php
@@ -24,12 +24,4 @@ class Version20180702111018 extends AbstractMigration
 
         $this->sql('INSERT INTO order_number_sequences (id, number) VALUES (1, 0)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180702111019.php
+++ b/packages/framework/src/Migrations/Version20180702111019.php
@@ -27,12 +27,4 @@ class Version20180702111019 extends AbstractMigration
             'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'defaultAvailabilityInStockId\', 0, null, \'integer\')',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180702111020.php
+++ b/packages/framework/src/Migrations/Version20180702111020.php
@@ -31,14 +31,6 @@ class Version20180702111020 extends AbstractMigration
         $this->setFeedHash();
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function setInputPriceType()
     {
         $inputPriceTypeSettingCount = $this->sql(

--- a/packages/framework/src/Migrations/Version20180724060204.php
+++ b/packages/framework/src/Migrations/Version20180724060204.php
@@ -156,12 +156,4 @@ class Version20180724060204 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180730135725.php
+++ b/packages/framework/src/Migrations/Version20180730135725.php
@@ -25,12 +25,4 @@ class Version20180730135725 extends AbstractMigration
             LANGUAGE SQL STABLE',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20180830121204.php
+++ b/packages/framework/src/Migrations/Version20180830121204.php
@@ -33,12 +33,4 @@ class Version20180830121204 extends AbstractMigration
         }
         $this->sql('ALTER TABLE billing_addresses DROP COLUMN telephone');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20181008000001.php
+++ b/packages/framework/src/Migrations/Version20181008000001.php
@@ -24,12 +24,4 @@ class Version20181008000001 extends AbstractMigration
         );
         $this->sql('UPDATE setting_values SET type = \'none\' where value IS NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20181114102106.php
+++ b/packages/framework/src/Migrations/Version20181114102106.php
@@ -18,12 +18,4 @@ class Version20181114102106 extends AbstractMigration
     {
         $this->sql('ALTER TABLE pricing_groups ALTER COLUMN coefficient DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20181114120915.php
+++ b/packages/framework/src/Migrations/Version20181114120915.php
@@ -18,12 +18,4 @@ class Version20181114120915 extends AbstractMigration
     {
         $this->sql('ALTER TABLE products ALTER COLUMN price_calculation_type DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20181114134959.php
+++ b/packages/framework/src/Migrations/Version20181114134959.php
@@ -39,12 +39,4 @@ class Version20181114134959 extends AbstractMigration
         );
         $this->sql('UPDATE products SET price_calculation_type = \'manual\' WHERE price_calculation_type = \'auto\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20181114145244.php
+++ b/packages/framework/src/Migrations/Version20181114145244.php
@@ -18,12 +18,4 @@ class Version20181114145244 extends AbstractMigration
     {
         $this->sql('ALTER TABLE products ALTER price DROP NOT NULL;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20181114145250.php
+++ b/packages/framework/src/Migrations/Version20181114145250.php
@@ -20,12 +20,4 @@ class Version20181114145250 extends AbstractMigration
         $this->sql('ALTER TABLE products DROP COLUMN price');
         $this->sql('ALTER TABLE products DROP COLUMN price_calculation_type');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190121094400.php
+++ b/packages/framework/src/Migrations/Version20190121094400.php
@@ -129,12 +129,4 @@ class Version20190121094400 extends AbstractMigration implements ContainerAwareI
         $this->sql('ALTER TABLE country_domains ALTER priority DROP DEFAULT');
         $this->sql('CREATE UNIQUE INDEX countries_code_uni ON countries (code)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190122130312.php
+++ b/packages/framework/src/Migrations/Version20190122130312.php
@@ -72,12 +72,4 @@ class Version20190122130312 extends AbstractMigration
                 CONSTRAINT FK_BEF484451AD5CDBF FOREIGN KEY (cart_id) REFERENCES carts (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_BEF484451AD5CDBF ON cart_items (cart_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190215092226.php
+++ b/packages/framework/src/Migrations/Version20190215092226.php
@@ -27,12 +27,4 @@ class Version20190215092226 extends AbstractMigration
         $this->sql('COMMENT ON COLUMN product_manual_input_prices.input_price IS \'(DC2Type:money)\'');
         $this->sql('COMMENT ON COLUMN transport_prices.price IS \'(DC2Type:money)\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190220101938.php
+++ b/packages/framework/src/Migrations/Version20190220101938.php
@@ -20,12 +20,4 @@ class Version20190220101938 extends AbstractMigration
             'UPDATE setting_values SET type = \'money\' WHERE name = \'freeTransportAndPaymentPriceLimit\' AND type != \'none\'',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190521071335.php
+++ b/packages/framework/src/Migrations/Version20190521071335.php
@@ -21,12 +21,4 @@ class Version20190521071335 extends AbstractMigration
         $this->sql('ALTER TABLE products ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_B3BA5A5AD17F50A6 ON products (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190611114955.php
+++ b/packages/framework/src/Migrations/Version20190611114955.php
@@ -29,14 +29,6 @@ class Version20190611114955 extends AbstractMigration
     }
 
     /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
-    /**
      * Calculates the total prices of order items using via old price calculation (using VAT coefficients)
      *
      * @see https://github.com/shopsys/shopsys/blob/v7.2.1/packages/framework/src/Model/Order/Item/OrderItemPriceCalculation.php#L60-L76

--- a/packages/framework/src/Migrations/Version20190823110846.php
+++ b/packages/framework/src/Migrations/Version20190823110846.php
@@ -21,12 +21,4 @@ class Version20190823110846 extends AbstractMigration
         $this->sql('ALTER TABLE products ALTER selling_to TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
         $this->sql('ALTER TABLE products ALTER selling_to DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190824181350.php
+++ b/packages/framework/src/Migrations/Version20190824181350.php
@@ -23,12 +23,4 @@ class Version20190824181350 extends AbstractMigration
         $this->sql('ALTER TABLE cron_modules ADD last_finished_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         $this->sql('ALTER TABLE cron_modules ADD last_duration INT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20190930140221.php
+++ b/packages/framework/src/Migrations/Version20190930140221.php
@@ -21,12 +21,4 @@ class Version20190930140221 extends AbstractMigration
         $this->sql('ALTER TABLE categories ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_3AF34668D17F50A6 ON categories (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191029123329.php
+++ b/packages/framework/src/Migrations/Version20191029123329.php
@@ -19,12 +19,4 @@ class Version20191029123329 extends AbstractMigration
         $this->sql('ALTER TABLE currencies ADD min_fraction_digits INT NOT NULL DEFAULT 2');
         $this->sql('ALTER TABLE currencies ALTER min_fraction_digits DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191029210140.php
+++ b/packages/framework/src/Migrations/Version20191029210140.php
@@ -44,12 +44,4 @@ class Version20191029210140 extends AbstractMigration
             ['currencyRoundingType' => $currencyRoundingType],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191107162719.php
+++ b/packages/framework/src/Migrations/Version20191107162719.php
@@ -107,12 +107,4 @@ class Version20191107162719 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191108140919.php
+++ b/packages/framework/src/Migrations/Version20191108140919.php
@@ -63,12 +63,4 @@ class Version20191108140919 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191112122617.php
+++ b/packages/framework/src/Migrations/Version20191112122617.php
@@ -225,12 +225,4 @@ class Version20191112122617 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191113133455.php
+++ b/packages/framework/src/Migrations/Version20191113133455.php
@@ -38,12 +38,4 @@ class Version20191113133455 extends AbstractMigration
             FROM administrators
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191113212555.php
+++ b/packages/framework/src/Migrations/Version20191113212555.php
@@ -18,12 +18,4 @@ class Version20191113212555 extends AbstractMigration
     {
         $this->sql('ALTER TABLE administrators DROP COLUMN superadmin');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191113231735.php
+++ b/packages/framework/src/Migrations/Version20191113231735.php
@@ -19,12 +19,4 @@ class Version20191113231735 extends AbstractMigration
         $this->sql('ALTER TABLE administrators ADD roles_changed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         $this->sql('ALTER TABLE administrators ALTER roles_changed_at DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191121145700.php
+++ b/packages/framework/src/Migrations/Version20191121145700.php
@@ -40,12 +40,4 @@ class Version20191121145700 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191126105045.php
+++ b/packages/framework/src/Migrations/Version20191126105045.php
@@ -19,12 +19,4 @@ class Version20191126105045 extends AbstractMigration
         $this->sql('ALTER TABLE uploaded_files ADD type VARCHAR(100) NOT NULL DEFAULT \'default\'');
         $this->sql('ALTER TABLE uploaded_files ALTER type DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191127133143.php
+++ b/packages/framework/src/Migrations/Version20191127133143.php
@@ -19,12 +19,4 @@ class Version20191127133143 extends AbstractMigration
         $this->sql('ALTER TABLE uploaded_files ADD position INT NOT NULL DEFAULT 0');
         $this->sql('ALTER TABLE uploaded_files ALTER position DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191205145631.php
+++ b/packages/framework/src/Migrations/Version20191205145631.php
@@ -53,12 +53,4 @@ class Version20191205145631 extends AbstractMigration
 
         $this->sql('ALTER TABLE "users" DROP "billing_address_id"');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191210112451.php
+++ b/packages/framework/src/Migrations/Version20191210112451.php
@@ -22,12 +22,4 @@ class Version20191210112451 extends AbstractMigration
         $this->sql('ALTER TABLE uploaded_files ALTER slug DROP DEFAULT');
         $this->sql('ALTER TABLE uploaded_files ALTER name DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191211124055.php
+++ b/packages/framework/src/Migrations/Version20191211124055.php
@@ -26,12 +26,4 @@ class Version20191211124055 extends AbstractMigration
                 NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_E52FFDEEA76ED395 ON orders (user_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20191216143436.php
+++ b/packages/framework/src/Migrations/Version20191216143436.php
@@ -86,12 +86,4 @@ SELECT id, customer_id, delivery_address_id, pricing_group_id, first_name, last_
 
         $this->sql('DROP TABLE users');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200127085928.php
+++ b/packages/framework/src/Migrations/Version20200127085928.php
@@ -29,12 +29,4 @@ class Version20200127085928 extends AbstractMigration
         $this->sql('ALTER TABLE customer_users DROP delivery_address_id');
         $this->sql('ALTER TABLE delivery_addresses ALTER customer_id DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200129073328.php
+++ b/packages/framework/src/Migrations/Version20200129073328.php
@@ -19,12 +19,4 @@ class Version20200129073328 extends AbstractMigration
         $this->sql('ALTER TABLE products ADD export_product BOOLEAN NOT NULL DEFAULT false');
         $this->sql('ALTER TABLE products ALTER export_product DROP DEFAULT ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200206111017.php
+++ b/packages/framework/src/Migrations/Version20200206111017.php
@@ -38,12 +38,4 @@ class Version20200206111017 extends AbstractMigration
             EXECUTE PROCEDURE set_export_product_by_product_visibility();
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200211110913.php
+++ b/packages/framework/src/Migrations/Version20200211110913.php
@@ -26,12 +26,4 @@ class Version20200211110913 extends AbstractMigration
                 NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_DAB6D0D2422ED30C ON customer_users (default_delivery_address_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200219145345.php
+++ b/packages/framework/src/Migrations/Version20200219145345.php
@@ -21,12 +21,4 @@ class Version20200219145345 extends AbstractMigration
             $this->sql('ALTER TABLE adverts ADD datetime_visible_to TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200225102504.php
+++ b/packages/framework/src/Migrations/Version20200225102504.php
@@ -22,12 +22,4 @@ class Version20200225102504 extends AbstractMigration
         );
         $this->sql('ALTER TABLE customers ALTER domain_id DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200310120000.php
+++ b/packages/framework/src/Migrations/Version20200310120000.php
@@ -21,12 +21,4 @@ class Version20200310120000 extends AbstractMigration
         $this->sql('ALTER TABLE payments ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_65D29B32D17F50A6 ON payments (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200310130000.php
+++ b/packages/framework/src/Migrations/Version20200310130000.php
@@ -21,12 +21,4 @@ class Version20200310130000 extends AbstractMigration
         $this->sql('ALTER TABLE transports ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_C7BE69E5D17F50A6 ON transports (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200319124638.php
+++ b/packages/framework/src/Migrations/Version20200319124638.php
@@ -21,12 +21,4 @@ class Version20200319124638 extends AbstractMigration
         $this->sql('ALTER TABLE customer_users ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_DAB6D0D2D17F50A6 ON customer_users (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200325132105.php
+++ b/packages/framework/src/Migrations/Version20200325132105.php
@@ -18,12 +18,4 @@ class Version20200325132105 extends AbstractMigration
     {
         $this->sql('ALTER TABLE orders ADD origin VARCHAR(20) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200327080840.php
+++ b/packages/framework/src/Migrations/Version20200327080840.php
@@ -31,12 +31,4 @@ class Version20200327080840 extends AbstractMigration
             ADD
                 CONSTRAINT FK_DA9A5BFDBBB3772B FOREIGN KEY (customer_user_id) REFERENCES customer_users (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200330150340.php
+++ b/packages/framework/src/Migrations/Version20200330150340.php
@@ -21,12 +21,4 @@ class Version20200330150340 extends AbstractMigration
         $this->sql('ALTER TABLE orders ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_E52FFDEED17F50A6 ON orders (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200416114815.php
+++ b/packages/framework/src/Migrations/Version20200416114815.php
@@ -20,12 +20,4 @@ class Version20200416114815 extends AbstractMigration
         $this->sql('UPDATE customer_user_refresh_token_chain SET device_id = uuid_generate_v4()');
         $this->sql('ALTER TABLE customer_user_refresh_token_chain ALTER device_id SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200511110953.php
+++ b/packages/framework/src/Migrations/Version20200511110953.php
@@ -23,12 +23,4 @@ class Version20200511110953 extends AbstractMigration
             ADD
                 CONSTRAINT FK_DA9A5BFDBBB3772B FOREIGN KEY (customer_user_id) REFERENCES customer_users (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200803105229.php
+++ b/packages/framework/src/Migrations/Version20200803105229.php
@@ -23,12 +23,4 @@ class Version20200803105229 extends AbstractMigration
         $this->sql('ALTER TABLE products ALTER recalculate_price DROP DEFAULT');
         $this->sql('ALTER TABLE products ALTER recalculate_visibility DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200819165818.php
+++ b/packages/framework/src/Migrations/Version20200819165818.php
@@ -21,12 +21,4 @@ class Version20200819165818 extends AbstractMigration
         $this->sql('ALTER TABLE articles ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_BFDD3168D17F50A6 ON articles (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200828131906.php
+++ b/packages/framework/src/Migrations/Version20200828131906.php
@@ -23,12 +23,4 @@ class Version20200828131906 extends AbstractMigration
             ADD
                 CONSTRAINT FK_BEF484451AD5CDBF FOREIGN KEY (cart_id) REFERENCES carts (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200923075659.php
+++ b/packages/framework/src/Migrations/Version20200923075659.php
@@ -21,12 +21,4 @@ class Version20200923075659 extends AbstractMigration
         $this->sql('ALTER TABLE brands ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_7EA24434D17F50A6 ON brands (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20200930074334.php
+++ b/packages/framework/src/Migrations/Version20200930074334.php
@@ -26,12 +26,4 @@ class Version20200930074334 extends AbstractMigration
         $this->sql('ALTER TABLE parameters ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_69348FED17F50A6 ON parameters (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20201009082139.php
+++ b/packages/framework/src/Migrations/Version20201009082139.php
@@ -21,12 +21,4 @@ class Version20201009082139 extends AbstractMigration
         $this->sql('ALTER TABLE adverts ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_8C88E777D17F50A6 ON adverts (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20201120143414.php
+++ b/packages/framework/src/Migrations/Version20201120143414.php
@@ -21,12 +21,4 @@ class Version20201120143414 extends AbstractMigration
         $this->sql('ALTER TABLE flags ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_B0541BAD17F50A6 ON flags (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20210127085903.php
+++ b/packages/framework/src/Migrations/Version20210127085903.php
@@ -33,12 +33,4 @@ class Version20210127085903 extends AbstractMigration
         $this->sql('UPDATE transport_translations SET description = NULL WHERE TRIM(description) = \'\'');
         $this->sql('UPDATE transport_translations SET instructions = NULL WHERE TRIM(instructions) = \'\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20220711114131.php
+++ b/packages/framework/src/Migrations/Version20220711114131.php
@@ -59,12 +59,4 @@ class Version20220711114131 extends AbstractMigration
             ADD
                 CONSTRAINT FK_62809DB08D9F6D38 FOREIGN KEY (order_id) REFERENCES orders (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20220725104726.php
+++ b/packages/framework/src/Migrations/Version20220725104726.php
@@ -38,12 +38,4 @@ class Version20220725104726 extends AbstractMigration
         ) WHERE country_id IS NULL;');
         $this->sql('ALTER TABLE delivery_addresses ALTER country_id SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230120123538.php
+++ b/packages/framework/src/Migrations/Version20230120123538.php
@@ -19,12 +19,4 @@ class Version20230120123538 extends AbstractMigration
         $this->sql('CREATE INDEX IDX_3AF34668DA439252 ON categories (lft)');
         $this->sql('CREATE INDEX IDX_3AF34668D5E02D69 ON categories (rgt)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230313123007.php
+++ b/packages/framework/src/Migrations/Version20230313123007.php
@@ -35,12 +35,4 @@ class Version20230313123007 extends AbstractMigration
             SET
                 NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230320105359.php
+++ b/packages/framework/src/Migrations/Version20230320105359.php
@@ -35,12 +35,4 @@ class Version20230320105359 extends AbstractMigration
             ADD
                 CONSTRAINT FK_33DF375212469DE2 FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230404071649.php
+++ b/packages/framework/src/Migrations/Version20230404071649.php
@@ -33,12 +33,4 @@ class Version20230404071649 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230405111441.php
+++ b/packages/framework/src/Migrations/Version20230405111441.php
@@ -44,12 +44,4 @@ class Version20230405111441 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230817135234.php
+++ b/packages/framework/src/Migrations/Version20230817135234.php
@@ -18,12 +18,4 @@ class Version20230817135234 extends AbstractMigration
     {
         $this->sql('UPDATE setting_values SET value = \'\' WHERE name = \'seoRobotsTxtContent\' AND value IS NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230907132822.php
+++ b/packages/framework/src/Migrations/Version20230907132822.php
@@ -18,12 +18,4 @@ class Version20230907132822 extends AbstractMigration
     {
         $this->sql('UPDATE articles SET placement = \'none\' WHERE placement = \'topMenu\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20230919173422.php
+++ b/packages/framework/src/Migrations/Version20230919173422.php
@@ -35,12 +35,4 @@ class Version20230919173422 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231011095432.php
+++ b/packages/framework/src/Migrations/Version20231011095432.php
@@ -43,12 +43,4 @@ class Version20231011095432 extends AbstractMigration
             $this->sql('DELETE FROM migrations WHERE version = :version;', ['version' => self::WRONG_MIGRATION_VERSON]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231020101214.php
+++ b/packages/framework/src/Migrations/Version20231020101214.php
@@ -59,12 +59,4 @@ class Version20231020101214 extends AbstractMigration
             ADD
                 CONSTRAINT FK_A97AE4F9BBB3772B FOREIGN KEY (customer_user_id) REFERENCES customer_users (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231101182132.php
+++ b/packages/framework/src/Migrations/Version20231101182132.php
@@ -72,12 +72,4 @@ class Version20231101182132 extends AbstractMigration implements ContainerAwareI
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231102161313.php
+++ b/packages/framework/src/Migrations/Version20231102161313.php
@@ -91,12 +91,4 @@ class Version20231102161313 extends AbstractMigration
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231102205308.php
+++ b/packages/framework/src/Migrations/Version20231102205308.php
@@ -24,12 +24,4 @@ class Version20231102205308 extends AbstractMigration
         $this->sql('ALTER TABLE orders ADD order_payment_status_page_validity_hash UUID DEFAULT NULL');
         $this->sql('ALTER TABLE orders ALTER order_payment_status_page_validity_hash DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231106135517.php
+++ b/packages/framework/src/Migrations/Version20231106135517.php
@@ -20,12 +20,4 @@ class Version20231106135517 extends AbstractMigration
         $this->sql('DROP TRIGGER IF EXISTS mark_product_for_export ON product_visibilities');
         $this->sql('DROP FUNCTION IF EXISTS set_export_product_by_product_visibility');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231111232939.php
+++ b/packages/framework/src/Migrations/Version20231111232939.php
@@ -22,12 +22,4 @@ class Version20231111232939 extends AbstractMigration
             $this->sql('ALTER TABLE products DROP calculated_availability_id');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231112021215.php
+++ b/packages/framework/src/Migrations/Version20231112021215.php
@@ -19,12 +19,4 @@ class Version20231112021215 extends AbstractMigration
         $this->sql('ALTER TABLE products DROP COLUMN recalculate_visibility');
         $this->sql('ALTER TABLE products DROP COLUMN calculated_visibility');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231113135255.php
+++ b/packages/framework/src/Migrations/Version20231113135255.php
@@ -18,12 +18,4 @@ class Version20231113135255 extends AbstractMigration
     {
         $this->sql('ALTER TABLE products DROP COLUMN calculated_hidden');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231113140422.php
+++ b/packages/framework/src/Migrations/Version20231113140422.php
@@ -21,12 +21,4 @@ class Version20231113140422 extends AbstractMigration
         $this->sql('DROP FUNCTION IF EXISTS set_main_variant_price_recalculation_by_product_visibility');
         $this->sql('DROP TABLE product_calculated_prices');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231114121946.php
+++ b/packages/framework/src/Migrations/Version20231114121946.php
@@ -24,12 +24,4 @@ class Version20231114121946 extends AbstractMigration
                 PRIMARY KEY(name, domain_id)
             )');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231124121921.php
+++ b/packages/framework/src/Migrations/Version20231124121921.php
@@ -247,12 +247,4 @@ class Version20231124121921 extends AbstractMigration
         $this->sql('DROP INDEX IDX_62809DB0C5F1915D');
         $this->sql('ALTER TABLE order_items DROP COLUMN personal_pickup_store_id');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231130165217.php
+++ b/packages/framework/src/Migrations/Version20231130165217.php
@@ -85,12 +85,4 @@ class Version20231130165217 extends AbstractMigration
         $this->sql('ALTER TABLE product_domains RENAME COLUMN domain_ordering_priority TO ordering_priority');
         $this->sql('DROP TABLE product_flags');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231204154157.php
+++ b/packages/framework/src/Migrations/Version20231204154157.php
@@ -26,12 +26,4 @@ class Version20231204154157 extends AbstractMigration
 
         $this->sql('DELETE FROM setting_values WHERE name = :name', ['name' => 'deliveryDayOnStock']);
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231212114321.php
+++ b/packages/framework/src/Migrations/Version20231212114321.php
@@ -184,12 +184,4 @@ class Version20231212114321 extends AbstractMigration implements ContainerAwareI
             $this->sql('ALTER TABLE blog_article_translations ADD perex TEXT DEFAULT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231213165330.php
+++ b/packages/framework/src/Migrations/Version20231213165330.php
@@ -63,12 +63,4 @@ class Version20231213165330 extends AbstractMigration
             $this->sql('ALTER TABLE category_parameters ALTER collapsed DROP DEFAULT');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231214213235.php
+++ b/packages/framework/src/Migrations/Version20231214213235.php
@@ -31,12 +31,4 @@ class Version20231214213235 extends AbstractMigration
             $this->sql('ALTER TABLE articles ALTER url DROP NOT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231228112326.php
+++ b/packages/framework/src/Migrations/Version20231228112326.php
@@ -112,12 +112,4 @@ class Version20231228112326 extends AbstractMigration
             $this->sql('ALTER TABLE gopay_payment_methods ALTER currency_id SET NOT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20231228140243.php
+++ b/packages/framework/src/Migrations/Version20231228140243.php
@@ -29,12 +29,4 @@ class Version20231228140243 extends AbstractMigration
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240102112523.php
+++ b/packages/framework/src/Migrations/Version20240102112523.php
@@ -27,12 +27,4 @@ class Version20240102112523 extends AbstractMigration
                   AND order_items.type = \'product\'
         )');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240103095628.php
+++ b/packages/framework/src/Migrations/Version20240103095628.php
@@ -38,12 +38,4 @@ class Version20240103095628 extends AbstractMigration
         $this->sql('CREATE INDEX IDX_F1B008627DC3D55D ON entity_log (parent_entity_name)');
         $this->sql('CREATE INDEX IDX_F1B00862706E52B3 ON entity_log (parent_entity_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240105155555.php
+++ b/packages/framework/src/Migrations/Version20240105155555.php
@@ -49,12 +49,4 @@ class Version20240105155555 extends AbstractMigration
             WHERE description IS NOT NULL AND description NOT LIKE \'%gjs-text-ckeditor%\' 
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240108154624.php
+++ b/packages/framework/src/Migrations/Version20240108154624.php
@@ -22,12 +22,4 @@ class Version20240108154624 extends AbstractMigration
             $this->sql('ALTER TABLE friendly_urls ADD last_modification TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240108154625.php
+++ b/packages/framework/src/Migrations/Version20240108154625.php
@@ -143,12 +143,4 @@ class Version20240108154625 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240109054610.php
+++ b/packages/framework/src/Migrations/Version20240109054610.php
@@ -18,12 +18,4 @@ class Version20240109054610 extends AbstractMigration
     {
         $this->sql('ALTER TABLE blog_articles ALTER publish_date TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240111072911.php
+++ b/packages/framework/src/Migrations/Version20240111072911.php
@@ -43,12 +43,4 @@ class Version20240111072911 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240112094253.php
+++ b/packages/framework/src/Migrations/Version20240112094253.php
@@ -18,12 +18,4 @@ class Version20240112094253 extends AbstractMigration
     {
         $this->sql('ALTER TABLE vats ALTER percent TYPE NUMERIC(20, 6)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240130104139.php
+++ b/packages/framework/src/Migrations/Version20240130104139.php
@@ -28,12 +28,4 @@ class Version20240130104139 extends AbstractMigration
         $this->sql('ALTER TABLE stores ALTER domain_id DROP DEFAULT');
         $this->sql('DROP TABLE store_domains');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240131072541.php
+++ b/packages/framework/src/Migrations/Version20240131072541.php
@@ -64,12 +64,4 @@ class Version20240131072541 extends AbstractMigration
     {
         $this->sql(sprintf('ALTER TABLE %s DROP COLUMN IF EXISTS %s;', $tableName, $columnName));
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240131163656.php
+++ b/packages/framework/src/Migrations/Version20240131163656.php
@@ -52,14 +52,6 @@ class Version20240131163656 extends AbstractMigration
     }
 
     /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
-    /**
      * @param string $openingTime
      * @param string $closingTime
      * @param int $openingHoursId

--- a/packages/framework/src/Migrations/Version20240206145944.php
+++ b/packages/framework/src/Migrations/Version20240206145944.php
@@ -35,12 +35,4 @@ class Version20240206145944 extends AbstractMigration
     {
         $this->sql(sprintf('ALTER TABLE %s DROP COLUMN IF EXISTS %s', $tableName, $columnName));
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240209114704.php
+++ b/packages/framework/src/Migrations/Version20240209114704.php
@@ -19,12 +19,4 @@ class Version20240209114704 extends AbstractMigration
         $this->sql('CREATE UNIQUE INDEX cart_identifier ON carts (cart_identifier) WHERE cart_identifier <> \'\';');
         $this->sql('CREATE UNIQUE INDEX customer_user_id ON carts (customer_user_id);');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240301101208.php
+++ b/packages/framework/src/Migrations/Version20240301101208.php
@@ -19,12 +19,4 @@ class Version20240301101208 extends AbstractMigration
         $this->sql('CREATE INDEX IDX_63DABEAED46F4E3 ON cron_module_runs (started_at)');
         $this->sql('CREATE INDEX IDX_63DABEAE35CE7A2D ON cron_module_runs (finished_at)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240318162418.php
+++ b/packages/framework/src/Migrations/Version20240318162418.php
@@ -30,14 +30,6 @@ class Version20240318162418 extends AbstractMigration
         $this->editDefaultDbIndexes();
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function editDefaultDbIndexes(): void
     {
         $this->sql('DROP INDEX IF EXISTS product_translations_name_normalize_idx;');

--- a/packages/framework/src/Migrations/Version20240325165512.php
+++ b/packages/framework/src/Migrations/Version20240325165512.php
@@ -40,12 +40,4 @@ class Version20240325165512 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240403091822.php
+++ b/packages/framework/src/Migrations/Version20240403091822.php
@@ -417,12 +417,4 @@ class Version20240403091822 extends AbstractMigration implements ContainerAwareI
         $this->sql('ALTER TABLE cart_items ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_BEF48445D17F50A6 ON cart_items (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240403095810.php
+++ b/packages/framework/src/Migrations/Version20240403095810.php
@@ -20,12 +20,4 @@ class Version20240403095810 extends AbstractMigration
         $this->sql('ALTER INDEX uniq_57310e34772e836a RENAME TO UNIQ_802A3918772E836A;');
         $this->sql('ALTER SEQUENCE tranfers_id_seq RENAME TO transfers_id_seq');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240403122615.php
+++ b/packages/framework/src/Migrations/Version20240403122615.php
@@ -18,12 +18,4 @@ class Version20240403122615 extends AbstractMigration
     {
         $this->sql('ALTER TABLE promo_codes DROP identifier');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240415095045.php
+++ b/packages/framework/src/Migrations/Version20240415095045.php
@@ -19,12 +19,4 @@ class Version20240415095045 extends AbstractMigration
         $this->sql('ALTER TABLE orders ADD heureka_agreement BOOLEAN NOT NULL DEFAULT FALSE');
         $this->sql('ALTER TABLE orders ALTER heureka_agreement DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240416105031.php
+++ b/packages/framework/src/Migrations/Version20240416105031.php
@@ -18,12 +18,4 @@ class Version20240416105031 extends AbstractMigration
     {
         $this->sql('DROP TABLE scripts');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240421102006.php
+++ b/packages/framework/src/Migrations/Version20240421102006.php
@@ -19,12 +19,4 @@ class Version20240421102006 extends AbstractMigration
         $this->sql('ALTER TABLE order_items RENAME COLUMN price_without_vat TO unit_price_without_vat');
         $this->sql('ALTER TABLE order_items RENAME COLUMN price_with_vat TO unit_price_with_vat');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240426045700.php
+++ b/packages/framework/src/Migrations/Version20240426045700.php
@@ -20,12 +20,4 @@ class Version20240426045700 extends AbstractMigration
         $this->sql('DELETE FROM setting_values WHERE name = :name', ['name' => 'shopInfoEmail']);
         $this->sql('DELETE FROM setting_values WHERE name = :name', ['name' => 'shopInfoPhoneHours']);
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240527121326.php
+++ b/packages/framework/src/Migrations/Version20240527121326.php
@@ -72,12 +72,4 @@ class Version20240527121326 extends AbstractMigration
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240604152553.php
+++ b/packages/framework/src/Migrations/Version20240604152553.php
@@ -21,12 +21,4 @@ class Version20240604152553 extends AbstractMigration
         $this->sql('DROP TABLE IF EXISTS advert_category');
         $this->sql('DROP TABLE IF EXISTS entity');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240610181711.php
+++ b/packages/framework/src/Migrations/Version20240610181711.php
@@ -27,12 +27,4 @@ class Version20240610181711 extends AbstractMigration
             $this->sql('ALTER TABLE orders ADD gtm_coupon VARCHAR(64) DEFAULT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240612124051.php
+++ b/packages/framework/src/Migrations/Version20240612124051.php
@@ -58,12 +58,4 @@ class Version20240612124051 extends AbstractMigration
         $this->sql('ALTER TABLE navigation_items ALTER domain_id DROP DEFAULT');
         $this->sql('CREATE INDEX domain_id_idx ON navigation_items (domain_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240612131511.php
+++ b/packages/framework/src/Migrations/Version20240612131511.php
@@ -25,12 +25,4 @@ class Version20240612131511 extends AbstractMigration
         $this->sql('ALTER TABLE navigation_item_categories ADD CONSTRAINT FK_71699B7654ED5C2D FOREIGN KEY (navigation_item_id) REFERENCES navigation_items (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('ALTER TABLE navigation_item_categories ADD CONSTRAINT FK_71699B7612469DE2 FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240613105832.php
+++ b/packages/framework/src/Migrations/Version20240613105832.php
@@ -41,12 +41,4 @@ class Version20240613105832 extends AbstractMigration
             $this->sql('ALTER TABLE parameters ALTER ordering_priority DROP DEFAULT');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240613231000.php
+++ b/packages/framework/src/Migrations/Version20240613231000.php
@@ -26,12 +26,4 @@ class Version20240613231000 extends AbstractMigration
         $this->sql('ALTER TABLE cart_promo_codes DROP CONSTRAINT fk_5de6e36c2fae4625');
         $this->sql('ALTER TABLE delivery_addresses DROP CONSTRAINT fk_2baf3984e76aa954');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240613235059.php
+++ b/packages/framework/src/Migrations/Version20240613235059.php
@@ -31,12 +31,4 @@ class Version20240613235059 extends AbstractMigration
         $this->sql('ALTER TABLE closed_day_excluded_stores ADD CONSTRAINT FK_B4EC517608F9E8F FOREIGN KEY (closed_day_id) REFERENCES closed_days (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('ALTER TABLE closed_day_excluded_stores ADD CONSTRAINT FK_B4EC517B092A811 FOREIGN KEY (store_id) REFERENCES stores (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240614142126.php
+++ b/packages/framework/src/Migrations/Version20240614142126.php
@@ -18,12 +18,4 @@ class Version20240614142126 extends AbstractMigration
     {
         $this->sql('ALTER TABLE orders RENAME COLUMN gtm_coupon TO promo_code');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240614144002.php
+++ b/packages/framework/src/Migrations/Version20240614144002.php
@@ -22,12 +22,4 @@ class Version20240614144002 extends AbstractMigration
         $this->sql('UPDATE order_statuses SET type = \'done\' WHERE type = \'3\'');
         $this->sql('UPDATE order_statuses SET type = \'cancelled\' WHERE type = \'4\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240617204710.php
+++ b/packages/framework/src/Migrations/Version20240617204710.php
@@ -50,12 +50,4 @@ class Version20240617204710 extends AbstractMigration
             $this->sql('ALTER TABLE order_items DROP related_order_item_id');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240704105750.php
+++ b/packages/framework/src/Migrations/Version20240704105750.php
@@ -33,12 +33,4 @@ class Version20240704105750 extends AbstractMigration
             ADD
                 CONSTRAINT FK_52CCF9172C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES uploaded_files (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240704143616.php
+++ b/packages/framework/src/Migrations/Version20240704143616.php
@@ -183,12 +183,4 @@ class Version20240704143616 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240709134704.php
+++ b/packages/framework/src/Migrations/Version20240709134704.php
@@ -18,12 +18,4 @@ class Version20240709134704 extends AbstractMigration
     {
         $this->sql('ALTER TABLE parameter_values ADD numeric_value NUMERIC(20, 6) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240710123712.php
+++ b/packages/framework/src/Migrations/Version20240710123712.php
@@ -31,12 +31,4 @@ class Version20240710123712 extends AbstractMigration
             ADD
                 CONSTRAINT FK_5474CBC4276973A0 FOREIGN KEY (uploaded_file_id) REFERENCES uploaded_files (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240711100044.php
+++ b/packages/framework/src/Migrations/Version20240711100044.php
@@ -57,12 +57,4 @@ class Version20240711100044 extends AbstractMigration implements ContainerAwareI
 
         $this->sql('INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'customerUserDefaultGroupRoleId\', 0, ' . $customerUserRoleGroupId . ', \'integer\')');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240712070530.php
+++ b/packages/framework/src/Migrations/Version20240712070530.php
@@ -18,12 +18,4 @@ class Version20240712070530 extends AbstractMigration
     {
         $this->sql('ALTER TABLE uploaded_files_relations ADD position INT NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240712133748.php
+++ b/packages/framework/src/Migrations/Version20240712133748.php
@@ -18,12 +18,4 @@ class Version20240712133748 extends AbstractMigration
     {
         $this->sql('ALTER TABLE customer_users ALTER password DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240719104316.php
+++ b/packages/framework/src/Migrations/Version20240719104316.php
@@ -26,12 +26,4 @@ class Version20240719104316 extends AbstractMigration
         $this->sql('ALTER TABLE uploaded_files DROP COLUMN position');
         $this->sql('ALTER TABLE uploaded_files DROP COLUMN type');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240722095556.php
+++ b/packages/framework/src/Migrations/Version20240722095556.php
@@ -19,12 +19,4 @@ class Version20240722095556 extends AbstractMigration
         $this->sql('ALTER TABLE stores RENAME COLUMN location_latitude to latitude');
         $this->sql('ALTER TABLE stores RENAME COLUMN location_longitude to longitude');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240724062626.php
+++ b/packages/framework/src/Migrations/Version20240724062626.php
@@ -25,12 +25,4 @@ class Version20240724062626 extends AbstractMigration
         $this->sql('ALTER TABLE customer_users ALTER first_name DROP NOT NULL');
         $this->sql('ALTER TABLE customer_users ALTER last_name DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240725200526.php
+++ b/packages/framework/src/Migrations/Version20240725200526.php
@@ -23,12 +23,4 @@ class Version20240725200526 extends AbstractMigration
                 entity_name, entity_id, type, uploaded_file_id
             )');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240729072354.php
+++ b/packages/framework/src/Migrations/Version20240729072354.php
@@ -24,12 +24,4 @@ class Version20240729072354 extends AbstractMigration
         $this->sql('UPDATE customer_users SET first_name = NULL WHERE first_name = \'\'');
         $this->sql('UPDATE customer_users SET last_name = NULL WHERE last_name = \'\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240729082317.php
+++ b/packages/framework/src/Migrations/Version20240729082317.php
@@ -20,12 +20,4 @@ class Version20240729082317 extends AbstractMigration
         $this->sql('ALTER TABLE billing_addresses ALTER uuid DROP DEFAULT');
         $this->sql('CREATE UNIQUE INDEX UNIQ_DBD91748D17F50A6 ON billing_addresses (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240729120703.php
+++ b/packages/framework/src/Migrations/Version20240729120703.php
@@ -20,12 +20,4 @@ class Version20240729120703 extends AbstractMigration
         $this->sql('ALTER TABLE customer_user_role_groups ALTER uuid DROP DEFAULT');
         $this->sql('CREATE UNIQUE INDEX UNIQ_E2F14348D17F50A6 ON customer_user_role_groups (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240730045035.php
+++ b/packages/framework/src/Migrations/Version20240730045035.php
@@ -28,12 +28,4 @@ class Version20240730045035 extends AbstractMigration
             )');
         $this->sql('CREATE UNIQUE INDEX UNIQ_8A1D0961D17F50A6 ON sales_representatives (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240730070101.php
+++ b/packages/framework/src/Migrations/Version20240730070101.php
@@ -21,12 +21,4 @@ class Version20240730070101 extends AbstractMigration
         $this->sql('ALTER TABLE billing_addresses ALTER city DROP NOT NULL');
         $this->sql('ALTER TABLE billing_addresses ALTER postcode DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240730113802.php
+++ b/packages/framework/src/Migrations/Version20240730113802.php
@@ -22,12 +22,4 @@ class Version20240730113802 extends AbstractMigration
             [Setting::FILE_STRUCTURE_MIGRATED_FOR_RELATIONS],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240731141013.php
+++ b/packages/framework/src/Migrations/Version20240731141013.php
@@ -81,12 +81,4 @@ class Version20240731141013 extends AbstractMigration
             ADD
                 CONSTRAINT FK_A05AAF3AE76AA954 FOREIGN KEY (delivery_country_id) REFERENCES countries (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240731150432.php
+++ b/packages/framework/src/Migrations/Version20240731150432.php
@@ -29,12 +29,4 @@ class Version20240731150432 extends AbstractMigration
                 NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_E52FFDEE9395C3F3 ON orders (customer_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240801061521.php
+++ b/packages/framework/src/Migrations/Version20240801061521.php
@@ -24,12 +24,4 @@ class Version20240801061521 extends AbstractMigration
                 CONSTRAINT FK_DAB6D0D28B54B08B FOREIGN KEY (sales_representative_id) REFERENCES sales_representatives (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_DAB6D0D28B54B08B ON customer_users (sales_representative_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240801095527.php
+++ b/packages/framework/src/Migrations/Version20240801095527.php
@@ -31,12 +31,4 @@ class Version20240801095527 extends AbstractMigration
 
         $this->sql('INSERT INTO complaint_number_sequences (id, number) VALUES (1, 0)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240801114052.php
+++ b/packages/framework/src/Migrations/Version20240801114052.php
@@ -21,12 +21,4 @@ class Version20240801114052 extends AbstractMigration
         $this->sql('ALTER TABLE order_items ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_62809DB0D17F50A6 ON order_items (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240803005343.php
+++ b/packages/framework/src/Migrations/Version20240803005343.php
@@ -58,12 +58,4 @@ class Version20240803005343 extends AbstractMigration implements ContainerAwareI
         $this->sql('ALTER TABLE payment_domains ALTER COLUMN hidden_by_go_pay DROP DEFAULT ');
         $this->sql('ALTER TABLE payments DROP COLUMN hidden_by_go_pay');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240806084610.php
+++ b/packages/framework/src/Migrations/Version20240806084610.php
@@ -31,12 +31,4 @@ class Version20240806084610 extends AbstractMigration
             )');
         $this->sql('CREATE INDEX IDX_970DDB7F16EFC72D81257D5D ON customer_uploaded_files (entity_name, entity_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240806175816.php
+++ b/packages/framework/src/Migrations/Version20240806175816.php
@@ -33,12 +33,4 @@ class Version20240806175816 extends AbstractMigration
         $this->sql('
             CREATE INDEX IDX_970DDB7FBF396750989D9B629FB73D77D1B862B8 ON customer_uploaded_files (id, slug, extension, hash)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240813071845.php
+++ b/packages/framework/src/Migrations/Version20240813071845.php
@@ -19,12 +19,4 @@ final class Version20240813071845 extends AbstractMigration
         $this->sql('UPDATE adverts SET position_name = \'productListSecondRow\' WHERE position_name = \'productListMiddle\'');
         $this->sql('UPDATE adverts SET position_name = \'productListSecondRow\' WHERE position_name = \'productList\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240813183535.php
+++ b/packages/framework/src/Migrations/Version20240813183535.php
@@ -26,12 +26,4 @@ class Version20240813183535 extends AbstractMigration implements ContainerAwareI
 
         $this->sql('ALTER TABLE administrators ALTER display_only_domain_ids DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240814132958.php
+++ b/packages/framework/src/Migrations/Version20240814132958.php
@@ -32,12 +32,4 @@ class Version20240814132958 extends AbstractMigration
         );
         $this->sql('ALTER TABLE images ALTER "position" SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240815065344.php
+++ b/packages/framework/src/Migrations/Version20240815065344.php
@@ -20,12 +20,4 @@ class Version20240815065344 extends AbstractMigration
         $this->sql('ALTER TABLE sales_representatives ALTER last_name DROP NOT NULL');
         $this->sql('ALTER TABLE sales_representatives ALTER email DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240816110309.php
+++ b/packages/framework/src/Migrations/Version20240816110309.php
@@ -25,12 +25,4 @@ class Version20240816110309 extends AbstractMigration
             SET
                 NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240816164022.php
+++ b/packages/framework/src/Migrations/Version20240816164022.php
@@ -22,12 +22,4 @@ class Version20240816164022 extends AbstractMigration
 
         $this->sql('ALTER TABLE complaints ALTER domain_id SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240816221930.php
+++ b/packages/framework/src/Migrations/Version20240816221930.php
@@ -95,12 +95,4 @@ class Version20240816221930 extends AbstractMigration implements ContainerAwareI
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240822144131.php
+++ b/packages/framework/src/Migrations/Version20240822144131.php
@@ -19,12 +19,4 @@ class Version20240822144131 extends AbstractMigration
         $this->sql('ALTER TABLE gopay_payment_methods ADD available BOOLEAN NOT NULL DEFAULT TRUE');
         $this->sql('ALTER TABLE gopay_payment_methods ALTER available DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240826114720.php
+++ b/packages/framework/src/Migrations/Version20240826114720.php
@@ -24,12 +24,4 @@ class Version20240826114720 extends AbstractMigration
                 CONSTRAINT FK_17F263ED685DFB98 FOREIGN KEY (complaint_status_id) REFERENCES complaint_statuses (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_17F263ED685DFB98 ON mail_templates (complaint_status_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240827110317.php
+++ b/packages/framework/src/Migrations/Version20240827110317.php
@@ -29,12 +29,4 @@ class Version20240827110317 extends AbstractMigration implements ContainerAwareI
             }
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240829093048.php
+++ b/packages/framework/src/Migrations/Version20240829093048.php
@@ -45,12 +45,4 @@ class Version20240829093048 extends AbstractMigration
         $this->sql('ALTER TABLE complaint_items ALTER product_name SET NOT NULL');
         $this->sql('ALTER TABLE complaint_items ALTER catnum SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240831121309.php
+++ b/packages/framework/src/Migrations/Version20240831121309.php
@@ -35,12 +35,4 @@ class Version20240831121309 extends AbstractMigration
             ADD
                 CONSTRAINT FK_7A9C76509909C13F FOREIGN KEY (transport_id) REFERENCES transports (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240902171506.php
+++ b/packages/framework/src/Migrations/Version20240902171506.php
@@ -23,12 +23,4 @@ class Version20240902171506 extends AbstractMigration
         $this->sql('ALTER TABLE transport_prices ADD id SERIAL NOT NULL');
         $this->sql('ALTER TABLE transport_prices ADD PRIMARY KEY (id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240906201521.php
+++ b/packages/framework/src/Migrations/Version20240906201521.php
@@ -18,12 +18,4 @@ class Version20240906201521 extends AbstractMigration
     {
         $this->sql('ALTER TABLE customer_users ADD last_security_change TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240910054629.php
+++ b/packages/framework/src/Migrations/Version20240910054629.php
@@ -65,14 +65,6 @@ class Version20240910054629 extends AbstractMigration implements ContainerAwareI
     }
 
     /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
-    /**
      * @param string $mailTemplateName
      * @param bool $sendMail
      * @param int $complaintStatusId

--- a/packages/framework/src/Migrations/Version20240911090337.php
+++ b/packages/framework/src/Migrations/Version20240911090337.php
@@ -18,12 +18,4 @@ class Version20240911090337 extends AbstractMigration
     {
         $this->sql('ALTER TABLE transports DROP COLUMN max_weight');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240911092730.php
+++ b/packages/framework/src/Migrations/Version20240911092730.php
@@ -18,12 +18,4 @@ class Version20240911092730 extends AbstractMigration
     {
         $this->sql('CREATE UNIQUE INDEX unique_weight_limit_on_domain ON transport_prices (max_weight, domain_id, transport_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240911133739.php
+++ b/packages/framework/src/Migrations/Version20240911133739.php
@@ -27,12 +27,4 @@ class Version20240911133739 extends AbstractMigration
         $this->sql('DROP TABLE transport_type_translations');
         $this->sql('DROP TABLE transport_types');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240924082209.php
+++ b/packages/framework/src/Migrations/Version20240924082209.php
@@ -20,12 +20,4 @@ class Version20240924082209 extends AbstractMigration
         $this->sql('UPDATE products SET product_type = \'basic\'');
         $this->sql('ALTER TABLE products ALTER product_type SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20240926162253.php
+++ b/packages/framework/src/Migrations/Version20240926162253.php
@@ -54,12 +54,4 @@ class Version20240926162253 extends AbstractMigration
                 NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_1CCE4D5BBB3772B ON inquiries (customer_user_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241001113136.php
+++ b/packages/framework/src/Migrations/Version20241001113136.php
@@ -93,12 +93,4 @@ class Version20241001113136 extends AbstractMigration implements ContainerAwareI
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241002121943.php
+++ b/packages/framework/src/Migrations/Version20241002121943.php
@@ -18,12 +18,4 @@ class Version20241002121943 extends AbstractMigration
     {
         $this->sql('ALTER TABLE customer_users DROP COLUMN newsletter_subscription');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241008072724.php
+++ b/packages/framework/src/Migrations/Version20241008072724.php
@@ -29,12 +29,4 @@ class Version20241008072724 extends AbstractMigration
         $this->sql('ALTER SEQUENCE complaint_items_id_seq OWNED BY complaint_items.id');
         $this->sql('ALTER SEQUENCE complaints_id_seq OWNED BY complaints.id');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241014125411.php
+++ b/packages/framework/src/Migrations/Version20241014125411.php
@@ -25,12 +25,4 @@ class Version20241014125411 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241017084042.php
+++ b/packages/framework/src/Migrations/Version20241017084042.php
@@ -109,12 +109,4 @@ class Version20241017084042 extends AbstractMigration
             $this->sql('CREATE UNIQUE INDEX UNIQ_74803E8FD17F50A6 ON ready_category_seo_mixes (uuid)');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241023142037.php
+++ b/packages/framework/src/Migrations/Version20241023142037.php
@@ -29,12 +29,4 @@ final class Version20241023142037 extends AbstractMigration
         );
         $this->sql('CREATE INDEX IDX_A05AAF3A9395C3F3 ON complaints (customer_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241031100638.php
+++ b/packages/framework/src/Migrations/Version20241031100638.php
@@ -22,12 +22,4 @@ class Version20241031100638 extends AbstractMigration
         $this->sql('ALTER TABLE slider_items ALTER rgb_background_color DROP DEFAULT');
         $this->sql('ALTER TABLE slider_items ALTER opacity DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241101073720.php
+++ b/packages/framework/src/Migrations/Version20241101073720.php
@@ -59,12 +59,4 @@ class Version20241101073720 extends AbstractMigration
         $this->sql('ALTER TABLE parameters DROP COLUMN IF EXISTS akeneo_code');
         $this->sql('ALTER TABLE parameters DROP COLUMN IF EXISTS akeneo_type');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241101081004.php
+++ b/packages/framework/src/Migrations/Version20241101081004.php
@@ -19,12 +19,4 @@ class Version20241101081004 extends AbstractMigration
         $this->sql('ALTER TABLE parameters DROP CONSTRAINT FK_69348FEFE54D947');
         $this->sql('ALTER TABLE parameters ADD CONSTRAINT FK_69348FEFE54D947 FOREIGN KEY (group_id) REFERENCES parameter_groups (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241101083720.php
+++ b/packages/framework/src/Migrations/Version20241101083720.php
@@ -29,12 +29,4 @@ final class Version20241101083720 extends AbstractMigration
         $this->sql('ALTER TABLE parameter_groups ALTER position DROP DEFAULT');
         $this->sql('ALTER TABLE parameter_groups DROP ordering_priority');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241104151802.php
+++ b/packages/framework/src/Migrations/Version20241104151802.php
@@ -53,12 +53,4 @@ final class Version20241104151802 extends AbstractMigration
             ADD
                 CONSTRAINT FK_418F3D235688DED7 FOREIGN KEY (price_list_id) REFERENCES price_lists (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241105132620.php
+++ b/packages/framework/src/Migrations/Version20241105132620.php
@@ -28,12 +28,4 @@ class Version20241105132620 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241106123834.php
+++ b/packages/framework/src/Migrations/Version20241106123834.php
@@ -37,14 +37,6 @@ class Version20241106123834 extends AbstractMigration implements ContainerAwareI
     }
 
     /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
-    /**
      * @param \Symfony\Component\DependencyInjection\ContainerInterface|null $container
      */
     public function setContainer(?ContainerInterface $container = null): void

--- a/packages/framework/src/Migrations/Version20241112100245.php
+++ b/packages/framework/src/Migrations/Version20241112100245.php
@@ -45,12 +45,4 @@ class Version20241112100245 extends AbstractMigration implements ContainerAwareI
             throw new Exception('There is more than one root blog category. Please see upgrade notes.');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241113124734.php
+++ b/packages/framework/src/Migrations/Version20241113124734.php
@@ -24,12 +24,4 @@ class Version20241113124734 extends AbstractMigration
             $this->sql('ALTER TABLE product_translations ALTER name_sufix DROP DEFAULT');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241113185044.php
+++ b/packages/framework/src/Migrations/Version20241113185044.php
@@ -18,12 +18,4 @@ class Version20241113185044 extends AbstractMigration
     {
         $this->sql('ALTER TABLE product_translations RENAME COLUMN name_sufix TO name_suffix');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241114124339.php
+++ b/packages/framework/src/Migrations/Version20241114124339.php
@@ -20,12 +20,4 @@ class Version20241114124339 extends AbstractMigration
         $this->sql('ALTER TABLE administrators ADD reset_password_hash_valid_through TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         $this->sql('ALTER TABLE administrators ALTER COLUMN password DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241119123503.php
+++ b/packages/framework/src/Migrations/Version20241119123503.php
@@ -32,12 +32,4 @@ class Version20241119123503 extends AbstractMigration
 
         $this->sql('ALTER TABLE seo_page_domains ALTER page_slug DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241121094752.php
+++ b/packages/framework/src/Migrations/Version20241121094752.php
@@ -18,12 +18,4 @@ class Version20241121094752 extends AbstractMigration
     {
         $this->sql('UPDATE product_stocks SET product_quantity = 0 WHERE product_id IN (SELECT id FROM products WHERE variant_type = \'main\')');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241126152128.php
+++ b/packages/framework/src/Migrations/Version20241126152128.php
@@ -20,12 +20,4 @@ class Version20241126152128 extends AbstractMigration
         $this->sql('UPDATE promo_codes SET discount_type = \'percent\' WHERE discount_type = \'1\'');
         $this->sql('UPDATE promo_codes SET discount_type = \'nominal\' WHERE discount_type = \'2\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241128111224.php
+++ b/packages/framework/src/Migrations/Version20241128111224.php
@@ -19,12 +19,4 @@ class Version20241128111224 extends AbstractMigration
         $this->sql('ALTER TABLE orders ADD free_transport_and_payment_applied BOOLEAN NOT NULL DEFAULT FALSE');
         $this->sql('ALTER TABLE orders ALTER free_transport_and_payment_applied DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241204101113.php
+++ b/packages/framework/src/Migrations/Version20241204101113.php
@@ -34,12 +34,4 @@ class Version20241204101113 extends AbstractMigration
             ADD
                 CONSTRAINT FK_45F09E784584665A FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241205094315.php
+++ b/packages/framework/src/Migrations/Version20241205094315.php
@@ -108,12 +108,4 @@ class Version20241205094315 extends AbstractMigration implements ContainerAwareI
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241205144230.php
+++ b/packages/framework/src/Migrations/Version20241205144230.php
@@ -33,12 +33,4 @@ class Version20241205144230 extends AbstractMigration
 
         $this->sql('CREATE INDEX billing_addresses_company_name_trgm_idx ON billing_addresses USING gin (normalized(company_name) gin_trgm_ops);');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241212064226.php
+++ b/packages/framework/src/Migrations/Version20241212064226.php
@@ -84,12 +84,4 @@ class Version20241212064226 extends AbstractMigration implements ContainerAwareI
             ],
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241216165539.php
+++ b/packages/framework/src/Migrations/Version20241216165539.php
@@ -19,12 +19,4 @@ class Version20241216165539 extends AbstractMigration
         $this->sql('ALTER TABLE categories ADD automated_filters JSON NOT NULL DEFAULT \'{}\'');
         $this->sql('ALTER TABLE categories ALTER automated_filters DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241216210547.php
+++ b/packages/framework/src/Migrations/Version20241216210547.php
@@ -20,12 +20,4 @@ class Version20241216210547 extends AbstractMigration
         $this->sql('ALTER TABLE stores ADD phone VARCHAR(255) DEFAULT NULL');
         $this->sql('ALTER TABLE stores ADD directions TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241216210633.php
+++ b/packages/framework/src/Migrations/Version20241216210633.php
@@ -18,12 +18,4 @@ class Version20241216210633 extends AbstractMigration
     {
         $this->sql('ALTER TABLE stores DROP contact_info');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241220094923.php
+++ b/packages/framework/src/Migrations/Version20241220094923.php
@@ -18,12 +18,4 @@ class Version20241220094923 extends AbstractMigration
     {
         $this->sql('CREATE UNIQUE INDEX UNIQ_73A716FE7927C74 ON administrators (email)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20241223020558.php
+++ b/packages/framework/src/Migrations/Version20241223020558.php
@@ -23,12 +23,4 @@ class Version20241223020558 extends AbstractMigration
         $this->sql('COMMENT ON COLUMN messenger_messages.available_at IS \'(DC2Type:datetime_immutable)\'');
         $this->sql('COMMENT ON COLUMN messenger_messages.delivered_at IS \'(DC2Type:datetime_immutable)\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250103183756.php
+++ b/packages/framework/src/Migrations/Version20250103183756.php
@@ -29,12 +29,4 @@ class Version20250103183756 extends AbstractMigration
         $this->sql('ALTER TABLE complaints ALTER email DROP DEFAULT');
         $this->sql('ALTER TABLE complaints ALTER email SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250114063651.php
+++ b/packages/framework/src/Migrations/Version20250114063651.php
@@ -25,12 +25,4 @@ class Version20250114063651 extends AbstractMigration
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250117110742.php
+++ b/packages/framework/src/Migrations/Version20250117110742.php
@@ -25,12 +25,4 @@ class Version20250117110742 extends AbstractMigration
             )');
         $this->sql('DROP INDEX chose_category_seo_mix_combination_json');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250120130000.php
+++ b/packages/framework/src/Migrations/Version20250120130000.php
@@ -42,12 +42,4 @@ class Version20250120130000 extends AbstractMigration
             $this->sql('ALTER TABLE language_constant_translations ALTER translation TYPE TEXT');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250120145445.php
+++ b/packages/framework/src/Migrations/Version20250120145445.php
@@ -30,12 +30,4 @@ class Version20250120145445 extends AbstractMigration
             )');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250121131930.php
+++ b/packages/framework/src/Migrations/Version20250121131930.php
@@ -49,12 +49,4 @@ class Version20250121131930 extends AbstractMigration
                 CONSTRAINT FK_95924E34DD9BA170 FOREIGN KEY (product_video) REFERENCES product_videos (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250121135043.php
+++ b/packages/framework/src/Migrations/Version20250121135043.php
@@ -21,12 +21,4 @@ class Version20250121135043 extends AbstractMigration
             $this->sql('ALTER TABLE slider_items ADD datetime_visible_to TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250121135309.php
+++ b/packages/framework/src/Migrations/Version20250121135309.php
@@ -120,12 +120,4 @@ class Version20250121135309 extends AbstractMigration implements ContainerAwareI
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250124092957.php
+++ b/packages/framework/src/Migrations/Version20250124092957.php
@@ -19,12 +19,4 @@ class Version20250124092957 extends AbstractMigration
         $this->sql('ALTER TABLE product_video_translations ALTER description DROP NOT NULL');
         $this->sql('UPDATE product_video_translations SET description = NULL WHERE description = \'\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250124125113.php
+++ b/packages/framework/src/Migrations/Version20250124125113.php
@@ -23,12 +23,4 @@ class Version20250124125113 extends AbstractMigration
             WHERE NOT (roles::jsonb @> \'["ROLE_API_ALL"]\'::jsonb);',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250127142754.php
+++ b/packages/framework/src/Migrations/Version20250127142754.php
@@ -20,12 +20,4 @@ class Version20250127142754 extends AbstractMigration
         $this->sql('ALTER TABLE complaints ALTER resolution DROP DEFAULT');
         $this->sql('ALTER TABLE complaints ADD bank_account_number VARCHAR(34) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250130153449.php
+++ b/packages/framework/src/Migrations/Version20250130153449.php
@@ -23,12 +23,4 @@ class Version20250130153449 extends AbstractMigration
             WHERE NOT (roles::jsonb @> \'["ROLE_API_ALL"]\'::jsonb);',
         );
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250208081702.php
+++ b/packages/framework/src/Migrations/Version20250208081702.php
@@ -20,12 +20,4 @@ class Version20250208081702 extends AbstractMigration
         $this->sql('ALTER TABLE complaints ALTER order_id DROP NOT NULL');
         $this->sql('ALTER TABLE complaint_items ALTER catnum DROP NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250209123001.php
+++ b/packages/framework/src/Migrations/Version20250209123001.php
@@ -21,12 +21,4 @@ class Version20250209123001 extends AbstractMigration
         $this->sql('CREATE INDEX complaint_delivery_last_name_trgm_idx ON complaints USING gin (normalized(delivery_last_name) gin_trgm_ops);');
         $this->sql('CREATE INDEX complaint_delivery_company_name_trgm_idx ON complaints USING gin (normalized(delivery_company_name) gin_trgm_ops);');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250214133657.php
+++ b/packages/framework/src/Migrations/Version20250214133657.php
@@ -19,12 +19,4 @@ class Version20250214133657 extends AbstractMigration
         $this->sql('DELETE FROM setting_values WHERE name = \'imageStructureMigratedForProxy\'');
         $this->sql('DELETE FROM migrations WHERE version = \'Shopsys\FrameworkBundle\Migrations\Version20231020173331\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250226102020.php
+++ b/packages/framework/src/Migrations/Version20250226102020.php
@@ -19,12 +19,4 @@ class Version20250226102020 extends AbstractMigration
         $this->sql('ALTER TABLE currencies ADD rounding_places_price_without_vat INT NOT NULL DEFAULT 2');
         $this->sql('ALTER TABLE currencies ALTER rounding_places_price_without_vat DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250302234333.php
+++ b/packages/framework/src/Migrations/Version20250302234333.php
@@ -19,12 +19,4 @@ class Version20250302234333 extends AbstractMigration
         $this->sql('DELETE FROM cron_module_runs WHERE cron_module_id = \'Shopsys\\FrameworkBundle\\Component\\Error\\ErrorPageCronModule\'');
         $this->sql('DELETE FROM cron_modules WHERE service_id = \'Shopsys\\FrameworkBundle\\Component\\Error\\ErrorPageCronModule\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250303130234.php
+++ b/packages/framework/src/Migrations/Version20250303130234.php
@@ -20,12 +20,4 @@ class Version20250303130234 extends AbstractMigration
         $this->sql('ALTER TABLE promo_code_limit RENAME COLUMN from_price_with_vat TO from_price');
         $this->sql('ALTER TABLE promo_code_limit ADD PRIMARY KEY (promo_code_id, from_price)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250312132504.php
+++ b/packages/framework/src/Migrations/Version20250312132504.php
@@ -19,12 +19,4 @@ class Version20250312132504 extends AbstractMigration
         $this->sql('ALTER TABLE promo_code_limit ALTER from_price TYPE NUMERIC(20, 6)');
         $this->sql('ALTER TABLE promo_code_limit ALTER discount TYPE NUMERIC(20, 6)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/framework/src/Migrations/Version20250313074307.php
+++ b/packages/framework/src/Migrations/Version20250313074307.php
@@ -19,12 +19,4 @@ class Version20250313074307 extends AbstractMigration
         $this->sql('CREATE INDEX IDX_64EC05ABF3667F8381257D5D115F0EE5BF28CD64 
             ON friendly_urls (route_name, entity_id, domain_id, main)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/frontend-api/src/Migrations/Version20240715055215.php
+++ b/packages/frontend-api/src/Migrations/Version20240715055215.php
@@ -31,12 +31,4 @@ class Version20240715055215 extends AbstractMigration
             ADD
                 CONSTRAINT FK_E6FAD52DBBB3772B FOREIGN KEY (customer_user_id) REFERENCES customer_users (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/frontend-api/src/Migrations/Version20240718092642.php
+++ b/packages/frontend-api/src/Migrations/Version20240718092642.php
@@ -19,12 +19,4 @@ class Version20240718092642 extends AbstractMigration
         $this->sql('ALTER TABLE customer_user_login_types ADD last_logged_in_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT now()');
         $this->sql('ALTER TABLE customer_user_login_types ALTER last_logged_in_at DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/frontend-api/src/Migrations/Version20240718144108.php
+++ b/packages/frontend-api/src/Migrations/Version20240718144108.php
@@ -18,12 +18,4 @@ class Version20240718144108 extends AbstractMigration
     {
         $this->sql('ALTER TABLE customer_user_login_types ADD external_id TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/frontend-api/src/Migrations/Version20240722150000.php
+++ b/packages/frontend-api/src/Migrations/Version20240722150000.php
@@ -35,12 +35,4 @@ class Version20240722150000 extends AbstractMigration
 
         $this->sql('ALTER TABLE customer_users DROP last_login');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\MigrationBundle\Component\Doctrine\Migrations;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration as DoctrineAbstractMigration;
 use Doctrine\Migrations\Query\Query;
 use Exception;
@@ -131,5 +132,13 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
         return $this->sql('SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = :table_name)', [
             'table_name' => $tableName,
         ])->fetchOne();
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function down(Schema $schema): void
+    {
     }
 }

--- a/packages/migrations/src/Resources/views/Migration/migration.php.twig
+++ b/packages/migrations/src/Resources/views/Migration/migration.php.twig
@@ -18,11 +18,4 @@ class {{ migrationClassName }} extends AbstractMigration
         $this->sql('{{ sqlCommand|raw }}');
 {% endfor %}
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-google/src/Migrations/Version20180329092348.php
+++ b/packages/product-feed-google/src/Migrations/Version20180329092348.php
@@ -32,12 +32,4 @@ class Version20180329092348 extends AbstractMigration
                 CONSTRAINT FK_628F4AA44584665A FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('ALTER TABLE google_product_domains ALTER show SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-google/src/Migrations/Version20180413102102.php
+++ b/packages/product-feed-google/src/Migrations/Version20180413102102.php
@@ -25,14 +25,6 @@ class Version20180413102102 extends AbstractMigration
         }
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function migrateProducts(): void
     {
         $rows = $this->sql(

--- a/packages/product-feed-heureka/src/Migrations/Version20180327093930.php
+++ b/packages/product-feed-heureka/src/Migrations/Version20180327093930.php
@@ -44,12 +44,4 @@ class Version20180327093930 extends AbstractMigration
             ADD
                 CONSTRAINT FK_FE112A6912469DE2 FOREIGN KEY (category_id) REFERENCES categories (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-heureka/src/Migrations/Version20180327094552.php
+++ b/packages/product-feed-heureka/src/Migrations/Version20180327094552.php
@@ -31,12 +31,4 @@ class Version20180327094552 extends AbstractMigration
             ADD
                 CONSTRAINT FK_AB17DC3B4584665A FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-heureka/src/Migrations/Version20180413102103.php
+++ b/packages/product-feed-heureka/src/Migrations/Version20180413102103.php
@@ -29,14 +29,6 @@ class Version20180413102103 extends AbstractMigration
         $this->migrateHeurekaCategoryToCategoryLinks();
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function migrateProducts(): void
     {
         $rows = $this->sql(

--- a/packages/product-feed-heureka/src/Migrations/Version20190215092227.php
+++ b/packages/product-feed-heureka/src/Migrations/Version20190215092227.php
@@ -18,12 +18,4 @@ class Version20190215092227 extends AbstractMigration
     {
         $this->sql('COMMENT ON COLUMN heureka_product_domains.cpc IS \'(DC2Type:money)\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-heureka/src/Migrations/Version20241119105039.php
+++ b/packages/product-feed-heureka/src/Migrations/Version20241119105039.php
@@ -29,12 +29,4 @@ class Version20241119105039 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-luigis-box/src/Migrations/Version20241113193905.php
+++ b/packages/product-feed-luigis-box/src/Migrations/Version20241113193905.php
@@ -29,12 +29,4 @@ class Version20241113193905 extends AbstractMigration implements ContainerAwareI
             ]);
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-zbozi/src/Migrations/Version20180329142420.php
+++ b/packages/product-feed-zbozi/src/Migrations/Version20180329142420.php
@@ -34,12 +34,4 @@ class Version20180329142420 extends AbstractMigration
                 CONSTRAINT FK_605AB7A64584665A FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('ALTER TABLE zbozi_product_domains ALTER show SET NOT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/packages/product-feed-zbozi/src/Migrations/Version20180413102101.php
+++ b/packages/product-feed-zbozi/src/Migrations/Version20180413102101.php
@@ -25,14 +25,6 @@ class Version20180413102101 extends AbstractMigration
         }
     }
 
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
     private function migrateProducts(): void
     {
         $rows = $this->sql(

--- a/packages/product-feed-zbozi/src/Migrations/Version20190215092228.php
+++ b/packages/product-feed-zbozi/src/Migrations/Version20190215092228.php
@@ -19,12 +19,4 @@ class Version20190215092228 extends AbstractMigration
         $this->sql('COMMENT ON COLUMN zbozi_product_domains.cpc IS \'(DC2Type:money)\'');
         $this->sql('COMMENT ON COLUMN zbozi_product_domains.cpc_search IS \'(DC2Type:money)\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20180425143739.php
+++ b/project-base/app/src/Migrations/Version20180425143739.php
@@ -19,12 +19,4 @@ class Version20180425143739 extends AbstractMigration
         $this->sql('ALTER TABLE articles ADD created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT now()');
         $this->sql('ALTER TABLE articles ALTER created_at DROP DEFAULT;');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20191121171000.php
+++ b/project-base/app/src/Migrations/Version20191121171000.php
@@ -19,12 +19,4 @@ class Version20191121171000 extends AbstractMigration
         $this->sql('DELETE FROM friendly_urls WHERE slug=\'contact\'');
         $this->sql('DELETE FROM articles WHERE name=\'Contact\' AND placement=\'footer\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200113143308.php
+++ b/project-base/app/src/Migrations/Version20200113143308.php
@@ -30,12 +30,4 @@ class Version20200113143308 extends AbstractMigration
             ADD
                 CONSTRAINT FK_B8436D28D9F6D38 FOREIGN KEY (order_id) REFERENCES orders (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200119160953.php
+++ b/project-base/app/src/Migrations/Version20200119160953.php
@@ -20,12 +20,4 @@ class Version20200119160953 extends AbstractMigration
             (\'akeneoTransferProductsLastUpdatedDatetime\', 0, \'1970-01-01T00:00:00+0000\', \'datetime\')
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200120082349.php
+++ b/project-base/app/src/Migrations/Version20200120082349.php
@@ -23,12 +23,4 @@ class Version20200120082349 extends AbstractMigration
             ADD
                 CONSTRAINT FK_B8436D28D9F6D38 FOREIGN KEY (order_id) REFERENCES orders (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200121170827.php
+++ b/project-base/app/src/Migrations/Version20200121170827.php
@@ -19,12 +19,4 @@ class Version20200121170827 extends AbstractMigration
         $this->sql('ALTER TABLE categories ADD akeneo_code VARCHAR(100) DEFAULT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_3AF34668CC7118A2 ON categories (akeneo_code)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200213080642.php
+++ b/project-base/app/src/Migrations/Version20200213080642.php
@@ -18,12 +18,4 @@ class Version20200213080642 extends AbstractMigration
     {
         $this->sql('UPDATE setting_values SET "value" = 1 WHERE "name"= \'inputPriceType\' AND domain_id = 0');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200221155940.php
+++ b/project-base/app/src/Migrations/Version20200221155940.php
@@ -68,12 +68,4 @@ final class Version20200221155940 extends AbstractMigration implements Container
             $translationId++;
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200226145013.php
+++ b/project-base/app/src/Migrations/Version20200226145013.php
@@ -18,12 +18,4 @@ class Version20200226145013 extends AbstractMigration
     {
         $this->sql('ALTER TABLE categories ADD svg_icon VARCHAR(32) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200228150615.php
+++ b/project-base/app/src/Migrations/Version20200228150615.php
@@ -18,12 +18,4 @@ class Version20200228150615 extends AbstractMigration
     {
         $this->sql('ALTER TABLE category_domains ADD short_description TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200302111832.php
+++ b/project-base/app/src/Migrations/Version20200302111832.php
@@ -23,12 +23,4 @@ class Version20200302111832 extends AbstractMigration
         $this->sql('ALTER TABLE product_domains ADD assembly_instruction_code VARCHAR(255) DEFAULT NULL');
         $this->sql('ALTER TABLE product_domains ADD product_type_plan_code VARCHAR(255) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200306131824.php
+++ b/project-base/app/src/Migrations/Version20200306131824.php
@@ -19,12 +19,4 @@ class Version20200306131824 extends AbstractMigration
         $this->sql('ALTER TABLE slider_items ADD slider_extended_text TEXT DEFAULT NULL');
         $this->sql('ALTER TABLE slider_items ADD slider_extended_text_link TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200409121857.php
+++ b/project-base/app/src/Migrations/Version20200409121857.php
@@ -19,12 +19,4 @@ class Version20200409121857 extends AbstractMigration
         $this->sql('ALTER TABLE products DROP out_of_stock_availability_id');
         $this->sql('ALTER TABLE products DROP calculated_availability_id');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200414143255.php
+++ b/project-base/app/src/Migrations/Version20200414143255.php
@@ -20,12 +20,4 @@ class Version20200414143255 extends AbstractMigration
         $this->sql('ALTER TABLE products DROP out_of_stock_action');
         $this->sql('ALTER TABLE products DROP using_stock');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200418102440.php
+++ b/project-base/app/src/Migrations/Version20200418102440.php
@@ -21,12 +21,4 @@ final class Version20200418102440 extends AbstractMigration
     {
         $this->sql('ALTER TABLE parameters DROP visible');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200430122227.php
+++ b/project-base/app/src/Migrations/Version20200430122227.php
@@ -19,12 +19,4 @@ class Version20200430122227 extends AbstractMigration
         $this->sql('ALTER TABLE payments ADD hidden_by_go_pay BOOLEAN NOT NULL DEFAULT FALSE');
         $this->sql('ALTER TABLE payments ALTER hidden_by_go_pay DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200504142810.php
+++ b/project-base/app/src/Migrations/Version20200504142810.php
@@ -19,12 +19,4 @@ class Version20200504142810 extends AbstractMigration
         $this->sql('ALTER TABLE images ADD akeneo_code VARCHAR(100) DEFAULT NULL');
         $this->sql('ALTER TABLE images ADD akeneo_image_type VARCHAR(100) DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200520133358.php
+++ b/project-base/app/src/Migrations/Version20200520133358.php
@@ -18,12 +18,4 @@ class Version20200520133358 extends AbstractMigration
     {
         $this->sql('ALTER TABLE images ALTER akeneo_code TYPE VARCHAR(255)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200707171540.php
+++ b/project-base/app/src/Migrations/Version20200707171540.php
@@ -19,12 +19,4 @@ final class Version20200707171540 extends AbstractMigration
         $this->sql("SELECT SETVAL(pg_get_serial_sequence('flags', 'id'), COALESCE((SELECT MAX(id) FROM flags) + 1, 1), false)");
         $this->sql("SELECT SETVAL(pg_get_serial_sequence('flag_translations', 'id'), COALESCE((SELECT MAX(id) FROM flag_translations) + 1, 1), false)");
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200713040211.php
+++ b/project-base/app/src/Migrations/Version20200713040211.php
@@ -21,12 +21,4 @@ class Version20200713040211 extends AbstractMigration
 
         $this->sql('ALTER TABLE slider_items ADD gtm_creative TEXT DEFAULT NULL');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200714071640.php
+++ b/project-base/app/src/Migrations/Version20200714071640.php
@@ -34,12 +34,4 @@ class Version20200714071640 extends AbstractMigration implements ContainerAwareI
             $this->sql(sprintf('INSERT INTO flag_translations (translatable_id, name, locale) VALUES (%d, \'' . t('Price hit', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale) . '\', \'' . $locale . '\')', $lastFlagsId));
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200720134134.php
+++ b/project-base/app/src/Migrations/Version20200720134134.php
@@ -19,12 +19,4 @@ class Version20200720134134 extends AbstractMigration
         $this->sql('ALTER TABLE products ALTER catnum SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_B3BA5A5A5CAFC31D ON products (catnum)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200817110249.php
+++ b/project-base/app/src/Migrations/Version20200817110249.php
@@ -22,12 +22,4 @@ class Version20200817110249 extends AbstractMigration
         $this->sql('ALTER TABLE transports ADD is_over_limit_transport BOOLEAN NOT NULL DEFAULT FALSE');
         $this->sql('ALTER TABLE transports ALTER is_over_limit_transport DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200825083150.php
+++ b/project-base/app/src/Migrations/Version20200825083150.php
@@ -19,12 +19,4 @@ class Version20200825083150 extends AbstractMigration
         $this->sql('ALTER TABLE product_domains ADD calculated_sale_exclusion BOOLEAN NOT NULL DEFAULT FALSE');
         $this->sql('ALTER TABLE product_domains ALTER calculated_sale_exclusion DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200914130309.php
+++ b/project-base/app/src/Migrations/Version20200914130309.php
@@ -21,12 +21,4 @@ class Version20200914130309 extends AbstractMigration
         $this->sql('ALTER TABLE transports ADD type_of_delivery_key INT NOT NULL DEFAULT 1');
         $this->sql('ALTER TABLE transports ALTER type_of_delivery_key DROP DEFAULT');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20200921071900.php
+++ b/project-base/app/src/Migrations/Version20200921071900.php
@@ -29,14 +29,6 @@ class Version20200921071900 extends AbstractMigration
     }
 
     /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
-
-    /**
      * @param string $mailTemplateName
      * @param int $domainId
      * @param string $sendMail

--- a/project-base/app/src/Migrations/Version20201010164758.php
+++ b/project-base/app/src/Migrations/Version20201010164758.php
@@ -42,12 +42,4 @@ final class Version20201010164758 extends AbstractMigration implements Container
             );
         }
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20210520112854.php
+++ b/project-base/app/src/Migrations/Version20210520112854.php
@@ -27,12 +27,4 @@ class Version20210520112854 extends AbstractMigration
                 CONSTRAINT FK_69348FEF8BD700D FOREIGN KEY (unit_id) REFERENCES units (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_69348FEF8BD700D ON parameters (unit_id)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20210727191108.php
+++ b/project-base/app/src/Migrations/Version20210727191108.php
@@ -21,12 +21,4 @@ class Version20210727191108 extends AbstractMigration
         $this->sql('ALTER TABLE slider_items ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_67AAA529D17F50A6 ON slider_items (uuid)');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20210902031741.php
+++ b/project-base/app/src/Migrations/Version20210902031741.php
@@ -35,12 +35,4 @@ class Version20210902031741 extends AbstractMigration
             ADD
                 CONSTRAINT FK_153914F7EC53CE08 FOREIGN KEY (related_product) REFERENCES products (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20220202124636.php
+++ b/project-base/app/src/Migrations/Version20220202124636.php
@@ -18,12 +18,4 @@ class Version20220202124636 extends AbstractMigration
     {
         $this->sql('DROP TABLE gopay_transactions');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20220510090948.php
+++ b/project-base/app/src/Migrations/Version20220510090948.php
@@ -23,12 +23,4 @@ class Version20220510090948 extends AbstractMigration
             AND friendly_urls.slug = \'article/\' || products.catnum
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20220729131426.php
+++ b/project-base/app/src/Migrations/Version20220729131426.php
@@ -21,12 +21,4 @@ class Version20220729131426 extends AbstractMigration
         $this->sql('UPDATE orders SET status_id = 1 WHERE status_id = 5');
         $this->sql('DELETE FROM order_statuses WHERE type = 5');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20220730131426.php
+++ b/project-base/app/src/Migrations/Version20220730131426.php
@@ -18,12 +18,4 @@ class Version20220730131426 extends AbstractMigration
     {
         $this->sql('ALTER TABLE payments DROP COLUMN is_over_limit_payment');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20220830204025.php
+++ b/project-base/app/src/Migrations/Version20220830204025.php
@@ -28,12 +28,4 @@ class Version20220830204025 extends AbstractMigration
             WHERE text IS NOT NULL AND text NOT LIKE \'%gjs-text-ckeditor%\' 
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20221130083437.php
+++ b/project-base/app/src/Migrations/Version20221130083437.php
@@ -18,12 +18,4 @@ class Version20221130083437 extends AbstractMigration
     {
         $this->sql('UPDATE currencies SET min_fraction_digits = 0, rounding_type = \'integer\' WHERE id = 1');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20221205123619.php
+++ b/project-base/app/src/Migrations/Version20221205123619.php
@@ -149,12 +149,4 @@ class Version20221205123619 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20230307140442.php
+++ b/project-base/app/src/Migrations/Version20230307140442.php
@@ -19,12 +19,4 @@ class Version20230307140442 extends AbstractMigration
         $this->sql('ALTER TABLE transports DROP COLUMN delivery_code');
         $this->sql('ALTER TABLE transports DROP COLUMN type_of_delivery_key');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20230908095905.php
+++ b/project-base/app/src/Migrations/Version20230908095905.php
@@ -20,12 +20,4 @@ class Version20230908095905 extends AbstractMigration
         $this->sql('ALTER TABLE categories DROP svg_icon');
         $this->sql('ALTER TABLE categories DROP over_limit_quantity');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20231130115257.php
+++ b/project-base/app/src/Migrations/Version20231130115257.php
@@ -21,12 +21,4 @@ class Version20231130115257 extends AbstractMigration
         $this->sql('ALTER TABLE products DROP download_assembly_instruction_files');
         $this->sql('ALTER TABLE products DROP download_product_type_plan_files');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20231227143511.php
+++ b/project-base/app/src/Migrations/Version20231227143511.php
@@ -44,12 +44,4 @@ class Version20231227143511 extends AbstractMigration
             UPDATE
                 ON messenger_messages FOR EACH ROW EXECUTE PROCEDURE notify_messenger_messages();');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20240403122421.php
+++ b/project-base/app/src/Migrations/Version20240403122421.php
@@ -22,12 +22,4 @@ class Version20240403122421 extends AbstractMigration implements ContainerAwareI
     {
         $this->sql('ALTER TABLE order_items DROP promo_code_identifier');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20240702065648.php
+++ b/project-base/app/src/Migrations/Version20240702065648.php
@@ -27,12 +27,4 @@ class Version20240702065648 extends AbstractMigration implements ContainerAwareI
         $this->sql('ALTER TABLE units DROP akeneo_code');
         $this->sql('DELETE FROM setting_values WHERE name=\'akeneoTransferProductsLastUpdatedDatetime\'');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }

--- a/project-base/app/src/Migrations/Version20241114072907.php
+++ b/project-base/app/src/Migrations/Version20241114072907.php
@@ -19,12 +19,4 @@ class Version20241114072907 extends AbstractMigration
         $this->sql('ALTER TABLE slider_items DROP COLUMN slider_extended_text');
         $this->sql('ALTER TABLE slider_items DROP COLUMN slider_extended_text_link');
     }
-
-    /**
-     * @param \Doctrine\DBAL\Schema\Schema $schema
-     */
-    #[Override]
-    public function down(Schema $schema): void
-    {
-    }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
I do not see any point in having empty method in all the migration classes when the empty method can be defined just once in their `AbstractMigration` parent class :slightly_smiling_face: 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-abstract-migration-down.odin.shopsys.cloud
  - https://cz.rv-abstract-migration-down.odin.shopsys.cloud
<!-- Replace -->
