### PR TITLE
tweaks of code generator

### DIFF
--- a/packages/maker/src/Maker/FrontendApiTypeMaker.php
+++ b/packages/maker/src/Maker/FrontendApiTypeMaker.php
@@ -165,7 +165,7 @@ class FrontendApiTypeMaker extends AbstractMaker
         }
 
         foreach ($metadata->getAssociationNames() as $fieldName) {
-            if (in_array($fieldName, self::EXCLUDED_ASSOCIATION_NAMES, true)) {
+            if (in_array($fieldName, [...self::EXCLUDED_ASSOCIATION_NAMES, lcfirst(Str::getShortClassName($this->selectedEntityClass))], true)) {
                 continue;
             }
             $fieldsConfig[$fieldName] = $this->getFieldDefinition($metadata, $fieldName);

--- a/packages/maker/src/Utils/EntityChoiceHelper.php
+++ b/packages/maker/src/Utils/EntityChoiceHelper.php
@@ -55,7 +55,10 @@ class EntityChoiceHelper
 
         $availableEntityNames = $this->filterOutShopsysEntitiesThatHaveExtensionInProjectBase($allEntityNames);
 
-        return array_map($this->convertFqcnToAutocompleteFormat(...), $availableEntityNames);
+        $choices = array_map($this->convertFqcnToAutocompleteFormat(...), $availableEntityNames);
+        sort($choices);
+
+        return $choices;
     }
 
     /**


### PR DESCRIPTION
#### Description, the reason for the PR
1. FE API maker: exclude entity itself from generated fields - the relation to the given entity exists in the entityDomain but unlike the other domain fields, we do not want that in the resulting API type, e.g. `ProductDomain` has `$product` relation, but we do not want the "product" field in the generated `Product.types.yaml`
2. when selecting an entity, the autocomplete values are now sorted for better and more predictable UX (when you type "Product", the first suggested value is "Product (App\Model\Product\Product)" which is probably the entity you are looking for :slightly_smiling_face: )

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-maker-tweaks.odin.shopsys.cloud
  - https://cz.rv-maker-tweaks.odin.shopsys.cloud
<!-- Replace -->
