### PR TITLE
fixed long banner button name

### DIFF
--- a/project-base/storefront/components/Blocks/Banners/BannersDot.tsx
+++ b/project-base/storefront/components/Blocks/Banners/BannersDot.tsx
@@ -49,7 +49,7 @@ export const BannersDot: FC<BannersDotProps> = ({
             )}
             onClick={() => moveToSlide(index)}
         >
-            <h6 className="vl:line-clamp-4 hidden">{sliderItem.name}</h6>
+            <h6 className="vl:line-clamp-4 hidden wrap-anywhere">{sliderItem.name}</h6>
             <div
                 className={twMergeCustom(
                     'z-above bg-textAccent vl:block absolute top-0 left-0 hidden h-[3px] w-0 transition-all duration-[0s] ease-linear',

--- a/upgrade-notes/storefront_20250429_122139.md
+++ b/upgrade-notes/storefront_20250429_122139.md
@@ -1,0 +1,4 @@
+#### Long banner name ([#3957](https://github.com/shopsys/shopsys/pull/3957))
+
+- fixed long banner button name with class name `wrap-aywhere`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed long banner button name with class name `wrap-aywhere`

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3328-fix-long-banner-button.odin.shopsys.cloud
  - https://cz.tc-ssp-3328-fix-long-banner-button.odin.shopsys.cloud
<!-- Replace -->
