### PR TITLE
enable adding related products on product creation

### DIFF
--- a/project-base/app/src/Model/Product/Product.php
+++ b/project-base/app/src/Model/Product/Product.php
@@ -72,8 +72,6 @@ class Product extends BaseProduct
     protected function __construct(ProductData $productData, ?array $variants = null)
     {
         parent::__construct($productData, $variants);
-
-        $this->relatedProducts = new ArrayCollection();
     }
 
     /**

--- a/upgrade-notes/backend_20250424_130657.md
+++ b/upgrade-notes/backend_20250424_130657.md
@@ -1,0 +1,3 @@
+#### fix creating a product with related products set ([#3941](https://github.com/shopsys/shopsys/pull/3941))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
It is not possible to set related products, when creating product. This PR solves the problem. It is also good to point out, that product picker for `relatedProducts` does not allow variants, while product picker for `accessories` allows them.
Reported by @florianjiri 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-related-products.odin.shopsys.cloud
  - https://cz.mt-related-products.odin.shopsys.cloud
<!-- Replace -->
