### PR TITLE
fixed attempt to login as admin without password

### DIFF
--- a/packages/framework/src/Model/Administrator/AdministratorRepository.php
+++ b/packages/framework/src/Model/Administrator/AdministratorRepository.php
@@ -85,6 +85,20 @@ class AdministratorRepository
 
     /**
      * @param string $administratorUserName
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null
+     */
+    public function findByUserNameWithPasswordFilled(string $administratorUserName): ?Administrator
+    {
+        return $this->getAdministratorRepository()->createQueryBuilder('a')
+            ->where('a.username = :username')
+            ->andWhere('a.password is not NULL')
+            ->setParameter('username', $administratorUserName)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
+     * @param string $administratorUserName
      * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator
      */
     public function getByUserName($administratorUserName)

--- a/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
@@ -36,7 +36,7 @@ class AdministratorUserProvider implements UserProviderInterface
      */
     public function loadUserByUsername($username)
     {
-        $administrator = $this->administratorRepository->findByUserName($username);
+        $administrator = $this->administratorRepository->findByUserNameWithPasswordFilled($username);
 
         if ($administrator === null) {
             $message = sprintf(

--- a/project-base/app/src/Model/Administrator/AdministratorRepository.php
+++ b/project-base/app/src/Model/Administrator/AdministratorRepository.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository as BaseA
  * @method \App\Model\Administrator\Administrator getByUserName(string $administratorUserName)
  * @method \App\Model\Administrator\Administrator|null findByUuid(string $uuid)
  * @method \App\Model\Administrator\Administrator getByEmail(string $administratorEmail)
+ * @method \App\Model\Administrator\Administrator|null findByUserNameWithPasswordFilled(string $administratorUserName)
  */
 class AdministratorRepository extends BaseAdministratorRepository
 {


### PR DESCRIPTION
#### Description, the reason for the PR

When admin did not had the password yet filled and he tried to log in, the error 500 occured.
This is fixed now

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-admin-pass.odin.shopsys.cloud
  - https://cz.mg-fix-admin-pass.odin.shopsys.cloud
<!-- Replace -->
