### PR TITLE
admin product detail: display main category full path

### DIFF
--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -32,7 +32,6 @@ use Shopsys\FrameworkBundle\Form\ProductsType;
 use Shopsys\FrameworkBundle\Form\Transformers\ProductParameterValueToProductParameterValuesLocalizedTransformer;
 use Shopsys\FrameworkBundle\Form\Transformers\RemoveDuplicatesFromArrayTransformer;
 use Shopsys\FrameworkBundle\Form\UrlListType;
-use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\SpecialPrice\SpecialPriceFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade;
@@ -65,7 +64,6 @@ final class ProductFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade
-     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Form\Transformers\RemoveDuplicatesFromArrayTransformer $removeDuplicatesTransformer
      * @param \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginDataFormExtensionFacade
      * @param \Shopsys\FrameworkBundle\Form\Transformers\ProductParameterValueToProductParameterValuesLocalizedTransformer $productParameterValueToProductParameterValuesLocalizedTransformer
@@ -81,7 +79,6 @@ final class ProductFormType extends AbstractType
         private readonly UnitFacade $unitFacade,
         private readonly Domain $domain,
         private readonly SeoSettingFacade $seoSettingFacade,
-        private readonly CategoryFacade $categoryFacade,
         private readonly RemoveDuplicatesFromArrayTransformer $removeDuplicatesTransformer,
         private readonly PluginCrudExtensionFacade $pluginDataFormExtensionFacade,
         private readonly ProductParameterValueToProductParameterValuesLocalizedTransformer $productParameterValueToProductParameterValuesLocalizedTransformer,
@@ -380,41 +377,12 @@ final class ProductFormType extends AbstractType
         FormBuilderInterface $builder,
         ?Product $product,
     ): FormBuilderInterface {
-        $productMainCategoriesIndexedByDomainId = [];
-
-        if ($product !== null) {
-            $productMainCategoriesIndexedByDomainId = $this->categoryFacade->getProductMainCategoriesIndexedByDomainId(
-                $product,
-            );
-        }
-
-        $mainCategoriesOptionsByDomainId = [];
-
-        foreach ($this->domain->getAdminEnabledDomainIds() as $domainId) {
-            if (count($productMainCategoriesIndexedByDomainId) <= 0) {
-                continue;
-            }
-
-            $productMainCategory = $productMainCategoriesIndexedByDomainId[$domainId];
-            $mainCategoriesOptionsByDomainId[$domainId] = [
-                'attr' => [
-                    'readonly' => 'readonly',
-                    'show_label' => true,
-                ],
-                'label' => count($productMainCategoriesIndexedByDomainId) > 1 ? $this->domain->getDomainConfigById(
-                    $domainId,
-                )->getName() : t(
-                    'Main category',
-                ),
-                'data' => $productMainCategory === null ? '-' : $productMainCategory->getName(),
-            ];
-        }
-
         $categoriesOptionsByDomainId = [];
 
         foreach ($this->domain->getAdminEnabledDomainIds() as $domainId) {
             $categoriesOptionsByDomainId[$domainId] = [
                 'domain_id' => $domainId,
+                'product' => $product,
             ];
         }
 
@@ -468,17 +436,6 @@ final class ProductFormType extends AbstractType
             $builderDisplayAvailabilityGroup
                 ->add('productCalculatedSellingDeniedInfo', MessageType::class, [
                     'data' => t('Product is excluded from the sale'),
-                ]);
-        }
-
-        if ($product !== null) {
-            $builderDisplayAvailabilityGroup
-                ->add('productMainCategories', MultidomainType::class, [
-                    'entry_type' => TextType::class,
-                    'required' => false,
-                    'mapped' => false,
-                    'options_by_domain_id' => $mainCategoriesOptionsByDomainId,
-                    'label' => t('Main category on domains'),
                 ]);
         }
 

--- a/packages/framework/src/Form/CategoriesType.php
+++ b/packages/framework/src/Form/CategoriesType.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Form\Transformers\CategoriesTypeTransformer;
+use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Product\Product;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -16,14 +21,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CategoriesType extends AbstractType
 {
-    private CategoriesTypeTransformer $categoriesTypeTransformer;
-
     /**
-     * @param \Shopsys\FrameworkBundle\Form\Transformers\CategoriesTypeTransformer $categoryTransformer
+     * @param \Shopsys\FrameworkBundle\Form\Transformers\CategoriesTypeTransformer $categoriesTypeTransformer
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
-    public function __construct(CategoriesTypeTransformer $categoryTransformer)
-    {
-        $this->categoriesTypeTransformer = $categoryTransformer;
+    public function __construct(
+        private readonly CategoriesTypeTransformer $categoriesTypeTransformer,
+        private readonly CategoryFacade $categoryFacade,
+        private readonly Domain $domain,
+        private readonly Localization $localization,
+    ) {
     }
 
     /**
@@ -36,6 +45,7 @@ class CategoriesType extends AbstractType
     {
         $view->vars['domain_id'] = $options['domain_id'];
         $view->vars['display_as_row'] = $options['display_as_row'];
+        $view->vars['main_category_path'] = $this->getMainCategoryPath($options);
     }
 
     /**
@@ -62,8 +72,10 @@ class CategoriesType extends AbstractType
 
         $resolver
             ->setRequired(['domain_id', 'display_as_row'])
+            ->setDefined(['product'])
             ->setAllowedTypes('domain_id', 'int')
             ->setAllowedTypes('display_as_row', 'bool')
+            ->setAllowedTypes('product', [Product::class, 'null'])
             ->setDefaults([
                 'required' => false,
                 'entry_type' => CategoryCheckboxType::class,
@@ -71,6 +83,7 @@ class CategoriesType extends AbstractType
                 'allow_delete' => true,
                 'prototype' => true,
                 'display_as_row' => false,
+                'product' => null,
             ]);
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
@@ -83,5 +96,29 @@ class CategoriesType extends AbstractType
     public function getParent(): ?string
     {
         return CollectionType::class;
+    }
+
+    /**
+     * @param array $options
+     * @return string|null
+     */
+    private function getMainCategoryPath(array $options): ?string
+    {
+        if ($options['product'] === null) {
+            return null;
+        }
+
+        try {
+            $domainConfig = $this->domain->getDomainConfigById($options['domain_id']);
+            $categoriesInPath = $this->categoryFacade->getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(
+                $options['product'],
+                $domainConfig,
+                $this->localization->getCurrentLocaleForTranslatableEntities(),
+            );
+
+            return implode(' > ', $categoriesInPath);
+        } catch (CategoryNotFoundException) {
+            return null;
+        }
     }
 }

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -400,15 +400,18 @@ class CategoryFacade
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string|null $locale
      * @return string[]
      */
     public function getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(
         Product $product,
         DomainConfig $domainConfig,
-    ) {
+        ?string $locale = null,
+    ): array {
         return $this->categoryRepository->getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(
             $product,
             $domainConfig,
+            $locale,
         );
     }
 

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -553,15 +553,17 @@ class CategoryRepository extends NestedTreeRepository
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string|null $locale
      * @return string[]
      */
     public function getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(
         Product $product,
         DomainConfig $domainConfig,
+        ?string $locale = null,
     ): array {
         $queryBuilder = $this->getAllQueryBuilder();
         $domainId = $domainConfig->getId();
-        $locale = $domainConfig->getLocale();
+        $locale = $locale ?? $domainConfig->getLocale();
         $mainCategory = $this->getProductMainCategoryOnDomain($product, $domainId);
 
         $this->addTranslation($queryBuilder, $locale);

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2590,9 +2590,6 @@ msgstr "Hlavní administrátorský e-mail"
 msgid "Main category"
 msgstr "Hlavní kategorie"
 
-msgid "Main category on domains"
-msgstr "Hlavní kategorie na doménách"
-
 msgid "Main image"
 msgstr "Hlavní obrázek"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2590,9 +2590,6 @@ msgstr ""
 msgid "Main category"
 msgstr ""
 
-msgid "Main category on domains"
-msgstr ""
-
 msgid "Main image"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -614,6 +614,13 @@
 {% endblock products_widget %}
 
 {% block categories_widget %}
+    {% if main_category_path is not null %}
+        <div class="form-line__item form-line__item--full-width">
+            {{ ux_icon('tag') }}
+            <strong>{{ 'Main category'|trans }}:</strong>
+            {{ main_category_path }}
+        </div>
+    {% endif %}
     <div class="form-line__{% if display_as_row == true %}side{% else %}line{% endif %}">
         <div
             class="form-tree form-tree--open js-category-tree-form"

--- a/project-base/app/src/Model/Category/CategoryFacade.php
+++ b/project-base/app/src/Model/Category/CategoryFacade.php
@@ -20,7 +20,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade as BaseCategoryFacade;
  * @method \App\Model\Category\Category[]|null[] getProductMainCategoriesIndexedByDomainId(\App\Model\Product\Product $product)
  * @method \App\Model\Category\Category getProductMainCategoryByDomainId(\App\Model\Product\Product $product, int $domainId)
  * @method \App\Model\Category\Category|null findProductMainCategoryByDomainId(\App\Model\Product\Product $product, int $domainId)
- * @method string[] getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
+ * @method string[] getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig, string|null $locale = null)
  * @method \App\Model\Category\Category getRootCategory()
  * @method \App\Model\Category\Category getVisibleOnDomainById(int $domainId, int $categoryId)
  * @method int[] getListableProductCountsIndexedByCategoryId(\App\Model\Category\Category[] $categories, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, int $domainId)

--- a/project-base/app/src/Model/Category/CategoryRepository.php
+++ b/project-base/app/src/Model/Category/CategoryRepository.php
@@ -30,7 +30,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
  * @method \App\Model\Category\Category|null findProductMainCategoryOnDomain(\App\Model\Product\Product $product, int $domainId)
  * @method \App\Model\Category\Category getProductMainCategoryOnDomain(\App\Model\Product\Product $product, int $domainId)
  * @method \App\Model\Category\Category[] getVisibleCategoriesInPathFromRootOnDomain(\App\Model\Category\Category $category, int $domainId)
- * @method string[] getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
+ * @method string[] getCategoryNamesInPathFromRootToProductMainCategoryOnDomain(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig, string|null $locale = null)
  * @method \App\Model\Category\Category[] getCategoriesByIds(int[] $categoryIds)
  * @method \App\Model\Category\Category[] getCategoriesWithVisibleChildren(\App\Model\Category\Category[] $categories, int $domainId)
  * @method \App\Model\Category\Category[] getAllTranslated(string $locale)

--- a/upgrade-notes/backend_20250328_132407.md
+++ b/upgrade-notes/backend_20250328_132407.md
@@ -1,0 +1,4 @@
+#### admin product detail: display main category full path ([#3889](https://github.com/shopsys/shopsys/pull/3889))
+
+- `productMainCategories` field was removed from `displayAvailabilityGroup` in `ProductFormType`
+    - instead, you can now pass `product` option to `CategoriesType` to display main categories full paths within the categories widget


### PR DESCRIPTION
#### Description, the reason for the PR

Displaying just the main category name could be confusing (there might be multiple categories with the same name) so displaying the full path is clearer for the administrators. Moreover, moving the information inside the categories widget makes the product detail page more compact.

Before:
![Screenshot from 2025-03-28 14-15-02](https://github.com/user-attachments/assets/364be667-3fa6-44ca-952e-2b005a3b7e8f)

After:
![Screenshot from 2025-03-28 14-15-34](https://github.com/user-attachments/assets/fdf80190-8cca-429d-9e7e-c208099d5bbf)


Moreover, the new style is better for one-domain projects, where the original approach was at least weird, see the screens below:

Before:
![image](https://github.com/user-attachments/assets/bed9e4d4-492e-4b99-bdca-46a8fa2a467f)

After:
![image](https://github.com/user-attachments/assets/6b3e9be7-6455-468d-9238-555c231f2a18)

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-main-category.odin.shopsys.cloud
  - https://cz.rv-main-category.odin.shopsys.cloud
<!-- Replace -->
