### PR TITLE
Improved InlineEdit and Grid administrator rights

### DIFF
--- a/packages/administration/src/Component/Datagrid/Datagrid.php
+++ b/packages/administration/src/Component/Datagrid/Datagrid.php
@@ -14,6 +14,7 @@ use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\AdapterInterface;
 use Shopsys\AdministrationBundle\Component\Datagrid\Field\FieldDescriptor;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridView;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -229,7 +230,7 @@ final class Datagrid
     public function createView(): GridView
     {
         $datasource = $this->adapter->getDatasource($this->identificationName, $this->fields->getValues());
-        $grid = $this->gridFactory->create($this->options['name'], $datasource);
+        $grid = $this->gridFactory->create($this->options['name'], $datasource, Roles::ROLE_ADMIN);
 
         if ($this->fields->isEmpty() || $this->fields->forAll(fn ($key, FieldDescriptor $field) => $field->isVisible() === false)) {
             return $grid->createView();

--- a/packages/framework/src/Component/Grid/Exception/GridEditRoleNotSetException.php
+++ b/packages/framework/src/Component/Grid/Exception/GridEditRoleNotSetException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Grid\Exception;
+
+use Exception;
+
+class GridEditRoleNotSetException extends Exception
+{
+    /**
+     * @param string $message
+     */
+    public function __construct(
+        string $message = 'Grid edit role has to be set for correct displaying of delete columns.',
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -6,9 +6,11 @@ namespace Shopsys\FrameworkBundle\Component\Grid;
 
 use Shopsys\FrameworkBundle\Component\Grid\Exception\DuplicateColumnIdException;
 use Shopsys\FrameworkBundle\Component\Grid\Exception\EmptyGridIdException;
+use Shopsys\FrameworkBundle\Component\Grid\Exception\GridEditRoleNotSetException;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
@@ -86,19 +88,24 @@ class Grid
 
     /**
      * @param string $id
+     * @param string|null $editRole
      * @param \Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface $dataSource
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      * @param \Symfony\Component\Routing\RouterInterface $router
      * @param \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector $routeCsrfProtector
      * @param \Twig\Environment $twig
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
+     * @throws \Shopsys\FrameworkBundle\Component\Grid\Exception\EmptyGridIdException
      */
     public function __construct(
         protected readonly string $id,
+        protected readonly ?string $editRole,
         protected readonly DataSourceInterface $dataSource,
         protected readonly RequestStack $requestStack,
         protected readonly RouterInterface $router,
         protected readonly RouteCsrfProtector $routeCsrfProtector,
         protected readonly Environment $twig,
+        protected readonly Security $security,
     ) {
         if ($id === '') {
             $message = 'Grid id cannot be empty.';
@@ -192,20 +199,24 @@ class Grid
      * @param string $route
      * @param array $bindingRouteParams
      * @param array $additionalRouteParams
-     * @return \Shopsys\FrameworkBundle\Component\Grid\ActionColumn
+     * @return \Shopsys\FrameworkBundle\Component\Grid\ActionColumn|null
      */
     public function addDeleteActionColumn(
         string $route,
         array $bindingRouteParams = [],
         array $additionalRouteParams = [],
-    ): ActionColumn {
-        return $this->addActionColumn(
-            ActionColumn::TYPE_DELETE,
-            t('Delete'),
-            $route,
-            $bindingRouteParams,
-            $additionalRouteParams,
-        );
+    ): ?ActionColumn {
+        if ($this->canEdit()) {
+            return $this->addActionColumn(
+                ActionColumn::TYPE_DELETE,
+                t('Delete'),
+                $route,
+                $bindingRouteParams,
+                $additionalRouteParams,
+            );
+        }
+
+        return null;
     }
 
     /**
@@ -224,7 +235,9 @@ class Grid
      */
     public function setInlineEditService(GridInlineEditInterface $inlineEditService): void
     {
-        $this->inlineEditService = $inlineEditService;
+        if ($this->canEdit()) {
+            $this->inlineEditService = $inlineEditService;
+        }
     }
 
     /**
@@ -753,5 +766,17 @@ class Grid
         }
 
         $this->columnsById = [...$orderedColumns, ...$this->columnsById];
+    }
+
+    /**
+     * @return bool
+     */
+    protected function canEdit(): bool
+    {
+        if ($this->editRole === null) {
+            throw new GridEditRoleNotSetException();
+        }
+
+        return $this->security->isGranted($this->editRole);
     }
 }

--- a/packages/framework/src/Component/Grid/GridFactory.php
+++ b/packages/framework/src/Component/Grid/GridFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Grid;
 
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
@@ -16,29 +17,35 @@ class GridFactory
      * @param \Symfony\Component\Routing\RouterInterface $router
      * @param \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector $routeCsrfProtector
      * @param \Twig\Environment $twig
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      */
     public function __construct(
         protected readonly RequestStack $requestStack,
         protected readonly RouterInterface $router,
         protected readonly RouteCsrfProtector $routeCsrfProtector,
         protected readonly Environment $twig,
+        protected readonly Security $security,
     ) {
     }
 
     /**
      * @param string $gridId
      * @param \Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface $dataSource
+     * @param string|null $editRole
+     * @throws \Shopsys\FrameworkBundle\Component\Grid\Exception\EmptyGridIdException
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create($gridId, DataSourceInterface $dataSource)
+    public function create(string $gridId, DataSourceInterface $dataSource, ?string $editRole = null)
     {
         return new Grid(
             $gridId,
+            $editRole,
             $dataSource,
             $this->requestStack,
             $this->router,
             $this->routeCsrfProtector,
             $this->twig,
+            $this->security,
         );
     }
 }

--- a/packages/framework/src/Component/Grid/GridFactoryInterface.php
+++ b/packages/framework/src/Component/Grid/GridFactoryInterface.php
@@ -7,7 +7,8 @@ namespace Shopsys\FrameworkBundle\Component\Grid;
 interface GridFactoryInterface
 {
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create();
+    public function create(?string $editRole): Grid;
 }

--- a/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
@@ -4,17 +4,24 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Grid\InlineEdit;
 
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\Exception\InvalidFormDataException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 abstract class AbstractGridInlineEdit implements GridInlineEditInterface
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface $gridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      */
-    public function __construct(protected readonly GridFactoryInterface $gridFactory)
-    {
+    public function __construct(
+        protected readonly GridFactoryInterface $gridFactory,
+        protected readonly Security $security,
+    ) {
     }
 
     /**
@@ -22,8 +29,10 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
      * @param int|string|null $rowId
      * @return int|string
      */
-    public function saveForm(Request $request, $rowId)
+    public function saveForm(Request $request, int|string|null $rowId): int|string
     {
+        $this->checkAdministratorHasEditRole();
+
         $form = $this->getForm($rowId);
         $form->handleRequest($request);
 
@@ -52,10 +61,13 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
     /**
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function getGrid()
+    public function getGrid(): Grid
     {
         $grid = $this->gridFactory->create();
-        $grid->setInlineEditService($this);
+
+        if ($this->canEdit()) {
+            $grid->setInlineEditService($this);
+        }
 
         return $grid;
     }
@@ -63,9 +75,9 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
     /**
      * @return bool
      */
-    public function canAddNewRow()
+    public function canAddNewRow(): bool
     {
-        return true;
+        return $this->canEdit();
     }
 
     /**
@@ -74,7 +86,7 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
      *
      * @return string
      */
-    public function getServiceName()
+    public function getServiceName(): string
     {
         return static::class;
     }
@@ -83,17 +95,37 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
      * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
-    abstract public function getForm($rowId);
+    abstract public function getForm(int|string|null $rowId): FormInterface;
 
     /**
      * @param int|string $rowId
      * @param mixed $formData
      */
-    abstract protected function editEntity($rowId, $formData);
+    abstract protected function editEntity(int|string $rowId, mixed $formData): void;
 
     /**
      * @param mixed $formData
      * @return int|string
      */
-    abstract protected function createEntityAndGetId($formData);
+    abstract protected function createEntityAndGetId(mixed $formData): int|string;
+
+    /**
+     * @return string
+     */
+    abstract protected function getEditRole(): string;
+
+    protected function checkAdministratorHasEditRole(): void
+    {
+        if (!$this->canEdit()) {
+            throw new AccessDeniedException();
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function canEdit(): bool
+    {
+        return $this->security->isGranted($this->getEditRole());
+    }
 }

--- a/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
@@ -63,7 +63,7 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
      */
     public function getGrid(): Grid
     {
-        $grid = $this->gridFactory->create();
+        $grid = $this->gridFactory->create($this->getEditRole());
 
         if ($this->canEdit()) {
             $grid->setInlineEditService($this);

--- a/packages/framework/src/Component/Grid/InlineEdit/GridInlineEditInterface.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/GridInlineEditInterface.php
@@ -4,35 +4,37 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Grid\InlineEdit;
 
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 interface GridInlineEditInterface
 {
     /**
-     * @param mixed $rowId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
-    public function getForm($rowId);
+    public function getForm(int|string|null $rowId): FormInterface;
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param mixed $rowId
-     * @return mixed
+     * @param int|string|null $rowId
+     * @return int|string
      */
-    public function saveForm(Request $request, $rowId);
+    public function saveForm(Request $request, int|string|null $rowId): int|string;
 
     /**
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function getGrid();
+    public function getGrid(): Grid;
 
     /**
      * @return bool
      */
-    public function canAddNewRow();
+    public function canAddNewRow(): bool;
 
     /**
      * @return string
      */
-    public function getServiceName();
+    public function getServiceName(): string;
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGridFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGridFactory.php
@@ -86,9 +86,10 @@ class FriendlyUrlGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(): Grid
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->friendlyUrlFacade->getNonUsedFriendlyUrlQueryBuilderByDomainIdAndQuickSearch(
             $this->adminDomainTabsFacade->getSelectedDomainId(),
@@ -106,7 +107,7 @@ class FriendlyUrlGridFactory implements GridFactoryInterface
             },
         );
 
-        $grid = $this->gridFactory->create('notUsedFriendlyUrls', $dataSource);
+        $grid = $this->gridFactory->create('notUsedFriendlyUrls', $dataSource, $editRole);
         $grid->enablePaging();
         $grid->setDefaultOrder('fu.slug');
         $grid->addColumn('slug', 'fu.slug', t('Slug'), true);
@@ -119,7 +120,7 @@ class FriendlyUrlGridFactory implements GridFactoryInterface
             'domainId' => 'fu.domainId',
             'slug' => 'fu.slug',
         ])
-            ->setConfirmMessage(t('Do you really want to remove this friendly URL? Removing friendly URL may have bad impact to SEO performance.'));
+            ?->setConfirmMessage(t('Do you really want to remove this friendly URL? Removing friendly URL may have bad impact to SEO performance.'));
 
         return $grid;
     }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlInlineEdit.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlInlineEdit.php
@@ -7,10 +7,14 @@ namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 use LogicException;
 use Override;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\AbstractGridInlineEdit;
 use Shopsys\FrameworkBundle\Form\Admin\FriendlyUrl\FriendlyUrlFormType;
 use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * @property \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlGridFactory $gridFactory
@@ -21,6 +25,7 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlGridFactory $gridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactory $friendlyUrlDataFactory
@@ -28,12 +33,13 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
      */
     public function __construct(
         FriendlyUrlGridFactory $gridFactory,
+        Security $security,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly FriendlyUrlFacade $friendlyUrlFacade,
         protected readonly FriendlyUrlDataFactory $friendlyUrlDataFactory,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
     ) {
-        parent::__construct($gridFactory);
+        parent::__construct($gridFactory, $security);
 
         $this->gridQuickSearchFormData = new QuickSearchFormData();
     }
@@ -43,7 +49,7 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($rowId)
+    public function getForm(int|string|null $rowId): FormInterface
     {
         $friendlyUrl = $this->friendlyUrlFacade->findByDomainIdAndSlug($this->adminDomainTabsFacade->getSelectedDomainId(), $rowId);
         $friendlyUrlData = $this->friendlyUrlDataFactory->createFromFriendlyUrl($friendlyUrl);
@@ -55,10 +61,11 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
     #[Override]
-    public function getGrid()
+    public function getGrid(): Grid
     {
         $this->gridFactory->setQuickSearchFormData($this->getGridQuickSearchFormData());
         $grid = $this->gridFactory->create();
+
         $grid->setInlineEditService($this);
 
         return $grid;
@@ -74,11 +81,11 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param string $rowId
+     * @param int|string $rowId
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlData $formData
      */
     #[Override]
-    protected function editEntity($rowId, $formData)
+    protected function editEntity(int|string $rowId, mixed $formData): void
     {
         $this->friendlyUrlFacade->setRedirect(
             $this->adminDomainTabsFacade->getSelectedDomainId(),
@@ -91,7 +98,7 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
      * @param mixed $formData
      */
     #[Override]
-    protected function createEntityAndGetId($formData): never
+    protected function createEntityAndGetId(mixed $formData): never
     {
         throw new LogicException('Creating a new unused friendly URL is not supported.');
     }
@@ -110,5 +117,14 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
     public function setGridQuickSearchFormData(QuickSearchFormData $gridQuickSearchFormData): void
     {
         $this->gridQuickSearchFormData = $gridQuickSearchFormData;
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_FRIENDLY_URL_FULL;
     }
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlInlineEdit.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlInlineEdit.php
@@ -64,7 +64,7 @@ class FriendlyUrlInlineEdit extends AbstractGridInlineEdit
     public function getGrid(): Grid
     {
         $this->gridFactory->setQuickSearchFormData($this->getGridQuickSearchFormData());
-        $grid = $this->gridFactory->create();
+        $grid = $this->gridFactory->create($this->getEditRole());
 
         $grid->setInlineEditService($this);
 

--- a/packages/framework/src/Component/UploadedFile/Grid/AbstractUploadedFileGridFactory.php
+++ b/packages/framework/src/Component/UploadedFile/Grid/AbstractUploadedFileGridFactory.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\UploadedFile\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class AbstractUploadedFileGridFactory
 {
@@ -24,7 +25,7 @@ class AbstractUploadedFileGridFactory
      */
     protected function createInstance(string $gridName, DataSourceInterface $dataSource): Grid
     {
-        $grid = $this->gridFactory->create($gridName, $dataSource);
+        $grid = $this->gridFactory->create($gridName, $dataSource, Roles::ROLE_FILES_FULL);
 
         $grid->enablePaging();
 

--- a/packages/framework/src/Component/UploadedFile/Grid/UploadedFileGridFactory.php
+++ b/packages/framework/src/Component/UploadedFile/Grid/UploadedFileGridFactory.php
@@ -45,7 +45,7 @@ class UploadedFileGridFactory extends AbstractUploadedFileGridFactory
 
         $grid->addEditActionColumn('admin_uploadedfile_edit', ['id' => 'u.id']);
         $grid->addDeleteActionColumn('admin_uploadedfile_delete', ['id' => 'u.id'])
-            ->setConfirmMessage(t('Do you really want to delete this file? It will be permanently deleted and unassigned from related records.'));
+            ?->setConfirmMessage(t('Do you really want to delete this file? It will be permanently deleted and unassigned from related records.'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/UploadedFile/listGrid.html.twig');
 

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -74,7 +74,7 @@ class AdministratorController extends AdminBaseController
         $queryBuilder = $this->administratorFacade->getAllListableQueryBuilder();
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'a.id');
 
-        $grid = $this->gridFactory->create('administratorList', $dataSource);
+        $grid = $this->gridFactory->create('administratorList', $dataSource, Roles::ROLE_ADMINISTRATOR_FULL);
         $grid->setDefaultOrder('realName');
 
         $grid->addColumn('realName', 'a.realName', t('Full name'), true);
@@ -83,7 +83,7 @@ class AdministratorController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_administrator_edit', ['id' => 'a.id']);
         $grid->addDeleteActionColumn('admin_administrator_delete', ['id' => 'a.id'])
-            ->setConfirmMessage(t('Do you really want to remove this administrator?'));
+            ?->setConfirmMessage(t('Do you really want to remove this administrator?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Administrator/listGrid.html.twig');
 

--- a/packages/framework/src/Controller/Admin/AdministratorRoleGroupController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorRoleGroupController.php
@@ -46,7 +46,7 @@ class AdministratorRoleGroupController extends AdminBaseController
         $queryBuilder = $this->administratorRoleGroupFacade->getAllQueryBuilder();
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'arg.id');
 
-        $grid = $this->gridFactory->create('administratorRoleGroupsList', $dataSource);
+        $grid = $this->gridFactory->create('administratorRoleGroupsList', $dataSource, Roles::ROLE_ADMINISTRATOR_FULL);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'arg.name', t('Role name'), true);

--- a/packages/framework/src/Controller/Admin/AdvertController.php
+++ b/packages/framework/src/Controller/Admin/AdvertController.php
@@ -123,7 +123,7 @@ class AdvertController extends AdminBaseController
             },
         );
 
-        $grid = $this->gridFactory->create('advertList', $dataSource);
+        $grid = $this->gridFactory->create('advertList', $dataSource, Roles::ROLE_ADVERT_FULL);
         $grid->enablePaging();
         $grid->setDefaultOrder('name');
 
@@ -135,7 +135,7 @@ class AdvertController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_advert_edit', ['id' => 'a.id']);
         $grid->addDeleteActionColumn('admin_advert_delete', ['id' => 'a.id'])
-            ->setConfirmMessage(t('Do you really want to remove this advert?'));
+            ?->setConfirmMessage(t('Do you really want to remove this advert?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Advert/listGrid.html.twig', [
             'advertPositionNames' => $this->advertPositionRegistry->getAllLabelsIndexedByNames(),

--- a/packages/framework/src/Controller/Admin/ArticleController.php
+++ b/packages/framework/src/Controller/Admin/ArticleController.php
@@ -244,7 +244,7 @@ class ArticleController extends AdminBaseController
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'a.id');
 
         $gridId = $articlePlacement;
-        $grid = $this->gridFactory->create($gridId, $dataSource);
+        $grid = $this->gridFactory->create($gridId, $dataSource, Roles::ROLE_ARTICLE_FULL);
         $grid->setDefaultOrder('position');
 
         $grid->addColumn('name', 'a.name', t('Name'));
@@ -252,7 +252,7 @@ class ArticleController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_article_edit', ['id' => 'a.id']);
         $grid->addDeleteActionColumn('admin_article_deleteconfirm', ['id' => 'a.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->enableMultipleDragAndDrop();
         $grid->setTheme('@ShopsysFramework/Admin/Content/Article/listGrid.html.twig');

--- a/packages/framework/src/Controller/Admin/BrandController.php
+++ b/packages/framework/src/Controller/Admin/BrandController.php
@@ -98,7 +98,7 @@ class BrandController extends AdminBaseController
         $queryBuilder = $this->entityManager->createQueryBuilder()->select('b')->from(Brand::class, 'b');
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'b.id');
 
-        $grid = $this->gridFactory->create('brandList', $dataSource);
+        $grid = $this->gridFactory->create('brandList', $dataSource, Roles::ROLE_BRAND_FULL);
         $grid->enablePaging();
         $grid->setDefaultOrder('name');
 
@@ -107,7 +107,7 @@ class BrandController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_brand_edit', ['id' => 'b.id']);
         $grid->addDeleteActionColumn('admin_brand_delete', ['id' => 'b.id'])
-            ->setConfirmMessage(
+            ?->setConfirmMessage(
                 t('Do you really want to remove this brand? If it is used anywhere it will be unset.'),
             );
 

--- a/packages/framework/src/Controller/Admin/CountryController.php
+++ b/packages/framework/src/Controller/Admin/CountryController.php
@@ -41,7 +41,7 @@ class CountryController extends AdminBaseController
     #[AccessControlRule([Roles::ROLE_COUNTRY_VIEW])]
     public function listAction(): Response
     {
-        $grid = $this->countryGridFactory->create();
+        $grid = $this->countryGridFactory->create(Roles::ROLE_COUNTRY_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/Country/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -206,7 +206,7 @@ class CustomerController extends AdminBaseController
         );
         $dataSource = new MoneyConvertingDataSourceDecorator($innerDataSource, ['ordersSumPrice']);
 
-        $grid = $this->gridFactory->create('customerList', $dataSource);
+        $grid = $this->gridFactory->create('customerList', $dataSource, Roles::ROLE_CUSTOMER_FULL);
         $grid->enablePaging();
         $grid->setDefaultOrder('name');
 
@@ -225,7 +225,7 @@ class CustomerController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_customer_edit', ['id' => 'id']);
         $grid->addDeleteActionColumn('admin_customer_delete', ['id' => 'id'])
-            ->setConfirmMessage(t('Do you really want to remove this customer?'));
+            ?->setConfirmMessage(t('Do you really want to remove this customer?'));
         $grid->addActionColumn(ActionColumn::TYPE_RESET_PASSWORD, t('Send reset password'), 'admin_customer_send_reset_password', ['id' => 'cu.id'])
             ->setConfirmMessage(t('This will send an email to customer user for resetting password. Do you really want to send it ?'));
 

--- a/packages/framework/src/Controller/Admin/CustomerUserRoleGroupController.php
+++ b/packages/framework/src/Controller/Admin/CustomerUserRoleGroupController.php
@@ -42,7 +42,7 @@ class CustomerUserRoleGroupController extends AdminBaseController
     #[AccessControlRule([Roles::ROLE_SUPER_ADMIN])]
     public function listAction(): Response
     {
-        $grid = $this->gridFactory->create();
+        $grid = $this->gridFactory->create(Roles::ROLE_SUPER_ADMIN);
 
         return $this->render('@ShopsysFramework/Admin/Content/Customer/RoleGroup/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/FlagController.php
+++ b/packages/framework/src/Controller/Admin/FlagController.php
@@ -46,7 +46,7 @@ class FlagController extends AdminBaseController
     #[AccessControlRule([Roles::ROLE_FLAG_VIEW])]
     public function listAction(): Response
     {
-        $grid = $this->flagGridFactory->create();
+        $grid = $this->flagGridFactory->create(Roles::ROLE_FLAG_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/Flag/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/GridController.php
+++ b/packages/framework/src/Controller/Admin/GridController.php
@@ -30,7 +30,7 @@ class GridController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/_grid/get-form/')]
-    #[AccessControlRule([Roles::ROLE_ALL])]
+    #[AccessControlRule([Roles::ROLE_ADMIN])]
     public function getFormAction(Request $request): JsonResponse
     {
         $rowId = $request->get('rowId') !== null ? json_decode($request->get('rowId')) : null;
@@ -48,7 +48,7 @@ class GridController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/_grid/save-form/')]
-    #[AccessControlRule([Roles::ROLE_ALL])]
+    #[AccessControlRule([Roles::ROLE_ADMIN])]
     public function saveFormAction(Request $request): JsonResponse
     {
         $responseData = [];
@@ -76,7 +76,7 @@ class GridController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/_grid/save-ordering/')]
-    #[AccessControlRule([Roles::ROLE_ALL])]
+    #[AccessControlRule([Roles::ROLE_ADMIN])]
     public function saveOrderingAction(Request $request): JsonResponse
     {
         $this->gridOrderingFacade->saveOrdering(

--- a/packages/framework/src/Controller/Admin/MailController.php
+++ b/packages/framework/src/Controller/Admin/MailController.php
@@ -58,7 +58,7 @@ class MailController extends AdminBaseController
     #[AccessControlRule([Roles::ROLE_MAIL_TEMPLATE_VIEW])]
     public function templateAction(): Response
     {
-        $grid = $this->mailTemplateGridFactory->create();
+        $grid = $this->mailTemplateGridFactory->create(Roles::ROLE_MAIL_TEMPLATE_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/Mail/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/NavigationController.php
+++ b/packages/framework/src/Controller/Admin/NavigationController.php
@@ -176,13 +176,13 @@ class NavigationController extends AdminBaseController
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'ni.id');
 
-        $grid = $this->gridFactory->create('navigationItemsList', $dataSource);
+        $grid = $this->gridFactory->create('navigationItemsList', $dataSource, Roles::ROLE_NAVIGATION_FULL);
 
         $grid->addColumn('name', 'ni.name', t('Name'));
 
         $grid->addEditActionColumn('admin_navigation_edit', ['id' => 'ni.id']);
         $grid->addDeleteActionColumn('admin_navigation_delete', ['id' => 'ni.id'])
-            ->setConfirmMessage(t('Do you really want to remove this navigation item?'));
+            ?->setConfirmMessage(t('Do you really want to remove this navigation item?'));
 
         $grid->enableDragAndDrop(NavigationItem::class);
 

--- a/packages/framework/src/Controller/Admin/NewsletterController.php
+++ b/packages/framework/src/Controller/Admin/NewsletterController.php
@@ -51,14 +51,14 @@ class NewsletterController extends AdminBaseController
         );
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'u.id');
-        $grid = $this->gridFactory->create('customerList', $dataSource);
+        $grid = $this->gridFactory->create('customerList', $dataSource, Roles::ROLE_NEWSLETTER_FULL);
         $grid->enablePaging();
 
         $grid->addColumn('email', 'email', 'Email');
         $grid->addColumn('createdAt', 'createdAt', t('Subscribed at'));
         $grid->setDefaultOrder('email');
         $grid->addDeleteActionColumn('admin_newsletter_delete', ['id' => 'id'])
-            ->setConfirmMessage(t('Do you really want to remove this subscriber?'));
+            ?->setConfirmMessage(t('Do you really want to remove this subscriber?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Newsletter/listGrid.html.twig');
 

--- a/packages/framework/src/Controller/Admin/NotificationBarController.php
+++ b/packages/framework/src/Controller/Admin/NotificationBarController.php
@@ -45,7 +45,7 @@ class NotificationBarController extends AdminBaseController
         $queryBuilder = $this->notificationBarFacade->getAllByDomainIdQueryBuilderForGrid($this->adminDomainTabsFacade->getSelectedDomainId());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'nb.id');
 
-        $grid = $this->gridFactory->create('NotificationBarList', $dataSource);
+        $grid = $this->gridFactory->create('NotificationBarList', $dataSource, Roles::ROLE_NOTIFICATION_BAR_FULL);
 
         $grid->addColumn('visible', 'visibility', t('Visibility'), true)->setClassAttribute('table-col table-col-10');
         $grid->addColumn('text', 'nb.text', t('Text'));
@@ -53,7 +53,7 @@ class NotificationBarController extends AdminBaseController
         $grid->addColumn('validityTo', 'nb.validityTo', t('Valid to'), true);
         $grid->addEditActionColumn('admin_notificationbar_edit', ['id' => 'nb.id']);
         $grid->addDeleteActionColumn('admin_notificationbar_delete', ['id' => 'nb.id'])
-            ->setConfirmMessage(t('Do you really want to remove this notification bar?'));
+            ?->setConfirmMessage(t('Do you really want to remove this notification bar?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/NotificationBar/listGrid.html.twig');
 

--- a/packages/framework/src/Controller/Admin/OrderController.php
+++ b/packages/framework/src/Controller/Admin/OrderController.php
@@ -229,7 +229,7 @@ class OrderController extends AdminBaseController
             null,
         );
 
-        $grid = $this->gridFactory->create('orderList', $dataSource);
+        $grid = $this->gridFactory->create('orderList', $dataSource, Roles::ROLE_ORDER_FULL);
         $grid->enablePaging();
         $grid->setDefaultOrder('created_at', DataSourceInterface::ORDER_DESC);
 
@@ -248,7 +248,7 @@ class OrderController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_order_edit', ['id' => 'id']);
         $grid->addDeleteActionColumn('admin_order_delete', ['id' => 'id'])
-            ->setConfirmMessage(t('Do you really want to remove the order?'));
+            ?->setConfirmMessage(t('Do you really want to remove the order?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Order/listGrid.html.twig');
 

--- a/packages/framework/src/Controller/Admin/ParameterController.php
+++ b/packages/framework/src/Controller/Admin/ParameterController.php
@@ -41,7 +41,7 @@ class ParameterController extends AdminBaseController
     #[AccessControlRule([Roles::ROLE_PARAMETER_VIEW])]
     public function listAction(): Response
     {
-        $grid = $this->parameterGridFactory->create();
+        $grid = $this->parameterGridFactory->create(Roles::ROLE_PARAMETER_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/Parameter/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/ParameterGroupController.php
+++ b/packages/framework/src/Controller/Admin/ParameterGroupController.php
@@ -166,7 +166,7 @@ class ParameterGroupController extends AdminBaseController
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'pg.id');
 
-        $grid = $this->gridFactory->create('parameterGroupsList', $dataSource);
+        $grid = $this->gridFactory->create('parameterGroupsList', $dataSource, Roles::ROLE_PARAMETER_GROUP_FULL);
 
         $grid->addColumn('name', 'pgt.name', t('Name'));
         $grid->setDefaultOrder('pg.position');
@@ -174,7 +174,7 @@ class ParameterGroupController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_parametergroup_edit', ['id' => 'pg.id']);
         $grid->addDeleteActionColumn('admin_parametergroup_delete', ['id' => 'pg.id'])
-            ->setConfirmMessage(t('Do you really want to remove this parameter groups? By deleting this parameter group you will '
+            ?->setConfirmMessage(t('Do you really want to remove this parameter groups? By deleting this parameter group you will '
                 . 'unset all groups by associated parameters. This step is irreversible!'));
 
         $grid->enableDragAndDrop(ParameterGroup::class);

--- a/packages/framework/src/Controller/Admin/PaymentController.php
+++ b/packages/framework/src/Controller/Admin/PaymentController.php
@@ -152,7 +152,7 @@ class PaymentController extends AdminBaseController
      */
     public function listAction(): Response
     {
-        $grid = $this->paymentGridFactory->create();
+        $grid = $this->paymentGridFactory->create(Roles::ROLE_TRANSPORT_AND_PAYMENT_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/Payment/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/PromoCodeController.php
+++ b/packages/framework/src/Controller/Admin/PromoCodeController.php
@@ -54,7 +54,7 @@ class PromoCodeController extends AdminBaseController
         $quickSearchForm = $this->createForm(QuickSearchFormType::class, new QuickSearchFormData());
         $quickSearchForm->handleRequest($request);
 
-        $grid = $this->promoCodeGridFactory->create(search: $quickSearchForm->getData()->text);
+        $grid = $this->promoCodeGridFactory->create(Roles::ROLE_PROMO_CODE_FULL, search: $quickSearchForm->getData()->text);
         $grid->enablePaging();
 
         $this->administratorGridFacade->restoreAndRememberGridLimit($this->getCurrentAdministrator(), $grid);

--- a/packages/framework/src/Controller/Admin/SalesRepresentativeController.php
+++ b/packages/framework/src/Controller/Admin/SalesRepresentativeController.php
@@ -48,7 +48,7 @@ class SalesRepresentativeController extends AdminBaseController
     #[AccessControlRule([Roles::ROLE_SALES_REPRESENTATIVE_VIEW])]
     public function listAction(): Response
     {
-        $grid = $this->salesRepresentativeGridFactory->create();
+        $grid = $this->salesRepresentativeGridFactory->create(Roles::ROLE_SALES_REPRESENTATIVE_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/SalesRepresentative/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Controller/Admin/SliderController.php
+++ b/packages/framework/src/Controller/Admin/SliderController.php
@@ -57,14 +57,14 @@ class SliderController extends AdminBaseController
             ->addOrderBy('s.id');
         $dataSource = new QueryBuilderDataSource($queryBuilder, 's.id');
 
-        $grid = $this->gridFactory->create('sliderItemList', $dataSource);
+        $grid = $this->gridFactory->create('sliderItemList', $dataSource, Roles::ROLE_SLIDER_ITEM_FULL);
         $grid->enableDragAndDrop(SliderItem::class);
 
         $grid->addColumn('name', 's.name', t('Name'));
         $grid->addColumn('link', 's.link', t('Link'));
         $grid->addEditActionColumn('admin_slider_edit', ['id' => 's.id']);
         $grid->addDeleteActionColumn('admin_slider_delete', ['id' => 's.id'])
-            ->setConfirmMessage(t('Do you really want to remove this page?'));
+            ?->setConfirmMessage(t('Do you really want to remove this page?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Slider/listGrid.html.twig');
 

--- a/packages/framework/src/Controller/Admin/StockController.php
+++ b/packages/framework/src/Controller/Admin/StockController.php
@@ -282,7 +282,7 @@ class StockController extends AdminBaseController
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 's.id');
 
-        $grid = $this->gridFactory->create('stockList', $dataSource);
+        $grid = $this->gridFactory->create('stockList', $dataSource, Roles::ROLE_STOCK_FULL);
 
         $grid->addColumn('name', 's.name', t('Name'));
         $grid->setDefaultOrder('s.position');
@@ -290,7 +290,7 @@ class StockController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_stock_edit', ['id' => 's.id']);
         $grid->addDeleteActionColumn('admin_stock_delete', ['id' => 's.id'])
-            ->setConfirmMessage(t('Do you really want to remove this warehouse? By deleting this warehouse you will '
+            ?->setConfirmMessage(t('Do you really want to remove this warehouse? By deleting this warehouse you will '
                 . 'remove all stock quantities from products and association to stores. This step is irreversible!'));
         $grid->enableDragAndDrop(Stock::class);
 

--- a/packages/framework/src/Controller/Admin/StoreController.php
+++ b/packages/framework/src/Controller/Admin/StoreController.php
@@ -58,7 +58,7 @@ class StoreController extends AdminBaseController
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 's.id');
 
-        $grid = $this->gridFactory->create('storeList', $dataSource);
+        $grid = $this->gridFactory->create('storeList', $dataSource, Roles::ROLE_STORE_FULL);
 
         $grid->addColumn('name', 's.name', t('Name'));
         $grid->setDefaultOrder('s.position');
@@ -66,7 +66,7 @@ class StoreController extends AdminBaseController
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_store_edit', ['id' => 's.id']);
         $grid->addDeleteActionColumn('admin_store_delete', ['id' => 's.id'])
-            ->setConfirmMessage(t('Do you really want to remove this store? This step is irreversible!'));
+            ?->setConfirmMessage(t('Do you really want to remove this store? This step is irreversible!'));
         $grid->enableDragAndDrop(Store::class);
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Store/listGrid.html.twig');

--- a/packages/framework/src/Controller/Admin/TransferIssueController.php
+++ b/packages/framework/src/Controller/Admin/TransferIssueController.php
@@ -63,7 +63,7 @@ class TransferIssueController extends AdminBaseController
         }
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'ti.id');
 
-        $grid = $this->gridFactory->create('transferIssueList', $dataSource);
+        $grid = $this->gridFactory->create('transferIssueList', $dataSource, Roles::ROLE_TRANSFER_FULL);
         $grid->enablePaging();
         $grid->setDefaultOrder('createdAt DESC, id');
 
@@ -71,7 +71,7 @@ class TransferIssueController extends AdminBaseController
         $grid->addColumn('message', 'ti.message', t('Message text'));
         $grid->addColumn('createdAt', 'ti.createdAt', t('Date and time'));
         $grid->addDeleteActionColumn('admin_transferissue_delete', ['id' => 'ti.id'])
-            ->setConfirmMessage(t('Do you really want to mark this issue as resolved?'));
+            ?->setConfirmMessage(t('Do you really want to mark this issue as resolved?'));
 
         $this->administratorGridFacade->restoreAndRememberGridLimit($administrator, $grid);
 

--- a/packages/framework/src/Controller/Admin/TransportController.php
+++ b/packages/framework/src/Controller/Admin/TransportController.php
@@ -152,9 +152,10 @@ class TransportController extends AdminBaseController
     /**
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[AccessControlRule([Roles::ROLE_TRANSPORT_AND_PAYMENT_VIEW])]
     public function listAction(): Response
     {
-        $grid = $this->transportGridFactory->create();
+        $grid = $this->transportGridFactory->create(Roles::ROLE_TRANSPORT_AND_PAYMENT_FULL);
 
         return $this->render('@ShopsysFramework/Admin/Content/Transport/list.html.twig', [
             'gridView' => $grid->createView(),

--- a/packages/framework/src/Model/Blog/Article/BlogArticleGridFactory.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleGridFactory.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class BlogArticleGridFactory
 {
@@ -32,7 +33,7 @@ class BlogArticleGridFactory
     {
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'ba.id');
 
-        $grid = $this->gridFactory->create('blog_article', $dataSource);
+        $grid = $this->gridFactory->create('blog_article', $dataSource, Roles::ROLE_BLOG_ARTICLE_FULL);
         $grid->setDefaultOrder('createdAt DESC');
         $grid->enablePaging();
 
@@ -42,7 +43,7 @@ class BlogArticleGridFactory
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_blogarticle_edit', ['id' => 'ba.id']);
         $grid->addDeleteActionColumn('admin_blogarticle_deleteconfirm', ['id' => 'ba.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Blog/Article/listGrid.html.twig');
 

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixGridFactory.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixGridFactory.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
 use Shopsys\FrameworkBundle\Model\Category\CategoryTranslation;
 use Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class ReadyCategorySeoMixGridFactory
 {
@@ -38,7 +39,7 @@ class ReadyCategorySeoMixGridFactory
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'rcsmId');
 
-        $grid = $this->gridFactory->create('ready_category_seo_mix', $dataSource);
+        $grid = $this->gridFactory->create('ready_category_seo_mix', $dataSource, Roles::ROLE_CATEGORY_SEO_FULL);
 
         $grid->addColumn('categoryName', 'categoryName', t('Category name'));
         $grid->addColumn('friendlyUrlSlug', 'fuSlug', t('Main URL'));

--- a/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusGridFactory.php
+++ b/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusGridFactory.php
@@ -29,9 +29,10 @@ class ComplaintStatusGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(): Grid
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -41,14 +42,14 @@ class ComplaintStatusGridFactory implements GridFactoryInterface
             ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'cs.id');
 
-        $grid = $this->gridFactory->create('complaintStatusList', $dataSource);
+        $grid = $this->gridFactory->create('complaintStatusList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'cst.name', t('Name'), true);
 
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_complaintstatus_deleteconfirm', ['id' => 'cs.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/ComplaintStatus/listGrid.html.twig', [
             'STATUS_TYPE_NEW' => ComplaintStatusTypeEnum::STATUS_TYPE_NEW,

--- a/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusInlineEdit.php
+++ b/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusInlineEdit.php
@@ -11,6 +11,8 @@ use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\Exception\InvalidFormDataE
 use Shopsys\FrameworkBundle\Form\Admin\Complaint\Status\ComplaintStatusFormType;
 use Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusDataFactory;
 use Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusFacade;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -18,6 +20,7 @@ class ComplaintStatusInlineEdit extends AbstractGridInlineEdit
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Complaint\Status\Grid\ComplaintStatusGridFactory $complaintStatusGridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusFacade $complaintStatusFacade
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
      * @param \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusDataFactory $complaintStatusDataFactory
@@ -25,12 +28,13 @@ class ComplaintStatusInlineEdit extends AbstractGridInlineEdit
      */
     public function __construct(
         ComplaintStatusGridFactory $complaintStatusGridFactory,
+        Security $security,
         protected readonly ComplaintStatusFacade $complaintStatusFacade,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly ComplaintStatusDataFactory $complaintStatusDataFactory,
         protected readonly Domain $domain,
     ) {
-        parent::__construct($complaintStatusGridFactory);
+        parent::__construct($complaintStatusGridFactory, $security);
     }
 
     /**
@@ -38,7 +42,7 @@ class ComplaintStatusInlineEdit extends AbstractGridInlineEdit
      * @return int
      */
     #[Override]
-    protected function createEntityAndGetId($complaintStatusData): int
+    protected function createEntityAndGetId(mixed $complaintStatusData): int
     {
         if (!$this->domain->hasAdminAllDomainsEnabled()) {
             throw new InvalidFormDataException([
@@ -52,29 +56,38 @@ class ComplaintStatusInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param int $complaintStatusId
+     * @param int|string $complaintStatusId
      * @param \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusData $complaintStatusData
      */
     #[Override]
-    protected function editEntity($complaintStatusId, $complaintStatusData): void
+    protected function editEntity(int|string $complaintStatusId, mixed $complaintStatusData): void
     {
         $this->complaintStatusFacade->edit($complaintStatusId, $complaintStatusData);
     }
 
     /**
-     * @param int|null $complaintStatusId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($complaintStatusId): FormInterface
+    public function getForm(int|string|null $rowId): FormInterface
     {
-        if ($complaintStatusId !== null) {
-            $complaintStatus = $this->complaintStatusFacade->getById((int)$complaintStatusId);
+        if ($rowId !== null) {
+            $complaintStatus = $this->complaintStatusFacade->getById((int)$rowId);
             $complaintStatusData = $this->complaintStatusDataFactory->createFromComplaintStatus($complaintStatus);
         } else {
             $complaintStatusData = $this->complaintStatusDataFactory->create();
         }
 
         return $this->formFactory->create(ComplaintStatusFormType::class, $complaintStatusData);
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_COMPLAINT_FULL;
     }
 }

--- a/packages/framework/src/Model/Country/Grid/CountryGridFactory.php
+++ b/packages/framework/src/Model/Country/Grid/CountryGridFactory.php
@@ -29,9 +29,10 @@ class CountryGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(): Grid
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->countryRepository
             ->createSortedJoinedQueryBuilder($this->localization->getCurrentLocaleForTranslatableEntities(), $this->domain->getId())
@@ -39,7 +40,7 @@ class CountryGridFactory implements GridFactoryInterface
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'c.id');
 
-        $grid = $this->gridFactory->create('CountryList', $dataSource);
+        $grid = $this->gridFactory->create('CountryList', $dataSource, $editRole);
 
         $grid->addColumn('name', 'ct.name', t('Name'), true);
         $grid->addColumn('code', 'c.code', t('Country code'), true);

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupGridFactory.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupGridFactory.php
@@ -26,15 +26,16 @@ class CustomerUserRoleGroupGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(): Grid
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->getGridQueryBuilder();
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'cug.id');
 
-        $grid = $this->gridFactory->create('customerUserRoleGroupsList', $dataSource);
+        $grid = $this->gridFactory->create('customerUserRoleGroupsList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'cugt.name', t('Role group name'), true);
@@ -42,7 +43,7 @@ class CustomerUserRoleGroupGridFactory implements GridFactoryInterface
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_superadmin_customer_user_role_group_edit', ['id' => 'cug.id']);
         $grid->addDeleteActionColumn('admin_superadmin_customer_user_role_group_delete', ['id' => 'cug.id'])
-            ->setConfirmMessage(t('Do you really want to remove this customer user role group?'));
+            ?->setConfirmMessage(t('Do you really want to remove this customer user role group?'));
 
         return $grid;
     }

--- a/packages/framework/src/Model/LanguageConstant/LanguageConstantGridFactory.php
+++ b/packages/framework/src/Model/LanguageConstant/LanguageConstantGridFactory.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\LanguageConstant;
 use Shopsys\FrameworkBundle\Component\Grid\ArrayWithPaginationDataSource;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class LanguageConstantGridFactory
 {
@@ -33,7 +34,7 @@ class LanguageConstantGridFactory
             ? $this->getTranslationsWithSearch($originalTranslations, $userTranslations, $locale, mb_strtolower($search))
             : $this->getTranslations($originalTranslations, $userTranslations, $locale);
 
-        $grid = $this->gridFactory->create('languageConstantList', new ArrayWithPaginationDataSource($translations, 'key'));
+        $grid = $this->gridFactory->create('languageConstantList', new ArrayWithPaginationDataSource($translations, 'key'), Roles::ROLE_LANGUAGE_CONSTANTS_FULL);
         $grid->setDefaultOrder('key');
         $grid->enablePaging();
 
@@ -51,7 +52,7 @@ class LanguageConstantGridFactory
         $grid->addEditActionColumn('admin_languageconstant_edit', ['key' => 'key']);
         $grid
             ->addDeleteActionColumn('admin_languageconstant_delete', ['key' => 'key'])
-            ->setConfirmMessage(t('Do you really want to remove this language constant translation?'));
+            ?->setConfirmMessage(t('Do you really want to remove this language constant translation?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/LanguageConstant/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Mail/Grid/MailTemplateGridFactory.php
+++ b/packages/framework/src/Model/Mail/Grid/MailTemplateGridFactory.php
@@ -30,11 +30,12 @@ class MailTemplateGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(): Grid
+    public function create(?string $editRole): Grid
     {
-        $grid = $this->gridFactory->create('MailTemplateList', $this->createDataSource());
+        $grid = $this->gridFactory->create('MailTemplateList', $this->createDataSource(), $editRole);
 
         $grid->addColumn('name', 'mt.name', t('Name'), true);
         $grid->addColumn('subject', 'mt.subject', t('Subject'), true);

--- a/packages/framework/src/Model/Order/PromoCode/Grid/PromoCodeGridFactory.php
+++ b/packages/framework/src/Model/Order/PromoCode/Grid/PromoCodeGridFactory.php
@@ -31,11 +31,14 @@ class PromoCodeGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @param bool $withEditButton
      * @param string|null $search
+     * @throws \Shopsys\FrameworkBundle\Component\Grid\Exception\DuplicateColumnIdException
+     * @throws \Shopsys\FrameworkBundle\Component\Grid\Exception\EmptyGridIdException
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(bool $withEditButton = true, ?string $search = null): Grid
+    public function create(?string $editRole, bool $withEditButton = true, ?string $search = null): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -58,7 +61,7 @@ class PromoCodeGridFactory implements GridFactoryInterface
 
         $dataSource = new QueryBuilderWithRowManipulatorDataSource($queryBuilder, 'pc.id', $manipulator);
 
-        $grid = $this->gridFactory->create('promoCodeList', $dataSource);
+        $grid = $this->gridFactory->create('promoCodeList', $dataSource, $editRole);
         $grid->setDefaultOrder('code');
         $grid->addColumn('code', 'pc.code', t('Code'), true);
         $grid->addColumn('percent', 'pc.percent', t('Discount'));
@@ -70,7 +73,7 @@ class PromoCodeGridFactory implements GridFactoryInterface
         }
 
         $grid->addDeleteActionColumn('admin_promocode_delete', ['id' => 'pc.id'])
-            ->setConfirmMessage(t('Do you really want to remove this promo code?'));
+            ?->setConfirmMessage(t('Do you really want to remove this promo code?'));
 
         $grid->addActionColumn('duplicate', t('Duplicate'), 'admin_promocode_new', ['fillFromPromoCodeId' => 'pc.id']);
 

--- a/packages/framework/src/Model/Order/Status/Grid/OrderStatusGridFactory.php
+++ b/packages/framework/src/Model/Order/Status/Grid/OrderStatusGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Order\Status\Grid;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
@@ -28,9 +29,10 @@ class OrderStatusGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -40,14 +42,14 @@ class OrderStatusGridFactory implements GridFactoryInterface
             ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'os.id');
 
-        $grid = $this->gridFactory->create('orderStatusList', $dataSource);
+        $grid = $this->gridFactory->create('orderStatusList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'ost.name', t('Name'), true);
 
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_orderstatus_deleteconfirm', ['id' => 'os.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/OrderStatus/listGrid.html.twig', [
             'TYPE_NEW' => OrderStatusTypeEnum::TYPE_NEW,

--- a/packages/framework/src/Model/Order/Status/Grid/OrderStatusInlineEdit.php
+++ b/packages/framework/src/Model/Order/Status/Grid/OrderStatusInlineEdit.php
@@ -11,12 +11,16 @@ use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\Exception\InvalidFormDataE
 use Shopsys\FrameworkBundle\Form\Admin\Order\Status\OrderStatusFormType;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 class OrderStatusInlineEdit extends AbstractGridInlineEdit
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\Grid\OrderStatusGridFactory $orderStatusGridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade $orderStatusFacade
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactory $orderStatusDataFactory
@@ -24,20 +28,21 @@ class OrderStatusInlineEdit extends AbstractGridInlineEdit
      */
     public function __construct(
         OrderStatusGridFactory $orderStatusGridFactory,
+        Security $security,
         protected readonly OrderStatusFacade $orderStatusFacade,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly OrderStatusDataFactory $orderStatusDataFactory,
         protected readonly Domain $domain,
     ) {
-        parent::__construct($orderStatusGridFactory);
+        parent::__construct($orderStatusGridFactory, $security);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $orderStatusData
-     * @return int
+     * @return int|string
      */
     #[Override]
-    protected function createEntityAndGetId($orderStatusData)
+    protected function createEntityAndGetId(mixed $orderStatusData): int|string
     {
         if (!$this->domain->hasAdminAllDomainsEnabled()) {
             throw new InvalidFormDataException([
@@ -51,29 +56,38 @@ class OrderStatusInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param int $orderStatusId
+     * @param int|string $orderStatusId
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $orderStatusData
      */
     #[Override]
-    protected function editEntity($orderStatusId, $orderStatusData)
+    protected function editEntity(int|string $orderStatusId, mixed $orderStatusData): void
     {
         $this->orderStatusFacade->edit($orderStatusId, $orderStatusData);
     }
 
     /**
-     * @param int|null $orderStatusId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($orderStatusId)
+    public function getForm(int|string|null $rowId): FormInterface
     {
-        if ($orderStatusId !== null) {
-            $orderStatus = $this->orderStatusFacade->getById((int)$orderStatusId);
+        if ($rowId !== null) {
+            $orderStatus = $this->orderStatusFacade->getById((int)$rowId);
             $orderStatusData = $this->orderStatusDataFactory->createFromOrderStatus($orderStatus);
         } else {
             $orderStatusData = $this->orderStatusDataFactory->create();
         }
 
         return $this->formFactory->create(OrderStatusFormType::class, $orderStatusData);
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_ORDER_STATUS_FULL;
     }
 }

--- a/packages/framework/src/Model/Payment/Grid/PaymentGridFactory.php
+++ b/packages/framework/src/Model/Payment/Grid/PaymentGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Payment\Grid;
 
 use Doctrine\ORM\Query\Expr\Join;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;
@@ -33,9 +34,10 @@ class PaymentGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->paymentRepository->getQueryBuilderForAll()
             ->addSelect('pt')
@@ -53,7 +55,7 @@ class PaymentGridFactory implements GridFactoryInterface
             },
         );
 
-        $grid = $this->gridFactory->create('paymentList', $dataSource);
+        $grid = $this->gridFactory->create('paymentList', $dataSource, $editRole);
         $grid->enableDragAndDrop(Payment::class);
 
         $grid->addColumn('name', 'pt.name', t('Name'));
@@ -62,7 +64,7 @@ class PaymentGridFactory implements GridFactoryInterface
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_payment_edit', ['id' => 'p.id']);
         $grid->addDeleteActionColumn('admin_payment_delete', ['id' => 'p.id'])
-            ->setConfirmMessage(t('Do you really want to remove this payment?'));
+            ?->setConfirmMessage(t('Do you really want to remove this payment?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Payment/listGrid.html.twig');
 

--- a/packages/framework/src/Model/PriceList/PriceListGridFactory.php
+++ b/packages/framework/src/Model/PriceList/PriceListGridFactory.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Component\Grid\GridView;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
 use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class PriceListGridFactory
 {
@@ -38,7 +39,7 @@ class PriceListGridFactory
     ): GridView {
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'pl.id');
 
-        $grid = $this->gridFactory->create('priceList', $dataSource);
+        $grid = $this->gridFactory->create('priceList', $dataSource, Roles::ROLE_PRICE_LIST_FULL);
 
         $grid->enablePaging();
         $grid->setDefaultOrder('lastUpdate', DataSourceInterface::ORDER_DESC);
@@ -57,7 +58,7 @@ class PriceListGridFactory
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_pricelist_edit', ['id' => 'pl.id']);
         $grid->addDeleteActionColumn('admin_pricelist_delete', ['id' => 'pl.id'])
-            ->setConfirmMessage(
+            ?->setConfirmMessage(
                 t('Do you really want to remove this product list? Special prices for products in this list will be removed.'),
             );
         $grid->addActionColumn('download', 'Export CSV', 'admin_pricelist_export', ['id' => 'pl.id']);

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing\Currency\Grid;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
@@ -26,9 +27,10 @@ class CurrencyGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -36,7 +38,7 @@ class CurrencyGridFactory implements GridFactoryInterface
             ->from(Currency::class, 'c');
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'c.id');
 
-        $grid = $this->gridFactory->create('currencyList', $dataSource);
+        $grid = $this->gridFactory->create('currencyList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
         $grid->addColumn('name', 'c.name', t('Name'), true);
         $grid->addColumn('code', 'c.code', t('Code'), true);
@@ -46,7 +48,7 @@ class CurrencyGridFactory implements GridFactoryInterface
         $grid->addColumn('roundingPlacesPriceWithoutVat', 'c.roundingPlacesPriceWithoutVat', t('Rounding places of price without VAT and VAT amount'), true);
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_currency_deleteconfirm', ['id' => 'c.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme(
             '@ShopsysFramework/Admin/Content/Currency/listGrid.html.twig',

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyInlineEdit.php
@@ -9,31 +9,36 @@ use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\AbstractGridInlineEdit;
 use Shopsys\FrameworkBundle\Form\Admin\Pricing\Currency\CurrencyFormType;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactory;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 class CurrencyInlineEdit extends AbstractGridInlineEdit
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Grid\CurrencyGridFactory $currencyGridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactory $currencyDataFactory
      */
     public function __construct(
         CurrencyGridFactory $currencyGridFactory,
+        Security $security,
         protected readonly CurrencyFacade $currencyFacade,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly CurrencyDataFactory $currencyDataFactory,
     ) {
-        parent::__construct($currencyGridFactory);
+        parent::__construct($currencyGridFactory, $security);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
-     * @return int
+     * @return int|string
      */
     #[Override]
-    protected function createEntityAndGetId($currencyData)
+    protected function createEntityAndGetId(mixed $currencyData): int|string
     {
         $currency = $this->currencyFacade->create($currencyData);
 
@@ -41,31 +46,31 @@ class CurrencyInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param int $currencyId
+     * @param int|string $currencyId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
      */
     #[Override]
-    protected function editEntity($currencyId, $currencyData)
+    protected function editEntity(int|string $currencyId, mixed $currencyData): void
     {
         $this->currencyFacade->edit($currencyId, $currencyData);
     }
 
     /**
-     * @param int|null $currencyId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($currencyId)
+    public function getForm(int|string|null $rowId): FormInterface
     {
-        if ($currencyId !== null) {
-            $currency = $this->currencyFacade->getById((int)$currencyId);
+        if ($rowId !== null) {
+            $currency = $this->currencyFacade->getById((int)$rowId);
             $currencyData = $this->currencyDataFactory->createFromCurrency($currency);
         } else {
             $currencyData = $this->currencyDataFactory->create();
         }
 
         return $this->formFactory->create(CurrencyFormType::class, $currencyData, [
-            'is_default_currency' => $this->isDefaultCurrencyId($currencyId),
+            'is_default_currency' => $this->isDefaultCurrencyId($rowId),
         ]);
     }
 
@@ -73,7 +78,7 @@ class CurrencyInlineEdit extends AbstractGridInlineEdit
      * @param int|null $currencyId
      * @return bool
      */
-    protected function isDefaultCurrencyId($currencyId)
+    protected function isDefaultCurrencyId(?int $currencyId): bool
     {
         if ($currencyId !== null) {
             $currency = $this->currencyFacade->getById($currencyId);
@@ -84,5 +89,14 @@ class CurrencyInlineEdit extends AbstractGridInlineEdit
         }
 
         return false;
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_SUPER_ADMIN;
     }
 }

--- a/packages/framework/src/Model/Pricing/Group/Grid/PricingGroupGridFactory.php
+++ b/packages/framework/src/Model/Pricing/Group/Grid/PricingGroupGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Group\Grid;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
@@ -26,9 +27,10 @@ class PricingGroupGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -38,12 +40,12 @@ class PricingGroupGridFactory implements GridFactoryInterface
             ->setParameter('selectedDomainId', $this->adminDomainTabsFacade->getSelectedDomainId());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'pg.id');
 
-        $grid = $this->gridFactory->create('pricingGroupList', $dataSource);
+        $grid = $this->gridFactory->create('pricingGroupList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
         $grid->addColumn('name', 'pg.name', t('Name'), true);
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_pricinggroup_deleteconfirm', ['id' => 'pg.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Pricing/Groups/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Pricing/Group/Grid/PricingGroupInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Group/Grid/PricingGroupInlineEdit.php
@@ -10,12 +10,16 @@ use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\AbstractGridInlineEdit;
 use Shopsys\FrameworkBundle\Form\Admin\Pricing\Group\PricingGroupFormType;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactory;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 class PricingGroupInlineEdit extends AbstractGridInlineEdit
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\Grid\PricingGroupGridFactory $pricingGroupGridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
@@ -23,20 +27,21 @@ class PricingGroupInlineEdit extends AbstractGridInlineEdit
      */
     public function __construct(
         PricingGroupGridFactory $pricingGroupGridFactory,
+        Security $security,
         protected readonly PricingGroupFacade $pricingGroupFacade,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly PricingGroupDataFactory $pricingGroupDataFactory,
     ) {
-        parent::__construct($pricingGroupGridFactory);
+        parent::__construct($pricingGroupGridFactory, $security);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $pricingGroupData
-     * @return int
+     * @return int|string
      */
     #[Override]
-    protected function createEntityAndGetId($pricingGroupData)
+    protected function createEntityAndGetId(mixed $pricingGroupData): int|string
     {
         $pricingGroup = $this->pricingGroupFacade->create(
             $pricingGroupData,
@@ -47,30 +52,39 @@ class PricingGroupInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param int $pricingGroupId
+     * @param int|string $pricingGroupId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $pricingGroupData
      */
     #[Override]
-    protected function editEntity($pricingGroupId, $pricingGroupData)
+    protected function editEntity(int|string $pricingGroupId, mixed $pricingGroupData): void
     {
         $this->pricingGroupFacade->edit($pricingGroupId, $pricingGroupData);
     }
 
     /**
-     * @param int|null $pricingGroupId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($pricingGroupId)
+    public function getForm(int|string|null $rowId): FormInterface
     {
-        if ($pricingGroupId !== null) {
-            $pricingGroupId = (int)$pricingGroupId;
-            $pricingGroup = $this->pricingGroupFacade->getById($pricingGroupId);
+        if ($rowId !== null) {
+            $rowId = (int)$rowId;
+            $pricingGroup = $this->pricingGroupFacade->getById($rowId);
             $pricingGroupData = $this->pricingGroupDataFactory->createFromPricingGroup($pricingGroup);
         } else {
             $pricingGroupData = $this->pricingGroupDataFactory->create();
         }
 
         return $this->formFactory->create(PricingGroupFormType::class, $pricingGroupData);
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_PRICING_GROUP_FULL;
     }
 }

--- a/packages/framework/src/Model/Pricing/Vat/VatGridFactory.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatGridFactory.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Vat;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;
@@ -28,9 +29,10 @@ class VatGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -47,13 +49,13 @@ class VatGridFactory implements GridFactoryInterface
             return $row;
         });
 
-        $grid = $this->gridFactory->create('vatList', $dataSource);
+        $grid = $this->gridFactory->create('vatList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
         $grid->addColumn('name', 'v.name', t('Name'), true);
         $grid->addColumn('percent', 'v.percent', t('Percent'), true);
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_vat_deleteconfirm', ['id' => 'v.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Vat/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Pricing/Vat/VatInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatInlineEdit.php
@@ -8,12 +8,16 @@ use Override;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\AbstractGridInlineEdit;
 use Shopsys\FrameworkBundle\Form\Admin\Vat\VatFormType;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 class VatInlineEdit extends AbstractGridInlineEdit
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatGridFactory $vatGridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactory $vatDataFactory
@@ -21,20 +25,21 @@ class VatInlineEdit extends AbstractGridInlineEdit
      */
     public function __construct(
         VatGridFactory $vatGridFactory,
+        Security $security,
         protected readonly VatFacade $vatFacade,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly VatDataFactory $vatDataFactory,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
     ) {
-        parent::__construct($vatGridFactory);
+        parent::__construct($vatGridFactory, $security);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $vatData
-     * @return int
+     * @return int|string
      */
     #[Override]
-    protected function createEntityAndGetId($vatData)
+    protected function createEntityAndGetId(mixed $vatData): int|string
     {
         $vat = $this->vatFacade->create($vatData, $this->adminDomainTabsFacade->getSelectedDomainId());
 
@@ -42,31 +47,40 @@ class VatInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param int $vatId
+     * @param int|string $vatId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $vatData
      */
     #[Override]
-    protected function editEntity($vatId, $vatData)
+    protected function editEntity(int|string $vatId, mixed $vatData): void
     {
         $this->vatFacade->edit($vatId, $vatData);
     }
 
     /**
-     * @param int|null $vatId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($vatId)
+    public function getForm(int|string|null $rowId): FormInterface
     {
-        if ($vatId !== null) {
-            $vat = $this->vatFacade->getById((int)$vatId);
+        if ($rowId !== null) {
+            $vat = $this->vatFacade->getById((int)$rowId);
             $vatData = $this->vatDataFactory->createFromVat($vat);
         } else {
             $vatData = $this->vatDataFactory->create();
         }
 
         return $this->formFactory->create(VatFormType::class, $vatData, [
-            'scenario' => ($vatId === null ? VatFormType::SCENARIO_CREATE : VatFormType::SCENARIO_EDIT),
+            'scenario' => ($rowId === null ? VatFormType::SCENARIO_CREATE : VatFormType::SCENARIO_EDIT),
         ]);
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_VAT_FULL;
     }
 }

--- a/packages/framework/src/Model/Product/Flag/FlagGridFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
@@ -26,9 +27,10 @@ class FlagGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -38,7 +40,7 @@ class FlagGridFactory implements GridFactoryInterface
             ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'f.id');
 
-        $grid = $this->gridFactory->create('flagList', $dataSource);
+        $grid = $this->gridFactory->create('flagList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'ft.name', t('Name'), true);
@@ -48,7 +50,7 @@ class FlagGridFactory implements GridFactoryInterface
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_flag_edit', ['id' => 'f.id']);
         $grid->addDeleteActionColumn('admin_flag_deleteconfirm', ['id' => 'f.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Flag/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterGridFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
@@ -26,13 +27,14 @@ class ParameterGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $locales = $this->localization->getLocalesOfAllDomains();
         $adminLocale = $this->localization->getCurrentLocaleForTranslatableEntities();
-        $grid = $this->gridFactory->create('parameterList', $this->getParametersDataSource());
+        $grid = $this->gridFactory->create('parameterList', $this->getParametersDataSource(), $editRole);
 
         if (count($locales) > 1) {
             $grid->addColumn(
@@ -70,7 +72,7 @@ class ParameterGridFactory implements GridFactoryInterface
         $grid->setActionColumnClassAttribute('table-col table-col-10');
 
         $grid->addDeleteActionColumn('admin_parameter_delete', ['id' => 'p.id'])
-            ->setConfirmMessage(t(
+            ?->setConfirmMessage(t(
                 'Do you really want to remove this parameter?'
                 . ' Deleting the parameter will remove this parameter from the products and parameters'
                 . ' of the extended SEO category where the parameter is assigned. This step is irreversible!',

--- a/packages/framework/src/Model/Product/ProductGridFactory.php
+++ b/packages/framework/src/Model/Product/ProductGridFactory.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class ProductGridFactory
 {
@@ -35,7 +36,7 @@ class ProductGridFactory
     public function getProductControllerGrid(QueryBuilder $queryBuilder): Grid
     {
         $dataSource = $this->getGridDataSource($queryBuilder);
-        $grid = $this->gridFactory->create('productList', $dataSource);
+        $grid = $this->gridFactory->create('productList', $dataSource, Roles::ROLE_PRODUCT_FULL);
         $grid->enablePaging();
         $grid->enableSelecting();
         $grid->setDefaultOrder('name');
@@ -49,7 +50,7 @@ class ProductGridFactory
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_product_edit', ['id' => 'p.id']);
         $grid->addDeleteActionColumn('admin_product_delete', ['id' => 'p.id'])
-            ->setConfirmMessage(t('Do you really want to remove this product?'));
+            ?->setConfirmMessage(t('Do you really want to remove this product?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Product/listGrid.html.twig', [
             'VARIANT_TYPE_MAIN' => Product::VARIANT_TYPE_MAIN,

--- a/packages/framework/src/Model/Product/Unit/UnitGridFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Unit;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
@@ -26,9 +27,10 @@ class UnitGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->em->createQueryBuilder();
         $queryBuilder
@@ -38,14 +40,14 @@ class UnitGridFactory implements GridFactoryInterface
             ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'u.id');
 
-        $grid = $this->gridFactory->create('unitList', $dataSource);
+        $grid = $this->gridFactory->create('unitList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('name', 'ut.name', t('Name'), true);
 
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_unit_deleteconfirm', ['id' => 'u.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Unit/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Product/Unit/UnitInlineEdit.php
+++ b/packages/framework/src/Model/Product/Unit/UnitInlineEdit.php
@@ -9,12 +9,16 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\AbstractGridInlineEdit;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\Exception\InvalidFormDataException;
 use Shopsys\FrameworkBundle\Form\Admin\Product\Unit\UnitFormType;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 
 class UnitInlineEdit extends AbstractGridInlineEdit
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitGridFactory $unitGridFactory
+     * @param \Symfony\Bundle\SecurityBundle\Security $security
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactory $unitDataFactory
@@ -22,20 +26,21 @@ class UnitInlineEdit extends AbstractGridInlineEdit
      */
     public function __construct(
         UnitGridFactory $unitGridFactory,
+        Security $security,
         protected readonly UnitFacade $unitFacade,
         protected readonly FormFactoryInterface $formFactory,
         protected readonly UnitDataFactory $unitDataFactory,
         protected readonly Domain $domain,
     ) {
-        parent::__construct($unitGridFactory);
+        parent::__construct($unitGridFactory, $security);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $unitData
-     * @return int
+     * @return int|string
      */
     #[Override]
-    protected function createEntityAndGetId($unitData)
+    protected function createEntityAndGetId(mixed $unitData): int|string
     {
         if (!$this->domain->hasAdminAllDomainsEnabled()) {
             throw new InvalidFormDataException([
@@ -49,29 +54,38 @@ class UnitInlineEdit extends AbstractGridInlineEdit
     }
 
     /**
-     * @param int $unitId
+     * @param int|string $unitId
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $unitData
      */
     #[Override]
-    protected function editEntity($unitId, $unitData)
+    protected function editEntity(int|string $unitId, mixed $unitData): void
     {
         $this->unitFacade->edit($unitId, $unitData);
     }
 
     /**
-     * @param int|null $unitId
+     * @param int|string|null $rowId
      * @return \Symfony\Component\Form\FormInterface
      */
     #[Override]
-    public function getForm($unitId)
+    public function getForm(int|string|null $rowId): FormInterface
     {
-        if ($unitId !== null) {
-            $unit = $this->unitFacade->getById((int)$unitId);
+        if ($rowId !== null) {
+            $unit = $this->unitFacade->getById((int)$rowId);
             $unitData = $this->unitDataFactory->createFromUnit($unit);
         } else {
             $unitData = $this->unitDataFactory->create();
         }
 
         return $this->formFactory->create(UnitFormType::class, $unitData);
+    }
+
+    /**
+     * @return string
+     */
+    #[Override]
+    protected function getEditRole(): string
+    {
+        return Roles::ROLE_UNIT_FULL;
     }
 }

--- a/packages/framework/src/Model/SalesRepresentative/SalesRepresentativeGridFactory.php
+++ b/packages/framework/src/Model/SalesRepresentative/SalesRepresentativeGridFactory.php
@@ -28,14 +28,15 @@ class SalesRepresentativeGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create(): Grid
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->salesRepresentativeFacade->getAllQueryBuilder();
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'sr.id');
 
-        $grid = $this->gridFactory->create('salesRepresentativesList', $dataSource);
+        $grid = $this->gridFactory->create('salesRepresentativesList', $dataSource, $editRole);
         $grid->setDefaultOrder('name');
 
         $grid->addColumn('firstName', 'sr.firstName', t('First name'), true);
@@ -46,7 +47,7 @@ class SalesRepresentativeGridFactory implements GridFactoryInterface
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_salesrepresentative_edit', ['id' => 'sr.id']);
         $grid->addDeleteActionColumn('admin_salesrepresentative_deleteconfirm', ['id' => 'sr.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         return $grid;
     }

--- a/packages/framework/src/Model/Seo/Page/SeoPageGridFactory.php
+++ b/packages/framework/src/Model/Seo/Page/SeoPageGridFactory.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Seo\Page;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class SeoPageGridFactory
 {
@@ -35,7 +36,7 @@ class SeoPageGridFactory
             'sp.id',
         );
 
-        $grid = $this->gridFactory->create('seo_page', $dataSource);
+        $grid = $this->gridFactory->create('seo_page', $dataSource, Roles::ROLE_SEO_FULL);
         $grid->enablePaging();
 
         $grid->addColumn('pageName', 'sp.pageName', t('Page name'), true);
@@ -44,7 +45,7 @@ class SeoPageGridFactory
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_seopage_edit', ['id' => 'sp.id']);
         $grid->addDeleteActionColumn('admin_seopage_deleteconfirm', ['id' => 'sp.id'])
-            ->setAjaxConfirm();
+            ?->setAjaxConfirm();
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Seo/Page/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Store/ClosedDay/Grid/ClosedDayGridFactory.php
+++ b/packages/framework/src/Model/Store/ClosedDay/Grid/ClosedDayGridFactory.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 use Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDay;
 use Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDayFacade;
 use Shopsys\FrameworkBundle\Model\Store\Store;
@@ -40,29 +41,32 @@ class ClosedDayGridFactory
             ->groupBy('cd')
             ->setParameter('domainId', $domainId);
 
-        $grid = $this->gridFactory->create('closedDayList', new QueryBuilderWithRowManipulatorDataSource(
-            $queryBuilder,
-            'cd.id',
-            function (array $row): array {
-                $closedDay = $this->closedDayFacade->getById($row['cd']['id']);
+        $grid = $this->gridFactory->create(
+            'closedDayList',
+            new QueryBuilderWithRowManipulatorDataSource(
+                $queryBuilder,
+                'cd.id',
+                function (array $row): array {
+                    $closedDay = $this->closedDayFacade->getById($row['cd']['id']);
 
-                $row['cd']['excludedStores'] = array_map(static fn (Store $store): array => [
-                    'id' => $store->getId(),
-                    'name' => $store->getName(),
-                ], $closedDay->getExcludedStores());
+                    $row['cd']['excludedStores'] = array_map(static fn (Store $store): array => [
+                        'id' => $store->getId(),
+                        'name' => $store->getName(),
+                    ], $closedDay->getExcludedStores());
 
-                return $row;
-            },
-        ));
+                    return $row;
+                },
+            ),
+            Roles::ROLE_CLOSED_DAYS_FULL,
+        );
         $grid->enablePaging();
         $grid->setDefaultOrder('date');
         $grid->addColumn('name', 'cd.name', t('Name'), true);
         $grid->addColumn('date', 'cd.date', t('Date'), true);
         $grid->addColumn('excludedStores', 'cd.excludedStores', t('Excluded stores'));
         $grid->addEditActionColumn('admin_closedday_edit', ['id' => 'cd.id']);
-        $grid->addDeleteActionColumn('admin_closedday_delete', ['id' => 'cd.id'])->setConfirmMessage(
-            t('Do you really want to remove this holiday / internal day?'),
-        );
+        $grid->addDeleteActionColumn('admin_closedday_delete', ['id' => 'cd.id'])
+            ?->setConfirmMessage(t('Do you really want to remove this holiday / internal day?'));
         $grid->setTheme('@ShopsysFramework/Admin/Content/ClosedDay/listGrid.html.twig', [
             'domainId' => $domainId,
         ]);

--- a/packages/framework/src/Model/Transport/Grid/TransportGridFactory.php
+++ b/packages/framework/src/Model/Transport/Grid/TransportGridFactory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Transport\Grid;
 
 use Doctrine\ORM\Query\Expr\Join;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;
@@ -33,9 +34,10 @@ class TransportGridFactory implements GridFactoryInterface
     }
 
     /**
+     * @param string|null $editRole
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    public function create()
+    public function create(?string $editRole): Grid
     {
         $queryBuilder = $this->transportRepository->getQueryBuilderForAll()
             ->addSelect('tt.name')
@@ -53,7 +55,7 @@ class TransportGridFactory implements GridFactoryInterface
             },
         );
 
-        $grid = $this->gridFactory->create('transportList', $dataSource);
+        $grid = $this->gridFactory->create('transportList', $dataSource, $editRole);
         $grid->enableDragAndDrop(Transport::class);
 
         $grid->addColumn('name', 'tt.name', t('Name'));
@@ -62,7 +64,7 @@ class TransportGridFactory implements GridFactoryInterface
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addEditActionColumn('admin_transport_edit', ['id' => 't.id']);
         $grid->addDeleteActionColumn('admin_transport_delete', ['id' => 't.id'])
-            ->setConfirmMessage(t('Do you really want to remove this shipping?'));
+            ?->setConfirmMessage(t('Do you really want to remove this shipping?'));
 
         $grid->setTheme('@ShopsysFramework/Admin/Content/Transport/listGrid.html.twig');
 

--- a/packages/framework/src/Model/Watchdog/WatchdogGridFactory.php
+++ b/packages/framework/src/Model/Watchdog/WatchdogGridFactory.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Grid\GridView;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
 use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class WatchdogGridFactory
 {
@@ -35,7 +36,7 @@ class WatchdogGridFactory
     ): GridView {
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'productId');
 
-        $grid = $this->gridFactory->create('watchdogList', $dataSource);
+        $grid = $this->gridFactory->create('watchdogList', $dataSource, Roles::ROLE_WATCHDOG_FULL);
 
         $grid->enablePaging();
         $grid->setDefaultOrder('createdAt', DataSourceInterface::ORDER_DESC);
@@ -63,7 +64,7 @@ class WatchdogGridFactory
     ): GridView {
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'w.id');
 
-        $grid = $this->gridFactory->create('watchdogList', $dataSource);
+        $grid = $this->gridFactory->create('watchdogList', $dataSource, Roles::ROLE_WATCHDOG_FULL);
 
         $grid->enablePaging();
         $grid->setDefaultOrder('createdAt', DataSourceInterface::ORDER_DESC);

--- a/packages/framework/tests/Unit/Component/Grid/GridTest.php
+++ b/packages/framework/tests/Unit/Component/Grid/GridTest.php
@@ -10,6 +10,8 @@ use Shopsys\FrameworkBundle\Component\Grid\Exception\DuplicateColumnIdException;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Router;
@@ -37,14 +39,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
 
         $this->assertSame('gridId', $grid->getId());
@@ -64,14 +69,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
         $grid->addColumn('columnId1', 'sourceColumnName1', 'title1', true)->setClassAttribute('classAttribute');
         $grid->addColumn('columnId2', 'sourceColumnName2', 'title2', false);
@@ -105,14 +113,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
         $grid->addColumn('columnId1', 'sourceColumnName1', 'title1');
 
@@ -130,14 +141,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
         $grid->enablePaging();
         $this->assertTrue($grid->isEnabledPaging());
@@ -153,14 +167,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
         $this->assertFalse($grid->isEnabledPaging());
     }
@@ -175,14 +192,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
 
         $grid->setDefaultOrder('columnId1', DataSourceInterface::ORDER_DESC);
@@ -210,14 +230,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
 
         $grid->setDefaultOrder('default', DataSourceInterface::ORDER_ASC);
@@ -237,14 +260,17 @@ class GridTest extends TestCase
         $dataSourceMock->expects($this->never())->method('getTotalRowsCount');
         $dataSourceMock->expects($this->once())->method('getPaginatedRows')
             ->willReturn(new PaginationResult(1, 1, 0, []));
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
         $grid->createView();
     }
@@ -262,14 +288,17 @@ class GridTest extends TestCase
         $dataSourceMock->expects($this->once())->method('getTotalRowsCount')->willReturn(0);
         $dataSourceMock->expects($this->once())->method('getPaginatedRows')
             ->willReturn(new PaginationResult(1, 1, 0, []));
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
         $grid->enablePaging();
         $grid->createView();
@@ -287,14 +316,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
 
         $this->assertFalse($grid->isDragAndDrop());
@@ -312,14 +344,17 @@ class GridTest extends TestCase
         $routerMock = $this->createMock(Router::class);
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
+        $securityMock = $this->createMock(Security::class);
 
         $grid = new Grid(
             'gridId',
+            Roles::ROLE_ALL,
             $dataSourceMock,
             $requestStack,
             $routerMock,
             $routeCsrfProtectorMock,
             $twigMock,
+            $securityMock,
         );
 
         $column1 = $grid->addColumn('columnId1', 'sourceColumnName1', 'title1');

--- a/upgrade-notes/backend_20250602_110750.md
+++ b/upgrade-notes/backend_20250602_110750.md
@@ -1,0 +1,5 @@
+#### improve administration right in inline edit and grid actions ([#4022](https://github.com/shopsys/shopsys/pull/4022))
+
+- revisit all your `*InlineEdit` classes and ensure that all your overridden methods are using correct security methods as in parent class
+- provide third argument `editRole` in `GridFactory::create()` method to ensure, that delete action is not displayed for users without `editRole` permission
+- `Grid::addDeleteActionColumn()` now may return `null` if the user does not have permission to delete the item, so ensure that calling `setConfirmMessage()` on the returned column is safe


### PR DESCRIPTION
#### Description, the reason for the PR
InlineEdit now correctly works with correct rights. Until now ROLES_ALL was required for an inline edition to work. Also, grid delete action is now displayed for administrators with a correct role.
#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-edit-rights.odin.shopsys.cloud
  - https://cz.tl-fix-edit-rights.odin.shopsys.cloud
<!-- Replace -->
