### PR TITLE
admin: grid now allows enabling drag and drop only if the admin has proper edit role for given agenda

### DIFF
--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -722,12 +722,16 @@ class Grid
      */
     public function enableDragAndDrop(string $entityClass): void
     {
-        $this->orderingEntityClass = $entityClass;
+        if ($this->canEdit()) {
+            $this->orderingEntityClass = $entityClass;
+        }
     }
 
     public function enableMultipleDragAndDrop(): void
     {
-        $this->multipleDragAndDrop = true;
+        if ($this->canEdit()) {
+            $this->multipleDragAndDrop = true;
+        }
     }
 
     /**

--- a/packages/framework/tests/Unit/Component/Grid/GridTest.php
+++ b/packages/framework/tests/Unit/Component/Grid/GridTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrameworkBundle\Unit\Component\Grid;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Exception\DuplicateColumnIdException;
@@ -304,7 +305,11 @@ class GridTest extends TestCase
         $grid->createView();
     }
 
-    public function testEnableDragAndDrop()
+    /**
+     * @param bool $isEditRoleGranted
+     */
+    #[DataProvider('enableDragAndDropDataProvider')]
+    public function testEnableDragAndDrop(bool $isEditRoleGranted): void
     {
         $entityClass = 'Path\To\Entity\Class';
 
@@ -317,6 +322,9 @@ class GridTest extends TestCase
         $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
         $dataSourceMock = $this->createMock(DataSourceInterface::class);
         $securityMock = $this->createMock(Security::class);
+        $securityMock->expects($this->any())
+            ->method('isGranted')
+            ->willReturn($isEditRoleGranted);
 
         $grid = new Grid(
             'gridId',
@@ -331,7 +339,17 @@ class GridTest extends TestCase
 
         $this->assertFalse($grid->isDragAndDrop());
         $grid->enableDragAndDrop($entityClass);
-        $this->assertTrue($grid->isDragAndDrop());
+        $this->assertSame($isEditRoleGranted, $grid->isDragAndDrop());
+    }
+
+    /**
+     * @return iterable
+     */
+    public static function enableDragAndDropDataProvider(): iterable
+    {
+        yield 'edit role granted' => ['isEditRoleGranted' => true];
+
+        yield 'edit role not granted' => ['isEditRoleGranted' => false];
     }
 
     public function testReorderColumns(): void


### PR DESCRIPTION
#### Description, the reason for the PR
So far, administrators have been able to save changes in the order of entities using drag and drop, even if they did not have full rights for the given agenda. This is fixed now and the grid can be set as drag and drop only when the administrator has full rights for the section.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-roles-tweaks.odin.shopsys.cloud
  - https://cz.rv-roles-tweaks.odin.shopsys.cloud
<!-- Replace -->
