### PR TITLE
variants can be set as related products

### DIFF
--- a/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
@@ -75,7 +75,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
                     'required' => false,
                     'main_product' => $product,
                     'label' => t('Related products'),
-                    'allow_variants' => false,
                 ]);
 
             $builder->add($relatedProductsGroupBuilder);

--- a/upgrade-notes/backend_20250424_180643.md
+++ b/upgrade-notes/backend_20250424_180643.md
@@ -1,0 +1,3 @@
+#### allow variants to be set as related product ([#3946](https://github.com/shopsys/shopsys/pull/3946))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Product variants can now be set as related products. This unifies behavior with the accessories

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-related-variants.odin.shopsys.cloud
  - https://cz.mg-related-variants.odin.shopsys.cloud
<!-- Replace -->
