### PR TITLE
removed all not necessary position settings from framework form types

### DIFF
--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -79,14 +79,13 @@ class CustomerUserFormType extends AbstractType
                 'label' => t('ID'),
                 'data' => $this->customerUser->getId(),
             ]);
-            $builderSystemDataGroup->add('domainIcon', DisplayOnlyDomainIconType::class, [
-                'label' => t('Domain'),
-                'data' => $this->customerUser->getDomainId(),
-            ]);
             $builderSystemDataGroup->add('activated', DisplayOnlyType::class, [
                 'label' => t('Active'),
                 'data' => $this->customerUser->isActivated() ? t('Yes') : t('No'),
-                'position' => ['after' => 'formId'],
+            ]);
+            $builderSystemDataGroup->add('domainIcon', DisplayOnlyDomainIconType::class, [
+                'label' => t('Domain'),
+                'data' => $this->customerUser->getDomainId(),
             ]);
             $pricingGroups = $this->pricingGroupFacade->getByDomainId($this->customerUser->getDomainId());
         } else {
@@ -181,7 +180,16 @@ class CustomerUserFormType extends AbstractType
                     new Constraints\Callback([$this, 'validateUniqueEmail']),
                 ],
                 'label' => t('Email'),
-            ])
+            ]);
+
+        if ($this->customerUser === null) {
+            $builderPersonalDataGroup->add('sendRegistrationMail', CheckboxType::class, [
+                'required' => false,
+                'label' => t('Send confirmation email about registration to customer'),
+            ]);
+        }
+
+        $builderPersonalDataGroup
             ->add('telephone', TextType::class, [
                 'required' => false,
                 'constraints' => [
@@ -192,15 +200,6 @@ class CustomerUserFormType extends AbstractType
                 ],
                 'label' => t('Telephone'),
             ]);
-
-        if ($this->customerUser === null) {
-            $builderPersonalDataGroup->add('sendRegistrationMail', CheckboxType::class, [
-                'required' => false,
-                'label' => t('Send confirmation email about registration to customer'),
-                'position' => ['after' => 'email'],
-            ]);
-        }
-
 
         if ($this->customerUser instanceof CustomerUser) {
             $builderSystemDataGroup->add('createdAt', DisplayOnlyType::class, [

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -88,11 +88,19 @@ class PaymentFormType extends AbstractType
             ->add('enabled', DomainsType::class, [
                 'required' => false,
                 'label' => t('Display on'),
-            ])
-            ->add('hidden', YesNoType::class, [
-                'required' => false,
-                'label' => t('Hidden'),
-            ])
+            ]);
+
+        if ($payment !== null) {
+            $this->addHiddenByGoPayWarning(
+                $options['data'],
+                $builderBasicInformationGroup,
+            );
+        }
+
+        $builderBasicInformationGroup->add('hidden', YesNoType::class, [
+            'required' => false,
+            'label' => t('Hidden'),
+        ])
             ->add('transports', ChoiceType::class, [
                 'required' => false,
                 'choices' => $this->transportFacade->getAll(),
@@ -136,13 +144,6 @@ class PaymentFormType extends AbstractType
                     'class' => 'js-payment-gopay-payment-method',
                 ],
             ]);
-
-        if ($payment !== null) {
-            $this->addHiddenByGoPayWarning(
-                $options['data'],
-                $builderBasicInformationGroup,
-            );
-        }
 
         $builderPriceGroup = $builder->create('prices', GroupType::class, [
             'label' => t('Prices'),
@@ -305,7 +306,6 @@ class PaymentFormType extends AbstractType
             'data' => t('This payment method is hidden by GoPay on domains: %domains%', [
                 '%domains%' => implode(', ', $domainNames),
             ]),
-            'position' => ['after' => 'enabled'],
         ]);
     }
 }

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
@@ -69,7 +69,12 @@ class PromoCodeFormType extends AbstractType
     {
         $this->promoCode = $options['promo_code'];
 
-        $this->buildBaseGroup($builder);
+        if ($options['mass_generate']) {
+            $builder->add($this->addMassGenerationGroup($builder));
+            $builder->remove('code');
+        }
+
+        $this->buildBaseGroup($builder, $options);
         $this->buildLimitsFormGroup($builder);
         $this->buildTimeValidationFormGroup($builder);
         $this->buildFlagsFormGroup($builder);
@@ -84,9 +89,6 @@ class PromoCodeFormType extends AbstractType
         ]);
 
         if ($options['mass_generate']) {
-            $builder->add($this->addMassGenerationGroup($builder));
-            $builder->remove('code');
-
             $actionBar->add('saveAndDownloadCsv', SubmitType::class, [
                 'label' => t('Create and download CSV'),
                 'position' => [
@@ -100,22 +102,33 @@ class PromoCodeFormType extends AbstractType
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array $options
      */
-    private function buildBaseGroup(FormBuilderInterface $builder): void
+    private function buildBaseGroup(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('code', TextType::class, [
-                'label' => t('Promo code'),
-                'required' => true,
-                'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter promo code',
-                    ]),
-                ],
-            ])
-            ->add('domainId', HiddenType::class, [
-                'data' => $this->getDomainId(),
-            ])
+        if (!$options['mass_generate']) {
+            $builder
+                ->add('code', TextType::class, [
+                    'label' => t('Promo code'),
+                    'required' => true,
+                    'constraints' => [
+                        new Constraints\NotBlank([
+                            'message' => 'Please enter promo code',
+                        ]),
+                    ],
+                ]);
+        }
+
+        if ($this->promoCode instanceof PromoCode) {
+            $builder->add('formId', DisplayOnlyType::class, [
+                'label' => t('ID'),
+                'data' => $this->promoCode->getId(),
+            ]);
+        }
+
+        $builder->add('domainId', HiddenType::class, [
+            'data' => $this->getDomainId(),
+        ])
             ->add('shownDomainId', DomainType::class, [
                 'mapped' => false,
                 'label' => t('Domain'),
@@ -134,14 +147,6 @@ class PromoCodeFormType extends AbstractType
                 'label' => t('Remaining number of uses'),
                 'required' => false,
             ]);
-
-        if ($this->promoCode instanceof PromoCode) {
-            $builder->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
-                'data' => $this->promoCode->getId(),
-                'position' => ['after' => 'code'],
-            ]);
-        }
     }
 
     /**
@@ -321,7 +326,6 @@ class PromoCodeFormType extends AbstractType
     {
         $builderMassPromoCodeGroup = $builder->create('massPromoCodeGroup', GroupType::class, [
             'label' => t('Bulk promo code generation'),
-            'position' => 'first',
         ]);
 
         $builderMassPromoCodeGroup


### PR DESCRIPTION
#### Description, the reason for the PR
Position should not be used in framework form types as it is not in most time necessary. It leads to worst experience for projects.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-remove-position.odin.shopsys.cloud
  - https://cz.tl-remove-position.odin.shopsys.cloud
<!-- Replace -->
