### PR TITLE
fix setting empty value for temporary file

### DIFF
--- a/packages/framework/src/Component/AbstractUploadedFile/AbstractUploadedFile.php
+++ b/packages/framework/src/Component/AbstractUploadedFile/AbstractUploadedFile.php
@@ -99,7 +99,7 @@ abstract class AbstractUploadedFile implements EntityFileUploadInterface, Upload
             throw new InvalidFileKeyException($key);
         }
 
-        $this->temporaryFilename = '';
+        $this->temporaryFilename = null;
     }
 
     /**


### PR DESCRIPTION
#### Description, the reason for the PR
Previous state enabled second upload of same file that could cause error

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-prevent-multiple-upload-of-same-file.odin.shopsys.cloud
  - https://cz.tl-prevent-multiple-upload-of-same-file.odin.shopsys.cloud
<!-- Replace -->
