### PR TITLE
ensure that /resolve-friendly-url is accessible only on internal networks

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -42,6 +42,12 @@ server {
     }
 
     location ~ ^/resolve-friendly-url {
+        allow 10.0.0.0/8;
+        allow 127.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
         fastcgi_pass php-upstream;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $realpath_root/resolveFriendlyUrl.php;

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -37,6 +37,12 @@ server {
     add_header X-Content-Type-Options "nosniff";
 
     location ~ ^/resolve-friendly-url {
+        allow 10.0.0.0/8;
+        allow 127.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
         fastcgi_pass php-upstream;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $realpath_root/resolveFriendlyUrl.php;


### PR DESCRIPTION
#### Description, the reason for the PR
This URL is for backend resolving of URLs of Storefront only

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-secure-resolve-friendly-url.odin.shopsys.cloud
  - https://cz.tl-secure-resolve-friendly-url.odin.shopsys.cloud
<!-- Replace -->
