### PR TITLE
DatabaseSearchingHelper::getFullTextLikeSearchString argument is not nullable anymore

### DIFF
--- a/packages/framework/src/Component/String/DatabaseSearchingHelper.php
+++ b/packages/framework/src/Component/String/DatabaseSearchingHelper.php
@@ -24,10 +24,10 @@ class DatabaseSearchingHelper
     }
 
     /**
-     * @param string|null $string
+     * @param string $string
      * @return string
      */
-    public function getFullTextLikeSearchString(?string $string): string
+    public function getFullTextLikeSearchString(string $string): string
     {
         return '%' . self::getLikeSearchString($string) . '%';
     }

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -307,21 +307,6 @@ class CategoryFacade
     }
 
     /**
-     * @param int $domainId
-     * @param string $locale
-     * @param string $searchText
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
-     */
-    public function getVisibleByDomainAndSearchText($domainId, $locale, $searchText)
-    {
-        return $this->categoryRepository->getVisibleByDomainIdAndSearchText(
-            $domainId,
-            $locale,
-            $searchText,
-        );
-    }
-
-    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
@@ -339,24 +324,6 @@ class CategoryFacade
     public function getAllTranslatedWithoutBranch(Category $category, string $locale): array
     {
         return $this->categoryRepository->getAllTranslatedWithoutBranch($category, $locale);
-    }
-
-    /**
-     * @param string|null $searchText
-     * @param int $limit
-     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
-     */
-    public function getSearchAutocompleteCategories($searchText, $limit)
-    {
-        $page = 1;
-
-        return $this->categoryRepository->getPaginationResultForSearchVisible(
-            $searchText,
-            $this->domain->getId(),
-            $this->domain->getLocale(),
-            $page,
-            $limit,
-        );
     }
 
     /**

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -12,8 +12,6 @@ use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\Doctrine\OrderByCollationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
-use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
-use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\String\DatabaseSearchingHelper;
 use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
 use Shopsys\FrameworkBundle\Model\Category\Exception\RootCategoryNotFoundException;
@@ -344,64 +342,6 @@ class CategoryRepository extends NestedTreeRepository
     }
 
     /**
-     * @param string|null $searchText
-     * @param int $domainId
-     * @param string $locale
-     * @param int $page
-     * @param int $limit
-     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
-     */
-    public function getPaginationResultForSearchVisible(
-        ?string $searchText,
-        int $domainId,
-        string $locale,
-        int $page,
-        int $limit,
-    ): PaginationResult {
-        $queryBuilder = $this->getVisibleByDomainIdAndSearchTextQueryBuilder($domainId, $locale, $searchText);
-        $queryBuilder->orderBy($this->orderByCollationHelper->createOrderByForLocale('ct.name', $locale));
-
-        $queryPaginator = new QueryPaginator($queryBuilder);
-
-        return $queryPaginator->getResult($page, $limit);
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $locale
-     * @param string|null $searchText
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
-     */
-    public function getVisibleByDomainIdAndSearchText(int $domainId, string $locale, ?string $searchText): array
-    {
-        $queryBuilder = $this->getVisibleByDomainIdAndSearchTextQueryBuilder(
-            $domainId,
-            $locale,
-            $searchText,
-        );
-
-        return $queryBuilder->getQuery()->execute();
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $locale
-     * @param string|null $searchText
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    protected function getVisibleByDomainIdAndSearchTextQueryBuilder(
-        int $domainId,
-        string $locale,
-        ?string $searchText,
-    ): QueryBuilder {
-        $queryBuilder = $this->getAllVisibleByDomainIdQueryBuilder($domainId);
-        $this->addTranslation($queryBuilder, $locale);
-        $this->filterBySearchText($queryBuilder, $searchText);
-
-        return $queryBuilder;
-    }
-
-    /**
      * @param int $domainId
      * @return \Doctrine\ORM\QueryBuilder
      */
@@ -476,9 +416,9 @@ class CategoryRepository extends NestedTreeRepository
 
     /**
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
-     * @param string|null $searchText
+     * @param string $searchText
      */
-    public function filterBySearchText(QueryBuilder $queryBuilder, ?string $searchText): void
+    public function filterBySearchText(QueryBuilder $queryBuilder, string $searchText): void
     {
         $queryBuilder->andWhere(
             'NORMALIZED(ct.name) LIKE NORMALIZED(:searchText)',

--- a/project-base/app/src/Model/Category/CategoryFacade.php
+++ b/project-base/app/src/Model/Category/CategoryFacade.php
@@ -15,7 +15,6 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade as BaseCategoryFacade;
  * @method \App\Model\Category\Category[] getFullPathsIndexedByIdsForDomain(int $domainId, string $locale)
  * @method \App\Model\Category\Category[] getVisibleCategoriesInPathFromRootOnDomain(\App\Model\Category\Category $category, int $domainId)
  * @method \Shopsys\FrameworkBundle\Model\Category\CategoryWithLazyLoadedVisibleChildren[] getCategoriesWithLazyLoadedVisibleChildrenForParent(\App\Model\Category\Category $parentCategory, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
- * @method \App\Model\Category\Category[] getVisibleByDomainAndSearchText(int $domainId, string $locale, string $searchText)
  * @method \App\Model\Category\Category[] getAllVisibleChildrenByCategoryAndDomainId(\App\Model\Category\Category $category, int $domainId)
  * @method \App\Model\Category\Category[]|null[] getProductMainCategoriesIndexedByDomainId(\App\Model\Product\Product $product)
  * @method \App\Model\Category\Category getProductMainCategoryByDomainId(\App\Model\Product\Product $product, int $domainId)

--- a/project-base/app/src/Model/Category/CategoryRepository.php
+++ b/project-base/app/src/Model/Category/CategoryRepository.php
@@ -25,7 +25,6 @@ use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
  * @method \App\Model\Category\Category[] getPreOrderTreeTraversalForAllCategories(string $locale)
  * @method \App\Model\Category\Category[] getPreOrderTreeTraversalForVisibleCategoriesByDomain(int $domainId, string $locale)
  * @method \App\Model\Category\Category[] getTranslatedVisibleSubcategoriesByDomain(\App\Model\Category\Category $parentCategory, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
- * @method \App\Model\Category\Category[] getVisibleByDomainIdAndSearchText(int $domainId, string $locale, string|null $searchText)
  * @method \App\Model\Category\Category[] getAllVisibleChildrenByCategoryAndDomainId(\App\Model\Category\Category $category, int $domainId)
  * @method \App\Model\Category\Category|null findProductMainCategoryOnDomain(\App\Model\Product\Product $product, int $domainId)
  * @method \App\Model\Category\Category getProductMainCategoryOnDomain(\App\Model\Product\Product $product, int $domainId)

--- a/upgrade-notes/backend_20250528_090023.md
+++ b/upgrade-notes/backend_20250528_090023.md
@@ -1,0 +1,8 @@
+#### DatabaseSearchingHelper::getFullTextLikeSearchString argument is not nullable anymore ([#4008](https://github.com/shopsys/shopsys/pull/4008))
+
+- `Shopsys\FrameworkBundle\Model\Category\CategoryFacade::getVisibleByDomainAndSearchText()` was removed, you can use `Shopsys\FrontendApiBundle\Model\Category\CategoryFacade::getVisibleCategoriesBySearchText()` instead
+- `Shopsys\FrameworkBundle\Model\Category\CategoryFacade::getSearchAutocompleteCategories()` was removed without replacement
+- `Shopsys\FrameworkBundle\Model\Category\CategoryRepository::getPaginationResultForSearchVisible()` was removed without replacement
+- `Shopsys\FrameworkBundle\Model\Category\CategoryRepository::getVisibleByDomainIdAndSearchText()` was removed, you can use `Shopsys\FrontendApiBundle\Model\Category\CategoryRepository::getVisibleCategoriesBySearchText()` instead
+- `Shopsys\FrameworkBundle\Model\Category\CategoryRepository::getVisibleByDomainIdAndSearchTextQueryBuilder()` was removed, you can use `Shopsys\FrontendApiBundle\Model\Category\CategoryRepository::getVisibleCategoriesBySearchTextQueryBuilder()` instead
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Inside, the method calls `getLikeSearchString` that also has not-nullable argument :shrug: 

Furthermore, removed some unused methods from `CategoryRepository` and `CategoryFacade` classes.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
closes #3473 <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-db-search.odin.shopsys.cloud
  - https://cz.rv-db-search.odin.shopsys.cloud
<!-- Replace -->
