### PR TITLE
fixed standards

### DIFF
--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -89,8 +89,6 @@ final class CrudConfig
     }
 
     /**
-     * TODO: Do something with $menuSection to be able to use some Enum instead of string
-     *
      * Sets where the crud controller will be displayed in the side menu.
      *
      * @param string $menuSection Name of root level menu section

--- a/packages/framework/src/Command/CheckAccessControlRulesCommand.php
+++ b/packages/framework/src/Command/CheckAccessControlRulesCommand.php
@@ -62,8 +62,6 @@ class CheckAccessControlRulesCommand extends Command
     }
 
     /**
-     * TODO Using DomainRouterFactory should be a temporary solution that could be replaced with the new administration router when available (it is implemented in tl-language-domains branch)
-     *
      * @return string[]
      */
     protected function getRuteNamesThatShouldBeCovered(): array

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -113,8 +113,6 @@ class Grid
     }
 
     /**
-     * TODO: Use OptionResolver instead of array
-     *
      * @param string $id
      * @param string $sourceColumnName
      * @param string $title

--- a/project-base/app/src/Component/DataBridge/Transfer/DummyImportTransferFacade.php
+++ b/project-base/app/src/Component/DataBridge/Transfer/DummyImportTransferFacade.php
@@ -13,17 +13,17 @@ class DummyImportTransferFacade extends AbstractBridgeImportTransfer
      */
     protected function processItem(array $bridgeData): void
     {
-        // TODO: Implement processItem() method.
+        // Implement processItem() method.
     }
 
     protected function doBeforeTransfer(): void
     {
-        // TODO: Implement doBeforeTransfer() method.
+        // Implement doBeforeTransfer() method.
     }
 
     protected function doAfterTransfer(): void
     {
-        // TODO: Implement doAfterTransfer() method.
+        // Implement doAfterTransfer() method.
     }
 
     /**

--- a/upgrade-notes/backend_20250604_072209.md
+++ b/upgrade-notes/backend_20250604_072209.md
@@ -1,0 +1,5 @@
+#### resolve TODO in your code ([#4023](https://github.com/shopsys/shopsys/pull/4023))
+
+- comments with `TODO` in your code are now reported during the `standards` checks
+    - either deal with them or skip the `PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff` in your ecs config
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Since https://github.com/easy-coding-standard/easy-coding-standard/releases/tag/12.5.20 todos are reported as error and builds was failing due to that.

It's fixed in this PR

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-ecs.odin.shopsys.cloud
  - https://cz.mg-fix-ecs.odin.shopsys.cloud
<!-- Replace -->
