### PR TITLE
ensure that GrapesJS content is always editable

### DIFF
--- a/packages/framework/src/Component/GrapesJs/EnsureCorrectGrapesJsFormatHelper.php
+++ b/packages/framework/src/Component/GrapesJs/EnsureCorrectGrapesJsFormatHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\GrapesJs;
+
+class EnsureCorrectGrapesJsFormatHelper
+{
+    /**
+     * @param string|null $string
+     * @param string $locale
+     * @return string
+     */
+    public function ensureStringIsInCorrectGrapesJsFormat(
+        ?string $string,
+        string $locale,
+    ): string {
+        if ($string === null || trim(strip_tags($string)) === '') {
+            $string = t('Please replace this text with your own content.', locale: $locale) . $string;
+        }
+
+        $isGrapeJsDivMissing = !str_contains('<div class="gjs-text-ckeditor">', $string);
+
+        if ($isGrapeJsDivMissing) {
+            $string = '<div class="gjs-text-ckeditor">' . $string . '</div>';
+        }
+
+        return $string;
+    }
+}

--- a/packages/framework/src/Model/Article/ArticleDataFactory.php
+++ b/packages/framework/src/Model/Article/ArticleDataFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Article;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 
 class ArticleDataFactory
@@ -12,10 +13,12 @@ class ArticleDataFactory
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper $ensureCorrectGrapesJsFormatHelper
      */
     public function __construct(
         protected readonly FriendlyUrlFacade $friendlyUrlFacade,
         protected readonly Domain $domain,
+        protected readonly EnsureCorrectGrapesJsFormatHelper $ensureCorrectGrapesJsFormatHelper,
     ) {
     }
 
@@ -58,7 +61,10 @@ class ArticleDataFactory
     protected function fillFromArticle(ArticleData $articleData, Article $article)
     {
         $articleData->name = $article->getName();
-        $articleData->text = $article->getText();
+        $articleData->text = $this->ensureCorrectGrapesJsFormatHelper->ensureStringIsInCorrectGrapesJsFormat(
+            $article->getText(),
+            $this->domain->getDomainConfigById($article->getDomainId())->getLocale(),
+        );
         $articleData->seoTitle = $article->getSeoTitle();
         $articleData->seoMetaDescription = $article->getSeoMetaDescription();
         $articleData->domainId = $article->getDomainId();

--- a/packages/framework/src/Model/Blog/Article/BlogArticleDataFactory.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleDataFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Blog\Article;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadDataFactory;
+use Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 
 class BlogArticleDataFactory
@@ -14,11 +15,13 @@ class BlogArticleDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadDataFactory $imageUploadDataFactory
+     * @param \Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper $ensureCorrectGrapesJsFormatHelper
      */
     public function __construct(
         protected readonly FriendlyUrlFacade $friendlyUrlFacade,
         protected readonly Domain $domain,
         protected readonly ImageUploadDataFactory $imageUploadDataFactory,
+        protected readonly EnsureCorrectGrapesJsFormatHelper $ensureCorrectGrapesJsFormatHelper,
     ) {
     }
 
@@ -73,7 +76,11 @@ class BlogArticleDataFactory
     protected function fillFromBlogArticle(BlogArticleData $blogArticleData, BlogArticle $blogArticle): void
     {
         $blogArticleData->names = $blogArticle->getNames();
-        $blogArticleData->descriptions = $blogArticle->getDescriptions();
+
+        foreach ($blogArticle->getDescriptions() as $locale => $description) {
+            $blogArticleData->descriptions[$locale] = $this->ensureCorrectGrapesJsFormatHelper->ensureStringIsInCorrectGrapesJsFormat($description, $locale);
+        }
+
         $blogArticleData->perexes = $blogArticle->getPerexes();
         $blogArticleData->hidden = $blogArticle->isHidden();
         $blogArticleData->visibleOnHomepage = $blogArticle->isVisibleOnHomepage();

--- a/packages/framework/src/Model/Mail/MailTemplateDataFactory.php
+++ b/packages/framework/src/Model/Mail/MailTemplateDataFactory.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Mail;
 
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper;
 use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\Mail\OrderMail;
 
@@ -11,9 +14,16 @@ class MailTemplateDataFactory
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileDataFactory $uploadedFileDataFactory
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade
+     * @param \Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper $ensureCorrectGrapesJsFormatHelper
      */
-    public function __construct(protected readonly UploadedFileDataFactory $uploadedFileDataFactory)
-    {
+    public function __construct(
+        protected readonly UploadedFileDataFactory $uploadedFileDataFactory,
+        protected readonly Domain $domain,
+        protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
+        protected readonly EnsureCorrectGrapesJsFormatHelper $ensureCorrectGrapesJsFormatHelper,
+    ) {
     }
 
     /**
@@ -57,7 +67,10 @@ class MailTemplateDataFactory
         $mailTemplateData->name = $mailTemplate->getName();
         $mailTemplateData->bccEmail = $mailTemplate->getBccEmail();
         $mailTemplateData->subject = $mailTemplate->getSubject();
-        $mailTemplateData->body = $mailTemplate->getBody();
+        $mailTemplateData->body = $this->ensureCorrectGrapesJsFormatHelper->ensureStringIsInCorrectGrapesJsFormat(
+            $mailTemplate->getBody(),
+            $this->domain->getDomainConfigById($mailTemplate->getDomainId())->getLocale(),
+        );
         $mailTemplateData->sendMail = $mailTemplate->isSendMail();
         $mailTemplateData->orderStatus = $mailTemplate->getOrderStatus();
         $mailTemplateData->complaintStatus = $mailTemplate->getComplaintStatus();

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -3478,6 +3478,9 @@ msgstr "Překontrolujte prosím zadané hodnoty.<br>"
 msgid "Please fill all default values before creating a product"
 msgstr "Prosím vyplňte všechny výchozí hodnoty před vytvořením produktu"
 
+msgid "Please replace this text with your own content."
+msgstr "Prosím nahraďte tento text vlastním obsahem."
+
 msgid "Please scan the QR code below using a one-time passcode generator application (such as Google Authenticator)."
 msgstr "Naskenujte prosím níže uvedený QR kód pomocí aplikace pro generování jednorázových přístupových kódů (jako je Google Authenticator)."
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -3478,6 +3478,9 @@ msgstr ""
 msgid "Please fill all default values before creating a product"
 msgstr ""
 
+msgid "Please replace this text with your own content."
+msgstr ""
+
 msgid "Please scan the QR code below using a one-time passcode generator application (such as Google Authenticator)."
 msgstr ""
 

--- a/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
+++ b/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
@@ -192,9 +192,7 @@ export default class InitGrapesJs {
 
     static openGrapesMailEditor (event, textareaId, elfinderUrl, templateHtml, bodyVariables, customPlugins) {
         InitGrapesJs.setupBodyForGrapesJsEditor();
-        const editableContent = $('#' + textareaId).val();
         const $templateHtml = $('<div>' + templateHtml + '</div>');
-        $templateHtml.find('.gjs-editable').append(editableContent);
 
         const variables = JSON.parse(JSON.stringify(bodyVariables));
 
@@ -269,6 +267,13 @@ export default class InitGrapesJs {
                     isMail: true
                 }
             },
+            styleManager: {
+                clearProperties: true,
+                appendTo: document.querySelector('#panels')
+            },
+            selectorManager: {
+                componentFirst: true
+            },
             assetManager: {
                 custom: {
                     open (props) {
@@ -290,6 +295,23 @@ export default class InitGrapesJs {
                         };
                     }
                 }
+            }
+        });
+
+        editor.addStyle(`
+            .gjs-editable {
+                min-height: 50px !important;
+            }
+        `);
+
+        editor.once('load', () => {
+            editor.Panels.getButton('options', 'sw-visibility').set('active', 1);
+
+            const editableContent = $('#' + textareaId).val();
+            const $gjsEditable = editor.getWrapper().find('.gjs-editable')[0];
+
+            if ($gjsEditable) {
+                $gjsEditable.append(editableContent);
             }
         });
 

--- a/upgrade-notes/backend_20250528_145603.md
+++ b/upgrade-notes/backend_20250528_145603.md
@@ -1,0 +1,4 @@
+#### update GrapesJS to ensure that GrapesJS content is always editable ([#3998](https://github.com/shopsys/shopsys/pull/3998))
+
+- if you are using GrapesJS for other entities than article, blog article or mail template, use `Shopsys\FrameworkBundle\Component\GrapesJs\EnsureCorrectGrapesJsFormatHelper::ensureStringIsInCorrectGrapesJsFormat` on GrapesJS variable
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
GrapesJS was not working until now, when there was only whitespace / empty html / null in body

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-empty-grapesjs-content.odin.shopsys.cloud
  - https://cz.tl-fix-empty-grapesjs-content.odin.shopsys.cloud
<!-- Replace -->
