### PR TITLE
dev dependencies fixes

### DIFF
--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -18,7 +18,6 @@ use Shopsys\FrameworkBundle\Model\Payment\AbstractPaymentTypeEnum;
 use Shopsys\FrameworkBundle\Model\Transport\AbstractTransportTypeEnum;
 use Shopsys\FrameworkBundle\Twig\NoVarDumperExtension;
 use Shopsys\FrameworkBundle\Twig\VarDumperExtension;
-use Shopsys\MakerBundle\Maker\BaseMaker;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -88,9 +87,6 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
 
         $container->registerForAutoconfiguration(CategoryAutomatedFilterInterface::class)
             ->addTag('shopsys.category_automated_filter');
-
-        $container->registerForAutoconfiguration(BaseMaker::class)
-            ->addTag('maker.command');
     }
 
     /**

--- a/packages/maker/src/ShopsysMakerBundle.php
+++ b/packages/maker/src/ShopsysMakerBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\MakerBundle;
 
 use Override;
+use Shopsys\MakerBundle\Maker\BaseMaker;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
@@ -18,6 +19,9 @@ class ShopsysMakerBundle extends AbstractBundle
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $container->import('../config/services.yaml');
+
+        $builder->registerForAutoconfiguration(BaseMaker::class)
+            ->addTag('maker.command');
     }
 
     /**

--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -67,7 +67,7 @@ test:standards-with-graphql-schema-check:
     needs:
         - build
     script:
-        - docker run -i ${TAG} /bin/bash -c "mv PRODUCTION DEVELOPMENT; npm install format-graphql && ./check-schema.sh && php phing composer-dev standards"
+        - docker run -i ${TAG} /bin/bash -c "mv PRODUCTION DEVELOPMENT; npm install format-graphql && php phing composer-dev && ./check-schema.sh && php phing standards"
         - |
             docker run -i ${TAG} /bin/bash -c "php bin/console ux:icons:lock" | grep "Imported 0 icons" \
             || { 

--- a/upgrade-notes/backend_20250514_111253.md
+++ b/upgrade-notes/backend_20250514_111253.md
@@ -1,0 +1,3 @@
+#### dev dependencies fixes ([#3976](https://github.com/shopsys/shopsys/pull/3976))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Moved the `shopsys.maker` tag autoconfiguration definition from framework to the maker bundle as the `shopsys/framework` package is not aware of the maker bundle at all, see e.g. https://github.com/shopsys/framework/actions/runs/14924081885/job/41924883720

Moreover, fixed environment change in gitlabCI before graphQL schema check so the proper dev dependencies are installed.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-maker.odin.shopsys.cloud
  - https://cz.rv-fix-maker.odin.shopsys.cloud
<!-- Replace -->
