### PR TITLE
2FA email template is now created in DB migration instead of data fixture

### DIFF
--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -334,7 +334,7 @@ class AdministratorController extends AdminBaseController
     protected function enableEmailTwoFactorAuthentication(Request $request, Administrator $administrator): Response
     {
         $formSendEmail = $this->createSendEmailForm();
-        $formVerification = $this->createVerificationForm($this->validateEmailCode(...));
+        $formVerification = $this->createVerificationForm($this->validateEmailCode(...), $administrator);
 
         $formSendEmail->handleRequest($request);
 
@@ -367,7 +367,7 @@ class AdministratorController extends AdminBaseController
         Request $request,
         Administrator $administrator,
     ): Response {
-        $form = $this->createVerificationForm($this->validateGoogleAuthCode(...));
+        $form = $this->createVerificationForm($this->validateGoogleAuthCode(...), $administrator);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -442,7 +442,7 @@ class AdministratorController extends AdminBaseController
         }
 
         $formSendEmail = $this->createSendEmailForm();
-        $formVerification = $this->createVerificationForm($codeValidationCallback);
+        $formVerification = $this->createVerificationForm($codeValidationCallback, $administrator);
 
         $formSendEmail->handleRequest($request);
 
@@ -469,10 +469,13 @@ class AdministratorController extends AdminBaseController
 
     /**
      * @param callable $twoFactorCodeValidationCallback
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
      * @return \Symfony\Component\Form\FormInterface
      */
-    protected function createVerificationForm(callable $twoFactorCodeValidationCallback): FormInterface
-    {
+    protected function createVerificationForm(
+        callable $twoFactorCodeValidationCallback,
+        Administrator $administrator,
+    ): FormInterface {
         $form = $this->createForm(FormType::class);
         $form->add(
             'code',
@@ -485,7 +488,12 @@ class AdministratorController extends AdminBaseController
                 ],
             ],
         );
-        $form->add('verify', SubmitType::class, ['label' => t('Confirm code and enable two-factor authentication')]);
+
+        $label = $administrator->isEnabledTwoFactorAuth()
+            ? t('Confirm code and disable two-factor authentication')
+            : t('Confirm code and enable two-factor authentication');
+
+        $form->add('verify', SubmitType::class, ['label' => $label]);
 
         return $form;
     }

--- a/packages/framework/src/Migrations/Version20250526101812.php
+++ b/packages/framework/src/Migrations/Version20250526101812.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+class Version20250526101812 extends AbstractMigration implements ContainerAwareInterface
+{
+    use MultidomainMigrationTrait;
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        foreach ($this->getAllDomainConfigs() as $domainConfig) {
+            $locale = $domainConfig->getLocale();
+            $domainId = $domainConfig->getId();
+            $subject = t('Authentication code', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
+            $body = t('
+            Dear customer,<br/>
+            <br/>
+            your two factor authentication code is: {authentication_code}<br/>
+            <br/>
+            Best regards
+            ', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
+
+            $this->createMailTemplateIfNotExist('two_factor_authentication_code', $domainId, $subject, $body);
+        }
+    }
+
+    /**
+     * @param string $mailTemplateName
+     * @param int $domainId
+     * @param string $subject
+     * @param string $body
+     */
+    private function createMailTemplateIfNotExist(
+        string $mailTemplateName,
+        int $domainId,
+        string $subject,
+        string $body,
+    ): void {
+        $mailTemplateCount = $this->sql(
+            'SELECT count(*) FROM mail_templates WHERE name = :mailTemplateName and domain_id = :domainId',
+            [
+                'mailTemplateName' => $mailTemplateName,
+                'domainId' => $domainId,
+            ],
+        )->fetchOne();
+
+        if ($mailTemplateCount !== 0) {
+            return;
+        }
+
+        $this->sql(
+            'INSERT INTO mail_templates (name, domain_id, send_mail, subject, body) VALUES (:mailTemplateName, :domainId, :sendMail, :subject, :body)',
+            [
+                'mailTemplateName' => $mailTemplateName,
+                'domainId' => $domainId,
+                'sendMail' => true,
+                'subject' => $subject,
+                'body' => sprintf('<div style="box-sizing: border-box;"><div class="gjs-text-ckeditor">%s</div></div>', $body),
+            ],
+        );
+    }
+}

--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -104,6 +104,7 @@ class SideMenuBuilder
     public const string NEW_ADMINISTRATOR = 'new';
     public const string EDIT_ADMINISTRATOR = 'edit';
     public const string ENABLE_TWO_FACTOR_AUTHENTICATION = 'enable-two-factor-authentication';
+    public const string DISABLE_TWO_FACTOR_AUTHENTICATION = 'disable-two-factor-authentication';
     public const string LIST_ADMINISTRATOR_ROLE_GROUP = 'role_groups';
     public const string NEW_ADMINISTRATOR_ROLE_GROUP = 'new';
     public const string EDIT_ADMINISTRATOR_ROLE_GROUP = 'edit';
@@ -668,6 +669,10 @@ class SideMenuBuilder
         $administratorViewMenu->addChild(
             static::ENABLE_TWO_FACTOR_AUTHENTICATION,
             ['route' => 'admin_administrator_enable-two-factor-authentication', 'label' => t('Enable two-factor authentication'), 'display' => false],
+        );
+        $administratorViewMenu->addChild(
+            static::DISABLE_TWO_FACTOR_AUTHENTICATION,
+            ['route' => 'admin_administrator_disable-two-factor-authentication', 'label' => t('Disable two factor authentication'), 'display' => false],
         );
 
         $administratorRoleGroupMenu = $menu->addChild(static::LIST_ADMINISTRATOR_ROLE_GROUP, ['route' => 'admin_administratorrolegroup_list', 'label' => t('Role Groups')]);

--- a/packages/framework/src/Resources/translations/dataFixtures.cs.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.cs.po
@@ -28,8 +28,14 @@ msgstr "<p> Úspěšně jste si zvolili platební metodu. Nyní čekáme na potv
 msgid "Administrator reset password request"
 msgstr "Požadavek na resetování hesla administrátora"
 
+msgid "Authentication code"
+msgstr "Autentifikační kód"
+
 msgid "Dear administrator.<br /><br />You can set a new password following this link: <a href=\"{new_password_url}\">{new_password_url}</a>"
 msgstr "Vážený administrátore.<br /><br />Můžete nastavit nové heslo následujícím odkazem: <a href=\"{new_password_url}\">{new_password_url}</a>"
+
+msgid "Dear customer,<br/> <br/> your two factor authentication code is: {authentication_code}<br/> <br/> Best regards"
+msgstr "Vážený zákazníku,<br/> <br/> váš dvoufaktorový ověřovací kód je: {authentication_code}<br/> <br/> S pozdravem"
 
 msgid "New product inquiry received"
 msgstr "Byla přijata nová poptávka produktu"

--- a/packages/framework/src/Resources/translations/dataFixtures.en.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.en.po
@@ -28,7 +28,13 @@ msgstr ""
 msgid "Administrator reset password request"
 msgstr ""
 
+msgid "Authentication code"
+msgstr ""
+
 msgid "Dear administrator.<br /><br />You can set a new password following this link: <a href=\"{new_password_url}\">{new_password_url}</a>"
+msgstr ""
+
+msgid "Dear customer,<br/> <br/> your two factor authentication code is: {authentication_code}<br/> <br/> Best regards"
 msgstr ""
 
 msgid "New product inquiry received"

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -880,6 +880,9 @@ msgstr "Doplněk k titulku"
 msgid "Complement to title will be set as suffix to all titles e.g. if complement is set “ | My shop” and product name is “iPhone 7” the result title for this products page will be “iPhone 7 | My shop”."
 msgstr "Doplněk k názvu bude nastaven jako přípona ke všem titulkům, např. pokud je doplněk nastaven jako “ | Můj obchod“ a název produktu je “iPhone 7”, výsledným názvem pro tuto stránku produktu bude “iPhone 7 | Můj obchod”."
 
+msgid "Confirm code and disable two-factor authentication"
+msgstr "Potvrdit kód a zakázat dvoufaktorovou autentizaci"
+
 msgid "Confirm code and enable two-factor authentication"
 msgstr "Potvrdit kód a povolit dvoufaktorovou autentizaci"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -880,6 +880,9 @@ msgstr ""
 msgid "Complement to title will be set as suffix to all titles e.g. if complement is set “ | My shop” and product name is “iPhone 7” the result title for this products page will be “iPhone 7 | My shop”."
 msgstr ""
 
+msgid "Confirm code and disable two-factor authentication"
+msgstr ""
+
 msgid "Confirm code and enable two-factor authentication"
 msgstr ""
 

--- a/project-base/app/src/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -15,7 +15,6 @@ use Override;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Administrator\Mail\ResetPasswordMail;
-use Shopsys\FrameworkBundle\Model\Administrator\Mail\TwoFactorAuthenticationMail;
 use Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactory;
 
 class MailTemplateDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
@@ -52,8 +51,6 @@ class MailTemplateDataFixture extends AbstractReferenceFixture implements Depend
             $this->createPersonalInformationExportMailTemplate($locale, $manager, $domainId);
 
             $this->createCustomerActivationMailTemplate($locale, $manager, $domainId);
-
-            $this->createAdminTwoFactorAuthenticationMailTemplate($locale, $manager, $domainId);
 
             $this->createAdministratorResetPasswordMailTemplate($locale, $manager, $domainId);
         }
@@ -417,31 +414,5 @@ class MailTemplateDataFixture extends AbstractReferenceFixture implements Depend
             ', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
 
         $this->createMailTemplate($manager, CustomerActivationMail::CUSTOMER_ACTIVATION_NAME, $mailTemplateData, $domainId);
-    }
-
-    /**
-     * @param string $locale
-     * @param \Doctrine\Persistence\ObjectManager $manager
-     * @param int $domainId
-     */
-    private function createAdminTwoFactorAuthenticationMailTemplate(
-        string $locale,
-        ObjectManager $manager,
-        int $domainId,
-    ): void {
-        $mailTemplateData = $this->mailTemplateDataFactory->create();
-        $mailTemplateData->sendMail = true;
-
-        $mailTemplateData->subject = t('
-            Authentication code
-            ', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
-        $mailTemplateData->body = t('
-            Dear customer,<br/>
-            <br/>
-            your two factor authentication code is: {authentication_code}<br/>
-            <br/>
-            Best regards
-            ', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
-        $this->createMailTemplate($manager, TwoFactorAuthenticationMail::TWO_FACTOR_AUTHENTICATION_CODE, $mailTemplateData, $domainId);
     }
 }

--- a/project-base/app/translations/dataFixtures.cs.po
+++ b/project-base/app/translations/dataFixtures.cs.po
@@ -472,9 +472,6 @@ msgstr "Článek pro testování vyhledávání"
 msgid "Article text for search testing, the search phrase is &#34;Dina&#34;."
 msgstr "Text článku pro testování vyhledávání, vyhledávací fráze je &#34;Dina&#34;."
 
-msgid "Authentication code"
-msgstr "Autentifikační kód"
-
 msgid "BROTHER PT-H300"
 msgstr "BROTHER PT-H300"
 
@@ -723,9 +720,6 @@ msgstr "Vážený zákazníku,<br/> <br/> můžete dokončit registraci a nastav
 
 msgid "Dear customer,<br/> <br/> your registration is completed.<br/> <br/> Name: {first_name} {last_name}<br /> Email: {email}<br/> <br/> E-shop: <a href=\"{url}\">link</a><br /> Login page: <a href=\"{login_page}\">Log in</a><br/> <br/> Best regards"
 msgstr "Vážený zákazníku,<br/> <br/> vaše registrace je dokončena.<br/> <br/> Jméno: {first_name} {last_name}<br /> E-mail: {email}<br/> <br/> E -shop: <a href=\"{url}\">odkaz</a><br /> Přihlašovací stránka: <a href=\"{login_page}\">Přihlásit se</a><br/> < br/> S pozdravem"
-
-msgid "Dear customer,<br/> <br/> your two factor authentication code is: {authentication_code}<br/> <br/> Best regards"
-msgstr "Vážený zákazníku,<br/> <br/> váš dvoufaktorový ověřovací kód je: {authentication_code}<br/> <br/> S pozdravem"
 
 msgid "Dear customer,<br/> based on your email {email}, we are sending you a link where you can download your personal details registered on our online store in readable format. Clicking on the link will take you to a page where you’ll be able to download these informations, which we have in evidence in our online store {domain}.<br/> <br/> To download your personal information please click <a href=\"{url}\">here</a>.<br/> The link is valid for next 24 hours.<br/> <br/> Best regards<br /> Team of {domain}"
 msgstr "Vážený zákazníku,<br/> na základě Vašeho emailu {email} Vám zasíláme odkaz, kde si můžete stáhnout Vaše osobní údaje registrované v našem internetovém obchodě v čitelném formátu. Kliknutím na odkaz se dostanete na stránku, kde si budete moci stáhnout tyto informace, které máme v evidenci v našem internetovém obchodě {domain}.<br/> <br/> Chcete-li stáhnout své osobní údaje, klikněte na < a href=\"{url}\">zde</a>.<br/> Odkaz je platný po dobu následujících 24 hodin.<br/> <br/> S pozdravem<br /> Tým {domain}"

--- a/project-base/app/translations/dataFixtures.en.po
+++ b/project-base/app/translations/dataFixtures.en.po
@@ -472,9 +472,6 @@ msgstr ""
 msgid "Article text for search testing, the search phrase is &#34;Dina&#34;."
 msgstr ""
 
-msgid "Authentication code"
-msgstr ""
-
 msgid "BROTHER PT-H300"
 msgstr ""
 
@@ -722,9 +719,6 @@ msgid "Dear customer,<br/> <br/> you can finish registration and set new passwor
 msgstr ""
 
 msgid "Dear customer,<br/> <br/> your registration is completed.<br/> <br/> Name: {first_name} {last_name}<br /> Email: {email}<br/> <br/> E-shop: <a href=\"{url}\">link</a><br /> Login page: <a href=\"{login_page}\">Log in</a><br/> <br/> Best regards"
-msgstr ""
-
-msgid "Dear customer,<br/> <br/> your two factor authentication code is: {authentication_code}<br/> <br/> Best regards"
 msgstr ""
 
 msgid "Dear customer,<br/> based on your email {email}, we are sending you a link where you can download your personal details registered on our online store in readable format. Clicking on the link will take you to a page where you’ll be able to download these informations, which we have in evidence in our online store {domain}.<br/> <br/> To download your personal information please click <a href=\"{url}\">here</a>.<br/> The link is valid for next 24 hours.<br/> <br/> Best regards<br /> Team of {domain}"

--- a/upgrade-notes/backend_20250526_102230.md
+++ b/upgrade-notes/backend_20250526_102230.md
@@ -1,0 +1,3 @@
+#### 2FA email template is now created in DB migration instead of data fixture ([#4006](https://github.com/shopsys/shopsys/pull/4006))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The mail template is essential for 2FA activation so it must be created via migration, not via data fixtures that are not loaded on the staging instances.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-2fa-mail-template.odin.shopsys.cloud
  - https://cz.rv-2fa-mail-template.odin.shopsys.cloud
<!-- Replace -->
