### PR TITLE
robots.txt: tweak the Crawl-delay value for new projects

### DIFF
--- a/packages/framework/src/Migrations/Version20230919173422.php
+++ b/packages/framework/src/Migrations/Version20230919173422.php
@@ -20,15 +20,7 @@ class Version20230919173422 extends AbstractMigration implements ContainerAwareI
     public function up(Schema $schema): void
     {
         foreach ($this->getAllDomainIds() as $domainId) {
-            $seoRobotsTxtContent = $this->sql('SELECT value FROM setting_values where name = \'seoRobotsTxtContent\' AND domain_id = :domainId', ['domainId' => $domainId])->fetchOne();
-
-            $seoRobotsTxtLines = explode("\n", $seoRobotsTxtContent);
-
-            if (count(preg_grep('/User-agent: \*/', $seoRobotsTxtLines)) !== 0) {
-                continue;
-            }
-
-            $seoRobotsTxtContent .= "\n\nUser-agent: *\nCrawl-delay: 3\nRequest-rate: 300/1m";
+            $seoRobotsTxtContent = "Crawl-delay: 0.3\nRequest-rate: 300/1m";
             $this->sql('UPDATE setting_values SET value = :value where name = \'seoRobotsTxtContent\'  AND domain_id = :domainId', [
                 'value' => $seoRobotsTxtContent,
                 'domainId' => $domainId,

--- a/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
@@ -131,11 +131,6 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
                 $domainId,
             );
             $this->setting->setForDomain(
-                SeoSettingFacade::SEO_ROBOTS_TXT_CONTENT,
-                "Crawl-delay: 3\nRequest-rate: 300/1m",
-                $domainId,
-            );
-            $this->setting->setForDomain(
                 Setting::TRANSFER_DAYS_BETWEEN_STOCKS,
                 7,
                 $domainId,

--- a/upgrade-notes/backend_20250529_144137.md
+++ b/upgrade-notes/backend_20250529_144137.md
@@ -1,0 +1,4 @@
+#### robots.txt: tweak the Crawl-delay value for new projects ([#4015](https://github.com/shopsys/shopsys/pull/4015))
+
+- the setting value was modified in an existing migration. If you are satisfied with your current settings on the staging servers, you do not need to do anything
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The original value was too strict.

Moreover, `seoRobotsTxtContent setting` is now set in DB migration only as duplicating it in data fixtures does not make sense.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-robots.odin.shopsys.cloud
  - https://cz.rv-robots.odin.shopsys.cloud
<!-- Replace -->
