### PR TITLE
fixed search by catnum exact match

### DIFF
--- a/project-base/app/src/Resources/definition/product/1.json
+++ b/project-base/app/src/Resources/definition/product/1.json
@@ -414,7 +414,7 @@
             },
             "searching_catnums": {
                 "type": "text",
-                "analyzer": "whitespace",
+                "analyzer": "whitespace_without_dots_lowercase",
                 "search_analyzer": "whitespace_without_dots_lowercase",
                 "fields": {
                     "edge_ngram_unanalyzed_words": {

--- a/project-base/app/src/Resources/definition/product/2.json
+++ b/project-base/app/src/Resources/definition/product/2.json
@@ -414,7 +414,7 @@
             },
             "searching_catnums": {
                 "type": "text",
-                "analyzer": "whitespace",
+                "analyzer": "whitespace_without_dots_lowercase",
                 "search_analyzer": "whitespace_without_dots_lowercase",
                 "fields": {
                     "edge_ngram_unanalyzed_words": {

--- a/upgrade-notes/backend_20250403_065029.md
+++ b/upgrade-notes/backend_20250403_065029.md
@@ -1,0 +1,3 @@
+#### fix search by catnum exact match ([#3900](https://github.com/shopsys/shopsys/pull/3900))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Search by catnum exact match, these results should be prefered over ngram results.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-catnum-exact-match-search.odin.shopsys.cloud
  - https://cz.mg-fix-catnum-exact-match-search.odin.shopsys.cloud
<!-- Replace -->
