### PR TITLE
XSS protection for GraphQL mutations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -192,6 +192,7 @@
         "tracy/tracy": "^2.4.13",
         "tuscanicz/enum": "^2.1",
         "twig/twig": "^3.14.0",
+        "voku/anti-xss": "^4.1",
         "webmozart/assert": "^1.4",
         "webonyx/graphql-php": "^15.6"
     },

--- a/docs/frontend-api/index.md
+++ b/docs/frontend-api/index.md
@@ -3,4 +3,5 @@
 - [Introduction to Frontend API](./introduction-to-frontend-api.md)
 - [Pagination in Frontend API](./pagination.md)
 - [Authentication in Frontend API](./authentication.md)
+- [Validation in Frontend API](./validation.md)
 - [API Methods](https://shopsysframework.docs.apiary.io/)

--- a/docs/frontend-api/navigation.yml
+++ b/docs/frontend-api/navigation.yml
@@ -4,3 +4,4 @@ arrange:
     - introduction-to-frontend-api.md
     - pagination.md
     - authentication.md
+    - validation.md

--- a/docs/frontend-api/validation.md
+++ b/docs/frontend-api/validation.md
@@ -1,0 +1,43 @@
+# Validation in Frontend API
+
+Shopsys Platform integrates Symfony's validation component with GraphQL through the [overblog/GraphQLBundle](https://github.com/overblog/GraphQLBundle/blob/master/docs/validation/index.md). This enables automatic validation of mutation inputs before they are processed.
+
+## How It Works
+
+The GraphQL bundle automatically validates input data when validation constraints are defined. When validation fails, an `ArgumentsValidationException` is thrown, which is then handled by the error subscriber to return properly formatted error responses.
+
+For more details about Symfony validation, see the [Symfony Validation documentation](https://symfony.com/doc/current/validation.html).
+
+## XSS Protection
+
+Shopsys Platform provides built-in XSS protection for all GraphQL mutations through the `MutationAntiXss` constraint:
+
+```yaml
+# config/graphql/types/Mutation/Mutation.types.yaml
+Mutation:
+    type: object
+    inherits:
+        - 'MutationDecorator'
+    validation:
+        - 'MutationAntiXss': ~ # Applied globally to all mutations
+```
+
+### How XSS Protection Works
+
+- The `MutationAntiXss` constraint scans all string inputs for potential XSS attacks
+- It uses the [voku/anti-xss](https://github.com/voku/anti-xss) library for detection
+- Certain fields are automatically excluded (IDs, tokens, passwords, UUIDs, etc.)
+- Additional exclusions can be configured via the `shopsys.frontend_api.anti_xss_excluded_fields` parameter
+
+### Configuring XSS Exclusions
+
+To exclude specific fields from XSS validation, add them to your parameters:
+
+```yaml
+# app/config/parameters_common.yaml
+parameters:
+    shopsys.frontend_api.anti_xss_excluded_fields:
+        - customHtml
+        - richTextContent
+        - jsonData
+```

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -117,6 +117,7 @@
         "symfony/polyfill-php80": "^1.24.0",
         "tracy/tracy": "^2.4.13",
         "twig/twig": "^3.14.0",
+        "voku/anti-xss": "^4.1",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/packages/framework/src/Form/Constraints/AntiXss.php
+++ b/packages/framework/src/Form/Constraints/AntiXss.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form\Constraints;
+
+use Attribute;
+use Override;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class AntiXss extends Constraint
+{
+    public string $message = 'This field contains potentially dangerous content and cannot be processed.';
+
+    public const ERROR_CODE = 'potential-xss';
+
+    /**
+     * @var string[]
+     */
+    public array $excludedFields = [];
+
+    /**
+     * @param mixed|null $options
+     * @param string|null $message
+     * @param array|null $excludedFields
+     * @param array|null $groups
+     * @param mixed|null $payload
+     */
+    public function __construct(
+        mixed $options = null,
+        ?string $message = null,
+        ?array $excludedFields = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct($options, $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->excludedFields = $excludedFields ?? $this->excludedFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return [
+            self::PROPERTY_CONSTRAINT,
+            self::CLASS_CONSTRAINT,
+        ];
+    }
+}

--- a/packages/framework/src/Form/Constraints/AntiXssValidator.php
+++ b/packages/framework/src/Form/Constraints/AntiXssValidator.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form\Constraints;
+
+use Override;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use voku\helper\AntiXSS as VokuAntiXSS;
+
+class AntiXssValidator extends ConstraintValidator
+{
+    /**
+     * @param mixed $value
+     * @param \Symfony\Component\Validator\Constraint $constraint
+     */
+    #[Override]
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof AntiXss) {
+            throw new UnexpectedTypeException($constraint, AntiXss::class);
+        }
+
+        $antiXss = new VokuAntiXSS();
+
+        $this->validateRecursive($value, '', '', $constraint, $antiXss);
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $fieldName
+     * @param string $path
+     * @param \Shopsys\FrameworkBundle\Form\Constraints\AntiXss $constraint
+     * @param \voku\helper\AntiXSS $antiXss
+     */
+    protected function validateRecursive(
+        mixed $value,
+        string $fieldName,
+        string $path,
+        AntiXss $constraint,
+        VokuAntiXSS $antiXss,
+    ): void {
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (is_string($value)) {
+            if (!$this->shouldExcludeField($fieldName, $value, $constraint->excludedFields)) {
+                $antiXss->xss_clean($value);
+
+                if ($antiXss->isXssFound()) {
+                    $this->context->buildViolation($constraint->message)->atPath($path)->setCode($constraint::ERROR_CODE)->addViolation();
+                }
+            }
+        } elseif (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $newPath = $path === '' ? $key : $path . ".{$key}";
+                $this->validateRecursive($item, (string)$key, $newPath, $constraint, $antiXss);
+            }
+        } elseif (is_object($value)) {
+            foreach (get_object_vars($value) as $property => $propertyValue) {
+                $newPath = $path === '' ? $property : $path . ".{$property}.";
+                $this->validateRecursive($propertyValue, $property, $newPath, $constraint, $antiXss);
+            }
+        }
+    }
+
+    /**
+     * @param string $fieldName
+     * @param string $value
+     * @param string[] $excludedFields
+     * @return bool
+     */
+    protected function shouldExcludeField(string $fieldName, string $value, array $excludedFields): bool
+    {
+        return in_array($fieldName, $excludedFields, true);
+    }
+}

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -622,6 +622,9 @@ msgstr "Tato částka musí být {{ limit }} nebo více."
 msgid "The email is already registered on given domain."
 msgstr "Tento email je na dané doméně již registrován."
 
+msgid "This field contains potentially dangerous content and cannot be processed."
+msgstr "Toto pole obsahuje potenciálně nebezpečný obsah a nelze ji zpracovat."
+
 msgid "This field must be empty"
 msgstr "Toto pole musí zůstat prázdné"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -622,6 +622,9 @@ msgstr ""
 msgid "The email is already registered on given domain."
 msgstr ""
 
+msgid "This field contains potentially dangerous content and cannot be processed."
+msgstr ""
+
 msgid "This field must be empty"
 msgstr ""
 

--- a/packages/framework/tests/Unit/Component/Constraints/AntiXssConstraintTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/AntiXssConstraintTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Constraints;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Form\Constraints\AntiXss;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CleanDataDto
+{
+    #[AntiXss]
+    public string $name = 'John Doe';
+
+    #[AntiXss]
+    public string $description = 'This is a clean description';
+
+    public string $unvalidatedField = '<script>anything</script>';
+}
+
+class XssDataDto
+{
+    #[AntiXss]
+    public string $name = 'John Doe';
+
+    #[AntiXss]
+    public string $description = '<script>alert("XSS")</script>';
+
+    public string $unvalidatedField = '<script>anything</script>';
+}
+
+#[AntiXss(excludedFields: [])]
+class ClassLevelXssDto
+{
+    public string $name = 'John Doe';
+
+    public string $bio = '<img src=x onerror=alert("XSS")>';
+
+    public string $email = 'john@example.com';
+}
+
+#[AntiXss(excludedFields: ['bio'])]
+class MixedConstraintsDto
+{
+    public string $name = '<script>alert("name")</script>';
+
+    public string $bio = '<script>alert("bio")</script>'; // Excluded by class constraint
+
+    public string $comment = '<img src=x onerror=alert("comment")>';
+}
+
+#[AntiXss(excludedFields: ['password', 'confirmPassword'])]
+class FormDto
+{
+    public string $username = 'john_doe';
+
+    public string $email = 'john@example.com';
+
+    public string $password = '<script>alert("password")</script>'; // Excluded
+
+    public string $confirmPassword = '<script>alert("confirm")</script>'; // Excluded
+
+    public string $firstName = 'John';
+
+    public string $lastName = '<iframe src="evil.com"></iframe>'; // Should trigger violation
+
+    /**
+     * @var array<string, string>
+     */
+    public array $preferences = [
+        'theme' => 'dark',
+        'customCss' => '<style>body { background: url("javascript:alert(1)") }</style>', // Should trigger violation
+    ];
+}
+
+#[AntiXss(excludedFields: ['allowedField'])]
+class ExplicitExclusionDto
+{
+    public string $allowedField = '<script>alert("allowed")</script>'; // Should be excluded
+
+    public string $validatedField = '<script>alert("validated")</script>'; // Should trigger validation
+}
+
+class CustomMessageDto
+{
+    /**
+     * @var string[]
+     */
+    #[AntiXss(
+        excludedFields: ['allowedHtml', 'richContent'],
+        message: 'Custom XSS error message',
+    )]
+    public array $data = [
+        'title' => 'Clean title',
+        'content' => '<script>alert("content")</script>',
+        'allowedHtml' => '<div onclick="alert(1)">Allowed</div>',
+        'richContent' => '<script>document.write("allowed")</script>',
+    ];
+}
+
+class AntiXssConstraintTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    public function testPropertyLevelConstraintWithCleanData(): void
+    {
+        $violations = $this->validator->validate(new CleanDataDto());
+        $this->assertCount(0, $violations);
+    }
+
+    public function testPropertyLevelConstraintWithXssContent(): void
+    {
+        $violations = $this->validator->validate(new XssDataDto());
+        $this->assertCount(1, $violations);
+        $this->assertEquals('description', $violations[0]->getPropertyPath());
+    }
+
+    public function testClassLevelConstraint(): void
+    {
+        $violations = $this->validator->validate(new ClassLevelXssDto());
+        $this->assertCount(1, $violations);
+        $this->assertEquals('bio', $violations[0]->getPropertyPath());
+    }
+
+    public function testMixedPropertyAndClassLevelConstraints(): void
+    {
+        $violations = $this->validator->validate(new MixedConstraintsDto());
+        $this->assertCount(2, $violations);
+
+        $paths = array_map(fn ($v) => $v->getPropertyPath(), iterator_to_array($violations));
+        $this->assertContains('name', $paths);
+        $this->assertContains('comment', $paths);
+        $this->assertNotContains('bio', $paths); // Should be excluded
+    }
+
+    public function testFormDtoWithConstraints(): void
+    {
+        $violations = $this->validator->validate(new FormDto());
+        $this->assertCount(2, $violations);
+
+        $paths = array_map(fn ($v) => $v->getPropertyPath(), iterator_to_array($violations));
+        $this->assertContains('lastName', $paths);
+        $this->assertContains('preferences.customCss', $paths);
+    }
+
+    public function testExplicitFieldExclusions(): void
+    {
+        $violations = $this->validator->validate(new ExplicitExclusionDto());
+        $this->assertCount(1, $violations);
+        $this->assertEquals('validatedField', $violations[0]->getPropertyPath());
+    }
+
+    public function testCustomConstraintParameters(): void
+    {
+        $violations = $this->validator->validate(new CustomMessageDto());
+        $this->assertCount(1, $violations);
+        $this->assertEquals('data.content', $violations[0]->getPropertyPath());
+        $this->assertEquals('Custom XSS error message', $violations[0]->getMessage());
+    }
+}

--- a/packages/framework/tests/Unit/Component/Constraints/AntiXssValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/AntiXssValidatorTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Constraints;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Form\Constraints\AntiXss;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class AntiXssValidatorTest extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+    }
+
+    public function testXssContentTriggersViolation(): void
+    {
+        $data = [
+            'name' => 'John Doe',
+            'message' => '<script>alert("XSS")</script>',
+        ];
+
+        $violations = $this->validator->validate($data, new AntiXss([
+            'excludedFields' => [],
+        ]));
+        $this->assertCount(1, $violations);
+        $this->assertEquals('message', $violations[0]->getPropertyPath());
+        $this->assertStringContainsString('potentially dangerous content', $violations[0]->getMessage());
+    }
+
+    public function testExcludedFieldsAreNotValidated(): void
+    {
+        $data = [
+            'password' => '<script>alert("XSS")</script>',
+            'token' => '<img src=x onerror=alert("XSS")>',
+            'name' => 'Clean Name',
+        ];
+
+        $violations = $this->validator->validate($data, new AntiXss(['excludedFields' => ['password', 'token']]));
+        $this->assertCount(0, $violations);
+    }
+
+    public function testNestedObjectValidation(): void
+    {
+        $data = [
+            'user' => [
+                'name' => 'John',
+                'bio' => '<iframe src="javascript:alert(\'XSS\')"></iframe>',
+            ],
+        ];
+
+        $violations = $this->validator->validate($data, new AntiXss(['excludedFields' => []]));
+        $this->assertCount(1, $violations);
+        $this->assertEquals('user.bio', $violations[0]->getPropertyPath());
+    }
+
+    public function testPropertyLevelValidation(): void
+    {
+        $xssContent = '<body onload=alert("XSS")>';
+
+        $violations = $this->validator->validate($xssContent, new AntiXss(['excludedFields' => []]));
+        $this->assertCount(1, $violations);
+        $this->assertEquals('', $violations[0]->getPropertyPath());
+    }
+
+    public function testNullAndEmptyValuesAreSkipped(): void
+    {
+        $violations = $this->validator->validate(null, new AntiXss());
+        $this->assertCount(0, $violations);
+
+        $violations = $this->validator->validate('', new AntiXss());
+        $this->assertCount(0, $violations);
+
+        $violations = $this->validator->validate([], new AntiXss());
+        $this->assertCount(0, $violations);
+    }
+
+    public function testCustomExcludedFieldsConfiguration(): void
+    {
+        $data = [
+            'customField' => '<script>alert("XSS")</script>',
+            'specialData' => '<img src=x onerror=alert("XSS")>',
+            'rawHtml' => '<iframe src="evil.com"></iframe>',
+            'content' => 'This is clean content',
+        ];
+
+        $violations = $this->validator->validate($data, new AntiXss([
+            'excludedFields' => ['customField', 'specialData', 'rawHtml'],
+        ]));
+        $this->assertCount(0, $violations);
+    }
+
+    public function testVariousXssAttackVectorsAreDetected(): void
+    {
+        $xssVectors = [
+            '<script>alert("XSS")</script>',
+            '<img src=x onerror=alert("XSS")>',
+            '<iframe src="javascript:alert(\'XSS\')"></iframe>',
+            '<body onload=alert("XSS")>',
+            'javascript:alert("XSS")',
+            '<svg onload=alert("XSS")>',
+            '<input onfocus=alert("XSS") autofocus>',
+            '<select onfocus=alert("XSS") autofocus>',
+            '<textarea onfocus=alert("XSS") autofocus>',
+            '<marquee onstart=alert("XSS")>',
+        ];
+
+        foreach ($xssVectors as $vector) {
+            $violations = $this->validator->validate($vector, new AntiXss(['excludedFields' => []]));
+            $this->assertCount(1, $violations, "Failed to detect XSS in: {$vector}");
+        }
+    }
+
+    public function testFrameworkValidatorOnlyUsesExplicitExclusions(): void
+    {
+        $data = [
+            'userId' => '<script>alert("XSS")</script>',
+            'accessToken' => '<img src=x onerror=alert("XSS")>',
+        ];
+
+        $violations = $this->validator->validate($data, new AntiXss(['excludedFields' => []]));
+        $this->assertCount(2, $violations); // Both fields should trigger violations
+
+        $paths = array_map(fn ($v) => $v->getPropertyPath(), iterator_to_array($violations));
+        $this->assertContains('userId', $paths);
+        $this->assertContains('accessToken', $paths);
+    }
+
+    public function testComplexNestedStructure(): void
+    {
+        $complexData = [
+            'orders' => [
+                [
+                    'id' => 1,
+                    'items' => [
+                        [
+                            'product' => 'Laptop',
+                            'customization' => '<svg onload=alert("XSS")>',
+                        ],
+                        [
+                            'product' => 'Mouse',
+                            'customization' => 'Engraving: John Doe',
+                        ],
+                    ],
+                    'shipping' => [
+                        'address' => '123 Main St',
+                        'instructions' => 'Leave at door',
+                    ],
+                ],
+                [
+                    'id' => 2,
+                    'items' => [
+                        [
+                            'product' => 'Keyboard',
+                            'customization' => 'Custom keycaps',
+                        ],
+                    ],
+                    'shipping' => [
+                        'address' => '456 Oak Ave',
+                        'instructions' => '<iframe src="javascript:alert(\'XSS\')"></iframe>',
+                    ],
+                ],
+            ],
+        ];
+
+        $violations = $this->validator->validate($complexData, new AntiXss(['excludedFields' => []]));
+
+        $this->assertCount(2, $violations);
+
+        $paths = [];
+
+        foreach ($violations as $violation) {
+            $paths[] = $violation->getPropertyPath();
+        }
+
+        $this->assertContains('orders.0.items.0.customization', $paths);
+        $this->assertContains('orders.1.shipping.instructions', $paths);
+    }
+
+    public function testConstraintProperties(): void
+    {
+        $constraint = new AntiXss([
+            'message' => 'Custom message',
+            'excludedFields' => ['field1', 'field2'],
+        ]);
+
+        $this->assertEquals('Custom message', $constraint->message);
+        $this->assertEquals(['field1', 'field2'], $constraint->excludedFields);
+    }
+}

--- a/packages/frontend-api/src/Component/Constraints/MutationAntiXss.php
+++ b/packages/frontend-api/src/Component/Constraints/MutationAntiXss.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\Constraints;
+
+use Shopsys\FrameworkBundle\Form\Constraints\AntiXss as BaseAntiXss;
+
+class MutationAntiXss extends BaseAntiXss
+{
+}

--- a/packages/frontend-api/src/Component/Constraints/MutationAntiXssValidator.php
+++ b/packages/frontend-api/src/Component/Constraints/MutationAntiXssValidator.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\Constraints;
+
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Validator\ValidationNode;
+use Override;
+use Shopsys\FrameworkBundle\Form\Constraints\AntiXss as BaseAntiXss;
+use Shopsys\FrameworkBundle\Form\Constraints\AntiXssValidator as BaseAntiXssValidator;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use voku\helper\AntiXSS as VokuAntiXSS;
+
+class MutationAntiXssValidator extends BaseAntiXssValidator
+{
+    /**
+     * @param mixed $value
+     * @param \Symfony\Component\Validator\Constraint $constraint
+     */
+    #[Override]
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof BaseAntiXss) {
+            throw new UnexpectedTypeException($constraint, BaseAntiXss::class);
+        }
+
+        if ($value instanceof ValidationNode) {
+            $this->validateGraphQlNode($value, $constraint);
+
+            return;
+        }
+
+        parent::validate($value, $constraint);
+    }
+
+    /**
+     * @param \Overblog\GraphQLBundle\Validator\ValidationNode $validationNode
+     * @param \Shopsys\FrameworkBundle\Form\Constraints\AntiXss $constraint
+     */
+    protected function validateGraphQlNode(ValidationNode $validationNode, BaseAntiXss $constraint): void
+    {
+        $args = $validationNode->getResolverArg('args');
+
+        if (!$args instanceof Argument || $args->count() === 0) {
+            return;
+        }
+
+        $antiXss = new VokuAntiXSS();
+
+        foreach ($args->getArrayCopy() as $name => $argValue) {
+            $this->validateRecursive($argValue, $name, $name, $constraint, $antiXss);
+        }
+    }
+
+    /**
+     * @param string $fieldName
+     * @param string $value
+     * @param array $excludedFields
+     * @return bool
+     */
+    #[Override]
+    protected function shouldExcludeField(string $fieldName, string $value, array $excludedFields): bool
+    {
+        if (parent::shouldExcludeField($fieldName, $value, $excludedFields)) {
+            return true;
+        }
+
+        $excludedSuffixes = ['Id', 'Uuid', 'Token', 'Password', 'Hash', 'Url', 'Code'];
+
+        foreach ($excludedSuffixes as $suffix) {
+            if ($fieldName === strtolower($suffix) || str_ends_with($fieldName, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/frontend-api/src/Model/Error/ErrorCodeSubscriber.php
+++ b/packages/frontend-api/src/Model/Error/ErrorCodeSubscriber.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrontendApiBundle\Model\Error;
 use Exception;
 use Overblog\GraphQLBundle\Event\ErrorFormattingEvent;
 use Overblog\GraphQLBundle\Event\Events;
+use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ErrorCodeSubscriber implements EventSubscriberInterface
@@ -21,6 +22,11 @@ class ErrorCodeSubscriber implements EventSubscriberInterface
         $userCode = null;
 
         $previousError = $error->getPrevious();
+
+        if ($previousError instanceof ArgumentsValidationException) {
+            $userCode = 'validation';
+            $code = 400;
+        }
 
         if ($previousError instanceof Exception && $previousError instanceof UserErrorWithCodeInterface) {
             $userCode = $previousError->getUserErrorCode();

--- a/packages/frontend-api/src/Resources/config/parameters.yaml
+++ b/packages/frontend-api/src/Resources/config/parameters.yaml
@@ -1,3 +1,4 @@
 parameters:
+    shopsys.frontend_api.anti_xss_excluded_fields: []
     shopsys.frontend_api.domains: []
     shopsys.frontend_api.validation_logged_as_error: false

--- a/packages/frontend-api/tests/Unit/Component/Constraints/MutationAntiXssGraphQLValidatorTest.php
+++ b/packages/frontend-api/tests/Unit/Component/Constraints/MutationAntiXssGraphQLValidatorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Unit\Component\Constraints;
+
+use Override;
+use Shopsys\FrontendApiBundle\Component\Constraints\MutationAntiXss;
+use Shopsys\FrontendApiBundle\Component\Constraints\MutationAntiXssValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class MutationAntiXssGraphQLValidatorTest extends ConstraintValidatorTestCase
+{
+    /**
+     * @return \Shopsys\FrontendApiBundle\Component\Constraints\MutationAntiXssValidator
+     */
+    #[Override]
+    protected function createValidator(): MutationAntiXssValidator
+    {
+        return new MutationAntiXssValidator();
+    }
+
+    public function testValidationOfCleanData(): void
+    {
+        $constraint = new MutationAntiXss([
+            'excludedFields' => [],
+        ]);
+
+        $this->validator->validate([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'message' => 'This is a clean message',
+        ], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidationOfXssData(): void
+    {
+        $constraint = new MutationAntiXss(['excludedFields' => []]);
+
+        $this->validator->validate([
+            'name' => 'John Doe',
+            'message' => '<script>alert("XSS")</script>',
+        ], $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->atPath('property.path.message')
+            ->setCode($constraint::ERROR_CODE)
+            ->assertRaised();
+    }
+
+    public function testValidationWithExcludedFields(): void
+    {
+        $constraint = new MutationAntiXss(['excludedFields' => ['sessionToken']]);
+
+        $this->validator->validate([
+            'sessionToken' => '<script>alert("XSS")</script>', // Should be excluded
+            'message' => 'Clean message',
+        ], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidationOfNestedData(): void
+    {
+        $constraint = new MutationAntiXss(['excludedFields' => []]);
+
+        $this->validator->validate([
+            'user' => [
+                'name' => 'John Doe',
+                'bio' => '<iframe src="javascript:alert(\'XSS\')"></iframe>',
+            ],
+        ], $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->atPath('property.path.user.bio')
+            ->setCode($constraint::ERROR_CODE)
+            ->assertRaised();
+    }
+
+    public function testValidationWithAutoExcludedFields(): void
+    {
+        $constraint = new MutationAntiXss(['excludedFields' => []]);
+
+        $this->validator->validate([
+            'userId' => '<script>alert("XSS")</script>', // Should be auto-excluded (ends with Id)
+            'orderUuid' => '<img src=x onerror=alert("XSS")>', // Should be auto-excluded (ends with Uuid)
+            'accessToken' => 'javascript:alert("XSS")', // Should be auto-excluded (ends with Token)
+            'promoCode' => '<iframe src="evil.com"></iframe>', // Should be auto-excluded (ends with Code)
+            'message' => 'Clean message',
+        ], $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidationOfComplexMutationData(): void
+    {
+        $constraint = new MutationAntiXss(['excludedFields' => []]);
+
+        $this->validator->validate([
+            'input' => [
+                'customerData' => [
+                    'firstName' => 'John',
+                    'lastName' => 'Doe',
+                    'email' => 'john@example.com',
+                ],
+                'orderData' => [
+                    'items' => [
+                        [
+                            'productUuid' => '123e4567-e89b-12d3-a456-426614174000', // Auto-excluded
+                            'quantity' => 2,
+                            'note' => '<script>alert("XSS in note")</script>', // Should trigger violation
+                        ],
+                    ],
+                    'deliveryAddress' => [
+                        'street' => '123 Main St',
+                        'note' => 'Clean delivery note',
+                    ],
+                ],
+            ],
+        ], $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->atPath('property.path.input.orderData.items.0.note')
+            ->setCode($constraint::ERROR_CODE)
+            ->assertRaised();
+    }
+
+    public function testValidationOfStringValue(): void
+    {
+        $constraint = new MutationAntiXss(['excludedFields' => []]);
+
+        $this->validator->validate('<body onload=alert("XSS")>', $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->atPath('property.path')
+            ->setCode($constraint::ERROR_CODE)
+            ->assertRaised();
+    }
+}

--- a/project-base/app/config/graphql/types/Mutation/Mutation.types.yaml
+++ b/project-base/app/config/graphql/types/Mutation/Mutation.types.yaml
@@ -1,5 +1,9 @@
 Mutation:
     type: object
+    config:
+        validation:
+            - Shopsys\FrontendApiBundle\Component\Constraints\MutationAntiXss:
+                excludedFields: "%shopsys.frontend_api.anti_xss_excluded_fields%"
     inherits:
         - 'MutationDecorator'
         - 'CustomerUserMutation'

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -12,6 +12,9 @@ parameters:
     shopsys.allowed_admin_locales: ['en', 'cs']
     shopsys.cron_timezone: Europe/Prague
 
+    # List of fields that are excluded from AntiXSS validation in the Frontend API
+    shopsys.frontend_api.anti_xss_excluded_fields: []
+
     # Set to true to log validation errors with log level ERROR instead of INFO
     shopsys.frontend_api.validation_logged_as_error: false
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/MutationAntiXss/MutationAntiXssValidationTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/MutationAntiXss/MutationAntiXssValidationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\MutationAntiXss;
+
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class MutationAntiXssValidationTest extends GraphQlTestCase
+{
+    /**
+     * Test that clean input passes validation
+     */
+    public function testValidContactFormMutation(): void
+    {
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ContactFormMutation.graphql', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'message' => 'This is a clean message without any XSS content.',
+        ]);
+
+        self::assertTrue($response['data']['ContactForm'] ?? null);
+    }
+
+    /**
+     * Test that XSS content in message field triggers validation error
+     */
+    public function testXssInMessageTriggersValidation(): void
+    {
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ContactFormMutation.graphql', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'message' => '<script>alert("XSS attack")</script>',
+        ]);
+
+        $this->assertResponseContainsArrayOfErrors($response);
+        $validationErrors = $this->getErrorsExtensionValidationFromResponse($response);
+
+        // Check that the validation error is related to dangerous content
+        $this->assertArrayHasKey('input.message', $validationErrors);
+        $errorMessage = $validationErrors['input.message'][0]['message'];
+        $this->assertStringContainsString('potentially dangerous content', $errorMessage);
+    }
+
+    /**
+     * Test that XSS content in name field triggers validation error
+     */
+    public function testXssInNameTriggersValidation(): void
+    {
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ContactFormMutation.graphql', [
+            'name' => '<img src=x onerror=alert("XSS")>',
+            'email' => 'john@example.com',
+            'message' => 'Clean message',
+        ]);
+
+        $this->assertResponseContainsArrayOfErrors($response);
+        $validationErrors = $this->getErrorsExtensionValidationFromResponse($response);
+
+        $this->assertArrayHasKey('input.name', $validationErrors);
+        $errorMessage = $validationErrors['input.name'][0]['message'];
+        $this->assertStringContainsString('potentially dangerous content', $errorMessage);
+    }
+
+    /**
+     * Test that multiple XSS fields trigger multiple validation errors
+     */
+    public function testMultipleXssFieldsTriggersMultipleValidationErrors(): void
+    {
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ContactFormMutation.graphql', [
+            'name' => '<iframe src="javascript:alert(\'XSS\')"></iframe>',
+            'email' => 'john@example.com',
+            'message' => '<body onload=alert("XSS")>',
+        ]);
+
+        $this->assertResponseContainsArrayOfErrors($response);
+        $validationErrors = $this->getErrorsExtensionValidationFromResponse($response);
+
+        // Both name and message should have validation errors
+        $this->assertArrayHasKey('input.name', $validationErrors);
+        $this->assertArrayHasKey('input.message', $validationErrors);
+
+        $this->assertStringContainsString('potentially dangerous content', $validationErrors['input.name'][0]['message']);
+        $this->assertStringContainsString('potentially dangerous content', $validationErrors['input.message'][0]['message']);
+    }
+
+    /**
+     * Test various XSS attack vectors are properly detected
+     */
+    public function testVariousXssVectorsAreDetected(): void
+    {
+        $xssVectors = [
+            '<script>alert("XSS")</script>',
+            '<img src=x onerror=alert("XSS")>',
+            '<iframe src="javascript:alert(\'XSS\')"></iframe>',
+            '<body onload=alert("XSS")>',
+            'javascript:alert("XSS")',
+            '<svg onload=alert("XSS")>',
+            '<input onfocus=alert("XSS") autofocus>',
+            '<marquee onstart=alert("XSS")>',
+        ];
+
+        foreach ($xssVectors as $vector) {
+            $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ContactFormMutation.graphql', [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'message' => $vector,
+            ]);
+
+            $this->assertResponseContainsArrayOfErrors($response);
+            $validationErrors = $this->getErrorsExtensionValidationFromResponse($response);
+            $this->assertArrayHasKey('input.message', $validationErrors, "Failed to detect XSS in: {$vector}");
+        }
+    }
+
+    /**
+     * Test edge cases with special characters that should not trigger false positives
+     */
+    public function testSpecialCharactersFalsePositives(): void
+    {
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ContactFormMutation.graphql', [
+            'name' => 'John & Jane <Company>',
+            'email' => 'test+tag@example.com',
+            'message' => 'We need info about <product name> and pricing > $100.',
+        ]);
+
+        // Should succeed as these are legitimate uses of < and > characters
+        self::assertTrue($response['data']['ContactForm'] ?? null);
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/MutationAntiXss/graphql/ContactFormMutation.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/MutationAntiXss/graphql/ContactFormMutation.graphql
@@ -1,0 +1,7 @@
+mutation ContactFormMutation($name: String!, $email: String!, $message: String!) {
+    ContactForm(input: {
+        name: $name,
+        email: $email,
+        message: $message
+    })
+}

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
@@ -78,8 +78,6 @@ export const useCreateOrder = (
     const handleCreateOrderResult = useHandleCreateOrderResult();
 
     const createOrder: SubmitHandler<ContactInformation> = async (formValues) => {
-        updatePageLoadingState({ isPageLoading: true, redirectPageType: 'order-confirmation' });
-
         const createOrderResult = await createOrderMutation(
             getCreateOrderMutationVariables(
                 cartUuid,
@@ -89,6 +87,10 @@ export const useCreateOrder = (
                 isPacketeryTransport(currentCart.transport?.transportTypeCode),
             ),
         );
+
+        if (createOrderResult.data?.CreateOrder) {
+            updatePageLoadingState({ isPageLoading: true, redirectPageType: 'order-confirmation' });
+        }
 
         handleCreateOrderResult(formProviderMethods, formMeta, createOrderResult, formValues);
     };

--- a/project-base/storefront/utils/forms/handleFormErrors.ts
+++ b/project-base/storefront/utils/forms/handleFormErrors.ts
@@ -24,8 +24,16 @@ export const handleFormErrors = <T extends FieldValues>(
     }
 
     if (userError?.validation !== undefined) {
+        let formFieldNames: string[];
+
+        if (fields !== undefined) {
+            formFieldNames = Object.keys(fields).map((fieldKey) => fields[fieldKey].name);
+        } else {
+            formFieldNames = Object.keys(formProviderMethods.control._fields).map((fieldKey) => fieldKey);
+        }
+
         for (const fieldName in userError.validation) {
-            if (fields !== undefined && Object.keys(fields).some((fieldKey) => fields[fieldKey].name === fieldName)) {
+            if (formFieldNames.includes(fieldName)) {
                 formProviderMethods.setError(fieldName as Path<T>, userError.validation[fieldName]);
                 continue;
             }


### PR DESCRIPTION
#### Description, the reason for the PR

- Add comprehensive XSS validation to all GraphQL mutations using new MutationAntiXss constraint
- Improve error handling for validation failures in both backend and storefront
- Automatically exclude common non-content fields (IDs, tokens, passwords) from XSS checks
- Enhance form error mapping to display clear validation messages to users

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-xss-api-protect.odin.shopsys.cloud
  - https://cz.jg-xss-api-protect.odin.shopsys.cloud
<!-- Replace -->
