### PR TITLE
make all form classes final as they are not extended directly but via extension

### DIFF
--- a/docs/contributing/code-quality-principles.md
+++ b/docs/contributing/code-quality-principles.md
@@ -122,7 +122,7 @@ Also, it would be difficult to change the shared code just for one use-case.
 Modules don't depend on details of each other, modules depend on interfaces.
 
 ```diff
-class DatePickerType extends AbstractType
+final class DatePickerType extends AbstractType
 {
 -   public function __construct(protected readonly DisplayTimeZoneProvider $displayTimeZoneProvider)
 +   public function __construct(protected readonly DisplayTimeZoneProviderInterface $displayTimeZoneProvider)

--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -186,7 +186,7 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
 
-class ProductFormTypeExtension extends AbstractTypeExtension
+final class ProductFormTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/docs/cookbook/create-advanced-grid.md
+++ b/docs/cookbook/create-advanced-grid.md
@@ -197,7 +197,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class SalesmanFormType extends AbstractType
+final class SalesmanFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/docs/extensibility/extending-form-from-plugin.md
+++ b/docs/extensibility/extending-form-from-plugin.md
@@ -20,7 +20,7 @@ First, you must add your form type you want to show in administration. (e.g., `p
 
 //...
 
-class HeurekaProductFormType extends AbstractType
+final class HeurekaProductFormType extends AbstractType
 {
 
     //...

--- a/docs/introduction/using-form-types.md
+++ b/docs/introduction/using-form-types.md
@@ -400,7 +400,7 @@ The `ActionBarType` form type provides a standardized action bar, rendered at th
 ##### Most common usage
 
 ```php
-class MyEntityFormType extends AbstractType
+final class MyEntityFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/ecs.php
+++ b/ecs.php
@@ -8,6 +8,7 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunction
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff as PhpCsValidVariableNameSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use Shopsys\CodingStandards\CsFixer\FinalFormTypeFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Helper\CyclomaticComplexitySniffSetting;
 use Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff;
@@ -54,6 +55,7 @@ return ECSConfig::configure()
     ->withRules([
         PhpdocToPropertyTypeFixer::class,
         ForceLateStaticBindingForProtectedConstantsSniff::class,
+        FinalFormTypeFixer::class,
     ])
     ->withConfiguredRule(ForbiddenPrivateVisibilityFixer::class,
         [
@@ -185,6 +187,10 @@ return ECSConfig::configure()
                 __DIR__ . '/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php',
                 __DIR__ . '/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php',
                 __DIR__ . '/packages/*/tests/*',
+            ],
+            FinalFormTypeFixer::class => [
+                __DIR__ . '/project-base',
+                __DIR__ . '/packages/framework/src/Form/Locale/LocalizedType.php',
             ],
         ],
     ));

--- a/packages/coding-standards/src/CsFixer/FinalFormTypeFixer.php
+++ b/packages/coding-standards/src/CsFixer/FinalFormTypeFixer.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer;
+
+use PhpCsFixer\Fixer\ClassNotation\FinalClassFixer;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+class FinalFormTypeFixer implements FixerInterface
+{
+    /**
+     * @return \PhpCsFixer\FixerDefinition\FixerDefinitionInterface
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Form types extending AbstractType or AbstractTypeExtension must be final.',
+            [],
+        );
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return bool
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_EXTENDS);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $namespacesAnalyzer = new NamespacesAnalyzer();
+        $namespaces = $namespacesAnalyzer->getDeclarations($tokens);
+
+        // Process each namespace (including global namespace)
+        foreach ($namespaces as $namespace) {
+            $this->fixNamespace($tokens, $namespace);
+        }
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param \PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis $namespace
+     */
+    private function fixNamespace(Tokens $tokens, NamespaceAnalysis $namespace): void
+    {
+        $usesAnalyzer = new NamespaceUsesAnalyzer();
+        $uses = $usesAnalyzer->getDeclarationsInNamespace($tokens, $namespace);
+
+        // Process tokens in reverse order to avoid index shifting
+        for ($index = $namespace->getScopeEndIndex(); $index >= $namespace->getScopeStartIndex(); --$index) {
+            $token = $tokens[$index];
+
+            if (!$token->isGivenKind(T_CLASS)) {
+                continue;
+            }
+
+            // Check if this is an abstract class or already final
+            $prevMeaningfulIndex = $tokens->getPrevMeaningfulToken($index);
+
+            if ($prevMeaningfulIndex !== null) {
+                $prevToken = $tokens[$prevMeaningfulIndex];
+
+                if ($prevToken->isGivenKind([T_ABSTRACT, T_FINAL])) {
+                    continue;
+                }
+            }
+
+            // Find extends keyword after class declaration
+            $extendsIndex = $tokens->getNextTokenOfKind($index, [[T_EXTENDS]]);
+
+            if ($extendsIndex === null) {
+                continue;
+            }
+
+            // Get the parent class name
+            $parentClassIndex = $tokens->getNextMeaningfulToken($extendsIndex);
+
+            if ($parentClassIndex === null) {
+                continue;
+            }
+
+            $parentName = $this->getClassNameFromTokens($tokens, $parentClassIndex);
+            $resolvedParentName = $this->resolveClassNameWithUses($parentName, $uses);
+
+            if (!$this->isFormTypeClass($resolvedParentName)) {
+                continue;
+            }
+
+            // Insert "final" before class keyword
+            $tokens->insertAt($index, new Token([T_FINAL, 'final']));
+            $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Shopsys/final_form_type';
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        // Before native FinalClassFixer
+        return (new FinalClassFixer())->getPriority() + 1;
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @return bool
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param int $startIndex
+     * @return string
+     */
+    private function getClassNameFromTokens(Tokens $tokens, int $startIndex): string
+    {
+        $className = '';
+        $index = $startIndex;
+
+        // Collect all parts of the class name (including namespace separators)
+        while ($index !== null && $tokens[$index]->isGivenKind([T_STRING, T_NS_SEPARATOR])) {
+            $className .= $tokens[$index]->getContent();
+            $index = $tokens->getNextMeaningfulToken($index);
+        }
+
+        return $className;
+    }
+
+    /**
+     * Resolve class name using use statements
+     *
+     * @param string $className
+     * @param \PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis[] $uses
+     * @return string
+     */
+    private function resolveClassNameWithUses(string $className, array $uses): string
+    {
+        // Already fully qualified - return as is
+        if (str_starts_with($className, '\\')) {
+            return $className;
+        }
+
+        // Check for exact match in use statements
+        foreach ($uses as $use) {
+            if ($className === $use->getShortName()) {
+                return $use->getFullName();
+            }
+        }
+
+        // Not found in imports - return as is (could be relative to current namespace)
+        return $className;
+    }
+
+    /**
+     * @param string $className
+     * @return bool
+     */
+    private function isFormTypeClass(string $className): bool
+    {
+        return in_array($className, [
+            'AbstractType',
+            'AbstractTypeExtension',
+            'Symfony\Component\Form\AbstractType',
+            'Symfony\Component\Form\AbstractTypeExtension',
+            '\Symfony\Component\Form\AbstractType',
+            '\Symfony\Component\Form\AbstractTypeExtension',
+        ], true);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/FinalFormTypeFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/FinalFormTypeFixerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\FinalFormTypeFixer;
+
+use Override;
+use Shopsys\CodingStandards\CsFixer\FinalFormTypeFixer;
+use Tests\CodingStandards\Unit\CsFixer\AbstractFixerTestCase;
+
+final class FinalFormTypeFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @return \Shopsys\CodingStandards\CsFixer\FinalFormTypeFixer
+     */
+    #[Override]
+    protected function createFixerService(): FinalFormTypeFixer
+    {
+        return new FinalFormTypeFixer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getTestingFiles(): iterable
+    {
+        // Test cases with expected fixes (fixed/wrong pairs)
+        yield [__DIR__ . '/fixed/simple-form-type.php', __DIR__ . '/wrong/simple-form-type.php'];
+
+        yield [__DIR__ . '/fixed/form-extension.php', __DIR__ . '/wrong/form-extension.php'];
+
+        yield [__DIR__ . '/fixed/fully-qualified.php', __DIR__ . '/wrong/fully-qualified.php'];
+
+        yield [__DIR__ . '/fixed/with-alias.php', __DIR__ . '/wrong/with-alias.php'];
+
+        yield [__DIR__ . '/fixed/namespaced.php', __DIR__ . '/wrong/namespaced.php'];
+
+        // Test cases that should not be changed (correct files)
+        yield [__DIR__ . '/correct/already-final.php'];
+
+        yield [__DIR__ . '/correct/abstract-form.php'];
+
+        yield [__DIR__ . '/correct/not-form-type.php'];
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/correct/abstract-form.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/correct/abstract-form.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class BaseFormType extends AbstractType
+{
+    // Abstract classes should not be made final
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        // Some configuration
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/correct/already-final.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/correct/already-final.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class AlreadyFinalFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        // Already final, should not be changed
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/correct/not-form-type.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/correct/not-form-type.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+class ControllerClass extends AbstractController
+{
+    // Extends different class, should not be changed
+    public function indexAction(): Response
+    {
+        return new Response();
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/form-extension.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/form-extension.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class MyFormExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('additionalField', TextType::class);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [AbstractType::class];
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/fully-qualified.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/fully-qualified.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class FullyQualifiedFormType extends \Symfony\Component\Form\AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('title', TextType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/namespaced.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/namespaced.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class NamespacedFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class)
+            ->add('name', TextType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/simple-form-type.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/simple-form-type.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class SimpleFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/with-alias.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/fixed/with-alias.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Form\AbstractType as BaseFormType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class AliasedFormType extends BaseFormType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('description', TextareaType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/form-extension.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/form-extension.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class MyFormExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('additionalField', TextType::class);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [AbstractType::class];
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/fully-qualified.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/fully-qualified.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class FullyQualifiedFormType extends \Symfony\Component\Form\AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('title', TextType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/namespaced.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/namespaced.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class NamespacedFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class)
+            ->add('name', TextType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/simple-form-type.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/simple-form-type.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class SimpleFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/with-alias.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/FinalFormTypeFixer/wrong/with-alias.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Form\AbstractType as BaseFormType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class AliasedFormType extends BaseFormType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('description', TextareaType::class);
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/correct/correct.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/correct/correct.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ZboziProductFormType extends AbstractType
+final class ZboziProductFormType extends AbstractType
 {
     /**
      * @var \Symfony\Contracts\Translation\TranslatorInterface

--- a/packages/form-types-bundle/src/MultidomainType.php
+++ b/packages/form-types-bundle/src/MultidomainType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MultidomainType extends AbstractType
+final class MultidomainType extends AbstractType
 {
     /**
      * @param \Shopsys\FormTypesBundle\Domain\DomainIdsProviderInterface $domainIdsProvider

--- a/packages/form-types-bundle/src/YesNoType.php
+++ b/packages/form-types-bundle/src/YesNoType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class YesNoType extends AbstractType
+final class YesNoType extends AbstractType
 {
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator
@@ -41,10 +41,10 @@ class YesNoType extends AbstractType
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/packages/framework/src/Component/Form/TimedFormTypeExtension.php
+++ b/packages/framework/src/Component/Form/TimedFormTypeExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TimedFormTypeExtension extends AbstractTypeExtension
+final class TimedFormTypeExtension extends AbstractTypeExtension
 {
     public const int MINIMUM_FORM_FILLING_SECONDS = 5;
     public const string OPTION_ENABLED = 'timed_spam_enabled';

--- a/packages/framework/src/Form/AbstractFileUploadType.php
+++ b/packages/framework/src/Form/AbstractFileUploadType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class AbstractFileUploadType extends AbstractType implements DataTransformerInterface
+final class AbstractFileUploadType extends AbstractType implements DataTransformerInterface
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload

--- a/packages/framework/src/Form/AbstractMultiplePickerType.php
+++ b/packages/framework/src/Form/AbstractMultiplePickerType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
-class AbstractMultiplePickerType extends AbstractType
+final class AbstractMultiplePickerType extends AbstractType
 {
     /**
      * @param \Symfony\Component\PropertyAccess\PropertyAccessorInterface $propertyAccessor
@@ -84,7 +84,7 @@ class AbstractMultiplePickerType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/Admin/Administrator/AdminDomainsFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdminDomainsFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class AdminDomainsFormType extends AbstractType
+final class AdminDomainsFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -26,7 +26,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class AdministratorFormType extends AbstractType
+final class AdministratorFormType extends AbstractType
 {
     public const string SCENARIO_CREATE = 'create';
     public const string SCENARIO_EDIT = 'edit';

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorResetPasswordFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorResetPasswordFormType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class AdministratorResetPasswordFormType extends AbstractType
+final class AdministratorResetPasswordFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorRoleGroupFormType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class AdministratorRoleGroupFormType extends AbstractType
+final class AdministratorRoleGroupFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -27,7 +27,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class AdvertFormType extends AbstractType
+final class AdvertFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_TYPE_IMAGE = 'typeImage';
     public const string VALIDATION_GROUP_TYPE_CODE = 'typeCode';

--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -29,7 +29,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ArticleFormType extends AbstractType
+final class ArticleFormType extends AbstractType
 {
     private const string VALIDATION_GROUP_TYPE_SITE = 'typeSite';
     private const string VALIDATION_GROUP_TYPE_LINK = 'typeLink';

--- a/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
+++ b/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class BestsellingProductFormType extends AbstractType
+final class BestsellingProductFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
@@ -29,7 +29,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class BlogArticleFormType extends AbstractType
+final class BlogArticleFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -30,7 +30,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class BlogCategoryFormType extends AbstractType
+final class BlogCategoryFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade $blogCategoryFacade

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class CategoryFormType extends AbstractType
+final class CategoryFormType extends AbstractType
 {
     public const string SCENARIO_CREATE = 'create';
     public const string SCENARIO_EDIT = 'edit';

--- a/packages/framework/src/Form/Admin/Category/TopCategory/TopCategoriesFormType.php
+++ b/packages/framework/src/Form/Admin/Category/TopCategory/TopCategoriesFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TopCategoriesFormType extends AbstractType
+final class TopCategoriesFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade

--- a/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
@@ -31,7 +31,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class ComplaintFormType extends AbstractType
+final class ComplaintFormType extends AbstractType
 {
     protected const string VALIDATION_GROUP_TYPE_MONEY_RETURN = 'typeMoneyReturn';
 

--- a/packages/framework/src/Form/Admin/Complaint/ComplaintItemFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/ComplaintItemFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ComplaintItemFormType extends AbstractType
+final class ComplaintItemFormType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/Complaint/Status/ComplaintItemsType.php
+++ b/packages/framework/src/Form/Admin/Complaint/Status/ComplaintItemsType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
-class ComplaintItemsType extends AbstractType
+final class ComplaintItemsType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/Admin/Complaint/Status/ComplaintStatusFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/Status/ComplaintStatusFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ComplaintStatusFormType extends AbstractType
+final class ComplaintStatusFormType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/ContactForm/ContactFormSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/ContactForm/ContactFormSettingsFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ContactFormSettingsFormType extends AbstractType
+final class ContactFormSettingsFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Country/CountryFormType.php
+++ b/packages/framework/src/Form/Admin/Country/CountryFormType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class CountryFormType extends AbstractType
+final class CountryFormType extends AbstractType
 {
     protected ?Country $country = null;
 

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressAndRelatedInfoFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressAndRelatedInfoFormType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class BillingAddressAndRelatedInfoFormType extends AbstractType
+final class BillingAddressAndRelatedInfoFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
@@ -69,10 +69,10 @@ class BillingAddressAndRelatedInfoFormType extends AbstractType
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return BillingAddressFormType::class;
     }

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class BillingAddressFormType extends AbstractType
+final class BillingAddressFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_COMPANY_CUSTOMER = 'companyCustomer';
 

--- a/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class DeliveryAddressFormType extends AbstractType
+final class DeliveryAddressFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade

--- a/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class CustomerUserRoleGroupFormType extends AbstractType
+final class CustomerUserRoleGroupFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRole $customerUserRole

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class CustomerUserFormType extends AbstractType
+final class CustomerUserFormType extends AbstractType
 {
     private ?CustomerUser $customerUser = null;
 

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserUpdateFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserUpdateFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CustomerUserUpdateFormType extends AbstractType
+final class CustomerUserUpdateFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory

--- a/packages/framework/src/Form/Admin/CustomerCommunication/CustomerUserCommunicationFormType.php
+++ b/packages/framework/src/Form/Admin/CustomerCommunication/CustomerUserCommunicationFormType.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Form\GroupType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class CustomerUserCommunicationFormType extends AbstractType
+final class CustomerUserCommunicationFormType extends AbstractType
 {
     public const string ORDER_SENT_CONTENT_FIELD_NAME = 'order-sent-content';
     public const string PAYMENT_FAILED_CONTENT_FIELD_NAME = 'payment-failed-content';

--- a/packages/framework/src/Form/Admin/Domain/DomainFormType.php
+++ b/packages/framework/src/Form/Admin/Domain/DomainFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class DomainFormType extends AbstractType
+final class DomainFormType extends AbstractType
 {
     public const string FIELD_ICON = 'icon';
 

--- a/packages/framework/src/Form/Admin/FriendlyUrl/FriendlyUrlFormType.php
+++ b/packages/framework/src/Form/Admin/FriendlyUrl/FriendlyUrlFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class FriendlyUrlFormType extends AbstractType
+final class FriendlyUrlFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Twig\DateTimeFormatterExtension $dateTimeFormatterExtension

--- a/packages/framework/src/Form/Admin/GrapesJsMailType.php
+++ b/packages/framework/src/Form/Admin/GrapesJsMailType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class GrapesJsMailType extends AbstractType
+final class GrapesJsMailType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\WysiwygCdnDataTransformer $wysiwygCdnDataTransformer
@@ -50,10 +50,10 @@ class GrapesJsMailType extends AbstractType
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextareaType::class;
     }

--- a/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
+++ b/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class HeurekaShopCertificationFormType extends AbstractType
+final class HeurekaShopCertificationFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/LanguageConstant/LanguageConstantFormType.php
+++ b/packages/framework/src/Form/Admin/LanguageConstant/LanguageConstantFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class LanguageConstantFormType extends AbstractType
+final class LanguageConstantFormType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/LegalConditions/PrivacyPolicySettingFormType.php
+++ b/packages/framework/src/Form/Admin/LegalConditions/PrivacyPolicySettingFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PrivacyPolicySettingFormType extends AbstractType
+final class PrivacyPolicySettingFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade

--- a/packages/framework/src/Form/Admin/LegalConditions/TermsAndConditionsSettingFormType.php
+++ b/packages/framework/src/Form/Admin/LegalConditions/TermsAndConditionsSettingFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TermsAndConditionsSettingFormType extends AbstractType
+final class TermsAndConditionsSettingFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade

--- a/packages/framework/src/Form/Admin/Login/LoginFormType.php
+++ b/packages/framework/src/Form/Admin/Login/LoginFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class LoginFormType extends AbstractType
+final class LoginFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class MailSettingFormType extends AbstractType
+final class MailSettingFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class MailTemplateFormType extends AbstractType
+final class MailTemplateFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_SEND_MAIL = 'sendMail';
 

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateSendFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateSendFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class MailTemplateSendFormType extends AbstractType
+final class MailTemplateSendFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade

--- a/packages/framework/src/Form/Admin/Mail/MailWhitelistCollectionType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailWhitelistCollectionType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
-class MailWhitelistCollectionType extends AbstractType
+final class MailWhitelistCollectionType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/Admin/Module/ModulesFormType.php
+++ b/packages/framework/src/Form/Admin/Module/ModulesFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ModulesFormType extends AbstractType
+final class ModulesFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/NotificationBar/NotificationBarFormType.php
+++ b/packages/framework/src/Form/Admin/NotificationBar/NotificationBarFormType.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class NotificationBarFormType extends AbstractType
+final class NotificationBarFormType extends AbstractType
 {
     public const string SCENARIO_CREATE = 'create';
     public const string SCENARIO_EDIT = 'edit';

--- a/packages/framework/src/Form/Admin/Order/OrderFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderFormType.php
@@ -37,7 +37,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraints\Length;
 
-class OrderFormType extends AbstractType
+final class OrderFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS = 'deliveryAddressSameAsBillingAddress';
 

--- a/packages/framework/src/Form/Admin/Order/OrderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderItemFormType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class OrderItemFormType extends AbstractType
+final class OrderItemFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION = 'notUsingPriceCalculation';
 

--- a/packages/framework/src/Form/Admin/Order/OrderPaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderPaymentFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class OrderPaymentFormType extends AbstractType
+final class OrderPaymentFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Order/OrderTransportFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderTransportFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class OrderTransportFormType extends AbstractType
+final class OrderTransportFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Order/Status/OrderStatusFormType.php
+++ b/packages/framework/src/Form/Admin/Order/Status/OrderStatusFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class OrderStatusFormType extends AbstractType
+final class OrderStatusFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class PaymentFormType extends AbstractType
+final class PaymentFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade

--- a/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionType.php
+++ b/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class PaymentTransactionType extends AbstractType
+final class PaymentTransactionType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionFacade $paymentTransactionFacade

--- a/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionsType.php
+++ b/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionsType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PaymentTransactionsType extends AbstractType
+final class PaymentTransactionsType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/PersonalData/PersonalDataFormType.php
+++ b/packages/framework/src/Form/Admin/PersonalData/PersonalDataFormType.php
@@ -10,7 +10,7 @@ use Shopsys\FormTypesBundle\ActionBarType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PersonalDataFormType extends AbstractType
+final class PersonalDataFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class CurrencyFormType extends AbstractType
+final class CurrencyFormType extends AbstractType
 {
     /**
      * @param \CommerceGuys\Intl\Currency\CurrencyRepositoryInterface $intlCurrencyRepository

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencySettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencySettingsFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class CurrencySettingsFormType extends AbstractType
+final class CurrencySettingsFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade

--- a/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class PricingGroupFormType extends AbstractType
+final class PricingGroupFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupSettingsFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class PricingGroupSettingsFormType extends AbstractType
+final class PricingGroupSettingsFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class BrandFormType extends AbstractType
+final class BrandFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/Admin/Product/Flag/FlagFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Flag/FlagFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class FlagFormType extends AbstractType
+final class FlagFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class ParameterFormType extends AbstractType
+final class ParameterFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class ParameterGroupFormType extends AbstractType
+final class ParameterGroupFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupFacade $parameterGroupFacade

--- a/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ProductParameterValueFormType extends AbstractType
+final class ProductParameterValueFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_TYPE_SLIDER = 'typeSlider';
 

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueConversionFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueConversionFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ParameterValueConversionFormType extends AbstractType
+final class ParameterValueConversionFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormView $view

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueConversionListType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueConversionListType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
-class ParameterValueConversionListType extends AbstractType
+final class ParameterValueConversionListType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueFormType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ParameterValueFormType extends AbstractType
+final class ParameterValueFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/SliderParameterValuesUpdateFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/SliderParameterValuesUpdateFormType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class SliderParameterValuesUpdateFormType extends AbstractType
+final class SliderParameterValuesUpdateFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Product/Price/PricesByPricingGroupsType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/PricesByPricingGroupsType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PricesByPricingGroupsType extends AbstractType
+final class PricesByPricingGroupsType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade

--- a/packages/framework/src/Form/Admin/Product/Price/PricingGroupPriceType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/PricingGroupPriceType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PricingGroupPriceType extends AbstractType
+final class PricingGroupPriceType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ProductPricesWithVatSelectType extends AbstractType
+final class ProductPricesWithVatSelectType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade

--- a/packages/framework/src/Form/Admin/Product/PriceListOverviewType.php
+++ b/packages/framework/src/Form/Admin/Product/PriceListOverviewType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PriceListOverviewType extends AbstractType
+final class PriceListOverviewType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/Product/ProductMassActionFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductMassActionFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ProductMassActionFormType extends AbstractType
+final class ProductMassActionFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Product/TopProduct/TopProductsFormType.php
+++ b/packages/framework/src/Form/Admin/Product/TopProduct/TopProductsFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TopProductsFormType extends AbstractType
+final class TopProductsFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\RemoveDuplicatesFromArrayTransformer $removeDuplicatesTransformer

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class UnitFormType extends AbstractType
+final class UnitFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class UnitSettingFormType extends AbstractType
+final class UnitSettingFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade

--- a/packages/framework/src/Form/Admin/Product/VariantFormType.php
+++ b/packages/framework/src/Form/Admin/Product/VariantFormType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class VariantFormType extends AbstractType
+final class VariantFormType extends AbstractType
 {
     public const string MAIN_VARIANT = 'mainVariant';
     public const string VARIANTS = 'variants';

--- a/packages/framework/src/Form/Admin/Product/VideoTokenType.php
+++ b/packages/framework/src/Form/Admin/Product/VideoTokenType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class VideoTokenType extends AbstractType
+final class VideoTokenType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagCollectionType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagCollectionType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
-class PromoCodeFlagCollectionType extends AbstractType
+final class PromoCodeFlagCollectionType extends AbstractType
 {
     /**
-     * @return string|null
+     * @return string
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class PromoCodeFlagType extends AbstractType
+final class PromoCodeFlagType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
@@ -37,7 +37,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Positive;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class PromoCodeFormType extends AbstractType
+final class PromoCodeFormType extends AbstractType
 {
     public const string VALIDATION_GROUP_TYPE_PERCENT = 'type_percent';
     public const string VALIDATION_GROUP_TYPE_NOMINAL = 'type_nominal';

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeLimitCollectionType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeLimitCollectionType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
-class PromoCodeLimitCollectionType extends AbstractType
+final class PromoCodeLimitCollectionType extends AbstractType
 {
     /**
-     * @return string|null
+     * @return string
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeLimitType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeLimitType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class PromoCodeLimitType extends AbstractType
+final class PromoCodeLimitType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Admin\PromoCode\Transformer\PromoCodeLimitTransformer $promoCodeLimitTransformer

--- a/packages/framework/src/Form/Admin/QuickSearch/QuickSearchFormType.php
+++ b/packages/framework/src/Form/Admin/QuickSearch/QuickSearchFormType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class QuickSearchFormType extends AbstractType
+final class QuickSearchFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/SalesRepresentative/SalesRepresentativeFormType.php
+++ b/packages/framework/src/Form/Admin/SalesRepresentative/SalesRepresentativeFormType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class SalesRepresentativeFormType extends AbstractType
+final class SalesRepresentativeFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Seo/HreflangSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/HreflangSettingFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class HreflangSettingFormType extends AbstractType
+final class HreflangSettingFormType extends AbstractType
 {
     public const FIELD_HREFLANG_COLLECTION = 'hreflang_collection';
 

--- a/packages/framework/src/Form/Admin/Seo/SeoPageFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoPageFormType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class SeoPageFormType extends AbstractType
+final class SeoPageFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/Admin/Seo/SeoRobotsSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoRobotsSettingFormType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class SeoRobotsSettingFormType extends AbstractType
+final class SeoRobotsSettingFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class SeoSettingFormType extends AbstractType
+final class SeoSettingFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -25,7 +25,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class SliderItemFormType extends AbstractType
+final class SliderItemFormType extends AbstractType
 {
     public const string SCENARIO_CREATE = 'create';
     public const string SCENARIO_EDIT = 'edit';

--- a/packages/framework/src/Form/Admin/Stock/ProductStockFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/ProductStockFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ProductStockFormType extends AbstractType
+final class ProductStockFormType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/Stock/StockFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/StockFormType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class StockFormType extends AbstractType
+final class StockFormType extends AbstractType
 {
     private ?Stock $stock;
 

--- a/packages/framework/src/Form/Admin/Stock/StockSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/StockSettingsFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Twig\Environment;
 
-class StockSettingsFormType extends AbstractType
+final class StockSettingsFormType extends AbstractType
 {
     /**
      * @param \Twig\Environment $environment

--- a/packages/framework/src/Form/Admin/Store/ClosedDayFormType.php
+++ b/packages/framework/src/Form/Admin/Store/ClosedDayFormType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class ClosedDayFormType extends AbstractType
+final class ClosedDayFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Store\StoreFacade $storeFacade

--- a/packages/framework/src/Form/Admin/Store/OpeningHours/OpeningHoursRangeCollectionFormType.php
+++ b/packages/framework/src/Form/Admin/Store/OpeningHours/OpeningHoursRangeCollectionFormType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class OpeningHoursRangeCollectionFormType extends AbstractType
+final class OpeningHoursRangeCollectionFormType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Form/Admin/Store/OpeningHours/OpeningHoursRangeFormType.php
+++ b/packages/framework/src/Form/Admin/Store/OpeningHours/OpeningHoursRangeFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class OpeningHoursRangeFormType extends AbstractType
+final class OpeningHoursRangeFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\OpeningHourTimeToStringTransformer $openingHourTimeToStringTransformer

--- a/packages/framework/src/Form/Admin/Store/StoreFormType.php
+++ b/packages/framework/src/Form/Admin/Store/StoreFormType.php
@@ -32,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class StoreFormType extends AbstractType
+final class StoreFormType extends AbstractType
 {
     private ?Store $store = null;
 

--- a/packages/framework/src/Form/Admin/Superadmin/InputPriceTypeFormType.php
+++ b/packages/framework/src/Form/Admin/Superadmin/InputPriceTypeFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class InputPriceTypeFormType extends AbstractType
+final class InputPriceTypeFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Transfer/TransferIssueSearchFormType.php
+++ b/packages/framework/src/Form/Admin/Transfer/TransferIssueSearchFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TransferIssueSearchFormType extends AbstractType
+final class TransferIssueSearchFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transfer\TransferFacade $transferFacade

--- a/packages/framework/src/Form/Admin/Transport/Price/PriceWithLimitType.php
+++ b/packages/framework/src/Form/Admin/Transport/Price/PriceWithLimitType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class PriceWithLimitType extends AbstractType
+final class PriceWithLimitType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Twig\InputPriceLabelExtension $inputPriceLabelExtension

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -37,7 +37,7 @@ use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class TransportFormType extends AbstractType
+final class TransportFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade

--- a/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
+++ b/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
+final class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
 {
     public const string DOMAINS_SUBFORM_NAME = 'priceLimits';
     public const string FIELD_ENABLED = 'enabled';

--- a/packages/framework/src/Form/Admin/UploadedFile/UploadedFileFormType.php
+++ b/packages/framework/src/Form/Admin/UploadedFile/UploadedFileFormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class UploadedFileFormType extends AbstractType
+final class UploadedFileFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/UserConsentPolicy/UserConsentPolicySettingFormType.php
+++ b/packages/framework/src/Form/Admin/UserConsentPolicy/UserConsentPolicySettingFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class UserConsentPolicySettingFormType extends AbstractType
+final class UserConsentPolicySettingFormType extends AbstractType
 {
     public const string USER_CONSENT_POLICY_ARTICLE_FIELD_NAME = 'userConsentPolicyArticle';
 

--- a/packages/framework/src/Form/Admin/Vat/VatFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class VatFormType extends AbstractType
+final class VatFormType extends AbstractType
 {
     public const string SCENARIO_CREATE = 'create';
     public const string SCENARIO_EDIT = 'edit';

--- a/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class VatSettingsFormType extends AbstractType
+final class VatSettingsFormType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade

--- a/packages/framework/src/Form/BasicFileUploadType.php
+++ b/packages/framework/src/Form/BasicFileUploadType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class BasicFileUploadType extends AbstractType
+final class BasicFileUploadType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
@@ -85,7 +85,7 @@ class BasicFileUploadType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return AbstractFileUploadType::class;
     }

--- a/packages/framework/src/Form/BlogCategoriesType.php
+++ b/packages/framework/src/Form/BlogCategoriesType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class BlogCategoriesType extends AbstractType
+final class BlogCategoriesType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\BlogCategoriesTypeTransformer $blogCategoriesTypeTransformer

--- a/packages/framework/src/Form/BlogCategoryCheckboxType.php
+++ b/packages/framework/src/Form/BlogCategoryCheckboxType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class BlogCategoryCheckboxType extends AbstractType
+final class BlogCategoryCheckboxType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade $blogCategoryFacade

--- a/packages/framework/src/Form/CategoriesType.php
+++ b/packages/framework/src/Form/CategoriesType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CategoriesType extends AbstractType
+final class CategoriesType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\CategoriesTypeTransformer $categoriesTypeTransformer
@@ -93,7 +93,7 @@ class CategoriesType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/CategoryCheckboxType.php
+++ b/packages/framework/src/Form/CategoryCheckboxType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CategoryCheckboxType extends AbstractType
+final class CategoryCheckboxType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
@@ -61,7 +61,7 @@ class CategoryCheckboxType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CheckboxType::class;
     }

--- a/packages/framework/src/Form/ChoiceTypeExtension.php
+++ b/packages/framework/src/Form/ChoiceTypeExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ChoiceTypeExtension extends AbstractTypeExtension
+final class ChoiceTypeExtension extends AbstractTypeExtension
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/CollectionTypeExtension.php
+++ b/packages/framework/src/Form/CollectionTypeExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * Make CollectionType use custom ResizeFormListener
  */
-class CollectionTypeExtension extends AbstractTypeExtension
+final class CollectionTypeExtension extends AbstractTypeExtension
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/ColorPickerType.php
+++ b/packages/framework/src/Form/ColorPickerType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
-class ColorPickerType extends AbstractType
+final class ColorPickerType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextType::class;
     }

--- a/packages/framework/src/Form/CustomerUserListType.php
+++ b/packages/framework/src/Form/CustomerUserListType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CustomerUserListType extends AbstractType
+final class CustomerUserListType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade

--- a/packages/framework/src/Form/DatePickerType.php
+++ b/packages/framework/src/Form/DatePickerType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DatePickerType extends AbstractType
+final class DatePickerType extends AbstractType
 {
     protected const string FORMAT_PHP = 'dd.MM.yyyy';
 
@@ -41,7 +41,7 @@ class DatePickerType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return DateType::class;
     }

--- a/packages/framework/src/Form/DateTimeType.php
+++ b/packages/framework/src/Form/DateTimeType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType as SymfonyDateTimeTy
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DateTimeType extends AbstractType
+final class DateTimeType extends AbstractType
 {
     protected const FORMAT_PHP = 'dd.MM.yyyy HH:mm:ss';
 
@@ -49,7 +49,7 @@ class DateTimeType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return SymfonyDateTimeType::class;
     }

--- a/packages/framework/src/Form/DeliveryAddressListType.php
+++ b/packages/framework/src/Form/DeliveryAddressListType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DeliveryAddressListType extends AbstractType
+final class DeliveryAddressListType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DisplayOnlyCompanyNameType.php
+++ b/packages/framework/src/Form/DisplayOnlyCompanyNameType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayOnlyCompanyNameType extends AbstractType
+final class DisplayOnlyCompanyNameType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DisplayOnlyCustomerType.php
+++ b/packages/framework/src/Form/DisplayOnlyCustomerType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayOnlyCustomerType extends AbstractType
+final class DisplayOnlyCustomerType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DisplayOnlyDomainIconType.php
+++ b/packages/framework/src/Form/DisplayOnlyDomainIconType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayOnlyDomainIconType extends AbstractType
+final class DisplayOnlyDomainIconType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormView $view

--- a/packages/framework/src/Form/DisplayOnlyOrderType.php
+++ b/packages/framework/src/Form/DisplayOnlyOrderType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayOnlyOrderType extends AbstractType
+final class DisplayOnlyOrderType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DisplayOnlyType.php
+++ b/packages/framework/src/Form/DisplayOnlyType.php
@@ -8,7 +8,7 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayOnlyType extends AbstractType
+final class DisplayOnlyType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DisplayOnlyUrlType.php
+++ b/packages/framework/src/Form/DisplayOnlyUrlType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayOnlyUrlType extends AbstractType
+final class DisplayOnlyUrlType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DisplayVariablesType.php
+++ b/packages/framework/src/Form/DisplayVariablesType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DisplayVariablesType extends AbstractType
+final class DisplayVariablesType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/DomainType.php
+++ b/packages/framework/src/Form/DomainType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DomainType extends AbstractType
+final class DomainType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/DomainsType.php
+++ b/packages/framework/src/Form/DomainsType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class DomainsType extends AbstractType
+final class DomainsType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/EmptyMessageChoiceTypeExtension.php
+++ b/packages/framework/src/Form/EmptyMessageChoiceTypeExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class EmptyMessageChoiceTypeExtension extends AbstractTypeExtension
+final class EmptyMessageChoiceTypeExtension extends AbstractTypeExtension
 {
     /**
      * @param \Symfony\Component\Form\FormView $view

--- a/packages/framework/src/Form/FileUploadType.php
+++ b/packages/framework/src/Form/FileUploadType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class FileUploadType extends AbstractType
+final class FileUploadType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
@@ -173,7 +173,7 @@ class FileUploadType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return AbstractFileUploadType::class;
     }

--- a/packages/framework/src/Form/FilesType.php
+++ b/packages/framework/src/Form/FilesType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class FilesType extends AbstractType
+final class FilesType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Routing\RouterInterface $router
@@ -55,7 +55,7 @@ class FilesType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return AbstractMultiplePickerType::class;
     }

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class FormRenderingConfigurationExtension extends AbstractTypeExtension
+final class FormRenderingConfigurationExtension extends AbstractTypeExtension
 {
     public const string DISPLAY_FORMAT_MULTIDOMAIN_ROWS_NO_PADDING = 'multidomain_form_rows_no_padding';
 

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class FriendlyUrlType extends AbstractType
+final class FriendlyUrlType extends AbstractType
 {
     protected const string SLUG_REGEX = '/^[\w_\-\/]+$/';
 

--- a/packages/framework/src/Form/GrapesJsType.php
+++ b/packages/framework/src/Form/GrapesJsType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class GrapesJsType extends AbstractType
+final class GrapesJsType extends AbstractType
 {
     public const GRAPESJS_TEMPLATE_PATH = '/grapesjs-template';
 
@@ -51,10 +51,10 @@ class GrapesJsType extends AbstractType
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextareaType::class;
     }

--- a/packages/framework/src/Form/GroupType.php
+++ b/packages/framework/src/Form/GroupType.php
@@ -8,7 +8,7 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class GroupType extends AbstractType
+final class GroupType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver

--- a/packages/framework/src/Form/HoneyPotType.php
+++ b/packages/framework/src/Form/HoneyPotType.php
@@ -10,13 +10,13 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class HoneyPotType extends AbstractType
+final class HoneyPotType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextType::class;
     }

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class ImageUploadType extends AbstractType
+final class ImageUploadType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
@@ -187,7 +187,7 @@ class ImageUploadType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return AbstractFileUploadType::class;
     }

--- a/packages/framework/src/Form/InvertChoiceTypeExtension.php
+++ b/packages/framework/src/Form/InvertChoiceTypeExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class InvertChoiceTypeExtension extends AbstractTypeExtension
+final class InvertChoiceTypeExtension extends AbstractTypeExtension
 {
     protected const string INVERT_OPTION = 'invert';
 

--- a/packages/framework/src/Form/LocalizedFullWidthType.php
+++ b/packages/framework/src/Form/LocalizedFullWidthType.php
@@ -6,6 +6,6 @@ namespace Shopsys\FrameworkBundle\Form;
 
 use Shopsys\FrameworkBundle\Form\Locale\LocalizedType;
 
-class LocalizedFullWidthType extends LocalizedType
+final class LocalizedFullWidthType extends LocalizedType
 {
 }

--- a/packages/framework/src/Form/MessageType.php
+++ b/packages/framework/src/Form/MessageType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MessageType extends AbstractType
+final class MessageType extends AbstractType
 {
     public const string MESSAGE_LEVEL_WARNING = 'warning';
     public const string MESSAGE_LEVEL_INFO = 'info';

--- a/packages/framework/src/Form/MoneyTypeExtension.php
+++ b/packages/framework/src/Form/MoneyTypeExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class MoneyTypeExtension extends AbstractTypeExtension
+final class MoneyTypeExtension extends AbstractTypeExtension
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization

--- a/packages/framework/src/Form/MultiLocaleBasicFileUploadType.php
+++ b/packages/framework/src/Form/MultiLocaleBasicFileUploadType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class MultiLocaleBasicFileUploadType extends AbstractType
+final class MultiLocaleBasicFileUploadType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
@@ -95,7 +95,7 @@ class MultiLocaleBasicFileUploadType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return BasicFileUploadType::class;
     }

--- a/packages/framework/src/Form/MultiLocaleFileUploadType.php
+++ b/packages/framework/src/Form/MultiLocaleFileUploadType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
 
-class MultiLocaleFileUploadType extends AbstractType
+final class MultiLocaleFileUploadType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/NumberSliderType.php
+++ b/packages/framework/src/Form/NumberSliderType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 
-class NumberSliderType extends AbstractType
+final class NumberSliderType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return NumberType::class;
     }

--- a/packages/framework/src/Form/OrderItemsType.php
+++ b/packages/framework/src/Form/OrderItemsType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class OrderItemsType extends AbstractType
+final class OrderItemsType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade

--- a/packages/framework/src/Form/OrderListType.php
+++ b/packages/framework/src/Form/OrderListType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class OrderListType extends AbstractType
+final class OrderListType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade

--- a/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
+++ b/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class PriceAndVatTableByDomainsType extends AbstractType
+final class PriceAndVatTableByDomainsType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/ProductParameterValueType.php
+++ b/packages/framework/src/Form/ProductParameterValueType.php
@@ -8,13 +8,13 @@ use Override;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
-class ProductParameterValueType extends AbstractType
+final class ProductParameterValueType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/ProductType.php
+++ b/packages/framework/src/Form/ProductType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ProductType extends AbstractType
+final class ProductType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\ProductIdToProductTransformer $productIdToProductTransformer
@@ -60,7 +60,7 @@ class ProductType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return HiddenType::class;
     }

--- a/packages/framework/src/Form/ProductsType.php
+++ b/packages/framework/src/Form/ProductsType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ProductsType extends AbstractType
+final class ProductsType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\ProductsIdsToProductsTransformer $productsIdsToProductsTransformer
@@ -72,7 +72,7 @@ class ProductsType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/RolesType.php
+++ b/packages/framework/src/Form/RolesType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class RolesType extends AbstractType
+final class RolesType extends AbstractType
 {
     /**
      * @var array<array<string, string>>

--- a/packages/framework/src/Form/SingleCheckboxChoiceType.php
+++ b/packages/framework/src/Form/SingleCheckboxChoiceType.php
@@ -11,13 +11,13 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class SingleCheckboxChoiceType extends AbstractType
+final class SingleCheckboxChoiceType extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/packages/framework/src/Form/SortableValuesType.php
+++ b/packages/framework/src/Form/SortableValuesType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class SortableValuesType extends AbstractType
+final class SortableValuesType extends AbstractType
 {
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
@@ -34,7 +34,7 @@ class SortableValuesType extends AbstractType
      * {@inheritdoc}
      */
     #[Override]
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/packages/framework/src/Form/TransportInputPricesType.php
+++ b/packages/framework/src/Form/TransportInputPricesType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class TransportInputPricesType extends AbstractType
+final class TransportInputPricesType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade

--- a/packages/framework/src/Form/UrlListType.php
+++ b/packages/framework/src/Form/UrlListType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class UrlListType extends AbstractType
+final class UrlListType extends AbstractType
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade

--- a/packages/framework/src/Form/WysiwygTypeExtension.php
+++ b/packages/framework/src/Form/WysiwygTypeExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class WysiwygTypeExtension extends AbstractTypeExtension
+final class WysiwygTypeExtension extends AbstractTypeExtension
 {
     protected const ALLOWED_FORMAT_TAGS = 'p;h2;h3;h4;h5;h6;pre;div;address';
 

--- a/packages/product-feed-google/src/Form/GoogleProductFormType.php
+++ b/packages/product-feed-google/src/Form/GoogleProductFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class GoogleProductFormType extends AbstractType
+final class GoogleProductFormType extends AbstractType
 {
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/packages/product-feed-heureka/src/Form/CategoryFormType.php
+++ b/packages/product-feed-heureka/src/Form/CategoryFormType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CategoryFormType extends AbstractType
+final class CategoryFormType extends AbstractType
 {
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/packages/product-feed-heureka/src/Form/HeurekaFeedSettingFormType.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaFeedSettingFormType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class HeurekaFeedSettingFormType extends AbstractType
+final class HeurekaFeedSettingFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/product-feed-heureka/src/Form/HeurekaProductFormType.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaProductFormType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class HeurekaProductFormType extends AbstractType
+final class HeurekaProductFormType extends AbstractType
 {
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/packages/product-feed-luigis-box/src/Form/LuigisBoxSettingFormType.php
+++ b/packages/product-feed-luigis-box/src/Form/LuigisBoxSettingFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
 
-class LuigisBoxSettingFormType extends AbstractType
+final class LuigisBoxSettingFormType extends AbstractType
 {
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/product-feed-zbozi/src/Form/ZboziProductFormType.php
+++ b/packages/product-feed-zbozi/src/Form/ZboziProductFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ZboziProductFormType extends AbstractType
+final class ZboziProductFormType extends AbstractType
 {
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/project-base/app/src/Form/Admin/BrandFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/BrandFormTypeExtension.php
@@ -9,7 +9,7 @@ use Shopsys\FrameworkBundle\Form\Admin\Product\Brand\BrandFormType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class BrandFormTypeExtension extends AbstractTypeExtension
+final class BrandFormTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/project-base/app/src/Form/Admin/Customer/BillingAddressFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/Customer/BillingAddressFormTypeExtension.php
@@ -10,7 +10,7 @@ use Shopsys\FrameworkBundle\Form\Admin\Customer\BillingAddressFormType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class BillingAddressFormTypeExtension extends AbstractTypeExtension
+final class BillingAddressFormTypeExtension extends AbstractTypeExtension
 {
     private const DISABLED_FIELDS = [];
 

--- a/project-base/app/src/Form/Admin/CustomerUserFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/CustomerUserFormTypeExtension.php
@@ -10,7 +10,7 @@ use Shopsys\FrameworkBundle\Form\Admin\Customer\User\CustomerUserFormType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class CustomerUserFormTypeExtension extends AbstractTypeExtension
+final class CustomerUserFormTypeExtension extends AbstractTypeExtension
 {
     private const array DISABLED_FIELDS = [];
 

--- a/project-base/app/src/Form/Admin/OrderItemFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/OrderItemFormTypeExtension.php
@@ -10,7 +10,7 @@ use Shopsys\FrameworkBundle\Form\Admin\Order\OrderItemFormType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class OrderItemFormTypeExtension extends AbstractTypeExtension
+final class OrderItemFormTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
@@ -12,7 +12,7 @@ use Shopsys\FrameworkBundle\Form\ProductsType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class ProductFormTypeExtension extends AbstractTypeExtension
+final class ProductFormTypeExtension extends AbstractTypeExtension
 {
     public const DISABLED_FIELDS = [];
 

--- a/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
 
-class SliderItemFormTypeExtension extends AbstractTypeExtension
+final class SliderItemFormTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/project-base/app/src/Form/Type/CKEditorTypeExtension.php
+++ b/project-base/app/src/Form/Type/CKEditorTypeExtension.php
@@ -10,7 +10,7 @@ use Override;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class CKEditorTypeExtension extends AbstractTypeExtension
+final class CKEditorTypeExtension extends AbstractTypeExtension
 {
     /**
      * @param \FOS\CKEditorBundle\Config\CKEditorConfigurationInterface $configuration


### PR DESCRIPTION
#### Description, the reason for the PR
Forms should not be extended directly but via extension

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-make-forms-final-again.odin.shopsys.cloud
  - https://cz.tl-make-forms-final-again.odin.shopsys.cloud
<!-- Replace -->
