### PR TITLE
transport prices are now copied to newly created domain

### DIFF
--- a/packages/framework/src/Model/MultidomainEntityClassProvider.php
+++ b/packages/framework/src/Model/MultidomainEntityClassProvider.php
@@ -16,6 +16,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductVisibility;
 use Shopsys\FrameworkBundle\Model\Seo\Page\SeoPageDomain;
 use Shopsys\FrameworkBundle\Model\Stock\StockDomain;
 use Shopsys\FrameworkBundle\Model\Transport\TransportDomain;
+use Shopsys\FrameworkBundle\Model\Transport\TransportPrice;
 
 class MultidomainEntityClassProvider implements MultidomainEntityClassProviderInterface
 {
@@ -45,6 +46,7 @@ class MultidomainEntityClassProvider implements MultidomainEntityClassProviderIn
             CountryDomain::class,
             SeoPageDomain::class,
             StockDomain::class,
+            TransportPrice::class,
         ];
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

When new domain is added and `./phing domains-data-create` is run, the transport prices were not copied, causing error 500 on the transport and payment list page (with filter set on new domain) and on transport edit page.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-transport-price-add-domain.odin.shopsys.cloud
  - https://cz.mg-transport-price-add-domain.odin.shopsys.cloud
<!-- Replace -->
