### PR TITLE
yaml standards: ignore kubernetes config files

### DIFF
--- a/project-base/app/yaml-standards.yaml
+++ b/project-base/app/yaml-standards.yaml
@@ -31,5 +31,6 @@
         - ./migrations-lock.yaml
         - ./migrations-lock.yml
         - ./node_modules/*
+        - ./orchestration/kubernetes/**/*.yaml
         - ./var/*
         - ./vendor/*

--- a/upgrade-notes/backend_20250505_150355.md
+++ b/upgrade-notes/backend_20250505_150355.md
@@ -1,0 +1,3 @@
+#### yaml standards: ignore kubernetes config files ([#3964](https://github.com/shopsys/shopsys/pull/3964))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The kubernetes config files do not satisfy the yaml standards so we need to ignore them within our checks. By default, there are no kubernetes configuration files in `project-base`, however, when implementing a project, sooner or later, the custom config might be needed (see https://github.com/shopsys/deployment#customize-deployment)

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-yaml-standards.odin.shopsys.cloud
  - https://cz.rv-yaml-standards.odin.shopsys.cloud
<!-- Replace -->
