### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -636,27 +636,12 @@ jobs:
                     docker compose run cypress-regenerate
                 env:
                     GROUP: ${{ matrix.group }}
-            -   name: Commit generated snapshots for ${{ matrix.group }}
+            -   name: Upload generated snapshots for ${{ matrix.group }}
                 if: steps.check-label-tests-regenerate.outputs.SHOULD_RUN_TESTS_REGENERATE == 'true'
-                id: commit-snapshots
-                run: |
-                    cp -rf snapshots/* project-base/storefront/cypress/snapshots/
-                    git config --global user.name 'ShopsysBot'
-                    git config --global user.email 'shopsysbot@users.noreply.github.com'
-                    git add project-base/storefront/cypress/snapshots/e2e
-                    if ! git diff --cached --quiet; then
-                        git commit -m "regenerate screenshots for ${{ matrix.group }}"
-                    else
-                        echo "No changes to commit."
-                    fi
-            -   name: Push changes for ${{ matrix.group }}
-                if: steps.check-label-tests-regenerate.outputs.SHOULD_RUN_TESTS_REGENERATE == 'true'
-                run: |
-                    git config --global user.name 'ShopsysBot'
-                    git config --global user.email 'shopsysbot@users.noreply.github.com'
-                    git fetch origin
-                    git rebase origin/${{ github.head_ref }}
-                    git push origin ${{ github.head_ref }} --force-with-lease
+                uses: actions/upload-artifact@v4
+                with:
+                    name: cypress-snapshots-${{ matrix.group }}
+                    path: ./snapshots
             -   name: PHP-FPM container logs
                 if: ${{ failure() }}
                 run: docker compose logs php-fpm
@@ -669,12 +654,42 @@ jobs:
             -   name: Cypress container logs
                 if: ${{ failure() }}
                 run: docker compose logs cypress
+    push-regenerated-snapshots:
+        name: Push regenerated snapshots
+        needs: [tests-storefront-acceptance-regenerate]
+        if: |
+            always() && !failure() && !cancelled() &&
+            needs.tests-storefront-acceptance-regenerate.outputs.SHOULD_RUN_TESTS_REGENERATE == 'true'
+        runs-on: ubuntu-22.04
+        steps:
+            -   name: GIT checkout branch - ${{ github.head_ref }}
+                uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.head_ref }}
+            -   name: Download all snapshot artifacts
+                uses: actions/download-artifact@v4
+                with:
+                    path: ./snapshots
+                    pattern: cypress-snapshots-*
+                    merge-multiple: true
+            -   name: Commit and push all snapshots
+                run: |
+                    git config --global user.name 'ShopsysBot'
+                    git config --global user.email 'shopsysbot@users.noreply.github.com'
+                    cp -rf snapshots/* project-base/storefront/cypress/snapshots/
+                    git add project-base/storefront/cypress/snapshots/e2e
+                    if ! git diff --cached --quiet; then
+                        git commit -m "regenerate all screenshots"
+                        git push origin ${{ github.head_ref }} --force-with-lease
+                    else
+                        echo "No changes to commit."
+                    fi
     tests-storefront-acceptance-regenerate-remove-label:
         name: Remove "regenerate screenshots" label
-        needs: tests-storefront-acceptance-regenerate
+        needs: [tests-storefront-acceptance-regenerate, push-regenerated-snapshots]
         if: |
-            always() && 
-            !failure() && 
+            always() &&
+            !failure() &&
             !cancelled()
         runs-on: ubuntu-22.04
         env:
@@ -1024,7 +1039,7 @@ jobs:
         if: |
             always()
         name: Build successful
-        needs: [tests-acceptance, standards, tests-unit-functional-smoke, tests-unit-functional-smoke-first-czech-domain, standards-storefront, translations-dump-check, review, build-fork-docker-images, check-console-commands, tests-storefront-smoke, tests-storefront-acceptance, tests-storefront-acceptance-regenerate, unit-test-storefront]
+        needs: [tests-acceptance, standards, tests-unit-functional-smoke, tests-unit-functional-smoke-first-czech-domain, standards-storefront, translations-dump-check, review, build-fork-docker-images, check-console-commands, tests-storefront-smoke, tests-storefront-acceptance, tests-storefront-acceptance-regenerate, push-regenerated-snapshots, unit-test-storefront,]
         runs-on: ubuntu-22.04
         env:
             BUILD_FORK_RESULT: ${{ needs.build-fork-docker-images.result }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -542,7 +542,16 @@ jobs:
                 if: env.SHOULD_RUN_TESTS == 'true'
                 run: |
                     mv docker-compose.cypress.yml docker-compose.yml
-                    docker compose up -d --wait
+                    for i in {1..2}; do
+                        if docker compose up -d --wait; then
+                            break
+                        else
+                            echo "Attempt $i failed, retrying..."
+                            docker compose down --remove-orphans || true
+                            sleep 5
+                            [ $i -eq 2 ] && exit 1
+                        fi
+                    done
                     docker compose exec php-fpm php phing -D production.confirm.action=y db-create frontend-api-generate-new-keys build-demo-dev-quick elasticsearch-index-recreate elasticsearch-export
             -   name: Run Cypress tests for ${{ matrix.group }}
                 if: env.SHOULD_RUN_TESTS == 'true'


### PR DESCRIPTION
#### Description, the reason for the PR
To fix race condition while pushing to git, all regenerated screenshots are now uploaded to artifacts and after regeneration is finished, they are downloaded, merged and pushed as a single commit.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


























<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new section with the text "next" in the footer and next to the logo in the header, both styled with a highlighted background.

- **Chores**
  - Improved the workflow for regenerating and pushing snapshot files, resulting in a more robust and reliable automation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-cypress-regenerate-race-condition-ssp-3337.odin.shopsys.cloud
  - https://cz.jm-cypress-regenerate-race-condition-ssp-3337.odin.shopsys.cloud
<!-- Replace -->
