### PR TITLE
fixed order confirmation skeleton responsive

### DIFF
--- a/project-base/storefront/components/Blocks/Skeleton/SkeletonPageConfirmation.tsx
+++ b/project-base/storefront/components/Blocks/Skeleton/SkeletonPageConfirmation.tsx
@@ -3,7 +3,7 @@ import { Webline } from 'components/Layout/Webline/Webline';
 
 export const SkeletonPageConfirmation: FC = () => (
     <Webline>
-        <Skeleton className="h-8 w-96 lg:h-10" />
+        <Skeleton className="h-8 md:w-96 lg:h-10" />
 
         <div className="mt-4 flex flex-col gap-1">
             <Skeleton className="h-6 w-3/4" />

--- a/upgrade-notes/storefront_20250521_073144.md
+++ b/upgrade-notes/storefront_20250521_073144.md
@@ -1,0 +1,4 @@
+#### Fix order confirmation skeleton responsive ([#3993](https://github.com/shopsys/shopsys/pull/3993))
+
+- order confirmation responsive skeleton is now showing correctly and not overflowing
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Order confirmation responsive skeleton is now showing correctly and not overflowing.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3403-fix-order-confirmation-skeleton.odin.shopsys.cloud
  - https://cz.tc-ssp-3403-fix-order-confirmation-skeleton.odin.shopsys.cloud
<!-- Replace -->
