### PR TITLE
fix disappearing RGB color of parameter values

### DIFF
--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -52,6 +52,7 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
             }
 
             $normData[$parameterId]->valueTextsByLocale[$locale] = $productParameterValueData->parameterValueData->text;
+            $normData[$parameterId]->rgbHex = $productParameterValueData->parameterValueData->rgbHex;
 
             if ($productParameterValueData->parameter->isSlider()) {
                 $normData[$parameterId]->numericValue = $productParameterValueData->parameterValueData->text;
@@ -78,6 +79,7 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
                         $productParameterValueData->parameter = $productParameterValuesLocalizedData->parameter;
                         $parameterValueData = $this->parameterValueDataFactory->create();
                         $parameterValueData->text = $valueText;
+                        $parameterValueData->rgbHex = $productParameterValuesLocalizedData->rgbHex;
 
                         if ($productParameterValuesLocalizedData->parameter->isSlider()) {
                             $parameterValueData->numericValue = $valueText;

--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -46,16 +46,9 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
             $locale = $productParameterValueData->parameterValueData->locale;
 
             if (!array_key_exists($parameterId, $normData)) {
-                $normData[$parameterId] = $this->productParameterValuesLocalizedDataFactory->create();
-                $normData[$parameterId]->parameter = $productParameterValueData->parameter;
-                $normData[$parameterId]->valueTextsByLocale = [];
-            }
-
-            $normData[$parameterId]->valueTextsByLocale[$locale] = $productParameterValueData->parameterValueData->text;
-            $normData[$parameterId]->rgbHex = $productParameterValueData->parameterValueData->rgbHex;
-
-            if ($productParameterValueData->parameter->isSlider()) {
-                $normData[$parameterId]->numericValue = $productParameterValueData->parameterValueData->text;
+                $normData[$parameterId] = $this->productParameterValuesLocalizedDataFactory->createFromProductParameterValueData($productParameterValueData);
+            } else {
+                $normData[$parameterId]->valueTextsByLocale[$locale] = $productParameterValueData->parameterValueData->text;
             }
         }
 
@@ -73,23 +66,8 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
 
             /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData $productParameterValuesLocalizedData */
             foreach ($value as $productParameterValuesLocalizedData) {
-                foreach ($productParameterValuesLocalizedData->valueTextsByLocale as $locale => $valueText) {
-                    if ($valueText !== null) {
-                        $productParameterValueData = $this->productParameterValueDataFactory->create();
-                        $productParameterValueData->parameter = $productParameterValuesLocalizedData->parameter;
-                        $parameterValueData = $this->parameterValueDataFactory->create();
-                        $parameterValueData->text = $valueText;
-                        $parameterValueData->rgbHex = $productParameterValuesLocalizedData->rgbHex;
-
-                        if ($productParameterValuesLocalizedData->parameter->isSlider()) {
-                            $parameterValueData->numericValue = $valueText;
-                        }
-
-                        $parameterValueData->locale = $locale;
-                        $productParameterValueData->parameterValueData = $parameterValueData;
-
-                        $modelData[] = $productParameterValueData;
-                    }
+                foreach ($this->productParameterValueDataFactory->createMultipleFromProductParameterValuesLocalizedData($productParameterValuesLocalizedData) as $productParameterValueData) {
+                    $modelData[] = $productParameterValueData;
                 }
             }
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
@@ -312,7 +312,6 @@ class ParameterFacade
             $parameterValue = $this->parameterRepository->getParameterValueById($parameterValueId);
             $parameterValueData = $this->parameterValueDataFactory->createFromParameterValue($parameterValue);
 
-            $parameterValueData->uuid = null;
             $parameterValueData->text = $parameterValueConversionData->newValueText;
             $parameterValueData->numericValue = $parameterValueConversionData->newValueText;
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
@@ -167,6 +167,16 @@ class ParameterFacade
     }
 
     /**
+     * @param string $valueText
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue|null
+     */
+    public function findParameterValueByValueTextAndLocale(string $valueText, string $locale): ?ParameterValue
+    {
+        return $this->parameterRepository->findParameterValueByValueTextAndLocale($valueText, $locale);
+    }
+
+    /**
      * @param int[] $parameterValueIdsByParameterId
      * @return string[]
      */

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -202,10 +202,10 @@ class ParameterRepository
     public function findOrCreateParameterValueByParameterValueData(
         ParameterValueData $parameterValueData,
     ): ParameterValue {
-        $parameterValue = $this->getParameterValueRepository()->findOneBy([
-            'text' => $parameterValueData->text,
-            'locale' => $parameterValueData->locale,
-        ]);
+        $parameterValue = $this->findParameterValueByValueTextAndLocale(
+            $parameterValueData->text,
+            $parameterValueData->locale,
+        );
 
         if ($parameterValue === null) {
             $parameterValue = $this->parameterValueFactory->create($parameterValueData);
@@ -230,17 +230,26 @@ class ParameterRepository
      */
     public function getParameterValueByValueTextAndLocale(string $valueText, string $locale): ParameterValue
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue|null $parameterValue */
-        $parameterValue = $this->getParameterValueRepository()->findOneBy([
-            'text' => $valueText,
-            'locale' => $locale,
-        ]);
+        $parameterValue = $this->findParameterValueByValueTextAndLocale($valueText, $locale);
 
         if ($parameterValue === null) {
             throw new ParameterValueNotFoundException();
         }
 
         return $parameterValue;
+    }
+
+    /**
+     * @param string $valueText
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue|null
+     */
+    public function findParameterValueByValueTextAndLocale(string $valueText, string $locale): ?ParameterValue
+    {
+        return $this->getParameterValueRepository()->findOneBy([
+            'text' => $valueText,
+            'locale' => $locale,
+        ]);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -196,25 +196,27 @@ class ParameterRepository
     }
 
     /**
-     * @param string $valueText
-     * @param string $locale
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData $parameterValueData
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue
      */
-    public function findOrCreateParameterValueByValueTextAndLocale(string $valueText, string $locale): ParameterValue
-    {
+    public function findOrCreateParameterValueByParameterValueData(
+        ParameterValueData $parameterValueData,
+    ): ParameterValue {
         $parameterValue = $this->getParameterValueRepository()->findOneBy([
-            'text' => $valueText,
-            'locale' => $locale,
+            'text' => $parameterValueData->text,
+            'locale' => $parameterValueData->locale,
         ]);
 
         if ($parameterValue === null) {
-            $parameterValueData = $this->parameterValueDataFactory->create();
-            $parameterValueData->text = $valueText;
-            $parameterValueData->locale = $locale;
             $parameterValue = $this->parameterValueFactory->create($parameterValueData);
             $this->em->persist($parameterValue);
             // Doctrine's identity map is not cache.
             // We have to flush now, so that next findOneBy() finds new ParameterValue.
+            $this->em->flush();
+        }
+
+        if ($parameterValue->getRgbHex() !== $parameterValueData->rgbHex) {
+            $parameterValue->edit($parameterValueData);
             $this->em->flush();
         }
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterValue.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValue.php
@@ -66,7 +66,7 @@ class ParameterValue
         $this->text = $parameterData->text;
         $this->numericValue = $parameterData->numericValue;
         $this->locale = $parameterData->locale;
-        $this->uuid = $parameterData->uuid ?: Uuid::uuid4()->toString();
+        $this->uuid = Uuid::uuid4()->toString();
         $this->rgbHex = $parameterData->rgbHex;
         $this->colourIcon = $parameterData->colourIcon;
     }

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueData.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueData.php
@@ -24,11 +24,6 @@ class ParameterValueData
     /**
      * @var string|null
      */
-    public $uuid;
-
-    /**
-     * @var string|null
-     */
     public $rgbHex;
 
     /**

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueDataFactory.php
@@ -57,7 +57,6 @@ class ParameterValueDataFactory
         $parameterValueData->text = $parameterValue->getText();
         $parameterValueData->numericValue = $parameterValue->getNumericValue();
         $parameterValueData->locale = $parameterValue->getLocale();
-        $parameterValueData->uuid = $parameterValue->getUuid();
         $parameterValueData->rgbHex = $parameterValue->getRgbHex();
         $parameterValueData->colourIcon = $this->uploadedFileDataFactory->create();
     }

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
@@ -8,9 +8,12 @@ class ProductParameterValueDataFactory
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueDataFactory $parameterValueDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade $parameterFacade
      */
-    public function __construct(protected readonly ParameterValueDataFactory $parameterValueDataFactory)
-    {
+    public function __construct(
+        protected readonly ParameterValueDataFactory $parameterValueDataFactory,
+        protected readonly ParameterFacade $parameterFacade,
+    ) {
     }
 
     /**
@@ -69,9 +72,15 @@ class ProductParameterValueDataFactory
             if ($valueText !== null) {
                 $productParameterValueData = $this->create();
                 $productParameterValueData->parameter = $productParameterValuesLocalizedData->parameter;
-                $parameterValueData = $this->parameterValueDataFactory->create();
+
+                $parameterValue = $this->parameterFacade->findParameterValueByValueTextAndLocale($valueText, $locale);
+
+                if ($parameterValue === null) {
+                    $parameterValueData = $this->parameterValueDataFactory->create();
+                } else {
+                    $parameterValueData = $this->parameterValueDataFactory->createFromParameterValue($parameterValue);
+                }
                 $parameterValueData->text = $valueText;
-                $parameterValueData->rgbHex = $productParameterValuesLocalizedData->rgbHex;
 
                 if ($productParameterValuesLocalizedData->parameter->isSlider()) {
                     $parameterValueData->numericValue = $valueText;

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
@@ -55,4 +55,35 @@ class ProductParameterValueDataFactory
             $productParameterValue->getValue(),
         );
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData $productParameterValuesLocalizedData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[]
+     */
+    public function createMultipleFromProductParameterValuesLocalizedData(
+        ProductParameterValuesLocalizedData $productParameterValuesLocalizedData,
+    ): array {
+        $productParameterValuesData = [];
+
+        foreach ($productParameterValuesLocalizedData->valueTextsByLocale as $locale => $valueText) {
+            if ($valueText !== null) {
+                $productParameterValueData = $this->create();
+                $productParameterValueData->parameter = $productParameterValuesLocalizedData->parameter;
+                $parameterValueData = $this->parameterValueDataFactory->create();
+                $parameterValueData->text = $valueText;
+                $parameterValueData->rgbHex = $productParameterValuesLocalizedData->rgbHex;
+
+                if ($productParameterValuesLocalizedData->parameter->isSlider()) {
+                    $parameterValueData->numericValue = $valueText;
+                }
+
+                $parameterValueData->locale = $locale;
+                $productParameterValueData->parameterValueData = $parameterValueData;
+
+                $productParameterValuesData[] = $productParameterValueData;
+            }
+        }
+
+        return $productParameterValuesData;
+    }
 }

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedData.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedData.php
@@ -20,9 +20,4 @@ class ProductParameterValuesLocalizedData
      * @var string|null
      */
     public $numericValue;
-
-    /**
-     * @var string|null
-     */
-    public $rgbHex;
 }

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedData.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedData.php
@@ -20,4 +20,9 @@ class ProductParameterValuesLocalizedData
      * @var string|null
      */
     public $numericValue;
+
+    /**
+     * @var string|null
+     */
+    public $rgbHex;
 }

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedDataFactory.php
@@ -27,7 +27,6 @@ class ProductParameterValuesLocalizedDataFactory
 
         $productParameterValuesLocalizedData->valueTextsByLocale[$parameterValueData->locale] = $parameterValueData->text;
         $productParameterValuesLocalizedData->parameter = $parameter;
-        $productParameterValuesLocalizedData->rgbHex = $parameterValueData->rgbHex;
 
         if ($parameter->isSlider()) {
             $productParameterValuesLocalizedData->numericValue = $parameterValueData->text;

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValuesLocalizedDataFactory.php
@@ -9,8 +9,30 @@ class ProductParameterValuesLocalizedDataFactory
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData
      */
-    public function create(): ProductParameterValuesLocalizedData
+    protected function createInstance(): ProductParameterValuesLocalizedData
     {
         return new ProductParameterValuesLocalizedData();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData $productParameterValueData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData
+     */
+    public function createFromProductParameterValueData(
+        ProductParameterValueData $productParameterValueData,
+    ): ProductParameterValuesLocalizedData {
+        $productParameterValuesLocalizedData = $this->createInstance();
+        $parameterValueData = $productParameterValueData->parameterValueData;
+        $parameter = $productParameterValueData->parameter;
+
+        $productParameterValuesLocalizedData->valueTextsByLocale[$parameterValueData->locale] = $parameterValueData->text;
+        $productParameterValuesLocalizedData->parameter = $parameter;
+        $productParameterValuesLocalizedData->rgbHex = $parameterValueData->rgbHex;
+
+        if ($parameter->isSlider()) {
+            $productParameterValuesLocalizedData->numericValue = $parameterValueData->text;
+        }
+
+        return $productParameterValuesLocalizedData;
     }
 }

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -242,9 +242,9 @@ class ProductFacade
         $toFlush = [];
 
         foreach ($productParameterValuesData as $productParameterValueData) {
-            $parameterValue = $this->parameterRepository->findOrCreateParameterValueByValueTextAndLocale(
-                $productParameterValueData->parameterValueData->text,
-                $productParameterValueData->parameterValueData->locale,
+            $parameterValueData = $productParameterValueData->parameterValueData;
+            $parameterValue = $this->parameterRepository->findOrCreateParameterValueByParameterValueData(
+                $parameterValueData,
             );
 
             if ($productParameterValueData->parameter->isSlider()) {

--- a/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
+++ b/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
@@ -7,8 +7,6 @@ namespace App\Model\Product\Parameter;
 use Doctrine\ORM\Query\Expr\Join;
 use Override;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository as BaseParameterRepository;
-use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue;
-use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValue;
 
 /**
@@ -25,34 +23,6 @@ use Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValue;
  */
 class ParameterRepository extends BaseParameterRepository
 {
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData $parameterValueData
-     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue
-     */
-    public function findOrCreateParameterValueByParameterValueData(
-        ParameterValueData $parameterValueData,
-    ): ParameterValue {
-        $parameterValue = $this->getParameterValueRepository()->findOneBy([
-            'text' => $parameterValueData->text,
-            'locale' => $parameterValueData->locale,
-        ]);
-
-        if ($parameterValue === null) {
-            $parameterValue = $this->parameterValueFactory->create($parameterValueData);
-            $this->em->persist($parameterValue);
-            // Doctrine's identity map is not cache.
-            // We have to flush now, so that next findOneBy() finds new ParameterValue.
-            $this->em->flush();
-        }
-
-        if ($parameterValue->getRgbHex() !== $parameterValueData->rgbHex) {
-            $parameterValue->edit($parameterValueData);
-            $this->em->flush();
-        }
-
-        return $parameterValue;
-    }
-
     /**
      * @param \App\Model\Product\Product[] $products
      * @param string $locale

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Model\Product;
 
-use Override;
-use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
 
 /**
@@ -33,51 +31,8 @@ use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
  * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductRepository $productRepository, \App\Model\Product\Parameter\ParameterRepository $parameterRepository, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Component\Image\ImageFacade $imageFacade, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupRepository $pricingGroupRepository, \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade $productManualInputPriceFacade, \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade, \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository $productAccessoryRepository, \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginCrudExtensionFacade, \App\Model\Product\ProductFactory $productFactory, \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryFactory $productAccessoryFactory, \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactory $productCategoryDomainFactory, \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueFactory $productParameterValueFactory, \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFactory $productVisibilityFactory, \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation $productPriceCalculation, \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher $productRecalculationDispatcher, \Shopsys\FrameworkBundle\Model\Stock\ProductStockFacade $productStockFacade, \Shopsys\FrameworkBundle\Model\Stock\StockFacade $stockFacade, \App\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade $pricingGroupSettingFacade, \Shopsys\FrameworkBundle\Model\ProductVideo\ProductVideoFacade $productVideoFacade)
  * @method \App\Model\Product\Product edit(int $productId, \App\Model\Product\ProductData $productData, string $priority = \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum::REGULAR)
  * @method refreshProductAccessories(\App\Model\Product\Product $product, \App\Model\Product\Product[] $accessories)
+ * @method saveParameters(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[] $productParameterValuesData)
  */
 class ProductFacade extends BaseProductFacade
 {
-    /**
-     * @param \App\Model\Product\Product $product
-     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[] $productParameterValuesData
-     */
-    #[Override]
-    protected function saveParameters(BaseProduct $product, array $productParameterValuesData)
-    {
-        // Doctrine runs INSERTs before DELETEs in UnitOfWork. In case of UNIQUE constraint
-        // in database, this leads in trying to insert duplicate entry.
-        // That's why it's necessary to do remove and flush first.
-
-        $oldProductParameterValues = $this->parameterRepository->getProductParameterValuesByProduct($product);
-
-        foreach ($oldProductParameterValues as $oldProductParameterValue) {
-            $this->em->remove($oldProductParameterValue);
-        }
-        $this->em->flush();
-
-        $toFlush = [];
-
-        foreach ($productParameterValuesData as $productParameterValueData) {
-            $parameterValueData = $productParameterValueData->parameterValueData;
-            $parameterValue = $this->parameterRepository->findOrCreateParameterValueByParameterValueData(
-                $parameterValueData,
-            );
-
-            if ($productParameterValueData->parameter->isSlider()) {
-                $parameterValue->setNumericValue($productParameterValueData->parameterValueData->numericValue);
-                $toFlush[] = $parameterValue;
-            }
-
-            $productParameterValue = $this->productParameterValueFactory->create(
-                $product,
-                $productParameterValueData->parameter,
-                $parameterValue,
-            );
-            $this->em->persist($productParameterValue);
-            $toFlush[] = $productParameterValue;
-        }
-
-        if (count($toFlush) > 0) {
-            $this->em->flush();
-        }
-    }
 }

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Model\Product;
 
 use Override;
-use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
 
@@ -37,19 +36,6 @@ use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
  */
 class ProductFacade extends BaseProductFacade
 {
-    /**
-     * @param string $productCatnum
-     * @return \App\Model\Product\Product|null
-     */
-    public function findOneByCatnumExcludeMainVariants($productCatnum): ?BaseProduct
-    {
-        try {
-            return $this->productRepository->getOneByCatnumExcludeMainVariants($productCatnum);
-        } catch (ProductNotFoundException $exception) {
-            return null;
-        }
-    }
-
     /**
      * @param \App\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[] $productParameterValuesData

--- a/upgrade-notes/backend_20250411_125117.md
+++ b/upgrade-notes/backend_20250411_125117.md
@@ -1,0 +1,9 @@
+#### fix disappearing RGB color of parameter values ([#3924](https://github.com/shopsys/shopsys/pull/3924))
+
+- `ParameterValueData::$uuid` was removed without replacement
+- `ParameterRepository::findOrCreateParameterValueByValueTextAndLocale()` was replaced by `findOrCreateParameterValueByParameterValueData()`
+- `ProductParameterValuesLocalizedDataFactory::create()` was renamed to `createInstance()` and made protected
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the framework package:
+    - `ProductFacade::saveParameters()` extension
+    - `ParameterRepository::findOrCreateParameterValueByParameterValueData()`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The RGB value of a parameter value was omitted from the transformation in product form, so it was lost after the product was saved in the admin.

Also, creation of `ProductParameterValuesLocalizedData` and `ProductParameterValueData` objects was moved from the transformer into their factories for better clarity.

Moreover, `uuid` property was removed from `ParameterValueData` object as it was useless (in some edge cases, it was even causing troubles when a new parameter value was created from the existing data).

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
closes #3833

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-parameter-values.odin.shopsys.cloud
  - https://cz.rv-fix-parameter-values.odin.shopsys.cloud
<!-- Replace -->
