### PR TITLE
added input type numeric to postcode

### DIFF
--- a/project-base/storefront/components/Blocks/Popup/CreateComplaintPopup.tsx
+++ b/project-base/storefront/components/Blocks/Popup/CreateComplaintPopup.tsx
@@ -438,6 +438,7 @@ export const CreateComplaintPopup: FC<CreateComplaintPopupProps> = ({ orderUuid 
                                                 type: 'text',
                                                 autoComplete: 'postal-code',
                                                 disabled: isSubmitting,
+                                                inputMode: 'numeric',
                                             }}
                                         />
                                     </FormColumn>

--- a/project-base/storefront/components/Blocks/Popup/DeliveryAddressPopup.tsx
+++ b/project-base/storefront/components/Blocks/Popup/DeliveryAddressPopup.tsx
@@ -205,6 +205,7 @@ export const DeliveryAddressPopup: FC<DeliveryAddressPopupProps> = ({ deliveryAd
                                         required: true,
                                         type: 'text',
                                         autoComplete: 'postal-code',
+                                        inputMode: 'numeric',
                                     }}
                                 />
                             </FormColumn>

--- a/project-base/storefront/components/Forms/TextInput/TextInput.tsx
+++ b/project-base/storefront/components/Forms/TextInput/TextInput.tsx
@@ -16,6 +16,7 @@ type NativeProps = ExtractNativePropsFromDefault<
     | 'children'
     | 'autoComplete'
     | 'onChange'
+    | 'inputMode'
 >;
 
 export type TextInputProps = NativeProps & {
@@ -43,6 +44,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             type,
             children,
             autoComplete,
+            inputMode,
         },
         textInputForwarderRef,
     ) => (
@@ -51,6 +53,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
                 autoComplete={autoComplete}
                 disabled={disabled}
                 id={id}
+                inputMode={inputMode}
                 name={name}
                 placeholder={typeof label === 'string' ? label : ' '}
                 ref={textInputForwarderRef}

--- a/project-base/storefront/components/Forms/TextInput/TextInputControlled.tsx
+++ b/project-base/storefront/components/Forms/TextInput/TextInputControlled.tsx
@@ -18,6 +18,7 @@ type TextInputControlledProps = {
         | 'inputSize'
         | 'autoComplete'
         | 'className'
+        | 'inputMode'
     >;
     control: Control<any>;
     formName: string;

--- a/project-base/storefront/components/Forms/validationRules.ts
+++ b/project-base/storefront/components/Forms/validationRules.ts
@@ -94,7 +94,11 @@ export const validatePostcode = (t: Translate): Schema => {
             t('Zip code cannot be longer than {{ postcodeLength }} characters', {
                 postcodeLength: VALIDATION_CONSTANTS.postcodeLength,
             }),
-            (value) => value.length <= VALIDATION_CONSTANTS.postcodeLength,
+            (value) => {
+                // Normalize the postal code by removing spaces
+                const normalizedValue = value ? value.replace(/\s/g, '') : '';
+                return normalizedValue.length <= VALIDATION_CONSTANTS.postcodeLength;
+            },
         );
 };
 

--- a/project-base/storefront/components/Pages/Customer/EditProfile/BillingAddress.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/BillingAddress.tsx
@@ -79,6 +79,7 @@ export const BillingAddress: FC = () => {
                         type: 'text',
                         autoComplete: 'postal-code',
                         disabled: !canManageCompanyData,
+                        inputMode: 'numeric',
                     }}
                 />
             </FormColumn>

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationAddress.tsx
@@ -70,6 +70,7 @@ export const ContactInformationAddress: FC = () => {
                         required: true,
                         type: 'text',
                         autoComplete: 'postal-code',
+                        inputMode: 'numeric',
                         onChange: (event) => updateContactInformation({ postcode: event.currentTarget.value }),
                     }}
                 />

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
@@ -240,6 +240,7 @@ export const ContactInformationDeliveryAddress: FC = () => {
                                                             required: true,
                                                             type: 'text',
                                                             autoComplete: 'postal-code',
+                                                            inputMode: 'numeric',
                                                             onChange: (event) =>
                                                                 updateContactInformation({
                                                                     deliveryPostcode: event.currentTarget.value,

--- a/project-base/storefront/components/Pages/Registration/RegistrationAddress.tsx
+++ b/project-base/storefront/components/Pages/Registration/RegistrationAddress.tsx
@@ -70,6 +70,7 @@ export const RegistrationAddress: FC = () => {
                         required: true,
                         type: 'text',
                         autoComplete: 'postal-code',
+                        inputMode: 'numeric',
                     }}
                 />
             </FormColumn>

--- a/upgrade-notes/storefront_20250429_114958.md
+++ b/upgrade-notes/storefront_20250429_114958.md
@@ -1,0 +1,4 @@
+#### Numeric keyboard for postcode input ([#3956](https://github.com/shopsys/shopsys/pull/3956))
+
+- added numeric keyboard in postcode input for better UX on mobile phones
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Added numeric keyboard in postcode input for better UX on mobile phones.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3353-numeric-postcode.odin.shopsys.cloud
  - https://cz.tc-ssp-3353-numeric-postcode.odin.shopsys.cloud
<!-- Replace -->
