### PR TITLE
OrderItem::hasProduct replaced with OrderItem::isTypeProductAndHasProduct

### DIFF
--- a/packages/framework/src/Model/Heureka/HeurekaShopCertificationFactory.php
+++ b/packages/framework/src/Model/Heureka/HeurekaShopCertificationFactory.php
@@ -39,7 +39,7 @@ class HeurekaShopCertificationFactory
         $heurekaShopCertification->setEmail($order->getEmail());
 
         foreach ($order->getProductItems() as $item) {
-            if ($item->hasProduct()) {
+            if ($item->isTypeProductAndHasProduct()) {
                 $heurekaShopCertification->addProductItemId((string)$item->getProduct()->getId());
             }
         }

--- a/packages/framework/src/Model/Order/Item/OrderItem.php
+++ b/packages/framework/src/Model/Order/Item/OrderItem.php
@@ -390,11 +390,9 @@ class OrderItem
     /**
      * @return bool
      */
-    public function hasProduct()
+    public function isTypeProductAndHasProduct()
     {
-        $this->checkTypeProduct();
-
-        return $this->product !== null;
+        return $this->isTypeProduct() && $this->product !== null;
     }
 
     /**

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderItemTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderItemTest.php
@@ -106,12 +106,11 @@ class OrderItemTest extends TestCase
         $orderItem->getProduct();
     }
 
-    public function testProductCannotHaveProduct(): void
+    public function testTransportDoesNotHaveProduct(): void
     {
         $orderItem = $this->createOrderTransport();
 
-        $this->expectException(WrongItemTypeException::class);
-        $orderItem->hasProduct();
+        $this->assertFalse($orderItem->isTypeProductAndHasProduct());
     }
 
     public function testEditProductTypeWithProduct()

--- a/upgrade-notes/backend_20250723_143958.md
+++ b/upgrade-notes/backend_20250723_143958.md
@@ -1,0 +1,3 @@
+#### OrderItem::hasProduct replaced with OrderItem::isTypeProductAndHasProduct ([#4054](https://github.com/shopsys/shopsys/pull/4054))
+
+- `OrderItem::hasProduct` method has been renamed to `OrderItem::isTypeProductAndHasProduct` and now always returns bool instead of throwing an exception when the order item is type of `product` and has no product assigned.


### PR DESCRIPTION
#### Description, the reason for the PR
Has method should be used for checking if value is set. Throwing error in such case does not make sense.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-order-item.odin.shopsys.cloud
  - https://cz.tl-fix-order-item.odin.shopsys.cloud
<!-- Replace -->
