### PR TITLE
admin menu: "identification" section is available for multidomain projects only

### DIFF
--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -533,9 +533,8 @@ class SideMenuBuilder
         $menu = $this->menuFactory->createItem('settings', ['label' => t('Settings')]);
         $menu->setExtra('icon', 'gear');
 
-        $identificationMenu = $menu->addChild('identification', ['label' => t('E-shop identification')]);
-
         if ($this->domain->isMultidomain()) {
+            $identificationMenu = $menu->addChild('identification', ['label' => t('E-shop identification')]);
             $domainsMenu = $identificationMenu->addChild(
                 'domains',
                 ['route' => 'admin_domain_list', 'label' => t('E-shop identification')],


### PR DESCRIPTION
#### Description, the reason for the PR
There is no point in having that section headline because there are no links under that anyway. 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-identification-menu.odin.shopsys.cloud
  - https://cz.rv-identification-menu.odin.shopsys.cloud
<!-- Replace -->
