### PR TITLE
fixed order confirmation product image size

### DIFF
--- a/project-base/storefront/components/Pages/Customer/OrderDetail/OrderDetailOrderItem.tsx
+++ b/project-base/storefront/components/Pages/Customer/OrderDetail/OrderDetailOrderItem.tsx
@@ -70,7 +70,7 @@ export const OrderDetailOrderItem: FC<OrderDetailOrderItemProps> = ({ orderItem,
                     <div className="flex h-20 w-20 shrink-0 items-center">
                         <Image
                             alt={orderItem.name}
-                            className="object-contain mix-blend-multiply"
+                            className="max-h-20 max-w-20 object-contain mix-blend-multiply"
                             height={48}
                             src={orderItem.product?.mainImage?.url}
                             width={80}

--- a/upgrade-notes/storefront_20250521_073913.md
+++ b/upgrade-notes/storefront_20250521_073913.md
@@ -1,0 +1,4 @@
+#### Order confirmation product image overflowing ([#3994](https://github.com/shopsys/shopsys/pull/3994))
+
+- product image has max size now
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Product image has max size now in order confirmation table.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3376-fix-order-confirmation-product-image.odin.shopsys.cloud
  - https://cz.tc-ssp-3376-fix-order-confirmation-product-image.odin.shopsys.cloud
<!-- Replace -->
