### PR TITLE
Fix load more limit

### DIFF
--- a/project-base/storefront/components/Blocks/Pagination/Pagination.tsx
+++ b/project-base/storefront/components/Blocks/Pagination/Pagination.tsx
@@ -1,8 +1,9 @@
 import { Button } from 'components/Forms/Button/Button';
+import { usePaginationContext } from 'components/providers/PaginationProvider';
 import { DEFAULT_PAGE_SIZE } from 'config/constants';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
-import { Fragment, MouseEventHandler, RefObject, forwardRef } from 'react';
+import { Fragment, MouseEventHandler, forwardRef } from 'react';
 import { twJoin } from 'tailwind-merge';
 import { getUrlQueriesWithoutDynamicPageQueries } from 'utils/parsing/getUrlQueriesWithoutDynamicPageQueries';
 import { useCurrentLoadMoreQuery } from 'utils/queryParams/useCurrentLoadMoreQuery';
@@ -11,10 +12,10 @@ import { useUpdateLoadMoreQuery } from 'utils/queryParams/useUpdateLoadMoreQuery
 import { useUpdatePaginationQuery } from 'utils/queryParams/useUpdatePaginationQuery';
 import { useMediaMin } from 'utils/ui/useMediaMin';
 import { usePagination } from 'utils/ui/usePagination';
+import { useScrollRestoration } from 'utils/ui/useScrollRestoration';
 
 type PaginationProps = {
     totalCount: number;
-    paginationScrollTargetRef: RefObject<HTMLDivElement> | null;
     hasNextPage?: boolean;
     isWithLoadMore?: boolean;
     pageSize?: number;
@@ -23,12 +24,12 @@ type PaginationProps = {
 
 export const Pagination: FC<PaginationProps> = ({
     totalCount,
-    paginationScrollTargetRef,
     hasNextPage,
     isWithLoadMore,
     pageSize = DEFAULT_PAGE_SIZE,
-    type = 'defualt',
+    type = 'default',
 }) => {
+    const { paginationScrollTargetRef } = usePaginationContext();
     const router = useRouter();
     const isDesktop = useMediaMin('sm');
     const currentPage = useCurrentPageQuery();
@@ -39,6 +40,11 @@ export const Pagination: FC<PaginationProps> = ({
     const paginationButtons = usePagination(totalCount, currentPageWithLoadMore, !isDesktop, pageSize);
     const { t } = useTranslation();
 
+    useScrollRestoration({
+        scrollTargetRef: paginationScrollTargetRef,
+        shouldScroll: currentPage > 1,
+    });
+
     if (!paginationButtons || paginationButtons.length === 1) {
         return null;
     }
@@ -48,7 +54,6 @@ export const Pagination: FC<PaginationProps> = ({
 
     const onChangePage = (pageNumber: number) => () => {
         updatePagination(pageNumber);
-
         // timeout for safari scroll
         setTimeout(() => {
             if (paginationScrollTargetRef?.current) {
@@ -65,7 +70,7 @@ export const Pagination: FC<PaginationProps> = ({
 
     return (
         <div className="vl:flex-row mt-5 flex flex-col items-center justify-between gap-5">
-            {isWithLoadMore && hasNextPage && (
+            {isWithLoadMore && hasNextPage && loadMoreCount > 0 && (
                 <Button className="px-3" variant="inverted" onClick={loadMore}>
                     {t('Load {{ count }} more {{ items }}', { count: loadMoreCount, items: itemsLabel })}
                 </Button>

--- a/project-base/storefront/components/Blocks/Product/ProductsList/ProductsListContent.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsList/ProductsListContent.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_PAGE_SIZE } from 'config/constants';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
-import React, { RefObject } from 'react';
+import { RefObject } from 'react';
 import { SwipeableHandlers } from 'react-swipeable';
 import { useComparison } from 'utils/productLists/comparison/useComparison';
 import { useWishlist } from 'utils/productLists/wishlist/useWishlist';

--- a/project-base/storefront/components/Pages/BlogCategory/BlogCategoryArticlesWrapper.tsx
+++ b/project-base/storefront/components/Pages/BlogCategory/BlogCategoryArticlesWrapper.tsx
@@ -1,6 +1,7 @@
 import { BlogArticlesList } from './BlogArticlesList';
 import { Pagination } from 'components/Blocks/Pagination/Pagination';
 import { SkeletonModuleArticleBlog } from 'components/Blocks/Skeleton/SkeletonModuleArticleBlog';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { DEFAULT_BLOG_PAGE_SIZE } from 'config/constants';
 import { TypeListedBlogArticleFragment } from 'graphql/requests/articlesInterface/blogArticles/fragments/ListedBlogArticleFragment.generated';
 import { BlogCategoryArticlesDocument } from 'graphql/requests/blogCategories/queries/BlogCategoryArticlesQuery.generated';
@@ -48,14 +49,15 @@ export const BlogCategoryArticlesWrapper: FC<BlogCategoryArticlesWrapperProps> =
                 articlesContent
             )}
 
-            <Pagination
-                isWithLoadMore
-                hasNextPage={hasNextPage}
-                pageSize={DEFAULT_BLOG_PAGE_SIZE}
-                paginationScrollTargetRef={paginationScrollTargetRef}
-                totalCount={blogCategoryTotalCount}
-                type="blog"
-            />
+            <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                <Pagination
+                    isWithLoadMore
+                    hasNextPage={hasNextPage}
+                    pageSize={DEFAULT_BLOG_PAGE_SIZE}
+                    totalCount={blogCategoryTotalCount}
+                    type="blog"
+                />
+            </PaginationProvider>
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/BrandDetail/BrandDetailContent.tsx
+++ b/project-base/storefront/components/Pages/BrandDetail/BrandDetailContent.tsx
@@ -6,6 +6,7 @@ import { FilterSelectedParameters } from 'components/Blocks/Product/Filter/Filte
 import { LastVisitedProducts } from 'components/Blocks/Product/LastVisitedProducts/LastVisitedProducts';
 import { DeferredFilterAndSortingBar } from 'components/Blocks/SortingBar/DeferredFilterAndSortingBar';
 import { VerticalStack } from 'components/Layout/VerticalStack/VerticalStack';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { TypeBrandDetailFragment } from 'graphql/requests/brands/fragments/BrandDetailFragment.generated';
 import { useRef } from 'react';
 import { useCurrentPageQuery } from 'utils/queryParams/useCurrentPageQuery';
@@ -53,7 +54,9 @@ export const BrandDetailContent: FC<BrandDetailContentProps> = ({ brand }) => {
                         />
                     </div>
 
-                    <BrandDetailProductsWrapper brand={brand} paginationScrollTargetRef={paginationScrollTargetRef} />
+                    <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                        <BrandDetailProductsWrapper brand={brand} />
+                    </PaginationProvider>
                 </div>
             </FilteredProductsWrapper>
 

--- a/project-base/storefront/components/Pages/BrandDetail/BrandDetailProductsWrapper.tsx
+++ b/project-base/storefront/components/Pages/BrandDetail/BrandDetailProductsWrapper.tsx
@@ -5,19 +5,14 @@ import { BrandProductsQueryDocument } from 'graphql/requests/products/queries/Br
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
 import { useGtmPaginatedProductListViewEvent } from 'gtm/utils/pageViewEvents/productList/useGtmPaginatedProductListViewEvent';
-import { RefObject } from 'react';
 import { useProductsData } from 'utils/loadMore/useProductsData';
 import { getMappedProducts } from 'utils/mappers/products';
 
 type BrandDetailProductsWrapperProps = {
     brand: TypeBrandDetailFragment;
-    paginationScrollTargetRef: RefObject<HTMLDivElement>;
 };
 
-export const BrandDetailProductsWrapper: FC<BrandDetailProductsWrapperProps> = ({
-    brand,
-    paginationScrollTargetRef,
-}) => {
+export const BrandDetailProductsWrapper: FC<BrandDetailProductsWrapperProps> = ({ brand }) => {
     const {
         products: brandProductsData,
         areProductsFetching,
@@ -37,12 +32,7 @@ export const BrandDetailProductsWrapper: FC<BrandDetailProductsWrapperProps> = (
                 isLoadingMoreProducts={isLoadingMoreProducts}
                 products={listedBrandProducts}
             />
-            <Pagination
-                isWithLoadMore
-                hasNextPage={hasNextPage}
-                paginationScrollTargetRef={paginationScrollTargetRef}
-                totalCount={brand.products.totalCount}
-            />
+            <Pagination isWithLoadMore hasNextPage={hasNextPage} totalCount={brand.products.totalCount} />
         </>
     );
 };

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -7,6 +7,7 @@ import { DeferredLastVisitedProducts } from 'components/Blocks/Product/LastVisit
 import { SimpleNavigation } from 'components/Blocks/SimpleNavigation/SimpleNavigation';
 import { DeferredFilterAndSortingBar } from 'components/Blocks/SortingBar/DeferredFilterAndSortingBar';
 import { VerticalStack } from 'components/Layout/VerticalStack/VerticalStack';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { TypeCategoryDetailFragment } from 'graphql/requests/categories/fragments/CategoryDetailFragment.generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/factories/useGtmFriendlyPageViewEvent';
 import { useGtmPageViewEvent } from 'gtm/utils/pageViewEvents/useGtmPageViewEvent';
@@ -72,10 +73,9 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
                         />
                     </div>
 
-                    <DeferredCategoryDetailProductsWrapper
-                        category={category}
-                        paginationScrollTargetRef={paginationScrollTargetRef}
-                    />
+                    <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                        <DeferredCategoryDetailProductsWrapper category={category} />
+                    </PaginationProvider>
                 </div>
             </FilteredProductsWrapper>
 

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailProductsWrapper/CategoryDetailProductsWrapper.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailProductsWrapper/CategoryDetailProductsWrapper.tsx
@@ -5,7 +5,7 @@ import { TypeListedProductFragment } from 'graphql/requests/products/fragments/L
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { getCategoryOrSeoCategoryGtmProductListName } from 'gtm/utils/getCategoryOrSeoCategoryGtmProductListName';
 import { useGtmPaginatedProductListViewEvent } from 'gtm/utils/pageViewEvents/productList/useGtmPaginatedProductListViewEvent';
-import { RefObject, useMemo } from 'react';
+import { useMemo } from 'react';
 
 export type CategoryDetailProductsWrapperProps = {
     category: TypeCategoryDetailFragment;
@@ -13,7 +13,6 @@ export type CategoryDetailProductsWrapperProps = {
     areProductsFetching: boolean;
     isLoadingMoreProducts: boolean;
     hasNextPage: boolean;
-    paginationScrollTargetRef: RefObject<HTMLDivElement>;
 };
 
 export const CategoryDetailProductsWrapper: FC<CategoryDetailProductsWrapperProps> = ({
@@ -22,7 +21,6 @@ export const CategoryDetailProductsWrapper: FC<CategoryDetailProductsWrapperProp
     areProductsFetching,
     isLoadingMoreProducts,
     hasNextPage,
-    paginationScrollTargetRef,
 }) => {
     const gtmProductListName = useMemo(
         () => getCategoryOrSeoCategoryGtmProductListName(category.originalCategorySlug),
@@ -40,12 +38,7 @@ export const CategoryDetailProductsWrapper: FC<CategoryDetailProductsWrapperProp
                 isLoadingMoreProducts={isLoadingMoreProducts}
                 products={products}
             />
-            <Pagination
-                isWithLoadMore
-                hasNextPage={hasNextPage}
-                paginationScrollTargetRef={paginationScrollTargetRef}
-                totalCount={category.products.totalCount}
-            />
+            <Pagination isWithLoadMore hasNextPage={hasNextPage} totalCount={category.products.totalCount} />
         </>
     );
 };

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailProductsWrapper/DeferredCategoryDetailProductsWrapper.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailProductsWrapper/DeferredCategoryDetailProductsWrapper.tsx
@@ -6,15 +6,9 @@ import { useProductsData } from 'utils/loadMore/useProductsData';
 import { getMappedProducts } from 'utils/mappers/products';
 import { useDeferredRender } from 'utils/useDeferredRender';
 
-type DeferredCategoryDetailProductsWrapperProps = Pick<
-    CategoryDetailProductsWrapperProps,
-    'category' | 'paginationScrollTargetRef'
->;
+type DeferredCategoryDetailProductsWrapperProps = Pick<CategoryDetailProductsWrapperProps, 'category'>;
 
-export const DeferredCategoryDetailProductsWrapper: FC<DeferredCategoryDetailProductsWrapperProps> = ({
-    category,
-    paginationScrollTargetRef,
-}) => {
+export const DeferredCategoryDetailProductsWrapper: FC<DeferredCategoryDetailProductsWrapperProps> = ({ category }) => {
     const wasRedirectedToSeoCategory = useSessionStore((s) => s.wasRedirectedToSeoCategory);
     const setWasRedirectedToSeoCategory = useSessionStore((s) => s.setWasRedirectedToSeoCategory);
     const { products, areProductsFetching, hasNextPage, isLoadingMoreProducts } = useProductsData(
@@ -34,7 +28,6 @@ export const DeferredCategoryDetailProductsWrapper: FC<DeferredCategoryDetailPro
             category={category}
             hasNextPage={hasNextPage}
             isLoadingMoreProducts={isLoadingMoreProducts}
-            paginationScrollTargetRef={paginationScrollTargetRef}
             products={mappedProducts}
         />
     ) : (

--- a/project-base/storefront/components/Pages/Customer/Complaints/ComplaintsContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/Complaints/ComplaintsContent.tsx
@@ -2,6 +2,7 @@ import { ComplaintItem } from './ComplaintItem';
 import { InfoIcon } from 'components/Basic/Icon/InfoIcon';
 import { Pagination } from 'components/Blocks/Pagination/Pagination';
 import { SkeletonModuleCustomerComplaints } from 'components/Blocks/Skeleton/SkeletonModuleCustomerComplaints';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { TypeComplaintDetailFragment } from 'graphql/requests/complaints/fragments/ComplaintDetailFragment.generated';
 import useTranslation from 'next-translate/useTranslation';
 import { useRef } from 'react';
@@ -37,7 +38,9 @@ export const ComplaintsContent: FC<ComplaintsContentProps> = ({ isFetching, item
                 ))}
             </div>
 
-            <Pagination paginationScrollTargetRef={paginationScrollTargetRef} totalCount={totalCount || 0} />
+            <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                <Pagination totalCount={totalCount || 0} />
+            </PaginationProvider>
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/Customer/OrderedItems/OrderedItemsContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/OrderedItems/OrderedItemsContent.tsx
@@ -2,6 +2,7 @@ import { OrderedItem } from './OrderedItem';
 import { InfoIcon } from 'components/Basic/Icon/InfoIcon';
 import { Pagination } from 'components/Blocks/Pagination/Pagination';
 import { SkeletonModuleCustomerComplaints } from 'components/Blocks/Skeleton/SkeletonModuleCustomerComplaints';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { TypeOrderDetailItemFragment } from 'graphql/requests/orders/fragments/OrderDetailItemFragment.generated';
 import useTranslation from 'next-translate/useTranslation';
 import { useRef } from 'react';
@@ -36,7 +37,9 @@ export const OrderedItemsContent: FC<OrderedItemsContentProps> = ({ isFetching, 
                     <OrderedItem key={item.uuid} orderedItem={item} />
                 ))}
             </div>
-            <Pagination paginationScrollTargetRef={paginationScrollTargetRef} totalCount={totalCount || 0} />
+            <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                <Pagination totalCount={totalCount || 0} />
+            </PaginationProvider>
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/Customer/Orders/OrdersContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/Orders/OrdersContent.tsx
@@ -2,6 +2,7 @@ import { OrderItem } from './OrderItem';
 import { InfoIcon } from 'components/Basic/Icon/InfoIcon';
 import { Pagination } from 'components/Blocks/Pagination/Pagination';
 import { SkeletonModuleCustomerOrders } from 'components/Blocks/Skeleton/SkeletonModuleCustomerOrders';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { DEFAULT_ORDERS_SIZE } from 'config/constants';
 import { TypeListedOrderFragment } from 'graphql/requests/orders/fragments/ListedOrderFragment.generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -44,12 +45,9 @@ export const OrdersContent: FC<OrdersContentProps> = ({ areOrdersFetching, order
                 />
             ))}
 
-            <Pagination
-                hasNextPage={hasNextPage}
-                pageSize={DEFAULT_ORDERS_SIZE}
-                paginationScrollTargetRef={paginationScrollTargetRef}
-                totalCount={totalCount || 0}
-            />
+            <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                <Pagination hasNextPage={hasNextPage} pageSize={DEFAULT_ORDERS_SIZE} totalCount={totalCount || 0} />
+            </PaginationProvider>
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/FlagDetail/FlagDetailContent.tsx
+++ b/project-base/storefront/components/Pages/FlagDetail/FlagDetailContent.tsx
@@ -6,6 +6,7 @@ import { LastVisitedProducts } from 'components/Blocks/Product/LastVisitedProduc
 import { DeferredFilterAndSortingBar } from 'components/Blocks/SortingBar/DeferredFilterAndSortingBar';
 import { VerticalStack } from 'components/Layout/VerticalStack/VerticalStack';
 import { Webline } from 'components/Layout/Webline/Webline';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { TypeFlagDetailFragment } from 'graphql/requests/flags/fragments/FlagDetailFragment.generated';
 import { useRef } from 'react';
 import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
@@ -47,7 +48,9 @@ export const FlagDetailContent: FC<FlagDetailContentProps> = ({ flag }) => {
                         />
                     </div>
 
-                    <FlagDetailProductsWrapper flag={flag} paginationScrollTargetRef={paginationScrollTargetRef} />
+                    <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                        <FlagDetailProductsWrapper flag={flag} />
+                    </PaginationProvider>
                 </div>
             </FilteredProductsWrapper>
 

--- a/project-base/storefront/components/Pages/FlagDetail/FlagDetailProductsWrapper.tsx
+++ b/project-base/storefront/components/Pages/FlagDetail/FlagDetailProductsWrapper.tsx
@@ -5,16 +5,14 @@ import { FlagProductsQueryDocument } from 'graphql/requests/products/queries/Fla
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
 import { useGtmPaginatedProductListViewEvent } from 'gtm/utils/pageViewEvents/productList/useGtmPaginatedProductListViewEvent';
-import { RefObject } from 'react';
 import { useProductsData } from 'utils/loadMore/useProductsData';
 import { getMappedProducts } from 'utils/mappers/products';
 
 type FlagDetailProductsWrapperProps = {
     flag: TypeFlagDetailFragment;
-    paginationScrollTargetRef: RefObject<HTMLDivElement>;
 };
 
-export const FlagDetailProductsWrapper: FC<FlagDetailProductsWrapperProps> = ({ flag, paginationScrollTargetRef }) => {
+export const FlagDetailProductsWrapper: FC<FlagDetailProductsWrapperProps> = ({ flag }) => {
     const { products, areProductsFetching, hasNextPage, isLoadingMoreProducts } = useProductsData(
         FlagProductsQueryDocument,
         flag.products.totalCount,
@@ -32,12 +30,8 @@ export const FlagDetailProductsWrapper: FC<FlagDetailProductsWrapperProps> = ({ 
                 isLoadingMoreProducts={isLoadingMoreProducts}
                 products={flagListedProducts}
             />
-            <Pagination
-                isWithLoadMore
-                hasNextPage={hasNextPage}
-                paginationScrollTargetRef={paginationScrollTargetRef}
-                totalCount={flag.products.totalCount}
-            />
+
+            <Pagination isWithLoadMore hasNextPage={hasNextPage} totalCount={flag.products.totalCount} />
         </>
     );
 };

--- a/project-base/storefront/components/Pages/Search/SearchProducts.tsx
+++ b/project-base/storefront/components/Pages/Search/SearchProducts.tsx
@@ -6,6 +6,7 @@ import { FilterSelectedParameters } from 'components/Blocks/Product/Filter/Filte
 import { DeferredFilterAndSortingBar } from 'components/Blocks/SortingBar/DeferredFilterAndSortingBar';
 import { Webline } from 'components/Layout/Webline/Webline';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { TypeProductOrderingModeEnum } from 'graphql/types';
 import useTranslation from 'next-translate/useTranslation';
 import { useRef } from 'react';
@@ -54,12 +55,13 @@ export const SearchProducts: FC = () => {
                         />
                     </div>
 
-                    <SearchProductsContent
-                        areSearchProductsFetching={areSearchProductsFetching}
-                        isLoadingMoreSearchProducts={isLoadingMoreSearchProducts}
-                        paginationScrollTargetRef={paginationScrollTargetRef}
-                        searchProductsData={searchProductsData}
-                    />
+                    <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                        <SearchProductsContent
+                            areSearchProductsFetching={areSearchProductsFetching}
+                            isLoadingMoreSearchProducts={isLoadingMoreSearchProducts}
+                            searchProductsData={searchProductsData}
+                        />
+                    </PaginationProvider>
                 </div>
             </FilteredProductsWrapper>
         </div>

--- a/project-base/storefront/components/Pages/Search/SearchProductsContent.tsx
+++ b/project-base/storefront/components/Pages/Search/SearchProductsContent.tsx
@@ -8,21 +8,18 @@ import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
 import { useGtmPaginatedProductListViewEvent } from 'gtm/utils/pageViewEvents/productList/useGtmPaginatedProductListViewEvent';
 import Trans from 'next-translate/Trans';
 import useTranslation from 'next-translate/useTranslation';
-import { RefObject } from 'react';
 import { createEmptyArray } from 'utils/arrays/createEmptyArray';
 import { getMappedProducts } from 'utils/mappers/products';
 
 type SearchProductsContentProps = {
     areSearchProductsFetching: boolean;
     isLoadingMoreSearchProducts: boolean;
-    paginationScrollTargetRef: RefObject<HTMLDivElement>;
     searchProductsData: TypeSearchProductsQuery['productsSearch'];
 };
 
 export const SearchProductsContent: FC<SearchProductsContentProps> = ({
     areSearchProductsFetching,
     isLoadingMoreSearchProducts,
-    paginationScrollTargetRef,
     searchProductsData,
 }) => {
     const { t } = useTranslation();
@@ -81,7 +78,6 @@ export const SearchProductsContent: FC<SearchProductsContentProps> = ({
             <Pagination
                 isWithLoadMore
                 hasNextPage={searchProductsData.pageInfo.hasNextPage}
-                paginationScrollTargetRef={paginationScrollTargetRef}
                 totalCount={searchProductsData.totalCount}
             />
         </>

--- a/project-base/storefront/components/providers/PaginationProvider.tsx
+++ b/project-base/storefront/components/providers/PaginationProvider.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+import { RefObject } from 'react';
+
+type PaginationContextType = {
+    paginationScrollTargetRef: RefObject<HTMLDivElement> | null;
+};
+export const PaginationContext = createContext<PaginationContextType | null>(null);
+
+type PaginationProviderProps = {
+    paginationScrollTargetRef: RefObject<HTMLDivElement> | null;
+};
+
+export const PaginationProvider: FC<PaginationProviderProps> = ({ paginationScrollTargetRef, children }) => {
+    return <PaginationContext.Provider value={{ paginationScrollTargetRef }}>{children}</PaginationContext.Provider>;
+};
+
+export const usePaginationContext = () => {
+    const paginationContext = useContext(PaginationContext);
+
+    if (!paginationContext) {
+        throw new Error(`usePaginationContext must be use within PaginationProvider`);
+    }
+
+    return paginationContext;
+};

--- a/project-base/storefront/config/constants.ts
+++ b/project-base/storefront/config/constants.ts
@@ -4,6 +4,9 @@ export const DEFAULT_PAGE_SIZE = 28;
 export const DEFAULT_ORDERS_SIZE = 28;
 export const DEFAULT_BLOG_PAGE_SIZE = 6;
 export const DEFAULT_SORT = TypeProductOrderingModeEnum.Priority as const;
+// Align PRODUCT_LIST_LIMIT with the API limit
+export const PRODUCT_LIST_LIMIT = 100;
+
 /**
  * For those that are set to "true", we optimistically navigate out from a SEO category when a value of that type is changed
  * This setting needs to mirror the API functionality in the following way

--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -131,10 +131,13 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            const [brandDetailResponse] = await Promise.all([brandDetailResponsePromise, brandProductsResponsePromise]);
+            const [brandDetailResponse, brandProductsResponse] = await Promise.all([
+                brandDetailResponsePromise,
+                brandProductsResponsePromise,
+            ]);
 
             if (getIsRedirectedFromSsr(context.req.headers)) {
-                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                const serverSideBrandDetailErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     brandDetailResponse.error,
                     brandDetailResponse.data?.brand,
                     context.res,
@@ -142,8 +145,20 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     urlSlug,
                 );
 
-                if (serverSideErrorResponse) {
-                    return serverSideErrorResponse;
+                if (serverSideBrandDetailErrorResponse) {
+                    return serverSideBrandDetailErrorResponse;
+                }
+
+                const serverSideBrandProductsErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    brandProductsResponse.error,
+                    brandProductsResponse.data?.products,
+                    context.res,
+                    domainConfig.url,
+                    urlSlug,
+                );
+
+                if (serverSideBrandProductsErrorResponse) {
+                    return serverSideBrandProductsErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -116,7 +116,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            const [categoryDetailResponse] = await Promise.all([
+            const [categoryDetailResponse, categoryProductsResponse] = await Promise.all([
                 categoryDetailResponsePromise,
                 categoryProductsResponsePromise,
             ]);
@@ -124,7 +124,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
             categoryUuid = categoryDetailResponse.data?.category?.uuid || null;
 
             if (getIsRedirectedFromSsr(context.req.headers)) {
-                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                const serverSideCategoryDetailErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     categoryDetailResponse.error,
                     categoryDetailResponse.data?.category,
                     context.res,
@@ -132,8 +132,20 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     urlSlug,
                 );
 
-                if (serverSideErrorResponse) {
-                    return serverSideErrorResponse;
+                if (serverSideCategoryDetailErrorResponse) {
+                    return serverSideCategoryDetailErrorResponse;
+                }
+
+                const serverSideCategoryProductsErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    categoryProductsResponse.error,
+                    categoryProductsResponse.data?.products,
+                    context.res,
+                    domainConfig.url,
+                    urlSlug,
+                );
+
+                if (serverSideCategoryProductsErrorResponse) {
+                    return serverSideCategoryProductsErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -119,10 +119,13 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            const [flagDetailResponse] = await Promise.all([flagDetailResponsePromise, flagProductsResponsePromise]);
+            const [flagDetailResponse, flagProductsResponse] = await Promise.all([
+                flagDetailResponsePromise,
+                flagProductsResponsePromise,
+            ]);
 
             if (getIsRedirectedFromSsr(context.req.headers)) {
-                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                const serverSideFlagDetailErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     flagDetailResponse.error,
                     flagDetailResponse.data?.flag,
                     context.res,
@@ -130,8 +133,20 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     urlSlug,
                 );
 
-                if (serverSideErrorResponse) {
-                    return serverSideErrorResponse;
+                if (serverSideFlagDetailErrorResponse) {
+                    return serverSideFlagDetailErrorResponse;
+                }
+
+                const serverSideFlagProductsErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    flagProductsResponse.error,
+                    flagProductsResponse.data?.products,
+                    context.res,
+                    domainConfig.url,
+                    urlSlug,
+                );
+
+                if (serverSideFlagProductsErrorResponse) {
+                    return serverSideFlagProductsErrorResponse;
                 }
             }
 

--- a/project-base/storefront/utils/loadMore/getOffsetPage.ts
+++ b/project-base/storefront/utils/loadMore/getOffsetPage.ts
@@ -1,0 +1,12 @@
+export const getOffsetPage = (currentPage: number, currentLoadMore: number) => {
+    const offsetPage = currentPage + currentLoadMore;
+
+    if (offsetPage === currentPage) {
+        return undefined;
+    }
+
+    return {
+        updatedPage: offsetPage,
+        updatedLoadMore: 0,
+    };
+};

--- a/project-base/storefront/utils/loadMore/getOffsetPageAndLoadMore.ts
+++ b/project-base/storefront/utils/loadMore/getOffsetPageAndLoadMore.ts
@@ -1,14 +1,13 @@
 import { calculatePageSize } from './calculatePageSize';
-import { DEFAULT_PAGE_SIZE } from 'config/constants';
-
-const PRODUCT_LIST_LIMIT = 310;
+import { DEFAULT_PAGE_SIZE, PRODUCT_LIST_LIMIT } from 'config/constants';
 
 export const getOffsetPageAndLoadMore = (
     currentPage: number,
     currentLoadMore: number,
     pageSize = DEFAULT_PAGE_SIZE,
+    productListLimit = PRODUCT_LIST_LIMIT,
 ) => {
-    const loadedProductsDifference = calculatePageSize(currentLoadMore, pageSize) - PRODUCT_LIST_LIMIT;
+    const loadedProductsDifference = calculatePageSize(currentLoadMore, pageSize) - productListLimit;
 
     if (loadedProductsDifference <= 0) {
         return undefined;

--- a/project-base/storefront/utils/loadMore/getRedirectWithOffsetPage.ts
+++ b/project-base/storefront/utils/loadMore/getRedirectWithOffsetPage.ts
@@ -1,9 +1,9 @@
 import { getOffsetPageAndLoadMore } from './getOffsetPageAndLoadMore';
-import { DEFAULT_PAGE_SIZE } from 'config/constants';
+import { DEFAULT_PAGE_SIZE, PRODUCT_LIST_LIMIT } from 'config/constants';
 import { Redirect } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import { getUrlQueriesWithoutDynamicPageQueries } from 'utils/parsing/getUrlQueriesWithoutDynamicPageQueries';
-import { PAGE_QUERY_PARAMETER_NAME, LOAD_MORE_QUERY_PARAMETER_NAME } from 'utils/queryParamNames';
+import { LOAD_MORE_QUERY_PARAMETER_NAME, PAGE_QUERY_PARAMETER_NAME } from 'utils/queryParamNames';
 
 export const getRedirectWithOffsetPage = (
     currentPage: number,
@@ -11,8 +11,9 @@ export const getRedirectWithOffsetPage = (
     currentSlug: string,
     currentQuery: ParsedUrlQuery,
     pageSize = DEFAULT_PAGE_SIZE,
+    productListLimit = PRODUCT_LIST_LIMIT,
 ): { redirect: Redirect } | undefined => {
-    const updatedQueries = getOffsetPageAndLoadMore(currentPage, currentLoadMore, pageSize);
+    const updatedQueries = getOffsetPageAndLoadMore(currentPage, currentLoadMore, pageSize, productListLimit);
 
     if (!updatedQueries) {
         return undefined;

--- a/project-base/storefront/utils/loadMore/getRedirectWithOffsetPage.ts
+++ b/project-base/storefront/utils/loadMore/getRedirectWithOffsetPage.ts
@@ -1,5 +1,4 @@
-import { getOffsetPageAndLoadMore } from './getOffsetPageAndLoadMore';
-import { DEFAULT_PAGE_SIZE, PRODUCT_LIST_LIMIT } from 'config/constants';
+import { getOffsetPage } from './getOffsetPage';
 import { Redirect } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import { getUrlQueriesWithoutDynamicPageQueries } from 'utils/parsing/getUrlQueriesWithoutDynamicPageQueries';
@@ -10,10 +9,8 @@ export const getRedirectWithOffsetPage = (
     currentLoadMore: number,
     currentSlug: string,
     currentQuery: ParsedUrlQuery,
-    pageSize = DEFAULT_PAGE_SIZE,
-    productListLimit = PRODUCT_LIST_LIMIT,
 ): { redirect: Redirect } | undefined => {
-    const updatedQueries = getOffsetPageAndLoadMore(currentPage, currentLoadMore, pageSize, productListLimit);
+    const updatedQueries = getOffsetPage(currentPage, currentLoadMore);
 
     if (!updatedQueries) {
         return undefined;

--- a/project-base/storefront/utils/ui/useScrollRestoration.ts
+++ b/project-base/storefront/utils/ui/useScrollRestoration.ts
@@ -1,0 +1,54 @@
+import { useRouter } from 'next/router';
+import { RefObject, useEffect, useRef } from 'react';
+
+type MutuallyExcludedProps = {
+    scrollTargetRef: RefObject<HTMLDivElement> | null;
+    scrollY: number;
+};
+
+type PickOne<T, F extends keyof T> = Pick<T, F> & { [K in keyof Omit<T, F>]?: never };
+
+type ScrollRestorationProps<E> = (E extends keyof MutuallyExcludedProps ? PickOne<MutuallyExcludedProps, E> : never) & {
+    shouldScroll: boolean;
+};
+
+export const useScrollRestoration = <E extends keyof MutuallyExcludedProps>({
+    scrollTargetRef,
+    scrollY,
+    shouldScroll,
+}: ScrollRestorationProps<E>) => {
+    const router = useRouter();
+    const scrollRestored = useRef(false);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            if (shouldScroll && !scrollRestored.current) {
+                scrollRestored.current = true;
+
+                if (window.scrollY === 0) {
+                    if (scrollTargetRef?.current) {
+                        scrollTargetRef.current.scrollIntoView({ behavior: 'smooth' });
+                    }
+
+                    if (scrollY && scrollY > 0) {
+                        window.scrollTo({
+                            top: scrollY,
+                            behavior: 'smooth',
+                        });
+                    }
+                }
+            }
+        }, 100); // Small delay to let Next.js restore scroll first
+
+        const handleRouteChange = () => {
+            scrollRestored.current = false;
+        };
+
+        router.events.on('routeChangeStart', handleRouteChange);
+
+        return () => {
+            clearTimeout(timer);
+            router.events.off('routeChangeStart', handleRouteChange);
+        };
+    }, [router]);
+};

--- a/project-base/storefront/vitest/utils/pagination/loadMore.test.ts
+++ b/project-base/storefront/vitest/utils/pagination/loadMore.test.ts
@@ -2,6 +2,8 @@ import { DEFAULT_PAGE_SIZE } from 'config/constants';
 import { CategoryProductsQueryDocument } from 'graphql/requests/products/queries/CategoryProductsQuery.generated';
 import { TypeProductOrderingModeEnum } from 'graphql/types';
 import { stringify } from 'querystring';
+import { UrlQueries } from 'types/urlQueries';
+import { getOffsetPage } from 'utils/loadMore/getOffsetPage';
 import { getOffsetPageAndLoadMore } from 'utils/loadMore/getOffsetPageAndLoadMore';
 import { getPreviousProductsFromCache } from 'utils/loadMore/getPreviousProductsFromCache';
 import { getRedirectWithOffsetPage } from 'utils/loadMore/getRedirectWithOffsetPage';
@@ -106,29 +108,88 @@ describe('getPreviouslyQueriedProductsFromCache tests', () => {
 
 describe('getOffsetPageAndLoadMore tests', () => {
     test('loading a valid number of products does not offset the page', () => {
-        expect(getOffsetPageAndLoadMore(2, 10)).toBe(undefined);
-
-        expect(getOffsetPageAndLoadMore(1, 10)).toBe(undefined);
-
         expect(getOffsetPageAndLoadMore(1, 0)).toBe(undefined);
 
+        expect(getOffsetPageAndLoadMore(1, 1)).toBe(undefined);
+
+        expect(getOffsetPageAndLoadMore(1, 2)).toBe(undefined);
+
         expect(getOffsetPageAndLoadMore(1, 1, 50)).toBe(undefined);
+
+        expect(getOffsetPageAndLoadMore(2, 10, undefined, 310)).toBe(undefined);
+
+        expect(getOffsetPageAndLoadMore(2, 10, undefined, 310)).toBe(undefined);
+
+        expect(getOffsetPageAndLoadMore(1, 10, undefined, 310)).toBe(undefined);
     });
 
     test('loading too many products offsets the page', () => {
-        expect(getOffsetPageAndLoadMore(2, 11)).toStrictEqual({
-            updatedPage: 3,
-            updatedLoadMore: 10,
+        expect(getOffsetPageAndLoadMore(1, 3)).toStrictEqual({
+            updatedPage: 2,
+            updatedLoadMore: 2,
         });
 
-        expect(getOffsetPageAndLoadMore(1, 11)).toStrictEqual({
+        expect(getOffsetPageAndLoadMore(1, 10)).toStrictEqual({
+            updatedPage: 9,
+            updatedLoadMore: 2,
+        });
+
+        expect(getOffsetPageAndLoadMore(2, 10, 50)).toStrictEqual({
+            updatedPage: 11,
+            updatedLoadMore: 1,
+        });
+
+        expect(getOffsetPageAndLoadMore(2, 10, 50, 310)).toStrictEqual({
+            updatedPage: 7,
+            updatedLoadMore: 5,
+        });
+
+        expect(getOffsetPageAndLoadMore(1, 11, undefined, 310)).toStrictEqual({
             updatedPage: 2,
             updatedLoadMore: 10,
         });
 
-        expect(getOffsetPageAndLoadMore(2, 10, 50)).toStrictEqual({
-            updatedPage: 7,
-            updatedLoadMore: 5,
+        expect(getOffsetPageAndLoadMore(2, 11, undefined, 310)).toStrictEqual({
+            updatedPage: 3,
+            updatedLoadMore: 10,
+        });
+    });
+});
+
+describe('getOffsetPage tests', () => {
+    test('loading a valid number of products does not offset the page', () => {
+        expect(getOffsetPage(1, 0)).toBe(undefined);
+    });
+
+    test('loading too many products offsets the page', () => {
+        expect(getOffsetPage(1, 1)).toStrictEqual({
+            updatedPage: 2,
+            updatedLoadMore: 0,
+        });
+
+        expect(getOffsetPage(1, 2)).toStrictEqual({
+            updatedPage: 3,
+            updatedLoadMore: 0,
+        });
+
+        expect(getOffsetPage(2, 2)).toStrictEqual({
+            updatedPage: 4,
+            updatedLoadMore: 0,
+        });
+
+        expect(getOffsetPage(2, 10)).toStrictEqual({
+            updatedPage: 12,
+            updatedLoadMore: 0,
+        });
+
+        expect(getOffsetPage(1, 11)).toStrictEqual({
+            updatedPage: 12,
+            updatedLoadMore: 0,
+        });
+
+        expect(getOffsetPage(2, 11)).toStrictEqual({
+            updatedPage: 13,
+            updatedLoadMore: 0,
         });
     });
 });
@@ -136,30 +197,10 @@ describe('getOffsetPageAndLoadMore tests', () => {
 describe('getRedirectWithOffsetPage tests', () => {
     test('loading a valid number of products does not redirect the page', () => {
         expect(
-            getRedirectWithOffsetPage(2, 10, '/my-url', {
-                [PAGE_QUERY_PARAMETER_NAME]: '2',
-                [LOAD_MORE_QUERY_PARAMETER_NAME]: '10',
+            getRedirectWithOffsetPage(1, 0, '/my-url', {
+                [PAGE_QUERY_PARAMETER_NAME]: '1',
+                [LOAD_MORE_QUERY_PARAMETER_NAME]: '0',
             }),
-        ).toBe(undefined);
-
-        expect(
-            getRedirectWithOffsetPage(1, 10, '/my-url', {
-                [LOAD_MORE_QUERY_PARAMETER_NAME]: '10',
-            }),
-        ).toBe(undefined);
-
-        expect(getRedirectWithOffsetPage(1, 0, '/my-url', {})).toBe(undefined);
-
-        expect(
-            getRedirectWithOffsetPage(
-                1,
-                1,
-                '/my-url',
-                {
-                    [LOAD_MORE_QUERY_PARAMETER_NAME]: '1',
-                },
-                50,
-            ),
         ).toBe(undefined);
     });
 
@@ -171,7 +212,7 @@ describe('getRedirectWithOffsetPage tests', () => {
             }),
         ).toStrictEqual({
             redirect: {
-                destination: '/my-url?page=3&lm=10',
+                destination: '/my-url?page=13',
                 permanent: false,
             },
         });
@@ -182,38 +223,26 @@ describe('getRedirectWithOffsetPage tests', () => {
             }),
         ).toStrictEqual({
             redirect: {
-                destination: '/my-url?lm=10&page=2',
+                destination: '/my-url?page=12',
                 permanent: false,
             },
         });
 
         expect(
-            getRedirectWithOffsetPage(
-                2,
-                10,
-                '/my-url',
-                {
-                    [LOAD_MORE_QUERY_PARAMETER_NAME]: '11',
-                },
-                50,
-            ),
+            getRedirectWithOffsetPage(2, 10, '/my-url', {
+                [LOAD_MORE_QUERY_PARAMETER_NAME]: '11',
+            }),
         ).toStrictEqual({
             redirect: {
-                destination: '/my-url?lm=5&page=7',
+                destination: '/my-url?page=12',
                 permanent: false,
             },
         });
 
         expect(
-            getRedirectWithOffsetPage(
-                2,
-                10,
-                '/my-url',
-                {
-                    [LOAD_MORE_QUERY_PARAMETER_NAME]: '11',
-                },
-                310,
-            ),
+            getRedirectWithOffsetPage(2, 10, '/my-url', {
+                [LOAD_MORE_QUERY_PARAMETER_NAME]: '11',
+            }),
         ).toStrictEqual({
             redirect: {
                 destination: '/my-url?page=12',
@@ -223,7 +252,7 @@ describe('getRedirectWithOffsetPage tests', () => {
     });
 
     test('redirecting correctly keeps other query parameters if both page and load more are kept', () => {
-        const currentQueryWithoutDynamicPageQuery = {
+        const currentQueryWithoutDynamicPageQuery: UrlQueries = {
             [PAGE_QUERY_PARAMETER_NAME]: '2',
             [LOAD_MORE_QUERY_PARAMETER_NAME]: '11',
             [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -251,8 +280,8 @@ describe('getRedirectWithOffsetPage tests', () => {
             categorySlug: '/category-url',
         };
 
-        currentQueryWithoutDynamicPageQuery[PAGE_QUERY_PARAMETER_NAME] = '3';
-        currentQueryWithoutDynamicPageQuery[LOAD_MORE_QUERY_PARAMETER_NAME] = '10';
+        currentQueryWithoutDynamicPageQuery[PAGE_QUERY_PARAMETER_NAME] = '13';
+        delete currentQueryWithoutDynamicPageQuery[LOAD_MORE_QUERY_PARAMETER_NAME];
 
         expect(getRedirectWithOffsetPage(2, 11, '/my-url', currentQuery)).toStrictEqual({
             redirect: {
@@ -292,7 +321,7 @@ describe('getRedirectWithOffsetPage tests', () => {
 
         currentQueryWithoutDynamicPageAndLoadMoreQuery[PAGE_QUERY_PARAMETER_NAME] = '13';
 
-        expect(getRedirectWithOffsetPage(2, 11, '/my-url', currentQuery, 310)).toStrictEqual({
+        expect(getRedirectWithOffsetPage(2, 11, '/my-url', currentQuery)).toStrictEqual({
             redirect: {
                 destination: `/my-url?${stringify(currentQueryWithoutDynamicPageAndLoadMoreQuery)}`,
                 permanent: false,

--- a/upgrade-notes/storefront_20250513_175616.md
+++ b/upgrade-notes/storefront_20250513_175616.md
@@ -1,0 +1,17 @@
+#### Fix product list limit ([#3977](https://github.com/shopsys/shopsys/pull/3977))
+
+- fix load more causing API error
+- fix ssr error handeling in case of API limit error response (defaults to `404` now) for `category`, `brand` and `flag` detail pages
+- fix tests
+- note that changing `PRODUCT_LIST_LIMIT` needs to be aligned with `maxAllowedItems` prop in `PageSizeValidator.php` to prevent API rejecting the request due to exceeding maximum allowed limit
+- refactored `paginationScrollRef` from prop drilling to `PaginationProvider` and accessing it via `usePaginationContext`
+- refactored `getRedirectWithOffsetPage` to use `getOffsetPage`
+  - this function just cuts off any loadmore and add it to current page
+  - that means we just redirect user to the last loaded page
+- improved UX of scroll restoration in case of offsetting page
+  - custom hook `useScrollRestoration` was implemented
+  - developer can specify `scrollTargetRef` or `scrollY` position to scroll into
+  - because of the page offset, the next router had no state for scroll position restoration
+  - in this case we simply scroll under the sort bar
+
+- see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20250513_175616.md
+++ b/upgrade-notes/storefront_20250513_175616.md
@@ -6,12 +6,13 @@
 - note that changing `PRODUCT_LIST_LIMIT` needs to be aligned with `maxAllowedItems` prop in `PageSizeValidator.php` to prevent API rejecting the request due to exceeding maximum allowed limit
 - refactored `paginationScrollRef` from prop drilling to `PaginationProvider` and accessing it via `usePaginationContext`
 - refactored `getRedirectWithOffsetPage` to use `getOffsetPage`
-  - this function just cuts off any loadmore and add it to current page
-  - that means we just redirect user to the last loaded page
+    - this function just cuts off any loadmore and add it to current page
+    - that means we just redirect user to the last loaded page
 - improved UX of scroll restoration in case of offsetting page
-  - custom hook `useScrollRestoration` was implemented
-  - developer can specify `scrollTargetRef` or `scrollY` position to scroll into
-  - because of the page offset, the next router had no state for scroll position restoration
-  - in this case we simply scroll under the sort bar
+
+    - custom hook `useScrollRestoration` was implemented
+    - developer can specify `scrollTargetRef` or `scrollY` position to scroll into
+    - because of the page offset, the next router had no state for scroll position restoration
+    - in this case we simply scroll under the sort bar
 
 - see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
In this PR I have fixed product list limit that was causing an error from API that exceeded limit of allowed products to be fetched.

I have aligned this limit to match the one in the API and also enhanced error handeling in case these values don't match again in the future. The default 404 page is displayed instead of endless product loading skeletons.

Also tests were fixed to match the new `PRODUCT_LIST_LIMIT` value.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-fix-load-more-ssp-3313.odin.shopsys.cloud
  - https://cz.jm-fix-load-more-ssp-3313.odin.shopsys.cloud
<!-- Replace -->
