### PR TITLE
fixed searching in unused friendly urls

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRepository.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRepository.php
@@ -237,7 +237,7 @@ class FriendlyUrlRepository
 
         if ($quickSearchData->text !== null && $quickSearchData->text !== '') {
             $queryBuilder
-                ->andWhere('NORMALIZE(fu.slug) LIKE NORMALIZE(:text)');
+                ->andWhere('NORMALIZED(fu.slug) LIKE NORMALIZED(:text)');
             $querySearchText = $this->databaseSearchingHelper->getFullTextLikeSearchString($quickSearchData->text);
             $queryBuilder->setParameter('text', $querySearchText);
         }


### PR DESCRIPTION
#### Description, the reason for the PR
Method NORMALIZE has been renamed to NORMALIZED in https://github.com/shopsys/shopsys/pull/3072 but this occursion was not changed.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-unused-url-search.odin.shopsys.cloud
  - https://cz.tl-fix-unused-url-search.odin.shopsys.cloud
<!-- Replace -->
