### PR TITLE
bump codeception versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -200,9 +200,9 @@
     },
     "require-dev": {
         "ext-pgsql": "*",
-        "codeception/codeception": "^5.0.10",
-        "codeception/module-db": "^3.1.0",
-        "codeception/module-webdriver": "^4.0",
+        "codeception/codeception": "^5.3.0",
+        "codeception/module-db": "^3.2.2",
+        "codeception/module-webdriver": "^4.0.3",
         "codeception/phpunit-wrapper": "^9.0.7",
         "friendsofphp/php-cs-fixer": "^3.58.1",
         "php-mock/php-mock-phpunit": "^2.7",
@@ -224,7 +224,6 @@
         "zalas/phpunit-injector": "2.5.x-dev as 2.5.1"
     },
     "conflict": {
-        "codeception/codeception": "^5.2.0",
         "symfony/symfony": "*",
         "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0",
         "doctrine/doctrine-migrations-bundle": "3.4.0"

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -121,9 +121,9 @@
     "require-dev": {
         "ext-pgsql": "*",
         "ext-zip": "*",
-        "codeception/codeception": "^5.0.10",
-        "codeception/module-db": "^3.1.0",
-        "codeception/module-webdriver": "^4.0",
+        "codeception/codeception": "^5.3.0",
+        "codeception/module-db": "^3.2.2",
+        "codeception/module-webdriver": "^4.0.3",
         "codeception/phpunit-wrapper": "^9.0.7",
         "phpstan/phpstan": "^1.11.7",
         "phpstan/phpstan-doctrine": "^1.4.8.",
@@ -140,7 +140,6 @@
         "zalas/phpunit-injector": "2.5.x-dev as 2.5.1"
     },
     "conflict": {
-        "codeception/codeception": "^5.2.0",
         "symfony/symfony": "*",
         "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0"
     },

--- a/upgrade-notes/backend_20250507_113220.md
+++ b/upgrade-notes/backend_20250507_113220.md
@@ -1,0 +1,3 @@
+#### bump codeception versions ([#3967](https://github.com/shopsys/shopsys/pull/3967))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

due to changes in behat/gherkin v4.13.0 the acceptance tests were failing on 

```
In Gherkin.php line 78:
                                                                               
  Warning: require(/var/www/html/vendor/behat/gherkin/src/../../../i18n.php):  
   Failed to open stream: No such file or directory     
```

this was fixed in https://github.com/Codeception/Codeception/pull/6839

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-bump-codeception.odin.shopsys.cloud
  - https://cz.mg-bump-codeception.odin.shopsys.cloud
<!-- Replace -->
