### PR TITLE
stores are ordered by position

### DIFF
--- a/packages/framework/src/Model/Store/StoreRepository.php
+++ b/packages/framework/src/Model/Store/StoreRepository.php
@@ -167,7 +167,7 @@ class StoreRepository
      */
     public function getStoresByIds(array $storeIds): array
     {
-        $queryBuilder = $this->getQueryBuilder()
+        $queryBuilder = $this->getAllStoresQueryBuilder()
             ->select('s')
             ->where('s.id IN (:storeIds)')
             ->setParameter('storeIds', $storeIds);


### PR DESCRIPTION
- without proper ordering, `storesBatchLoader` returns stores with random order
- `storesBatchLoader` is used for resolving Store in `StoreAvailabilityResolverMap`. Random order leads to pair availability status from on store to different store

#### Description, the reason for the PR
... 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-store-order.odin.shopsys.cloud
  - https://cz.mt-store-order.odin.shopsys.cloud
<!-- Replace -->
