### PR TITLE
fixed related products slider arrows

### DIFF
--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailTabs/ProductDetailRelatedProductsTab.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailTabs/ProductDetailRelatedProductsTab.tsx
@@ -7,8 +7,10 @@ export type ProductDetailRelatedProductsTabProps = {
 };
 
 export const ProductDetailRelatedProductsTab: FC<ProductDetailRelatedProductsTabProps> = ({ relatedProducts }) => (
-    <ProductsSlider
-        gtmProductListName={GtmProductListNameType.product_detail_related_products}
-        products={relatedProducts}
-    />
+    <div className="mt-10">
+        <ProductsSlider
+            gtmProductListName={GtmProductListNameType.product_detail_related_products}
+            products={relatedProducts}
+        />
+    </div>
 );

--- a/upgrade-notes/storefront_20250521_074738.md
+++ b/upgrade-notes/storefront_20250521_074738.md
@@ -1,0 +1,4 @@
+#### Fix related products slider in product detail page ([#3995](https://github.com/shopsys/shopsys/pull/3995))
+
+- slider arrows are now visible in related products slider
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Slider arrows are now visible in related product slider in product detail page.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3375-related-products-slider.odin.shopsys.cloud
  - https://cz.tc-ssp-3375-related-products-slider.odin.shopsys.cloud
<!-- Replace -->
