### PR TITLE
fix disappearing content after clicking to some links

### DIFF
--- a/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
+++ b/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
@@ -38,7 +38,8 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
 
     const handleOnClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
         const mouseWheelClick = e.button === 1;
-        const isWithoutOpeningInNewTab = !e.ctrlKey && !e.metaKey && !mouseWheelClick;
+        const isTargetBlank = props.target === '_blank';
+        const isWithoutOpeningInNewTab = !e.ctrlKey && !e.metaKey && !mouseWheelClick && !isTargetBlank;
 
         if (isTextSelected()) {
             e.preventDefault();

--- a/upgrade-notes/storefront_20250603_085733.md
+++ b/upgrade-notes/storefront_20250603_085733.md
@@ -1,0 +1,5 @@
+#### fix disappearing content after clicking to some links ([#4024](https://github.com/shopsys/shopsys/pull/4024))
+
+- when using `target="_blank"` in the `ExtendedLink` component, the content of page would disappear (it is stuck in a loading state without skeleton)
+- it is now reflected in the `isWithoutOpeningInNewTab` condition as well
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
This PR fixes missing content after navigating to ad banner's link bug.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ad-banner-link-fix-ssp-3422.odin.shopsys.cloud
  - https://cz.jm-ad-banner-link-fix-ssp-3422.odin.shopsys.cloud
<!-- Replace -->
