### PR TITLE
mailer does not try to send message to non-existing email

### DIFF
--- a/packages/framework/src/Model/Mail/EventListener/EnvelopeListener.php
+++ b/packages/framework/src/Model/Mail/EventListener/EnvelopeListener.php
@@ -9,7 +9,6 @@ use Shopsys\FrameworkBundle\Model\Mail\Email;
 use Shopsys\FrameworkBundle\Model\Mail\MailerSettingProvider;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Mailer\Event\MessageEvent;
-use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Message;
 
@@ -48,8 +47,9 @@ class EnvelopeListener implements EventSubscriberInterface
         }
 
         if ($allowedRecipients === []) {
-            // set a non-existing address because recipient list cannot be empty
-            $allowedRecipients = [new Address('no-reply@domain.tld')];
+            $event->reject();
+
+            return;
         }
 
         $event->getEnvelope()->setRecipients($allowedRecipients);

--- a/packages/framework/tests/Unit/Model/Mail/EnvelopeListenerTest.php
+++ b/packages/framework/tests/Unit/Model/Mail/EnvelopeListenerTest.php
@@ -26,6 +26,7 @@ class EnvelopeListenerTest extends TestCase
      * @param \Symfony\Component\Mime\Address|null $mailCc
      * @param \Symfony\Component\Mime\Address|null $mailBcc
      * @param array $expectedRecipients
+     * @param bool $expectedIsRejected
      */
     #[DataProvider('onMessageDataProvider')]
     public function testOnMessage(
@@ -36,6 +37,7 @@ class EnvelopeListenerTest extends TestCase
         ?Address $mailCc,
         ?Address $mailBcc,
         array $expectedRecipients,
+        bool $expectedIsRejected,
     ): void {
         $mailSettingFacadeMock = $this->getMockBuilder(MailSettingFacade::class)
             ->disableOriginalConstructor()
@@ -54,6 +56,7 @@ class EnvelopeListenerTest extends TestCase
 
         $envelopeListener->onMessage($messageEvent);
         $this->assertEquals($expectedRecipients, $messageEvent->getEnvelope()->getRecipients());
+        $this->assertEquals($expectedIsRejected, $messageEvent->isRejected());
     }
 
     /**
@@ -94,7 +97,6 @@ class EnvelopeListenerTest extends TestCase
         $shopsysNoReplyMail1 = new Address('no-reply@shopsys.com');
         $shopsysNoReplyMail2 = new Address('no-reply2@shopsys.com');
         $shopsysNoReplyMail3 = new Address('no-reply3@shopsys.com');
-        $nonExistingMail = new Address('no-reply@domain.tld');
 
         // when whitelist is set but not enabled, all mails are delivered to the required addresses without restrictions
         yield [
@@ -107,9 +109,10 @@ class EnvelopeListenerTest extends TestCase
             'expectedRecipients' => [
                 $netdeveloNoReplyMail,
             ],
+            'expectedIsRejected' => false,
         ];
 
-        // when whitelist is enabled but empty, all mails are sent to the non-existing address
+        // when whitelist is enabled but empty, the message is rejected
         yield [
             'deliveryWhitelist' => null,
             'isWhitelistEnabled' => true,
@@ -118,8 +121,11 @@ class EnvelopeListenerTest extends TestCase
             'mailCc' => $shopsysNoReplyMail2,
             'mailBcc' => $shopsysNoReplyMail3,
             'expectedRecipients' => [
-                $nonExistingMail,
+                $shopsysNoReplyMail1,
+                $shopsysNoReplyMail2,
+                $shopsysNoReplyMail3,
             ],
+            'expectedIsRejected' => true,
         ];
 
         // when whitelist is set and enabled, all mails are delivered to the recipients that match the whitelisted patterns only
@@ -134,6 +140,7 @@ class EnvelopeListenerTest extends TestCase
                 $shopsysNoReplyMail1,
                 $shopsysNoReplyMail2,
             ],
+            'expectedIsRejected' => false,
         ];
 
         // when whitelist is set disabled but forced, all mails are still delivered to the recipients that match the whitelisted patterns only
@@ -148,6 +155,7 @@ class EnvelopeListenerTest extends TestCase
                 $shopsysNoReplyMail1,
                 $shopsysNoReplyMail2,
             ],
+            'expectedIsRejected' => false,
         ];
 
         // when there are multiple patterns in the whitelist, mails are delivered to the addresses that match at least one of the patterns
@@ -163,6 +171,7 @@ class EnvelopeListenerTest extends TestCase
                 $shopsysNoReplyMail2,
                 $netdeveloNoReplyMail,
             ],
+            'expectedIsRejected' => false,
         ];
     }
 }


### PR DESCRIPTION
This PR solves problem with active mail whitelist. When mail whitelist is active and mail is not supposed to be sent, it sends mail to non-existing mail "no-reply@domain.tld". This is a problem, because mail cannot be delivered, therefore admin mail is spammed by Mail Delivery System with "Undelivered Mail Returned to Sender" for every mail address that meets whitelist criteria 

In https://github.com/symfony/symfony/pull/48409 was added feature to reject mail
... 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-mailer-reject.odin.shopsys.cloud
  - https://cz.mt-mailer-reject.odin.shopsys.cloud
<!-- Replace -->
