### PR TITLE
access control is no longer cached in dev environment

### DIFF
--- a/docs/administration/admin-rights.md
+++ b/docs/administration/admin-rights.md
@@ -27,3 +27,28 @@ The most important settings in the security config are:
 - the access control coverage of all the controller actions is checked automatically by the `access-control-rules-check` [phing](../introduction/console-commands-for-application-management-phing-targets.md) target (it is a part of `standards` check)
 
 If a particular page or section is restricted for the given administrator, it is automatically removed from the menu, see `Shopsys\FrameworkBundle\Model\AdminNavigation\MenuItemsGrantedRolesSubscriber`.
+
+## Overriding #[AccessControlRule] attribute from your project
+
+If you need to override the `#[AccessControlRule]` attribute on your project, you have to override Controller action and add the attribute there.
+For example, if you want to make `someAction` accessible for all admins, you can do that like this:
+
+```php
+#[Override]
+#[AccessControlRule([Roles::ROLE_ADMIN])
+public function someAction(Request $request): Response
+{
+    // ...
+}
+```
+
+In case you want to make the action accessible for everyone, you can use an empty array:
+
+```php
+#[Override]
+#[AccessControlRule([])
+public function someAction(Request $request): Response
+{
+    // ...
+}
+```

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -66,7 +66,7 @@
         </exec>
     </target>
 
-    <target name="access-control-rules-check" description="Checks access control rules in the project.">
+    <target name="access-control-rules-check" depends="clean" description="Checks access control rules in the project.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:check-access-control-rules"/>

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -38,6 +38,7 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
         $loader->load('parameters_common.yaml');
         $loader->load('services.yaml');
         $loader->load('paths.yaml');
+        $loader->load('packages_registry.yaml');
 
         if ($container->getParameter('kernel.environment') === EnvironmentType::DEVELOPMENT) {
             $loader->load('services_dev.yaml');

--- a/packages/framework/src/Model/Security/AccessControl/RouteAccessControlDataProvider.php
+++ b/packages/framework/src/Model/Security/AccessControl/RouteAccessControlDataProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Security\AccessControl;
 
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
+
 class RouteAccessControlDataProvider
 {
     /**
@@ -11,12 +13,14 @@ class RouteAccessControlDataProvider
      * @param string $cacheDirectory
      * @param string $frameworkRootDirectory
      * @param array $packagesRegistry
+     * @param string $environment
      */
     public function __construct(
         protected readonly string $projectRootDirectory,
         protected readonly string $cacheDirectory,
         protected readonly string $frameworkRootDirectory,
         protected readonly array $packagesRegistry,
+        protected readonly string $environment,
     ) {
     }
 
@@ -26,8 +30,9 @@ class RouteAccessControlDataProvider
     public function findAll(): array
     {
         $accessControlCacheFile = $this->cacheDirectory . '/access_control_rules.php';
+        $isDev = $this->environment === EnvironmentType::DEVELOPMENT;
 
-        if (file_exists($accessControlCacheFile)) {
+        if (!$isDev && file_exists($accessControlCacheFile)) {
             $accessControlRulesArray = require $accessControlCacheFile;
             $routeAccessControlRules = [];
 
@@ -39,7 +44,9 @@ class RouteAccessControlDataProvider
 
             $routeAccessControlRules = $accessControlRulesAttributeFinder->findAll($this->getControllerDirectories());
 
-            file_put_contents($accessControlCacheFile, sprintf('<?php return %s;', var_export($routeAccessControlRules, true)));
+            if (!$isDev) {
+                file_put_contents($accessControlCacheFile, sprintf('<?php return %s;', var_export($routeAccessControlRules, true)));
+            }
         }
 
         return $routeAccessControlRules;

--- a/packages/framework/src/Model/Security/AccessControl/RouteAccessControlDataProvider.php
+++ b/packages/framework/src/Model/Security/AccessControl/RouteAccessControlDataProvider.php
@@ -9,10 +9,14 @@ class RouteAccessControlDataProvider
     /**
      * @param string $projectRootDirectory
      * @param string $cacheDirectory
+     * @param string $frameworkRootDirectory
+     * @param array $packagesRegistry
      */
     public function __construct(
         protected readonly string $projectRootDirectory,
         protected readonly string $cacheDirectory,
+        protected readonly string $frameworkRootDirectory,
+        protected readonly array $packagesRegistry,
     ) {
     }
 
@@ -46,18 +50,29 @@ class RouteAccessControlDataProvider
      */
     protected function getControllerDirectories(): array
     {
-        if (file_exists($this->projectRootDirectory . '/../../parameters_monorepo.yaml')) {
-            return [
-                $this->projectRootDirectory . '/src/Controller/Admin',
-                $this->projectRootDirectory . '/../../packages/framework/src/Controller/Admin',
-                $this->projectRootDirectory . '/../../packages/frontend-api/src/Controller',
-            ];
+        $controllerDirectories = [
+            $this->projectRootDirectory . '/src/Controller/Admin',
+        ];
+
+        foreach ($this->packagesRegistry as $package) {
+            $expectedControllerPath = $this->getResolvedPackagePath($package['path']) . '/src/Controller';
+
+            if (is_dir($expectedControllerPath)) {
+                $controllerDirectories[] = $expectedControllerPath;
+            }
         }
 
-        return [
-            $this->projectRootDirectory . '/src/Controller/Admin',
-            $this->projectRootDirectory . '/vendor/shopsys/framework/src/Controller/Admin',
-            $this->projectRootDirectory . '/vendor/shopsys/frontend-api/src/Controller',
-        ];
+        return $controllerDirectories;
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    protected function getResolvedPackagePath(string $path): string
+    {
+        $path = str_replace(['%shopsys.framework.root_dir%', '//'], [$this->frameworkRootDirectory, '/'], $path);
+
+        return rtrim($path, '/');
     }
 }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -743,6 +743,8 @@ services:
         arguments:
             $projectRootDirectory: '%kernel.project_dir%'
             $cacheDirectory: '%kernel.cache_dir%'
+            $frameworkRootDirectory: '%shopsys.framework.root_dir%'
+            $packagesRegistry: '%shopsys.packages.registry%'
 
     Shopsys\FrameworkBundle\Model\Security\AdministratorChecker:
         arguments:

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -745,6 +745,7 @@ services:
             $cacheDirectory: '%kernel.cache_dir%'
             $frameworkRootDirectory: '%shopsys.framework.root_dir%'
             $packagesRegistry: '%shopsys.packages.registry%'
+            $environment: '%kernel.environment%'
 
     Shopsys\FrameworkBundle\Model\Security\AdministratorChecker:
         arguments:

--- a/packages/framework/src/Resources/config/services_dev.yaml
+++ b/packages/framework/src/Resources/config/services_dev.yaml
@@ -1,6 +1,3 @@
-imports:
-    - { resource: packages_registry.yaml }
-
 services:
     _defaults:
         autoconfigure: true

--- a/project-base/app/config/packages/security.php
+++ b/project-base/app/config/packages/security.php
@@ -88,6 +88,7 @@ function getRouteAccessControlRules(ContainerBuilder $container): array
         $container->getParameter('kernel.cache_dir'),
         $frameworkRootDir,
         $container->getParameter('shopsys.packages.registry'),
+        $container->getParameter('kernel.environment'),
     );
 
     return $routeAccessControlDataProvider->findAll();

--- a/project-base/app/config/packages/security.php
+++ b/project-base/app/config/packages/security.php
@@ -1,16 +1,17 @@
 <?php
 
-use App\Environment;
 use App\Model\Security\Roles;
 use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRole;
 use Shopsys\FrameworkBundle\Model\Security\AccessControl\RouteAccessControlDataProvider;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
 use Symfony\Config\SecurityConfig;
 
 /**
  * If your IDE does not recognize the SecurityConfig class, be sure to mark the "/var/cache/dev/Symfony" folder as not excluded
  * @see https://symfony.com/doc/current/configuration.html#using-php-configbuilders
  */
-return static function (SecurityConfig $security): void {
+return static function (SecurityConfig $security, ContainerBuilder $container): void {
     $roleHierarchy = [...Roles::getRolesHierarchy(), ...CustomerUserRole::getRolesHierarchy()];
 
     foreach ($roleHierarchy as $role => $inheritedRoles) {
@@ -34,7 +35,7 @@ return static function (SecurityConfig $security): void {
             ->roles($roles);
     }
 
-    foreach (getRouteAccessControlRules() as $routeAccessControlRule) {
+    foreach (getRouteAccessControlRules($container) as $routeAccessControlRule) {
         $accessControlRule = $routeAccessControlRule->accessControlRule;
         $accessControlConfig = $security->accessControl();
         $accessControlConfig
@@ -72,11 +73,22 @@ return static function (SecurityConfig $security): void {
 /**
  * @return \Shopsys\FrameworkBundle\Model\Security\AccessControl\RouteAccessControlData[]
  */
-function getRouteAccessControlRules(): array
+function getRouteAccessControlRules(ContainerBuilder $container): array
 {
-    $projectRootDirectory = __DIR__ . '/../..';
-    $cacheDirectory = sprintf('%s/var/cache/%s', $projectRootDirectory, Environment::getEnvironment());
-    $routeAccessControlDataProvider = new RouteAccessControlDataProvider($projectRootDirectory, $cacheDirectory);
+    $isMonorepo = $container->getParameter('shopsys.is_monorepo');
+
+    if ($isMonorepo) {
+        $frameworkRootDir = $container->getParameter('kernel.project_dir') . '/../../packages/framework/';
+    } else {
+        $frameworkRootDir = $container->getParameter('kernel.project_dir') . '/vendor/shopsys/framework/';
+    }
+
+    $routeAccessControlDataProvider = new RouteAccessControlDataProvider(
+        $container->getParameter('kernel.project_dir'),
+        $container->getParameter('kernel.cache_dir'),
+        $frameworkRootDir,
+        $container->getParameter('shopsys.packages.registry'),
+    );
 
     return $routeAccessControlDataProvider->findAll();
 }

--- a/project-base/app/src/Kernel.php
+++ b/project-base/app/src/Kernel.php
@@ -29,7 +29,7 @@ class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
-    private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
+    private const string CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
     #[Override]
     public function boot(): void
@@ -60,13 +60,29 @@ class Kernel extends BaseKernel
         ContainerBuilder $builder,
     ): void {
         $configDir = $this->getConfigDir();
+        $isMonorepo = false;
+
+        if (file_exists(__DIR__ . '/../../../parameters_monorepo.yaml')) {
+            $isMonorepo = true;
+        }
+
+        $container->parameters()->set('shopsys.is_monorepo', $isMonorepo);
+
+        if ($isMonorepo) {
+            $frameworkRootDir = $builder->getParameter('kernel.project_dir') . '/../../packages/framework/';
+        } else {
+            $frameworkRootDir = $builder->getParameter('kernel.project_dir') . '/vendor/shopsys/framework/';
+        }
+
+
+        $container->import($frameworkRootDir . 'src/Resources/config/packages_registry.yaml');
 
         $container->import($configDir . '/{packages}/*' . self::CONFIG_EXTS);
         $container->import($configDir . '/{packages}/' . $this->environment . '/**/*' . self::CONFIG_EXTS);
         $container->import($configDir . '/{services}' . self::CONFIG_EXTS);
         $container->import($configDir . '/{services}_' . $this->environment . self::CONFIG_EXTS);
 
-        if (file_exists(__DIR__ . '/../../../parameters_monorepo.yaml')) {
+        if ($isMonorepo) {
             $container->import(__DIR__ . '/../../../parameters_monorepo.yaml');
         }
 

--- a/upgrade-notes/backend_20250521_103546.md
+++ b/upgrade-notes/backend_20250521_103546.md
@@ -1,0 +1,3 @@
+#### improve access control checks in development environment ([#3997](https://github.com/shopsys/shopsys/pull/3997))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Access rights were cached for all environments, this has changed now. Also phing `access-control-rules-check` now checks all packages including administration.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-access-control-dev-environment.odin.shopsys.cloud
  - https://cz.tl-fix-access-control-dev-environment.odin.shopsys.cloud
<!-- Replace -->
