### PR TITLE
fixed responsive signpost zindex

### DIFF
--- a/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpost.tsx
+++ b/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpost.tsx
@@ -32,7 +32,8 @@ export const BlogSignpost: FC<BlogSingpostProps> = ({ blogCategoryItems, activeI
                         className={twJoin(
                             'relative w-full justify-between !text-base',
                             'xl:text-text-default xl:pointer-events-none xl:bg-transparent xl:p-0 xl:font-semibold xl:outline-hidden',
-                            'max-xl:z-aboveOverlay max-xl:font-default max-xl:py-2.5',
+                            'max-xl:font-default max-xl:py-2.5',
+                            isBlogSignpostOpen && 'max-xl:z-aboveOverlay',
                         )}
                         onClick={() => setIsBlogSignpostOpen(!isBlogSignpostOpen)}
                     >

--- a/upgrade-notes/storefront_20250616_122304.md
+++ b/upgrade-notes/storefront_20250616_122304.md
@@ -1,0 +1,3 @@
+#### Fix blog signpost z-index ([#4045](https://github.com/shopsys/shopsys/pull/4045))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Blog signpost is now showing correctly on responsive devices.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3410-fix-blog-signpost.odin.shopsys.cloud
  - https://cz.tc-ssp-3410-fix-blog-signpost.odin.shopsys.cloud
<!-- Replace -->
