### PR TITLE
fixed empty grapesjs template

### DIFF
--- a/packages/framework/src/Component/GrapesJs/EnsureCorrectGrapesJsFormatHelper.php
+++ b/packages/framework/src/Component/GrapesJs/EnsureCorrectGrapesJsFormatHelper.php
@@ -16,15 +16,13 @@ class EnsureCorrectGrapesJsFormatHelper
         string $locale,
     ): string {
         if ($string === null || trim(strip_tags($string)) === '') {
-            $string = t('Please replace this text with your own content.', locale: $locale) . $string;
+            return '<div class="gjs-text-ckeditor">' . t('Please replace this text with your own content.', locale: $locale) . '</div>';
         }
 
-        $isGrapeJsDivMissing = !str_contains('<div class="gjs-text-ckeditor">', $string);
-
-        if ($isGrapeJsDivMissing) {
-            $string = '<div class="gjs-text-ckeditor">' . $string . '</div>';
+        if (str_starts_with(trim($string), '<div')) {
+            return $string;
         }
 
-        return $string;
+        return '<div class="gjs-text-ckeditor">' . $string . '</div>';
     }
 }

--- a/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
+++ b/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
@@ -328,6 +328,10 @@ export default class InitGrapesJs {
         editor.BlockManager.remove('grid-items');
         editor.BlockManager.remove('list-items');
         editor.BlockManager.remove('text');
+
+        editor.BlockManager.get('link-block').set('category', Translator.trans('Basic objects')).set('attributes', { class: 'mail-icon' });
+        editor.BlockManager.get('sect50').set('category', Translator.trans('Basic objects')).set('attributes', { class: 'mail-icon' });
+        editor.BlockManager.get('sect100').set('category', Translator.trans('Basic objects')).set('attributes', { class: 'mail-icon' });
     }
 
     static setupBodyForGrapesJsEditor () {

--- a/project-base/app/assets/styles/admin/grapesjs.less
+++ b/project-base/app/assets/styles/admin/grapesjs.less
@@ -181,6 +181,13 @@
     }
 }
 
+.mail-icon .gjs-block__media {
+    svg {
+        width: 48px;
+        height: 48px;
+    }
+}
+
 .gjs-sm-field input {
     color: #000
 }

--- a/upgrade-notes/backend_20250619_060418.md
+++ b/upgrade-notes/backend_20250619_060418.md
@@ -1,0 +1,5 @@
+#### GrapesJS wrap all content after save ([#4050](https://github.com/shopsys/shopsys/pull/4050))
+
+- fixed an issue where GrapesJS was wrapping all content in additional HTML elements after saving
+- this change ensures that the content structure remains intact and prevents unwanted wrapper elements from being added to the saved content
+- added custom `mail-icon` class for mail template block icons to improve styling consistency and visual identification


### PR DESCRIPTION
#### Description, the reason for the PR
Empty GrapesJS template now should working correctly.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where extra HTML wrappers were added to content after saving in GrapesJS, preserving the original content structure.  
- **Refactor**
	- Improved the handling and formatting of text content for GrapesJS editing, ensuring more consistent and predictable display of placeholder text and HTML content.  
- **New Features**
	- Added a custom mail-icon style for mail template blocks to enhance visual consistency and identification in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->










<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3452-fix-empty-grapesjs.odin.shopsys.cloud
  - https://cz.tc-ssp-3452-fix-empty-grapesjs.odin.shopsys.cloud
<!-- Replace -->
