### PR TITLE
added product catnum to product list grid

### DIFF
--- a/packages/framework/src/Model/Product/ProductGridFactory.php
+++ b/packages/framework/src/Model/Product/ProductGridFactory.php
@@ -41,6 +41,7 @@ class ProductGridFactory
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'pt.name', t('Name'), true);
+        $grid->addColumn('catnum', 'p.catnum', t('Catalog number'), true);
         $grid->addColumn('price', 'priceForProductList', t('Price'), true)->setClassAttribute('text-right');
         $grid->addColumn('visibility', 'visibility', t('Visibility'))
             ->setClassAttribute('text-center table-col table-col-10');


### PR DESCRIPTION
#### Description, the reason for the PR

Product catnum is now displayed on product list grid in admin.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-catnum-list.odin.shopsys.cloud
  - https://cz.mg-catnum-list.odin.shopsys.cloud
<!-- Replace -->
