### PR TITLE
UX icons are now imported within standards-fix(-diff) phing targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ check-schema:
 	docker compose exec -u root storefront chown node:node schema.graphql
 	docker compose exec storefront sh check-code-gen.sh
 
-check-fix: generate-schema php-checks php-lock-icons php-translations storefront-checks storefront-translations
+check-fix: generate-schema php-checks php-translations storefront-checks storefront-translations
 
 php-checks:
 	docker compose exec php-fpm php phing standards-fix phpstan

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1042,9 +1042,9 @@
 
     <target name="standards-diff" depends="phplint-diff,ecs-diff,markdown-check,annotations-check,phpstan,twig-lint-diff,yaml-standards,eslint-check" description="Checks coding standards in changed files."/>
 
-    <target name="standards-fix" depends="ecs-fix,markdown-fix,annotations-fix,yaml-standards-fix,eslint-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix" depends="ecs-fix,markdown-fix,annotations-fix,yaml-standards-fix,eslint-fix,ux-icons-lock" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
 
-    <target name="standards-fix-diff" depends="ecs-fix-diff,markdown-fix,annotations-fix,yaml-standards-fix,eslint-fix" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix-diff" depends="ecs-fix-diff,markdown-fix,annotations-fix,yaml-standards-fix,eslint-fix,ux-icons-lock" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
 
     <target name="stylelint" description="Checks conventions in styles">
         <exec executable="${path.npm.executable}" logoutput="true" passthru="true" checkreturn="true">
@@ -1629,6 +1629,13 @@
                 </exec>
             </then>
         </if>
+    </target>
+
+    <target name="ux-icons-lock" description="Scan project and import icon(s) from iconify.design">
+        <exec executable="${path.php.executable}" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="ux:icons:lock"/>
+        </exec>
     </target>
 
     <target name="warmup" description="Warms up cache.">

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -16,7 +16,7 @@ generate-schema-native:
 	cd storefront; npm run gql
 	rm -rf storefront/schema.graphql
 
-check-fix: generate-schema php-checks php-lock-icons php-translations storefront-checks storefront-translations
+check-fix: generate-schema php-checks php-translations storefront-checks storefront-translations
 
 php-checks:
 	docker compose exec php-fpm php phing standards-fix phpstan

--- a/upgrade-notes/backend_20250508_134446.md
+++ b/upgrade-notes/backend_20250508_134446.md
@@ -1,0 +1,4 @@
+#### UX icons are now imported within standards-fix(-diff) phing targets ([#3969](https://github.com/shopsys/shopsys/pull/3969))
+
+- if you have extended `standards-fix` or/and `standards-fix-diff` phing targets, make sure they now depend on the new `ux-icons-lock` target
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
`standards-fix` and `standards-fix-diff` phing targets are most usually used locally before committing and pushing changes, so it makes sense to ensure the icons are locked within these targets.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-icons.odin.shopsys.cloud
  - https://cz.rv-icons.odin.shopsys.cloud
<!-- Replace -->
