### PR TITLE
DISABLE_FORM_FIELDS_FROM_TRANSFER now does not affect superadmin users

### DIFF
--- a/docs/administration/disabling-form-fields.md
+++ b/docs/administration/disabling-form-fields.md
@@ -1,13 +1,55 @@
 # Disabling form fields
 
-During project implementation, there is usually necessary to have imported some fields from other systems.
-Those imported fields do not need (or even must not) be changeable in administration.
-For this purpose, there is implemented the way how to define fields which should be disabled.
+During project implementation, it is usually necessary to import some fields from external systems.
+Those imported fields do not need to (or even must not) be changeable in administration.
+For this purpose, you can configure fields which should be disabled in the form.
 
-## Enable form disabling
+## Allow form fields disabling for non-superadmin administrators
 
-To enable disabling defined fields there, need to be set ENV variable `DISABLE_FORM_FIELDS_FROM_TRANSFER` to true.
+For the testing purposes, the fields are never disabled for administrators with `ROLE_SUPER_ADMIN`.
+To allow disabling defined form fields for the rest of administrators, you need to:
+- set ENV variable `DISABLE_FORM_FIELDS_FROM_TRANSFER` to true.
+- call `FormBuilderHelper::disableFieldsByConfigurations()` with an array of fields names you want to disable in the `buildForm` method your form type extension, e.g.:
+```php
+<?php
 
-## Define disabled fields
+declare(strict_types=1);
 
-Disabled fields are defined by constant `DISABLED_FIELDS` for example in: `App\Form\Admin\CategoryFormTypeExtension`
+namespace App\Form\Admin;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Form\FormBuilderHelper;
+use Shopsys\FrameworkBundle\Form\Admin\Category\CategoryFormType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class CategoryFormTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Form\FormBuilderHelper $formBuilderHelper
+     */
+    public function __construct(
+        private readonly FormBuilderHelper $formBuilderHelper,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $this->formBuilderHelper->disableFieldsByConfigurations($builder, ['name', 'descriptions']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getExtendedTypes(): iterable
+    {
+        yield CategoryFormType::class;
+    }
+}
+```
+

--- a/packages/framework/src/Component/Form/FormBuilderHelper.php
+++ b/packages/framework/src/Component/Form/FormBuilderHelper.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Form;
 
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class FormBuilderHelper
 {
     /**
      * @param bool $disableFields
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      */
     public function __construct(
         protected readonly bool $disableFields,
+        protected readonly Security $security,
     ) {
     }
 
@@ -22,7 +26,7 @@ class FormBuilderHelper
      */
     public function disableFieldsByConfigurations(FormBuilderInterface $builder, array $disabledFields): void
     {
-        if (!$this->disableFields) {
+        if (!$this->hasFormDisabledFields()) {
             return;
         }
         $this->trackFormElements($builder->all(), $disabledFields);
@@ -47,6 +51,6 @@ class FormBuilderHelper
      */
     public function hasFormDisabledFields(): bool
     {
-        return $this->disableFields;
+        return $this->disableFields && !$this->security->isGranted(Roles::ROLE_SUPER_ADMIN);
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
Now, we are able to allow form fields disabling on all environments while keeping the fields always enabled for superadmin. Hence, testers are able to ensure the desired fields are indeed disabled for regular administrators and still test the features even without access to an external system when logged as superadmin.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-disable-form-fields.odin.shopsys.cloud
  - https://cz.rv-disable-form-fields.odin.shopsys.cloud
<!-- Replace -->
