### PR TITLE
category bestseller items use onmouseup event for gtm

### DIFF
--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryBestsellers/CategoryBestsellersListItem.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryBestsellers/CategoryBestsellersListItem.tsx
@@ -32,7 +32,7 @@ export const CategoryBestsellersListItem: FC<CategoryBestsellersListItemProps> =
             draggable={false}
             href={productUrl}
             type={product.__typename === 'RegularProduct' ? 'product' : 'productMainVariant'}
-            onClick={() => onGtmProductClickEventHandler(product, gtmProductListName, listIndex, url, !canSeePrices)}
+            onMouseUp={() => onGtmProductClickEventHandler(product, gtmProductListName, listIndex, url, !canSeePrices)}
         >
             <div className="flex w-20 shrink-0">
                 <ProductListItemImage


### PR DESCRIPTION
#### Description, the reason for the PR

proper event to catch is onmouseup
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://grossmannmartin-patch-1.odin.shopsys.cloud
  - https://cz.grossmannmartin-patch-1.odin.shopsys.cloud
<!-- Replace -->
