### PR TITLE
addFieldsByOrderItemType now correctly sets Product for OrderItem of type product

### DIFF
--- a/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
@@ -87,6 +87,8 @@ class OrderItemDataFactory
             $orderItemData->transport = $orderItem->getTransport();
         } elseif ($orderItem->isTypePayment()) {
             $orderItemData->payment = $orderItem->getPayment();
+        } elseif ($orderItem->isTypeProduct()) {
+            $orderItemData->product = $orderItem->getProduct();
         }
     }
 


### PR DESCRIPTION
#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-addfieldsbyorderitemtype.odin.shopsys.cloud
  - https://cz.tl-fix-addfieldsbyorderitemtype.odin.shopsys.cloud
<!-- Replace -->
