### PR TITLE
updated list of supported currencies by intl library

### DIFF
--- a/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
+++ b/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
@@ -18,7 +18,6 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'AFN',
         'ALL',
         'AMD',
-        'ANG',
         'AOA',
         'ARS',
         'AUD',
@@ -38,15 +37,14 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'BTN',
         'BWP',
         'BYN',
-        'BYR',
         'BZD',
         'CAD',
         'CDF',
+        'CHF',
         'CLP',
         'CNY',
         'COP',
         'CRC',
-        'CUC',
         'CUP',
         'CVE',
         'CZK',
@@ -72,7 +70,6 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'HNL',
         'HTG',
         'HUF',
-        'CHF',
         'IDR',
         'ILS',
         'INR',
@@ -104,7 +101,6 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'MMK',
         'MNT',
         'MOP',
-        'MRO',
         'MRU',
         'MUR',
         'MVR',
@@ -142,7 +138,6 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'SOS',
         'SRD',
         'SSP',
-        'STD',
         'STN',
         'SVC',
         'SYP',
@@ -162,7 +157,7 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'UYU',
         'UYW',
         'UZS',
-        'VEF',
+        'VED',
         'VES',
         'VND',
         'VUV',
@@ -174,7 +169,6 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'YER',
         'ZAR',
         'ZMW',
-        'ZWL',
     ];
 
     /**
@@ -189,13 +183,7 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
 
         try {
             return parent::get($currencyCode, $locale);
-        } catch (UnknownCurrencyException $ex) {
-            $legacyCurrencies = $this->getLegacyCurrenciesIndexedByCurrencyCodes();
-
-            if (array_key_exists($currencyCode, $legacyCurrencies)) {
-                return $legacyCurrencies[$currencyCode];
-            }
-
+        } catch (UnknownCurrencyException) {
             throw new UndefinedLegacyCurrencyException($currencyCode);
         }
     }
@@ -221,7 +209,7 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
             }
         }
 
-        return array_merge($this->getLegacyCurrenciesIndexedByCurrencyCodes(), $supportedCurrencies);
+        return $supportedCurrencies;
     }
 
     /**
@@ -231,38 +219,5 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
     public function isSupportedCurrency(string $currencyCode): bool
     {
         return in_array($currencyCode, self::SUPPORTED_CURRENCY_CODES, true);
-    }
-
-    /**
-     * @return \CommerceGuys\Intl\Currency\Currency[]
-     */
-    protected function getLegacyCurrenciesIndexedByCurrencyCodes(): array
-    {
-        return [
-            'BYR' => new Currency([
-                'currency_code' => 'BYR',
-                'name' => 'Belarusian Ruble (2000–2016)',
-                'locale' => 'en',
-                'numeric_code' => '974',
-            ]),
-            'MRO' => new Currency([
-                'currency_code' => 'MRO',
-                'name' => 'Mauritanian Ouguiya',
-                'locale' => 'en',
-                'numeric_code' => '478',
-            ]),
-            'STD' => new Currency([
-                'currency_code' => 'STD',
-                'name' => 'São Tomé & Príncipe Dobra',
-                'locale' => 'en',
-                'numeric_code' => '678',
-            ]),
-            'VEF' => new Currency([
-                'currency_code' => 'VEF',
-                'name' => 'Venezuelan Bolívar',
-                'locale' => 'en',
-                'numeric_code' => '937',
-            ]),
-        ];
     }
 }

--- a/upgrade-notes/backend_20250411_093455.md
+++ b/upgrade-notes/backend_20250411_093455.md
@@ -1,0 +1,3 @@
+#### update upported currencies ([#3925](https://github.com/shopsys/shopsys/pull/3925))
+
+- `Shopsys\FrameworkBundle\Model\Localization\IntlCurrencyRepository::getLegacyCurrenciesIndexedByCurrencyCodes()` method has been removed without replacement


### PR DESCRIPTION
#### Description, the reason for the PR
New version of intl library has been released with dropped support for no longer used currencies. This PR updates our list of supported currencies and drops support for legacy currencies.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-intl-update.odin.shopsys.cloud
  - https://cz.tl-fix-intl-update.odin.shopsys.cloud
<!-- Replace -->
