### PR TITLE
added ability to easily add new item to OrderData that will be persisted after OrderFacade::edit

### DIFF
--- a/packages/framework/src/Model/Order/OrderData.php
+++ b/packages/framework/src/Model/Order/OrderData.php
@@ -313,7 +313,15 @@ class OrderData
      */
     public function addItem(OrderItemData $item): void
     {
-        $this->items[] = $item;
+        $count = 0;
+
+        foreach ($this->items as $key => $value) {
+            if (str_starts_with((string)$key, self::NEW_ITEM_PREFIX)) {
+                $count++;
+            }
+        }
+
+        $this->items[self::NEW_ITEM_PREFIX . $count] = $item;
     }
 
     /**

--- a/project-base/app/tests/App/Functional/Model/Order/OrderFacadeEditTest.php
+++ b/project-base/app/tests/App/Functional/Model/Order/OrderFacadeEditTest.php
@@ -14,7 +14,6 @@ use Override;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\OrderItemNotFoundException;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
-use Shopsys\FrameworkBundle\Model\Order\OrderData;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Tests\App\Test\TransactionFunctionalTestCase;
 use Tests\FrameworkBundle\Test\IsMoneyEqual;
@@ -121,7 +120,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
         $orderItemData->vatPercent = '50.00';
         $orderItemData->unitPriceWithVat = Money::create(100);
         $orderItemData->unitPriceWithoutVat = Money::create('66.67');
-        $orderData->items[OrderData::NEW_ITEM_PREFIX . '1'] = $orderItemData;
+        $orderData->addItem($orderItemData);
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
@@ -155,7 +154,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
         $orderItemData->unitPriceWithoutVat = Money::create(50);
         $orderItemData->totalPriceWithVat = Money::create(950);
         $orderItemData->totalPriceWithoutVat = Money::create(400);
-        $orderData->items[OrderData::NEW_ITEM_PREFIX . '1'] = $orderItemData;
+        $orderData->addItem($orderItemData);
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 

--- a/upgrade-notes/backend_20250625_161205.md
+++ b/upgrade-notes/backend_20250625_161205.md
@@ -1,0 +1,3 @@
+#### added ability to easily add new item to OrderData that will be persisted after OrderFacade::edit ([#4057](https://github.com/shopsys/shopsys/pull/4057))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
When developer wants to add new item via OrderFacade::edit, there was no easy way to do it. This PR finishes basic implementation from #3084 so it is easily available.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-add-new-item.odin.shopsys.cloud
  - https://cz.tl-fix-add-new-item.odin.shopsys.cloud
<!-- Replace -->
