### PR TITLE
added prevention for duplicate parameter values

### DIFF
--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
@@ -322,7 +322,7 @@ class ReadyCategorySeoMixFacade
                 // slider parameter, minimal and maximal value are the same (see checkPossibilityToFindReadyCategorySeoMix method),
                 // so it does not matter which one is used for grabbing the text
                 $text = $parameterFilterData['minimalValue'];
-                $parameterValueId = $this->parameterFacade->getParameterValueIdByText((string)$text, $currentLocale);
+                $parameterValueId = $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale((string)$text, (string)$text, $currentLocale);
             } else {
                 $parameterUuid = reset($parameterFilterData['values']);
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
@@ -158,22 +158,30 @@ class ParameterFacade
 
     /**
      * @param string $valueText
+     * @param string|null $numericValue
      * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue
      */
-    public function getParameterValueByValueTextAndLocale(string $valueText, string $locale): ParameterValue
-    {
-        return $this->parameterRepository->getParameterValueByValueTextAndLocale($valueText, $locale);
+    public function getParameterValueByValueTextNumericValueAndLocale(
+        string $valueText,
+        ?string $numericValue,
+        string $locale,
+    ): ParameterValue {
+        return $this->parameterRepository->getParameterValueByValueTextNumericValueAndLocale($valueText, $numericValue, $locale);
     }
 
     /**
      * @param string $valueText
+     * @param string|null $numericValue
      * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue|null
      */
-    public function findParameterValueByValueTextAndLocale(string $valueText, string $locale): ?ParameterValue
-    {
-        return $this->parameterRepository->findParameterValueByValueTextAndLocale($valueText, $locale);
+    public function findParameterValueByValueTextNumericValueAndLocale(
+        string $valueText,
+        ?string $numericValue,
+        string $locale,
+    ): ?ParameterValue {
+        return $this->parameterRepository->findParameterValueByValueTextNumericValueAndLocale($valueText, $numericValue, $locale);
     }
 
     /**
@@ -325,9 +333,7 @@ class ParameterFacade
             $parameterValueData->text = $parameterValueConversionData->newValueText;
             $parameterValueData->numericValue = $parameterValueConversionData->newValueText;
 
-            $newParameterValue = $this->parameterValueFactory->create($parameterValueData);
-            $this->em->persist($newParameterValue);
-            $this->em->flush();
+            $newParameterValue = $this->parameterRepository->findOrCreateParameterValueByParameterValueData($parameterValueData);
 
             $this->parameterRepository->updateParameterValueInProductsByConversion($parameter, $parameterValue, $newParameterValue);
             $newParameterValues[] = $newParameterValue;

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -196,14 +196,33 @@ class ParameterRepository
     }
 
     /**
+     * @param string $valueText
+     * @param string|null $numericValue
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue|null
+     */
+    public function findParameterValueByValueTextNumericValueAndLocale(
+        string $valueText,
+        ?string $numericValue,
+        string $locale,
+    ): ?ParameterValue {
+        return $this->getParameterValueRepository()->findOneBy([
+            'text' => $valueText,
+            'numericValue' => $numericValue,
+            'locale' => $locale,
+        ]);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData $parameterValueData
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue
      */
     public function findOrCreateParameterValueByParameterValueData(
         ParameterValueData $parameterValueData,
     ): ParameterValue {
-        $parameterValue = $this->findParameterValueByValueTextAndLocale(
+        $parameterValue = $this->findParameterValueByValueTextNumericValueAndLocale(
             $parameterValueData->text,
+            $parameterValueData->numericValue,
             $parameterValueData->locale,
         );
 
@@ -225,31 +244,22 @@ class ParameterRepository
 
     /**
      * @param string $valueText
+     * @param string|null $numericValue
      * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue
      */
-    public function getParameterValueByValueTextAndLocale(string $valueText, string $locale): ParameterValue
-    {
-        $parameterValue = $this->findParameterValueByValueTextAndLocale($valueText, $locale);
+    public function getParameterValueByValueTextNumericValueAndLocale(
+        string $valueText,
+        ?string $numericValue,
+        string $locale,
+    ): ParameterValue {
+        $parameterValue = $this->findParameterValueByValueTextNumericValueAndLocale($valueText, $numericValue, $locale);
 
         if ($parameterValue === null) {
             throw new ParameterValueNotFoundException();
         }
 
         return $parameterValue;
-    }
-
-    /**
-     * @param string $valueText
-     * @param string $locale
-     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue|null
-     */
-    public function findParameterValueByValueTextAndLocale(string $valueText, string $locale): ?ParameterValue
-    {
-        return $this->getParameterValueRepository()->findOneBy([
-            'text' => $valueText,
-            'locale' => $locale,
-        ]);
     }
 
     /**
@@ -737,6 +747,7 @@ class ParameterRepository
             ->from(ParameterValue::class, 'pv')
             ->where('pv.text = :text')
             ->andWhere('pv.locale = :locale')
+            ->andWhere('pv.numericValue IS NULL')
             ->setParameters([
                 'text' => $text,
                 'locale' => $locale,

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
@@ -70,11 +70,11 @@ class ProductParameterValueDataFactory
 
         foreach ($productParameterValuesLocalizedData->valueTextsByLocale as $locale => $valueText) {
             if ($valueText !== null) {
-                $isSlider = $productParameterValuesLocalizedData->parameter->isSlider();
+                $isSliderWithNumericValue = $productParameterValuesLocalizedData->parameter->isSlider() && is_numeric($valueText);
                 $productParameterValueData = $this->create();
                 $productParameterValueData->parameter = $productParameterValuesLocalizedData->parameter;
 
-                $parameterValue = $this->parameterFacade->findParameterValueByValueTextNumericValueAndLocale($valueText, $isSlider ? $valueText : null, $locale);
+                $parameterValue = $this->parameterFacade->findParameterValueByValueTextNumericValueAndLocale($valueText, $isSliderWithNumericValue ? $valueText : null, $locale);
 
                 if ($parameterValue === null) {
                     $parameterValueData = $this->parameterValueDataFactory->create();
@@ -83,7 +83,7 @@ class ProductParameterValueDataFactory
                 }
                 $parameterValueData->text = $valueText;
 
-                if ($isSlider) {
+                if ($isSliderWithNumericValue) {
                     $parameterValueData->numericValue = $valueText;
                 }
 

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
@@ -70,10 +70,11 @@ class ProductParameterValueDataFactory
 
         foreach ($productParameterValuesLocalizedData->valueTextsByLocale as $locale => $valueText) {
             if ($valueText !== null) {
+                $isSlider = $productParameterValuesLocalizedData->parameter->isSlider();
                 $productParameterValueData = $this->create();
                 $productParameterValueData->parameter = $productParameterValuesLocalizedData->parameter;
 
-                $parameterValue = $this->parameterFacade->findParameterValueByValueTextAndLocale($valueText, $locale);
+                $parameterValue = $this->parameterFacade->findParameterValueByValueTextNumericValueAndLocale($valueText, $isSlider ? $valueText : null, $locale);
 
                 if ($parameterValue === null) {
                     $parameterValueData = $this->parameterValueDataFactory->create();
@@ -82,7 +83,7 @@ class ProductParameterValueDataFactory
                 }
                 $parameterValueData->text = $valueText;
 
-                if ($productParameterValuesLocalizedData->parameter->isSlider()) {
+                if ($isSlider) {
                     $parameterValueData->numericValue = $valueText;
                 }
 

--- a/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
@@ -59,10 +59,10 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
             'flagId' => 3,
             'ordering' => ProductListOrderingConfig::ORDER_BY_PRIORITY,
             'parameterValueIdsByParameterIds' => [
-                $this->getReference(ParameterDataFixture::PARAM_WATER_RESERVOIR_CAPACITY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('2 l', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
-                $this->getReference(ParameterDataFixture::PARAM_MAGAZINE_CAPACITY_FOR_BEANS, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('400 g', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
-                $this->getReference(ParameterDataFixture::PARAM_PRESSURE, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('15 bar', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
-                $this->getReference(ParameterDataFixture::PARAM_MILK_RESERVOIR_CAPACITY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('600 ml', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
+                $this->getReference(ParameterDataFixture::PARAM_WATER_RESERVOIR_CAPACITY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('2 l', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
+                $this->getReference(ParameterDataFixture::PARAM_MAGAZINE_CAPACITY_FOR_BEANS, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('400 g', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
+                $this->getReference(ParameterDataFixture::PARAM_PRESSURE, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('15 bar', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
+                $this->getReference(ParameterDataFixture::PARAM_MILK_RESERVOIR_CAPACITY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('600 ml', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
             ],
         ];
 
@@ -87,7 +87,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
         $selectedCategorySeoMixCombinationArray['flagId'] = 2;
         $selectedCategorySeoMixCombinationArray['ordering'] = ProductListOrderingConfig::ORDER_BY_PRIORITY;
         $selectedCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
-            $this->getReference(ParameterDataFixture::PARAM_HDMI, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('No', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_HDMI, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('No', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
         ];
         $this->createReadyCategorySeoMix(
             $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
@@ -100,8 +100,8 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
         );
 
         $selectedCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
-            $this->getReference(ParameterDataFixture::PARAM_SCREEN_SIZE, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('30"', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
-            $this->getReference(ParameterDataFixture::PARAM_TECHNOLOGY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('LED', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_SCREEN_SIZE, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('30"', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_TECHNOLOGY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('LED', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
         ];
         $this->createReadyCategorySeoMix(
             $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
@@ -133,9 +133,9 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
         $selectedCategorySeoMixCombinationArray['ordering'] = ProductListOrderingConfig::ORDER_BY_PRIORITY;
         $selectedCategorySeoMixCombinationArray['flagId'] = null;
         $selectedCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
-            $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
-            $this->getReference(ParameterDataFixture::PARAM_TECHNOLOGY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('LED', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
-            $this->getReference(ParameterDataFixture::PARAM_RESOLUTION, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('1920×1080 (Full HD)', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_TECHNOLOGY, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('LED', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_RESOLUTION, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('1920×1080 (Full HD)', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
         ];
         $this->createReadyCategorySeoMix(
             $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
@@ -151,7 +151,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
 
         $selectedCategorySeoMixCombinationArray['flagId'] = null;
         $selectedCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
-            $this->getReference(ParameterDataFixture::PARAM_COLOR, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_COLOR, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
         ];
         $this->createReadyCategorySeoMix(
             $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
@@ -166,7 +166,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
         );
 
         $selectedCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
-            $this->getReference(ParameterDataFixture::PARAM_COLOR, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextAndLocale(t('red', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale)->getId(),
+            $this->getReference(ParameterDataFixture::PARAM_COLOR, Parameter::class)->getId() => $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(t('red', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale)->getId(),
         ];
         $this->createReadyCategorySeoMix(
             $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
@@ -220,8 +220,8 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
         $technologyParameter = $this->getReference(ParameterDataFixture::PARAM_TECHNOLOGY, Parameter::class);
         $hdmiParameter = $this->getReference(ParameterDataFixture::PARAM_HDMI, Parameter::class);
         $selectedCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
-            $hdmiParameter->getId() => $this->getParameterValueId(t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale),
-            $technologyParameter->getId() => $this->getParameterValueId(t('PLASMA', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale),
+            $hdmiParameter->getId() => $this->getParameterValueId(t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale),
+            $technologyParameter->getId() => $this->getParameterValueId(t('PLASMA', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale),
         ];
         $this->createReadyCategorySeoMix(
             $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
@@ -244,7 +244,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
             'flagId' => $newFlag->getId(),
             'ordering' => ProductListOrderingConfig::ORDER_BY_PRICE_DESC,
             'parameterValueIdsByParameterIds' => [
-                $usbParameter->getId() => $this->getParameterValueId(t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), $firstDomainLocale),
+                $usbParameter->getId() => $this->getParameterValueId(t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale), null, $firstDomainLocale),
             ],
         ];
         $this->createReadyCategorySeoMix(
@@ -320,12 +320,13 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
 
     /**
      * @param string $parameterValueTranslation
+     * @param string|null $numericValue
      * @param string $locale
      * @return int
      */
-    private function getParameterValueId(string $parameterValueTranslation, string $locale): int
+    private function getParameterValueId(string $parameterValueTranslation, ?string $numericValue, string $locale): int
     {
-        return $this->parameterFacade->getParameterValueByValueTextAndLocale($parameterValueTranslation, $locale)->getId();
+        return $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale($parameterValueTranslation, $numericValue, $locale)->getId();
     }
 
     /**

--- a/project-base/app/tests/App/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
@@ -47,7 +47,7 @@ class ParameterFilterChoiceRepositoryTest extends ParameterTransactionFunctional
         $parameterParameterValuePair = [
             $this->getReference(ParameterDataFixture::PARAM_COVER, Parameter::class)->getId() => [$this->getParameterValueIdForFirstDomain('hardcover'), $this->getParameterValueIdForFirstDomain('paper')],
             $this->getReference(ParameterDataFixture::PARAM_PAGES_COUNT, Parameter::class)->getId() => [$this->getParameterValueIdForFirstDomain('250'), $this->getParameterValueIdForFirstDomain('48'), $this->getParameterValueIdForFirstDomain('50'), $this->getParameterValueIdForFirstDomain('55')],
-            $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [$this->getParameterValueIdForFirstDomain('150'), $this->getParameterValueIdForFirstDomain('250'), $this->getParameterValueIdForFirstDomain('50')],
+            $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [$this->getParameterValueIdForFirstDomain('150', true), $this->getParameterValueIdForFirstDomain('250', true), $this->getParameterValueIdForFirstDomain('50', true)],
         ];
 
         foreach ($parameterParameterValuePair as $parameterId => $parameterValues) {

--- a/project-base/app/tests/App/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
@@ -156,15 +156,15 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
                 $this->getParameterValueIdForFirstDomain('Yes') => 10,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('5400') => 1,
-                $this->getParameterValueIdForFirstDomain('3500') => 9,
+                $this->getParameterValueIdForFirstDomain('5400', true) => 1,
+                $this->getParameterValueIdForFirstDomain('3500', true) => 9,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 8,
                 $this->getParameterValueIdForFirstDomain('No') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WARRANTY_IN_YEARS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('4') => 2,
+                $this->getParameterValueIdForFirstDomain('4', true) => 2,
             ],
         ];
 
@@ -220,15 +220,15 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
                 $this->getParameterValueIdForFirstDomain('Yes') => 3,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('5400') => 1,
-                $this->getParameterValueIdForFirstDomain('3500') => 2,
+                $this->getParameterValueIdForFirstDomain('5400', true) => 1,
+                $this->getParameterValueIdForFirstDomain('3500', true) => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 2,
                 $this->getParameterValueIdForFirstDomain('No') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WARRANTY_IN_YEARS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('4') => 2,
+                $this->getParameterValueIdForFirstDomain('4', true) => 2,
             ],
         ];
 
@@ -297,15 +297,15 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
                 $this->getParameterValueIdForFirstDomain('Yes') => 8,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('3500') => 7,
-                $this->getParameterValueIdForFirstDomain('5400') => 1,
+                $this->getParameterValueIdForFirstDomain('3500', true) => 7,
+                $this->getParameterValueIdForFirstDomain('5400', true) => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 6,
                 $this->getParameterValueIdForFirstDomain('No') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WARRANTY_IN_YEARS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('4') => 2,
+                $this->getParameterValueIdForFirstDomain('4', true) => 2,
             ],
         ];
 
@@ -351,8 +351,8 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
         $countData->countByFlagId = [];
         $countData->countByParameterIdAndValueId = [
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('5400') => 1,
-                $this->getParameterValueIdForFirstDomain('3500') => 2,
+                $this->getParameterValueIdForFirstDomain('5400', true) => 1,
+                $this->getParameterValueIdForFirstDomain('3500', true) => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 2,
@@ -454,8 +454,8 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
                 $this->getParameterValueIdForFirstDomain('Yes') => 7,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('3500') => 7,
-                $this->getParameterValueIdForFirstDomain('5400') => 1,
+                $this->getParameterValueIdForFirstDomain('3500', true) => 7,
+                $this->getParameterValueIdForFirstDomain('5400', true) => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 7,

--- a/project-base/app/tests/App/Test/ParameterTransactionFunctionalTestCase.php
+++ b/project-base/app/tests/App/Test/ParameterTransactionFunctionalTestCase.php
@@ -17,15 +17,17 @@ class ParameterTransactionFunctionalTestCase extends TransactionFunctionalTestCa
 
     /**
      * @param string $parameterValueNameId
+     * @param bool $isNumeric
      * @return int
      */
-    protected function getParameterValueIdForFirstDomain(string $parameterValueNameId): int
+    protected function getParameterValueIdForFirstDomain(string $parameterValueNameId, bool $isNumeric = false): int
     {
         $firstDomainLocale = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
         $parameterValueTranslatedName = t($parameterValueNameId, [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale);
 
-        return $this->parameterFacade->getParameterValueByValueTextAndLocale(
+        return $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(
             $parameterValueTranslatedName,
+            $isNumeric ? $parameterValueTranslatedName : null,
             $firstDomainLocale,
         )->getId();
     }

--- a/project-base/app/tests/FrontendApiBundle/Functional/CategorySeo/CategorySeoTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/CategorySeo/CategorySeoTest.php
@@ -300,8 +300,9 @@ class CategorySeoTest extends GraphQlTestCase
         $flagNew = $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class);
         $parameterUsb = $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class);
         $categorySlug = $this->urlGenerator->generate('front_product_list', ['id' => $categoryPc->getId()]);
-        $parameterValueYes = $this->parameterFacade->getParameterValueByValueTextAndLocale(
+        $parameterValueYes = $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale(
             t('Yes', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
+            null,
             $firstDomainLocale,
         );
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringOptionsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringOptionsTest.php
@@ -382,8 +382,9 @@ class ProductsFilteringOptionsTest extends GraphQlTestCase
         $parameterFacade = self::getContainer()->get(ParameterFacade::class);
         $parameter = $parameterFacade->getById(self::PARAMETER_HDMI);
 
-        $parameterValue = $parameterFacade->getParameterValueByValueTextAndLocale(
+        $parameterValue = $parameterFacade->getParameterValueByValueTextNumericValueAndLocale(
             t('No', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->firstDomainLocale),
+            null,
             $this->firstDomainLocale,
         );
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringTest.php
@@ -169,8 +169,9 @@ class ProductsFilteringTest extends ProductsGraphQlTestCase
         $parameterFacade = self::getContainer()->get(ParameterFacade::class);
         $parameter = $parameterFacade->getById($this->getReference(ParameterDataFixture::PARAM_NUMBER_OF_BUTTONS, Parameter::class)->getId());
 
-        $parameterValue = $parameterFacade->getParameterValueByValueTextAndLocale(
+        $parameterValue = $parameterFacade->getParameterValueByValueTextNumericValueAndLocale(
             t('5', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->firstDomainLocale),
+            null,
             $this->firstDomainLocale,
         );
 

--- a/upgrade-notes/backend_20250514_120051.md
+++ b/upgrade-notes/backend_20250514_120051.md
@@ -1,0 +1,5 @@
+#### prevent duplicit parameter values ([#3981](https://github.com/shopsys/shopsys/pull/3981))
+
+- methods `Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade::findParameterValueByValueTextAndLocale` and `Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository::findParameterValueByValueTextAndLocale` renamed to `findParameterValueByValueTextNumericValueAndLocale` including new parameter `numericValue`
+- methods `Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade::getParameterValueByValueTextAndLocale` and `Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository::getParameterValueByValueTextAndLocale` renamed to `getParameterValueByValueTextNumericValueAndLocale` including new parameter `numericValue`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
It was possible to create duplicate parameters using standard methods. These have been improved to include `numericValue` into evaluation.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-duplicit-parameter-values.odin.shopsys.cloud
  - https://cz.tl-fix-duplicit-parameter-values.odin.shopsys.cloud
<!-- Replace -->
