### PR TITLE
ProductVisibilityFacadeTest is now resistant to added domain without loaded data

### DIFF
--- a/project-base/app/tests/App/Functional/Model/Product/ProductVisibilityFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductVisibilityFacadeTest.php
@@ -31,7 +31,7 @@ class ProductVisibilityFacadeTest extends TransactionFunctionalTestCase
     public function testAreProductsVisibleForDefaultPricingGroupOnSomeDomainIndexedByProductId(): void
     {
         $productId = 1;
-        $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnEachDomainIndexedByProductId(
+        $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnSomeDomainIndexedByProductId(
             [$productId],
         );
         $this->assertTrue($visibilityIndexedByProductId[$productId]);
@@ -40,11 +40,6 @@ class ProductVisibilityFacadeTest extends TransactionFunctionalTestCase
     public function testAreProductsVisibleForDefaultPricingGroupOnEachDomainIndexedByProductId(): void
     {
         $productId = 1;
-
-        $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnEachDomainIndexedByProductId(
-            [$productId],
-        );
-        $this->assertTrue($visibilityIndexedByProductId[$productId], 'Product should be visible on all domains');
 
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productId);
         $productData = $this->productDataFactory->createFromProduct($product);

--- a/upgrade-notes/backend_20250505_095008.md
+++ b/upgrade-notes/backend_20250505_095008.md
@@ -1,0 +1,3 @@
+#### improve ProductVisibilityFacadeTest ([#3961](https://github.com/shopsys/shopsys/pull/3961))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

When a new domain without loaded demo data is added (set `load_demo_data: false` in domains.yaml file), this test started to fail because the product is not visible on some domains. But this is an expected behavior, so this test was changed

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://grossmannmartin-patch-1.odin.shopsys.cloud
  - https://cz.grossmannmartin-patch-1.odin.shopsys.cloud
<!-- Replace -->
