### PR TITLE
AddRoundingMiddleware now correctly uses OrderPriceCalculation::calculateOrderRoundingPrice as it was supposed to

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -275,11 +275,13 @@
             <arg value="--colors=always"/>
             <arg value="--configuration"/>
             <arg value="${path.packages}/framework/phpunit.xml"/>
+            <arg value="${path.packages}/framework/tests/"/>
         </exec>
         <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
             <arg value="--configuration"/>
             <arg value="${path.packages}/coding-standards/phpunit.xml"/>
+            <arg value="${path.packages}/coding-standards/tests/"/>
         </exec>
         <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
@@ -310,6 +312,142 @@
             <arg value="run"/>
             <arg value="tests:unit"/>
         </exec>
+    </target>
+
+    <target name="tests-unit-single" depends="set-test-name,production-protection,clean" description="Runs custom unit test.">
+        <if>
+            <not><equals arg1="${test.name}" arg2="all"/></not>
+            <then>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/article-feed-luigis-box/phpunit.xml"/>
+                    <arg value="${path.packages}/article-feed-luigis-box/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/brand-feed-luigis-box/phpunit.xml"/>
+                    <arg value="${path.packages}/brand-feed-luigis-box/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/category-feed-luigis-box/phpunit.xml"/>
+                    <arg value="${path.packages}/category-feed-luigis-box/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/product-feed-google/phpunit.xml"/>
+                    <arg value="${path.packages}/product-feed-google/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/product-feed-mergado/phpunit.xml"/>
+                    <arg value="${path.packages}/product-feed-mergado/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/product-feed-heureka/phpunit.xml"/>
+                    <arg value="${path.packages}/product-feed-heureka/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/product-feed-heureka-delivery/phpunit.xml"/>
+                    <arg value="${path.packages}/product-feed-heureka-delivery/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/product-feed-zbozi/phpunit.xml"/>
+                    <arg value="${path.packages}/product-feed-zbozi/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/product-feed-luigis-box/phpunit.xml"/>
+                    <arg value="${path.packages}/product-feed-luigis-box/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/http-smoke-testing/phpunit.xml"/>
+                    <arg value="${path.packages}/http-smoke-testing/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/migrations/phpunit.xml"/>
+                    <arg value="${path.packages}/migrations/tests"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/framework/phpunit.xml"/>
+                    <arg value="${path.packages}/framework/tests/"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/coding-standards/phpunit.xml"/>
+                    <arg value="${path.packages}/coding-standards/tests/"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/frontend-api/phpunit.xml"/>
+                    <arg value="${path.packages}/frontend-api/tests/"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.utils}/releaser/phpunit.xml"/>
+                    <arg value="${path.utils}/releaser/tests/"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.packages}/luigis-box/phpunit.xml"/>
+                    <arg value="${path.packages}/luigis-box/tests/"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+            </then>
+        </if>
     </target>
 
     <target name="translations-dump" depends="domains-info-load,admin-locales-load" description="Extracts translatable messages in the whole monorepo.">

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1041,12 +1041,12 @@
         </if>
     </target>
 
-    <target name="set-functional-test-name">
-        <input propertyName="test.functional.name" message="Enter functional test name to run:"/>
+    <target name="set-test-name">
+        <input propertyName="test.name" message="Enter test name to run:"/>
         <if>
-            <equals arg1="${test.functional.name}" arg2=""/>
+            <equals arg1="${test.name}" arg2=""/>
             <then>
-                <fail message="Functional name is not set. Enter functional test name to be run"/>
+                <fail message="Test name is not set. Enter test name to be run"/>
             </then>
         </if>
     </target>
@@ -1470,9 +1470,9 @@
         </if>
     </target>
 
-    <target name="tests-functional-single" depends="set-functional-test-name,production-protection,clean,test-clean-redis,domains-info-load" description="Runs custom functional test.">
+    <target name="tests-functional-single" depends="set-test-name,production-protection,clean,test-clean-redis,domains-info-load" description="Runs custom functional test.">
         <if>
-            <not><equals arg1="${test.functional.name}" arg2="all"/></not>
+            <not><equals arg1="${test.name}" arg2="all"/></not>
             <then>
                 <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="true">
                     <arg value="--colors=always"/>
@@ -1483,7 +1483,7 @@
                     <arg value="--configuration"/>
                     <arg value="${path.root}/phpunit.xml"/>
                     <arg value="--filter"/>
-                    <arg value="${test.functional.name}"/>
+                    <arg value="${test.name}"/>
                 </exec>
             </then>
         </if>

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
@@ -9,11 +9,10 @@ use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
+use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessingData;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessingStack;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
-use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
 
@@ -23,11 +22,13 @@ class AddRoundingMiddleware implements OrderProcessorMiddlewareInterface
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Rounding $rounding
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory $orderItemDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation $orderPriceCalculation
      */
     public function __construct(
         protected readonly CurrencyFacade $currencyFacade,
         protected readonly Rounding $rounding,
         protected readonly OrderItemDataFactory $orderItemDataFactory,
+        protected readonly OrderPriceCalculation $orderPriceCalculation,
     ) {
     }
 
@@ -43,23 +44,16 @@ class AddRoundingMiddleware implements OrderProcessorMiddlewareInterface
         $orderData = $orderProcessingData->orderData;
 
         $payment = $orderData->payment;
-        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($orderProcessingData->getDomainId());
 
-        if (!$payment?->isCzkRounding() || $currency->getCode() !== Currency::CODE_CZK) {
+        if ($payment === null) {
             return $orderProcessingStack->processNext($orderProcessingData);
         }
 
-        $priceWithVat = $orderData->totalPrice->getPriceWithVat();
-        $roundedPriceWithVat = $priceWithVat->round(0);
+        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($orderProcessingData->getDomainId());
 
-        $roundingPriceAmount = $this->rounding->roundPriceWithVatByCurrency(
-            $roundedPriceWithVat->subtract($priceWithVat),
-            $currency,
-        );
+        $roundingPrice = $this->orderPriceCalculation->calculateOrderRoundingPrice($payment, $currency, $orderData->totalPrice);
 
-        $roundingPrice = new Price($roundingPriceAmount, $roundingPriceAmount);
-
-        if (!$roundingPrice->isZero()) {
+        if ($roundingPrice !== null && !$roundingPrice->isZero()) {
             $orderData->addItem($this->createRoundingItemData($roundingPrice, $orderProcessingData->getDomainConfig()));
             $orderData->addTotalPrice($roundingPrice, OrderItemTypeEnum::TYPE_ROUNDING);
         }

--- a/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddlewareTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddlewareTest.php
@@ -6,7 +6,9 @@ namespace Tests\FrameworkBundle\Unit\Model\Order\Processing\OrderProcessorMiddle
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
+use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\AddRoundingMiddleware;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
@@ -171,10 +173,14 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
     private function createAddRoundingMiddleware(
         string $currencyCode = Currency::CODE_EUR,
     ): AddRoundingMiddleware {
+        $orderItemPriceCalculationMock = $this->createMock(OrderItemPriceCalculation::class);
+        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationMock, new Rounding());
+
         return new AddRoundingMiddleware(
             $this->createCurrencyFacade($currencyCode),
             new Rounding(),
             $this->createOrderItemDataFactory(),
+            $priceCalculation,
         );
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
- method was not used anywhere but in tests
- method is tested, so it makes more sense

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the order rounding logic by delegating rounding price calculation to a dedicated service, enhancing accuracy and maintainability.
- **Chores**
	- Added support for running single filtered unit tests across multiple packages to streamline testing workflows.
	- Renamed and generalized test configuration properties for more flexible test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-use-rounding-method-correctly.odin.shopsys.cloud
  - https://cz.tl-use-rounding-method-correctly.odin.shopsys.cloud
<!-- Replace -->
