### PR TITLE
fixed luigis box size in cart

### DIFF
--- a/project-base/storefront/components/Pages/Cart/CartContent.tsx
+++ b/project-base/storefront/components/Pages/Cart/CartContent.tsx
@@ -2,6 +2,7 @@ import { CartList } from './CartList/CartList';
 import { CartSummary } from './CartSummary';
 import { CartSteps } from 'components/Blocks/CartSteps/CartSteps';
 import { DeferredRecommendedProducts } from 'components/Blocks/Product/DeferredRecommendedProducts';
+import { VerticalStack } from 'components/Layout/VerticalStack/VerticalStack';
 import { Webline } from 'components/Layout/Webline/Webline';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { TypeCartFragment } from 'graphql/requests/cart/fragments/CartFragment.generated';
@@ -17,12 +18,14 @@ export const CartContent: FC<CartContentProps> = ({ cart }) => {
     const { url, isLuigisBoxActive } = useDomainConfig();
 
     return (
-        <Webline>
-            <CartSteps activeStep={1} domainUrl={url} />
+        <VerticalStack gap="md">
+            <Webline>
+                <CartSteps activeStep={1} domainUrl={url} />
 
-            <CartList items={cart.items} />
+                <CartList items={cart.items} />
 
-            <CartSummary />
+                <CartSummary />
+            </Webline>
 
             {isLuigisBoxActive && (
                 <DeferredRecommendedProducts
@@ -36,6 +39,6 @@ export const CartContent: FC<CartContentProps> = ({ cart }) => {
                     )}
                 />
             )}
-        </Webline>
+        </VerticalStack>
     );
 };

--- a/upgrade-notes/storefront_20250423_064409.md
+++ b/upgrade-notes/storefront_20250423_064409.md
@@ -1,0 +1,4 @@
+#### Fix Luigis box size in cart page ([#3943](https://github.com/shopsys/shopsys/pull/3943))
+
+- Luigis box size is now correct in cart page
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Luigis box size is now correct in cart page.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2966-fix-luigis-box.odin.shopsys.cloud
  - https://cz.tc-ssp-2966-fix-luigis-box.odin.shopsys.cloud
<!-- Replace -->
