### PR TITLE
UploadedFileDataFixture uses first allowed domain locale

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/UploadedFileDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/UploadedFileDataFixture.php
@@ -53,7 +53,7 @@ class UploadedFileDataFixture extends AbstractReferenceFixture implements Depend
         $this->addUploadedFile(
             $this->getReference(ProductDataFixture::PRODUCT_PREFIX . 2),
             'example-file.pdf',
-            [$this->domain->getLocale() => 'Example file'],
+            [$this->domainsForDataFixtureProvider->getFirstAllowedDomainConfig()->getLocale() => 'Example file'],
         );
 
         $this->addReferencedUploadedFiles($this->getReference(ProductDataFixture::PRODUCT_PREFIX . 2), [1]);


### PR DESCRIPTION
#### Description, the reason for the PR
UploadedFileDataFixture uses first allowed domain locale. Otherwise it is dependent on current domain config, which is not available in data fixtures, until CartDataFixture run. Current domain is set in CartDataFixture, therefore fixtures that run after  CartDataFixture can access current domain config :see_no_evil: . 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-demo-files.odin.shopsys.cloud
  - https://cz.mt-demo-files.odin.shopsys.cloud
<!-- Replace -->
