### PR TITLE
added listener for failed ProductRecalculationMessages that also removes scope settings from Redis

### DIFF
--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageFailedListener.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageFailedListener.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+
+class ProductRecalculationMessageFailedListener implements EventSubscriberInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade $productRecalculationDeduplicationFacade
+     * @param \Psr\Log\LoggerInterface $monologQueueLogger
+     */
+    public function __construct(
+        protected readonly ProductRecalculationDeduplicationFacade $productRecalculationDeduplicationFacade,
+        protected readonly LoggerInterface $monologQueueLogger,
+    ) {
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => 'onMessageFailed',
+        ];
+    }
+
+    /**
+     * @param \Symfony\Component\Messenger\Event\WorkerMessageFailedEvent $event
+     */
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        $envelope = $event->getEnvelope();
+        $message = $envelope->getMessage();
+
+        if (!$message instanceof AbstractProductRecalculationMessage) {
+            return;
+        }
+
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $this->productRecalculationDeduplicationFacade->delete([$message->productId], $this->getPriority($message));
+
+        $this->monologQueueLogger->info(
+            sprintf(
+                'Deleted deduplication lock for unprocessable message "%s" of product ID "%d"',
+                get_class($message),
+                $message->productId,
+            ),
+            ['productId' => $message->productId],
+        );
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage $message
+     * @return string
+     */
+    protected function getPriority(AbstractProductRecalculationMessage $message): string
+    {
+        return match (true) {
+            $message instanceof ProductRecalculationPriorityHighMessage => ProductRecalculationPriorityEnum::HIGH,
+            $message instanceof ProductRecalculationPriorityRegularMessage => ProductRecalculationPriorityEnum::REGULAR,
+            default => throw new UnknownProductRecalculationPriorityException($message::class),
+        };
+    }
+}

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -733,6 +733,10 @@ services:
             $redisClient: '@snc_redis.product_recalculation_queue'
             $isDeduplicationActive: '@=env("defined:MESSENGER_TRANSPORT_DSN") and not (parameter("kernel.environment") matches "/^(test|acc)$/")'
 
+    Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessageFailedListener:
+        arguments:
+            $monologQueueLogger: '@monolog.logger.queue'
+
     Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessageHandler:
         arguments:
             $logger: '@monolog.logger.queue'


### PR DESCRIPTION
#### Description, the reason for the PR
This is needed for errors that may occur during recalculation of products. In such case information about scope of message remained in the Redis, but its message was already gone. In such case application was not able to create new message and recalculations were frozen.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-deduplication-fix.odin.shopsys.cloud
  - https://cz.tl-deduplication-fix.odin.shopsys.cloud
<!-- Replace -->
