### PR TITLE
sending auth code without requesting email first no longer fails with 500

### DIFF
--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -395,7 +395,7 @@ class AdministratorController extends AdminBaseController
      */
     protected function validateEmailCode(string $code, ExecutionContextInterface $context): void
     {
-        if ($code !== $this->getCurrentAdministrator()->getEmailAuthCode()) {
+        if ($this->getCurrentAdministrator()->getEmailAuthCode() === null || $code !== $this->getCurrentAdministrator()->getEmailAuthCode()) {
             $context->addViolation(t('Entered code is not valid'));
         }
     }

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -560,17 +560,10 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getEmailAuthCode(): string
+    public function getEmailAuthCode(): ?string
     {
-        if ($this->emailAuthenticationCode === null) {
-            throw new LogicException(sprintf(
-                "You should not call '%s' when 2FA by email is not enabled. Maybe it is a bug.",
-                __METHOD__,
-            ));
-        }
-
         return $this->emailAuthenticationCode;
     }
 


### PR DESCRIPTION
#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-nullable-auth-code.odin.shopsys.cloud
  - https://cz.tl-fix-nullable-auth-code.odin.shopsys.cloud
<!-- Replace -->
