### PR TITLE
Improve TBT

### DIFF
--- a/project-base/storefront/components/Basic/Image/Image.tsx
+++ b/project-base/storefront/components/Basic/Image/Image.tsx
@@ -37,6 +37,7 @@ const ImageComponent: FC<ImageProps> = ({ src, hash, ...props }) => {
             loader={loader}
             overrideSrc={finalImageUrl as string}
             src={finalImageUrl}
+            unoptimized={shouldLoadFallbackImage}
             onError={onError}
             {...props}
         />

--- a/project-base/storefront/components/Blocks/Banners/BannersSlider.tsx
+++ b/project-base/storefront/components/Blocks/Banners/BannersSlider.tsx
@@ -36,10 +36,12 @@ export const BannersSlider: FC<BannersSliderProps> = ({ sliderItems }) => {
     };
 
     useEffect(() => {
-        checkAndClearInterval();
-        startInterval();
+        const timer = setTimeout(() => {
+            startInterval();
+        }, SLIDER_AUTOMATIC_SLIDE_INTERVAL);
 
         return () => {
+            clearTimeout(timer);
             checkAndClearInterval();
         };
     }, []);

--- a/project-base/storefront/components/Blocks/BlogPreview/DeferredBlogPreview.tsx
+++ b/project-base/storefront/components/Blocks/BlogPreview/DeferredBlogPreview.tsx
@@ -36,7 +36,11 @@ export const DeferredBlogPreview: FC = () => {
         <Webline width="xxl">
             <div
                 className={bgImageTwClass}
-                style={{ backgroundImage: `url(${blogData?.mainBlogCategoryMainImage?.url})` }}
+                style={
+                    blogData?.mainBlogCategoryMainImage?.url
+                        ? { backgroundImage: `url(${blogData.mainBlogCategoryMainImage.url})` }
+                        : {}
+                }
             >
                 {shouldRender ? (
                     <BlogPreview

--- a/project-base/storefront/components/Pages/App/AppPageContent.tsx
+++ b/project-base/storefront/components/Pages/App/AppPageContent.tsx
@@ -52,12 +52,12 @@ export const AppPageContent: FC<AppPageContentProps> = ({ Component, pageProps }
             <PageHeadScripts />
             <Fonts />
             <DeferredLoaders />
-            <DeferredGtmHeadScript />
             <ToastContainer autoClose={6000} position="top-center" theme="colored" />
             <Component {...pageProps} />
             <DeferredSymfonyDebugToolbar />
             <DeferredUserConsent url={pageProps.domainConfig.url} />
             <Portal />
+            <DeferredGtmHeadScript />
         </div>
     );
 };

--- a/project-base/storefront/instrumentation-client.ts
+++ b/project-base/storefront/instrumentation-client.ts
@@ -10,11 +10,6 @@ Sentry.init({
     dsn: dsn,
     environment: environment,
     tracesSampleRate: 0.1,
-
-    // remove, if you don't want replays
-    integrations: [Sentry.replayIntegration()],
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/project-base/storefront/middleware.ts
+++ b/project-base/storefront/middleware.ts
@@ -14,9 +14,14 @@ const MIDDLEWARE_STATUS_MESSAGE_KEY = 'middleware-status-message';
 
 export const middleware: NextMiddleware = async (request) => {
     try {
+        if (request.nextUrl.pathname === '/.well-known/appspecific/com.chrome.devtools.json') {
+            return new NextResponse(null, { status: 204 });
+        }
+
         if (request.url.includes('_next/data')) {
             return new NextResponse(null, { status: 404 });
         }
+
         const host = getHostFromRequest(request);
         const domainUrlFromStaticUrls = getDomainUrlFromStaticUrls(host);
         const staticUrlsAvailableForDomain = getStaticUrlsAvailableForDomain(domainUrlFromStaticUrls);

--- a/project-base/storefront/next.config.js
+++ b/project-base/storefront/next.config.js
@@ -128,9 +128,9 @@ const sentryConfig = {
     bundleSizeOptimizations: {
         excludeDebugStatements: true,
         // all bellow - remove (set false) if you want to use replays
-        excludeReplayShadowDom: false,
-        excludeReplayIframe: false,
-        excludeReplayWorker: false,
+        excludeReplayShadowDom: true,
+        excludeReplayIframe: true,
+        excludeReplayWorker: true,
     },
 };
 

--- a/project-base/storefront/urql/cache/cacheExchange.ts
+++ b/project-base/storefront/urql/cache/cacheExchange.ts
@@ -89,7 +89,6 @@ export const cache = cacheExchange({
         ProductList: keyUuid,
         SalesRepresentative: keyUuid,
         OrderPaymentsConfig: keyUuid,
-        Vat: keyUuid,
     },
     updates: cacheUpdates,
     optimistic: optimisticUpdates,

--- a/upgrade-notes/storefront_20250603_065922.md
+++ b/upgrade-notes/storefront_20250603_065922.md
@@ -1,0 +1,8 @@
+#### performance improvements for TBT metric ([#4012](https://github.com/shopsys/shopsys/pull/4012))
+
+- turned off Sentry replay to improve performance
+- added initial delay to banners slider
+- moved GTM head script to the bottom of app page content
+- fixed possible undefined in url(...)
+- fixed various warnings and QOL improvements
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
To improve TBT metric, that is slowly crawling into red figures, I have turned off sentry replay and implemented few improvements (fixinf warnings, prolong slider animation and delayed gtm head script). We should keep monitoring if these changes improve TBT metric in SpeedCurve.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-improve-tbt-ssp-3417.odin.shopsys.cloud
  - https://cz.jm-improve-tbt-ssp-3417.odin.shopsys.cloud
<!-- Replace -->
