### PR TITLE
updated order of created data fixtures of price lists to ensure correct working of testProperSpecialPriceIsReturnedForMultipleLists

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/PriceListDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/PriceListDataFixture.php
@@ -53,19 +53,6 @@ class PriceListDataFixture extends AbstractReferenceFixture implements Dependent
             $vat = $this->getReferenceForDomain(VatDataFixture::VAT_HIGH, $domainConfig->getId(), Vat::class);
 
             $priceListData = $this->priceListDataFactory->create();
-            $priceListData->name = t('Special offers', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainConfig->getLocale());
-            $priceListData->domainId = $domainConfig->getId();
-            $priceListData->validFrom = new DateTimeImmutable('2023-01-10 08:30:00');
-            $priceListData->validTo = new DateTimeImmutable('2084-01-10 08:30:00');
-            $priceListData->priceListProductPricesData = [
-                $this->createPriceListProductPriceData('27', '42', $domainConfig->getId(), $currencyCzk, $vat),
-                $this->createPriceListProductPriceData('28', '50', $domainConfig->getId(), $currencyCzk, $vat),
-                $this->createPriceListProductPriceData('54', '10123', $domainConfig->getId(), $currencyCzk, $vat),
-            ];
-            $priceList = $this->priceListFacade->create($priceListData);
-            $this->addReferenceForDomain(self::ACTIVE_SPECIAL_OFFERS_REFERENCE, $priceList, $domainConfig->getId());
-
-            $priceListData = $this->priceListDataFactory->create();
             $priceListData->name = t('Blue wednesday', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainConfig->getLocale());
             $priceListData->domainId = $domainConfig->getId();
             $priceListData->validFrom = new DateTimeImmutable('2023-11-10 00:00:00');
@@ -100,6 +87,19 @@ class PriceListDataFixture extends AbstractReferenceFixture implements Dependent
             ];
             $priceList = $this->priceListFacade->create($priceListData);
             $this->addReferenceForDomain(self::FUTURE_PROMOTED_PRODUCTS_REFERENCE, $priceList, $domainConfig->getId());
+
+            $priceListData = $this->priceListDataFactory->create();
+            $priceListData->name = t('Special offers', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainConfig->getLocale());
+            $priceListData->domainId = $domainConfig->getId();
+            $priceListData->validFrom = new DateTimeImmutable('2023-01-10 08:30:00');
+            $priceListData->validTo = new DateTimeImmutable('2084-01-10 08:30:00');
+            $priceListData->priceListProductPricesData = [
+                $this->createPriceListProductPriceData('27', '42', $domainConfig->getId(), $currencyCzk, $vat),
+                $this->createPriceListProductPriceData('28', '50', $domainConfig->getId(), $currencyCzk, $vat),
+                $this->createPriceListProductPriceData('54', '10123', $domainConfig->getId(), $currencyCzk, $vat),
+            ];
+            $priceList = $this->priceListFacade->create($priceListData);
+            $this->addReferenceForDomain(self::ACTIVE_SPECIAL_OFFERS_REFERENCE, $priceList, $domainConfig->getId());
         }
     }
 

--- a/upgrade-notes/backend_20250514_101911.md
+++ b/upgrade-notes/backend_20250514_101911.md
@@ -1,0 +1,3 @@
+#### update order of PriceListDataFixture to ensure tests always pass ([#3979](https://github.com/shopsys/shopsys/pull/3979))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
lastUpdate of price list does influence resolving of price list. Special offer is expected in tests so it has been moved to the last place in data fixtures.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-price-list-test.odin.shopsys.cloud
  - https://cz.tl-fix-price-list-test.odin.shopsys.cloud
<!-- Replace -->
