### PR TITLE
Add unit tests for order process util functions

### DIFF
--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/transportAndPaymentUtils.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/transportAndPaymentUtils.tsx
@@ -1,21 +1,18 @@
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { TypeLastOrderFragment } from 'graphql/requests/orders/fragments/LastOrderFragment.generated';
 import {
+    LastOrderQueryDocument,
     TypeLastOrderQuery,
     TypeLastOrderQueryVariables,
-    LastOrderQueryDocument,
 } from 'graphql/requests/orders/queries/LastOrderQuery.generated';
 import { TypeSimplePaymentFragment } from 'graphql/requests/payments/fragments/SimplePaymentFragment.generated';
 import {
+    StoreQueryDocument,
     TypeStoreQuery,
     TypeStoreQueryVariables,
-    StoreQueryDocument,
 } from 'graphql/requests/stores/queries/StoreQuery.generated';
 import { TypeTransportWithAvailablePaymentsFragment } from 'graphql/requests/transports/fragments/TransportWithAvailablePaymentsFragment.generated';
 import { Maybe } from 'graphql/types';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
-import { getGtmPickupPlaceFromLastOrder } from 'gtm/mappers/getGtmPickupPlaceFromLastOrder';
-import { getGtmPickupPlaceFromStore } from 'gtm/mappers/getGtmPickupPlaceFromStore';
 import { Translate } from 'next-translate';
 import getConfig from 'next/config';
 import dynamic from 'next/dynamic';
@@ -25,6 +22,7 @@ import { usePersistStore } from 'store/usePersistStore';
 import { useSessionStore } from 'store/useSessionStore';
 import { useClient } from 'urql';
 import { useIsUserLoggedIn } from 'utils/auth/useIsUserLoggedIn';
+import { getLastOrderPickupPlace, PICKUP_POINT_NOT_SET_ERROR_MESSAGE } from 'utils/cart/pickupPlaceCalculations';
 import { ChangePaymentInCart } from 'utils/cart/useChangePaymentInCart';
 import { ChangeTransportInCart } from 'utils/cart/useChangeTransportInCart';
 import { useCurrentCart } from 'utils/cart/useCurrentCart';
@@ -33,8 +31,6 @@ import { logException } from 'utils/errors/logException';
 import { isPacketeryTransport, mapPacketeryExtendedPoint, packeteryPick } from 'utils/packetery';
 import { StoreOrPacketeryPoint } from 'utils/packetery/types';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
-
-const PICKUP_POINT_NOT_SET_ERROR_MESSAGE = 'Packetery pickup point is not set';
 
 const PickupPlacePopup = dynamic(
     () => import('components/Blocks/Popup/PickupPlacePopup').then((component) => component.PickupPlacePopup),
@@ -181,27 +177,6 @@ export const useTransportChangeInSelect = (
         resetTransportAndPayment,
         openPickupPlacePopup,
     };
-};
-
-const getLastOrderPickupPlace = (
-    lastOrder: TypeLastOrderFragment,
-    lastOrderPickupPlaceIdentifier: string,
-    lastOrderPickupPlaceFromApi: StoreOrPacketeryPoint | undefined | null,
-    packeteryPickupPoint: StoreOrPacketeryPoint | null,
-): StoreOrPacketeryPoint | null => {
-    if (packeteryPickupPoint?.identifier === lastOrderPickupPlaceIdentifier) {
-        return packeteryPickupPoint;
-    }
-
-    if (lastOrderPickupPlaceFromApi?.identifier) {
-        return getGtmPickupPlaceFromStore(lastOrderPickupPlaceFromApi);
-    }
-
-    if (!packeteryPickupPoint) {
-        throw new Error(PICKUP_POINT_NOT_SET_ERROR_MESSAGE);
-    }
-
-    return getGtmPickupPlaceFromLastOrder(lastOrderPickupPlaceIdentifier, lastOrder);
 };
 
 type TransportAndPaymentErrorsType = {

--- a/project-base/storefront/utils/cart/pickupPlaceCalculations.ts
+++ b/project-base/storefront/utils/cart/pickupPlaceCalculations.ts
@@ -1,0 +1,50 @@
+import { TypeLastOrderFragment } from 'graphql/requests/orders/fragments/LastOrderFragment.generated';
+import { TypeTransportWithAvailablePaymentsAndStoresFragment } from 'graphql/requests/transports/fragments/TransportWithAvailablePaymentsAndStoresFragment.generated';
+import { Maybe } from 'graphql/types';
+import { getGtmPickupPlaceFromLastOrder } from 'gtm/mappers/getGtmPickupPlaceFromLastOrder';
+import { getGtmPickupPlaceFromStore } from 'gtm/mappers/getGtmPickupPlaceFromStore';
+import { isPacketeryTransport } from 'utils/packetery';
+import { StoreOrPacketeryPoint } from 'utils/packetery/types';
+
+export const PICKUP_POINT_NOT_SET_ERROR_MESSAGE = 'Packetery pickup point is not set';
+
+export const getLastOrderPickupPlace = (
+    lastOrder: TypeLastOrderFragment,
+    lastOrderPickupPlaceIdentifier: string,
+    lastOrderPickupPlaceFromApi: StoreOrPacketeryPoint | undefined | null,
+    packeteryPickupPoint: StoreOrPacketeryPoint | null,
+): StoreOrPacketeryPoint | null => {
+    if (packeteryPickupPoint?.identifier === lastOrderPickupPlaceIdentifier) {
+        return packeteryPickupPoint;
+    }
+
+    if (lastOrderPickupPlaceFromApi?.identifier) {
+        return getGtmPickupPlaceFromStore(lastOrderPickupPlaceFromApi);
+    }
+
+    if (!packeteryPickupPoint) {
+        throw new Error(PICKUP_POINT_NOT_SET_ERROR_MESSAGE);
+    }
+
+    return getGtmPickupPlaceFromLastOrder(lastOrderPickupPlaceIdentifier, lastOrder);
+};
+
+export const getSelectedPickupPlace = (
+    transport: Maybe<TypeTransportWithAvailablePaymentsAndStoresFragment> | undefined,
+    pickupPlaceIdentifier: string | null | undefined,
+    packeteryPickupPoint: StoreOrPacketeryPoint | null,
+): StoreOrPacketeryPoint | null => {
+    if (!transport || !pickupPlaceIdentifier) {
+        return null;
+    }
+
+    if (isPacketeryTransport(transport.transportTypeCode)) {
+        return packeteryPickupPoint;
+    }
+
+    const pickupPlace = transport.stores?.edges?.find(
+        (pickupPlaceNode) => pickupPlaceNode?.node?.identifier === pickupPlaceIdentifier,
+    );
+
+    return pickupPlace?.node === undefined ? null : pickupPlace.node;
+};

--- a/project-base/storefront/utils/cart/useCurrentCart.ts
+++ b/project-base/storefront/utils/cart/useCurrentCart.ts
@@ -1,14 +1,11 @@
 import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useCartQuery } from 'graphql/requests/cart/queries/CartQuery.generated';
-import { TypeTransportWithAvailablePaymentsAndStoresFragment } from 'graphql/requests/transports/fragments/TransportWithAvailablePaymentsAndStoresFragment.generated';
-import { Maybe } from 'graphql/types';
 import { useEffect } from 'react';
 import { usePersistStore } from 'store/usePersistStore';
 import { useSessionStore } from 'store/useSessionStore';
 import { CurrentCartType } from 'types/cart';
 import { useIsUserLoggedIn } from 'utils/auth/useIsUserLoggedIn';
-import { isPacketeryTransport } from 'utils/packetery';
-import { StoreOrPacketeryPoint } from 'utils/packetery/types';
+import { getSelectedPickupPlace } from 'utils/cart/pickupPlaceCalculations';
 
 export const useCurrentCart = (fromCache = true): CurrentCartType => {
     const isUserLoggedIn = useIsUserLoggedIn();
@@ -54,24 +51,4 @@ export const useCurrentCart = (fromCache = true): CurrentCartType => {
         roundingPrice: cart?.roundingPrice ?? null,
         modifications: cart?.modifications ?? null,
     };
-};
-
-const getSelectedPickupPlace = (
-    transport: Maybe<TypeTransportWithAvailablePaymentsAndStoresFragment> | undefined,
-    pickupPlaceIdentifier: string | null | undefined,
-    packeteryPickupPoint: StoreOrPacketeryPoint | null,
-): StoreOrPacketeryPoint | null => {
-    if (!transport || !pickupPlaceIdentifier) {
-        return null;
-    }
-
-    if (isPacketeryTransport(transport.transportTypeCode)) {
-        return packeteryPickupPoint;
-    }
-
-    const pickupPlace = transport.stores?.edges?.find(
-        (pickupPlaceNode) => pickupPlaceNode?.node?.identifier === pickupPlaceIdentifier,
-    );
-
-    return pickupPlace?.node === undefined ? null : pickupPlace.node;
 };

--- a/project-base/storefront/vitest/utils/auth/getIsUserAuthorizedToViewPage.test.ts
+++ b/project-base/storefront/vitest/utils/auth/getIsUserAuthorizedToViewPage.test.ts
@@ -1,0 +1,165 @@
+import { TypeCustomerUserRoleEnum } from 'graphql/types';
+import { CustomerUserAreaEnum } from 'types/customer';
+import { getIsUserAuthorizedToViewPage } from 'utils/auth/getIsUserAuthorizedToViewPage';
+import { describe, expect, test } from 'vitest';
+
+describe('getIsUserAuthorizedToViewPage', () => {
+    const mockUserRoles: TypeCustomerUserRoleEnum[] = [
+        TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation,
+        TypeCustomerUserRoleEnum.RoleApiAll,
+    ];
+
+    const mockUserArea = CustomerUserAreaEnum.B2C;
+
+    describe('Role-based authorization', () => {
+        test('should return true when user has required role', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                mockUserArea,
+                [TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation],
+                undefined,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        test('should return false when user does not have required role', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                mockUserArea,
+                [TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage],
+                undefined,
+            );
+
+            expect(result).toBe(false);
+        });
+
+        test('should return true when user has any of multiple required roles', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                mockUserArea,
+                [TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage, TypeCustomerUserRoleEnum.RoleApiAll],
+                undefined,
+            );
+
+            expect(result).toBe(true);
+        });
+
+        test('should return false when user has none of multiple required roles', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                mockUserArea,
+                [TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage, TypeCustomerUserRoleEnum.RoleApiComplaintCreation],
+                undefined,
+            );
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Area-based authorization', () => {
+        test('should return true when user is in required area', () => {
+            const result = getIsUserAuthorizedToViewPage(mockUserRoles, CustomerUserAreaEnum.B2C, undefined, [
+                CustomerUserAreaEnum.B2C,
+            ]);
+
+            expect(result).toBe(true);
+        });
+
+        test('should return false when user is not in required area', () => {
+            const result = getIsUserAuthorizedToViewPage(mockUserRoles, CustomerUserAreaEnum.B2C, undefined, [
+                CustomerUserAreaEnum.B2B,
+            ]);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return true when user is in any of multiple required areas', () => {
+            const result = getIsUserAuthorizedToViewPage(mockUserRoles, CustomerUserAreaEnum.B2C, undefined, [
+                CustomerUserAreaEnum.B2B,
+                CustomerUserAreaEnum.B2C,
+            ]);
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('Combined role and area authorization', () => {
+        test('should return true when user meets both role and area requirements', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                CustomerUserAreaEnum.B2C,
+                [TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation],
+                [CustomerUserAreaEnum.B2C],
+            );
+
+            expect(result).toBe(true);
+        });
+
+        test('should return false when user meets role but not area requirements', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                CustomerUserAreaEnum.B2C,
+                [TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation],
+                [CustomerUserAreaEnum.B2B],
+            );
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false when user meets area but not role requirements', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                CustomerUserAreaEnum.B2C,
+                [TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage],
+                [CustomerUserAreaEnum.B2C],
+            );
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false when user meets neither role nor area requirements', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                mockUserRoles,
+                CustomerUserAreaEnum.B2C,
+                [TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage],
+                [CustomerUserAreaEnum.B2B],
+            );
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('No restrictions (default behavior)', () => {
+        test('should return true when no role or area restrictions are specified', () => {
+            const result = getIsUserAuthorizedToViewPage(mockUserRoles, mockUserArea, undefined, undefined);
+
+            expect(result).toBe(true);
+        });
+
+        test('should return false when empty arrays are provided for restrictions', () => {
+            const result = getIsUserAuthorizedToViewPage(mockUserRoles, mockUserArea, [], []);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Edge cases', () => {
+        test('should handle empty user roles array', () => {
+            const result = getIsUserAuthorizedToViewPage(
+                [],
+                mockUserArea,
+                [TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation],
+                undefined,
+            );
+
+            expect(result).toBe(false);
+        });
+
+        test('should handle empty user roles array with no role restrictions', () => {
+            const result = getIsUserAuthorizedToViewPage([], mockUserArea, undefined, [CustomerUserAreaEnum.B2C]);
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/project-base/storefront/vitest/utils/cart/getLastOrderPickupPlace.test.ts
+++ b/project-base/storefront/vitest/utils/cart/getLastOrderPickupPlace.test.ts
@@ -1,0 +1,240 @@
+import { getGtmPickupPlaceFromLastOrder } from 'gtm/mappers/getGtmPickupPlaceFromLastOrder';
+import { getGtmPickupPlaceFromStore } from 'gtm/mappers/getGtmPickupPlaceFromStore';
+// Import after mocking
+import { getLastOrderPickupPlace, PICKUP_POINT_NOT_SET_ERROR_MESSAGE } from 'utils/cart/pickupPlaceCalculations';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the external dependencies BEFORE importing the function
+vi.mock('gtm/mappers/getGtmPickupPlaceFromStore', () => ({
+    getGtmPickupPlaceFromStore: vi.fn(),
+}));
+
+vi.mock('gtm/mappers/getGtmPickupPlaceFromLastOrder', () => ({
+    getGtmPickupPlaceFromLastOrder: vi.fn(),
+}));
+
+vi.mock('next/config', () => ({
+    default: () => ({
+        serverRuntimeConfig: { internalGraphqlEndpoint: 'https://test.ts/graphql/' },
+        publicRuntimeConfig: {
+            errorDebuggingLevel: 'no-debug',
+            domains: [{ url: 'https://test.ts/' }, { url: 'https://test.ts/' }],
+        },
+    }),
+}));
+
+// Type the mocked functions
+const mockGetGtmPickupPlaceFromStore = vi.mocked(getGtmPickupPlaceFromStore);
+const mockGetGtmPickupPlaceFromLastOrder = vi.mocked(getGtmPickupPlaceFromLastOrder);
+
+describe('getLastOrderPickupPlace', () => {
+    const mockLastOrder = {
+        uuid: 'order-123',
+        pickupPlaceIdentifier: 'pickup-456',
+        deliveryCity: 'Prague',
+        deliveryStreet: 'Test Street 123',
+        deliveryPostcode: '12345',
+        deliveryCountry: {
+            name: 'Czech Republic',
+            code: 'CZ',
+        },
+    } as any;
+
+    const mockPacketeryPoint = {
+        identifier: 'pickup-456',
+        name: 'Packetery Point',
+        city: 'Prague',
+        street: 'Main St 123',
+    } as any;
+
+    const mockApiPickupPlace = {
+        identifier: 'api-pickup-789',
+        name: 'API Store',
+        city: 'Brno',
+        street: 'API St 789',
+    } as any;
+
+    const mockGtmStoreResult = {
+        identifier: 'gtm-store-123',
+        name: 'GTM Store',
+    } as any;
+
+    const mockGtmLastOrderResult = {
+        identifier: 'gtm-last-order-456',
+        name: 'GTM Last Order',
+    } as any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetGtmPickupPlaceFromStore.mockReturnValue(mockGtmStoreResult);
+        mockGetGtmPickupPlaceFromLastOrder.mockReturnValue(mockGtmLastOrderResult);
+    });
+
+    describe('when packeteryPickupPoint matches identifier', () => {
+        it('should return packeteryPickupPoint when identifiers match exactly', () => {
+            const result = getLastOrderPickupPlace(mockLastOrder, 'pickup-456', mockApiPickupPlace, mockPacketeryPoint);
+
+            expect(result).toBe(mockPacketeryPoint);
+            expect(mockGetGtmPickupPlaceFromStore).not.toHaveBeenCalled();
+            expect(mockGetGtmPickupPlaceFromLastOrder).not.toHaveBeenCalled();
+        });
+
+        it('should prioritize packeteryPickupPoint over API data when identifiers match', () => {
+            const result = getLastOrderPickupPlace(
+                mockLastOrder,
+                'pickup-456',
+                { ...mockApiPickupPlace, identifier: 'different-id' } as any,
+                mockPacketeryPoint,
+            );
+
+            expect(result).toBe(mockPacketeryPoint);
+            expect(mockGetGtmPickupPlaceFromStore).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when packeteryPickupPoint does not match identifier', () => {
+        const nonMatchingPacketeryPoint = {
+            ...mockPacketeryPoint,
+            identifier: 'different-identifier',
+        } as any;
+
+        it('should use API pickup place when available', () => {
+            const result = getLastOrderPickupPlace(
+                mockLastOrder,
+                'pickup-456',
+                mockApiPickupPlace,
+                nonMatchingPacketeryPoint,
+            );
+
+            expect(result).toBe(mockGtmStoreResult);
+            expect(mockGetGtmPickupPlaceFromStore).toHaveBeenCalledWith(mockApiPickupPlace);
+            expect(mockGetGtmPickupPlaceFromLastOrder).not.toHaveBeenCalled();
+        });
+
+        it('should call getGtmPickupPlaceFromStore with correct parameters', () => {
+            getLastOrderPickupPlace(mockLastOrder, 'pickup-456', mockApiPickupPlace, nonMatchingPacketeryPoint);
+
+            expect(mockGetGtmPickupPlaceFromStore).toHaveBeenCalledTimes(1);
+            expect(mockGetGtmPickupPlaceFromStore).toHaveBeenCalledWith(mockApiPickupPlace);
+        });
+
+        it('should not use API pickup place when identifier is missing', () => {
+            const apiPlaceWithoutIdentifier = {
+                ...mockApiPickupPlace,
+                identifier: null,
+            } as any;
+
+            expect(() => {
+                getLastOrderPickupPlace(mockLastOrder, 'pickup-456', apiPlaceWithoutIdentifier, null);
+            }).toThrow(PICKUP_POINT_NOT_SET_ERROR_MESSAGE);
+
+            expect(mockGetGtmPickupPlaceFromStore).not.toHaveBeenCalled();
+        });
+
+        it('should not use API pickup place when identifier is undefined', () => {
+            const apiPlaceWithUndefinedIdentifier = {
+                ...mockApiPickupPlace,
+                identifier: undefined,
+            } as any;
+
+            expect(() => {
+                getLastOrderPickupPlace(mockLastOrder, 'pickup-456', apiPlaceWithUndefinedIdentifier, null);
+            }).toThrow(PICKUP_POINT_NOT_SET_ERROR_MESSAGE);
+
+            expect(mockGetGtmPickupPlaceFromStore).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('when API pickup place is not available', () => {
+        it('should use GTM last order mapping when packeteryPickupPoint exists', () => {
+            const result = getLastOrderPickupPlace(mockLastOrder, 'pickup-456', null, {
+                identifier: 'different-id',
+                name: 'Different Point',
+            } as any);
+
+            expect(result).toBe(mockGtmLastOrderResult);
+            expect(mockGetGtmPickupPlaceFromLastOrder).toHaveBeenCalledWith('pickup-456', mockLastOrder);
+            expect(mockGetGtmPickupPlaceFromStore).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when packeteryPickupPoint is null', () => {
+            expect(() => {
+                getLastOrderPickupPlace(mockLastOrder, 'pickup-456', null, null);
+            }).toThrow(PICKUP_POINT_NOT_SET_ERROR_MESSAGE);
+
+            expect(mockGetGtmPickupPlaceFromStore).not.toHaveBeenCalled();
+            expect(mockGetGtmPickupPlaceFromLastOrder).not.toHaveBeenCalled();
+        });
+
+        it('should throw error when packeteryPickupPoint is undefined', () => {
+            expect(() => {
+                getLastOrderPickupPlace(mockLastOrder, 'pickup-456', undefined as any, undefined as any);
+            }).toThrow(PICKUP_POINT_NOT_SET_ERROR_MESSAGE);
+        });
+
+        it('should call getGtmPickupPlaceFromLastOrder with correct parameters', () => {
+            getLastOrderPickupPlace(mockLastOrder, 'pickup-456', null, {
+                identifier: 'different-id',
+                name: 'Different Point',
+            } as any);
+
+            expect(mockGetGtmPickupPlaceFromLastOrder).toHaveBeenCalledTimes(1);
+            expect(mockGetGtmPickupPlaceFromLastOrder).toHaveBeenCalledWith('pickup-456', mockLastOrder);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle empty string identifiers', () => {
+            const emptyIdentifierPacketery = {
+                ...mockPacketeryPoint,
+                identifier: '',
+            } as any;
+
+            // Empty string identifier doesn't match, so it should fall back to GTM last order
+            const result = getLastOrderPickupPlace(mockLastOrder, 'pickup-456', null, emptyIdentifierPacketery);
+
+            expect(result).toBe(mockGtmLastOrderResult);
+            expect(mockGetGtmPickupPlaceFromLastOrder).toHaveBeenCalledWith('pickup-456', mockLastOrder);
+        });
+
+        it('should handle complex last order object', () => {
+            const complexLastOrder = {
+                uuid: 'complex-order',
+                pickupPlaceIdentifier: 'complex-pickup',
+                transport: { name: 'Express Transport' },
+                customer: { email: 'test@example.com' },
+                deliveryCity: 'Complex City',
+                deliveryStreet: 'Complex Street',
+                deliveryPostcode: '54321',
+                deliveryCountry: {
+                    name: 'Slovakia',
+                    code: 'SK',
+                },
+            } as any;
+
+            getLastOrderPickupPlace(complexLastOrder, 'pickup-456', null, {
+                identifier: 'different-id',
+                name: 'Different Point',
+            } as any);
+
+            expect(mockGetGtmPickupPlaceFromLastOrder).toHaveBeenCalledWith('pickup-456', complexLastOrder);
+        });
+
+        it('should handle API place with additional properties', () => {
+            const complexApiPlace = {
+                identifier: 'complex-api-123',
+                name: 'Complex API Store',
+                address: { street: 'Complex St', city: 'Complex City' },
+                openingHours: { monday: '9-17' },
+            } as any;
+
+            const result = getLastOrderPickupPlace(mockLastOrder, 'pickup-456', complexApiPlace, {
+                identifier: 'different-id',
+                name: 'Different Point',
+            } as any);
+
+            expect(result).toBe(mockGtmStoreResult);
+            expect(mockGetGtmPickupPlaceFromStore).toHaveBeenCalledWith(complexApiPlace);
+        });
+    });
+});

--- a/project-base/storefront/vitest/utils/cart/getSelectedPickupPlace.test.ts
+++ b/project-base/storefront/vitest/utils/cart/getSelectedPickupPlace.test.ts
@@ -1,0 +1,180 @@
+import { getSelectedPickupPlace } from 'utils/cart/pickupPlaceCalculations';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('utils/packetery', () => ({
+    isPacketeryTransport: vi.fn((transportTypeCode: string) => transportTypeCode === 'packetery'),
+}));
+
+vi.mock('next/config', () => ({
+    default: () => ({
+        serverRuntimeConfig: { internalGraphqlEndpoint: 'https://test.ts/graphql/' },
+        publicRuntimeConfig: {
+            errorDebuggingLevel: 'no-debug',
+            domains: [{ url: 'https://test.ts/' }, { url: 'https://test.ts/' }],
+        },
+    }),
+}));
+
+describe('getSelectedPickupPlace', () => {
+    const mockPacketeryPoint = {
+        identifier: 'packetery-123',
+        name: 'Packetery Point',
+        city: 'Prague',
+        street: 'Main St 123',
+    } as any;
+
+    const mockStorePoint = {
+        identifier: 'store-456',
+        name: 'Store Point',
+        city: 'Brno',
+        street: 'Store St 456',
+    };
+
+    const mockTransportWithStores = {
+        transportTypeCode: 'personal_pickup',
+        stores: {
+            edges: [{ node: mockStorePoint }, { node: { identifier: 'store-789', name: 'Another Store' } }],
+        },
+    } as any;
+
+    const mockPacketeryTransport = {
+        transportTypeCode: 'packetery',
+        stores: null,
+    } as any;
+
+    describe('when transport or pickupPlaceIdentifier is missing', () => {
+        it('should return null when transport is null', () => {
+            const result = getSelectedPickupPlace(null, 'some-id', mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null when transport is undefined', () => {
+            const result = getSelectedPickupPlace(undefined, 'some-id', mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null when pickupPlaceIdentifier is null', () => {
+            const result = getSelectedPickupPlace(mockTransportWithStores, null, mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null when pickupPlaceIdentifier is undefined', () => {
+            const result = getSelectedPickupPlace(mockTransportWithStores, undefined, mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null when pickupPlaceIdentifier is empty string', () => {
+            const result = getSelectedPickupPlace(mockTransportWithStores, '', mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('when transport is Packetery type', () => {
+        it('should return packeteryPickupPoint for Packetery transport', () => {
+            const result = getSelectedPickupPlace(mockPacketeryTransport, 'packetery-123', mockPacketeryPoint);
+
+            expect(result).toBe(mockPacketeryPoint);
+        });
+
+        it('should return packeteryPickupPoint even if identifier does not match', () => {
+            const result = getSelectedPickupPlace(mockPacketeryTransport, 'different-id', mockPacketeryPoint);
+
+            expect(result).toBe(mockPacketeryPoint);
+        });
+
+        it('should return null packeteryPickupPoint if it is null', () => {
+            const result = getSelectedPickupPlace(mockPacketeryTransport, 'packetery-123', null);
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('when transport has stores', () => {
+        it('should return matching store from transport.stores', () => {
+            const result = getSelectedPickupPlace(mockTransportWithStores, 'store-456', mockPacketeryPoint);
+
+            expect(result).toBe(mockStorePoint);
+        });
+
+        it('should return matching store even when packeteryPickupPoint is provided', () => {
+            const result = getSelectedPickupPlace(mockTransportWithStores, 'store-456', mockPacketeryPoint);
+
+            expect(result).toBe(mockStorePoint);
+            expect(result).not.toBe(mockPacketeryPoint);
+        });
+
+        it('should return null when store identifier is not found', () => {
+            const result = getSelectedPickupPlace(mockTransportWithStores, 'non-existent-store', mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null when stores edges is empty', () => {
+            const transportWithEmptyStores = {
+                transportTypeCode: 'personal_pickup',
+                stores: { edges: [] },
+            } as any;
+
+            const result = getSelectedPickupPlace(transportWithEmptyStores, 'store-456', mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null when stores is null', () => {
+            const transportWithNullStores = {
+                transportTypeCode: 'personal_pickup',
+                stores: null,
+            } as any;
+
+            const result = getSelectedPickupPlace(transportWithNullStores, 'store-456', mockPacketeryPoint);
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle store edge with null node', () => {
+            const transportWithNullNode = {
+                transportTypeCode: 'personal_pickup',
+                stores: {
+                    edges: [{ node: null }, { node: mockStorePoint }],
+                },
+            } as any;
+
+            const result = getSelectedPickupPlace(transportWithNullNode, 'store-456', mockPacketeryPoint);
+
+            expect(result).toBe(mockStorePoint);
+        });
+
+        it('should handle store edge with undefined node', () => {
+            const transportWithUndefinedNode = {
+                transportTypeCode: 'personal_pickup',
+                stores: {
+                    edges: [{ node: undefined }, { node: mockStorePoint }],
+                },
+            } as any;
+
+            const result = getSelectedPickupPlace(transportWithUndefinedNode, 'store-456', mockPacketeryPoint);
+
+            expect(result).toBe(mockStorePoint);
+        });
+
+        it('should return matching store node with partial properties', () => {
+            const transportWithMatchingNode = {
+                transportTypeCode: 'personal_pickup',
+                stores: {
+                    edges: [{ node: { identifier: 'store-456' } }],
+                },
+            } as any;
+
+            const result = getSelectedPickupPlace(transportWithMatchingNode, 'store-456', mockPacketeryPoint);
+
+            expect(result).toEqual({ identifier: 'store-456' });
+        });
+    });
+});

--- a/project-base/storefront/vitest/utils/errors/hasValidationErrors.test.ts
+++ b/project-base/storefront/vitest/utils/errors/hasValidationErrors.test.ts
@@ -1,0 +1,132 @@
+import { hasValidationErrors } from 'utils/errors/hasValidationErrors';
+import { describe, expect, test } from 'vitest';
+
+describe('hasValidationErrors', () => {
+    test('should return false for empty object', () => {
+        const result = hasValidationErrors({});
+
+        expect(result).toBe(false);
+    });
+
+    test('should return true for object with validation errors', () => {
+        const validationErrors = {
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport',
+            },
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with multiple validation errors', () => {
+        const validationErrors = {
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport',
+            },
+            payment: {
+                name: 'payment',
+                label: 'Choose payment',
+                errorMessage: 'Please select payment',
+            },
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with nested properties', () => {
+        const validationErrors = {
+            formField: {
+                nestedField: {
+                    value: 'error message',
+                },
+            },
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with only undefined values (has keys)', () => {
+        const validationErrors = {
+            field1: undefined,
+            field2: undefined,
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with mixed defined and undefined values', () => {
+        const validationErrors = {
+            field1: undefined,
+            field2: {
+                errorMessage: 'Some error',
+            },
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with null values', () => {
+        const validationErrors = {
+            field1: null,
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with string values', () => {
+        const validationErrors = {
+            field1: 'error message',
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with boolean values', () => {
+        const validationErrors = {
+            field1: true,
+            field2: false,
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with number values including zero', () => {
+        const validationErrors = {
+            field1: 0,
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+
+    test('should return true for object with array values including empty arrays', () => {
+        const validationErrors = {
+            field1: [],
+        };
+
+        const result = hasValidationErrors(validationErrors);
+
+        expect(result).toBe(true);
+    });
+});

--- a/project-base/storefront/vitest/utils/orderValidation/getDeliveryMessage.test.ts
+++ b/project-base/storefront/vitest/utils/orderValidation/getDeliveryMessage.test.ts
@@ -1,0 +1,119 @@
+import { getDeliveryMessage } from 'components/Pages/Order/TransportAndPayment/transportAndPaymentUtils';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('next/config', () => ({
+    default: () => ({
+        serverRuntimeConfig: { internalGraphqlEndpoint: 'https://test.ts/graphql/' },
+        publicRuntimeConfig: {
+            errorDebuggingLevel: 'no-debug',
+            domains: [{ url: 'https://test.ts/' }, { url: 'https://test.ts/' }],
+        },
+    }),
+}));
+
+// Mock the translate function
+const mockT = vi.fn((key: string, options?: any) => {
+    if (options?.count !== undefined) {
+        return `${key}:${options.count}`;
+    }
+    return key;
+}) as any;
+
+describe('getDeliveryMessage test', () => {
+    describe('Personal pickup messages', () => {
+        test('should return "Personal pickup today" for same day personal pickup', () => {
+            const result = getDeliveryMessage(0, true, mockT);
+
+            expect(result).toBe('Personal pickup today');
+            expect(mockT).toHaveBeenCalledWith('Personal pickup today');
+        });
+
+        test('should return personal pickup message with days for pickup within week', () => {
+            const result = getDeliveryMessage(3, true, mockT);
+
+            expect(result).toBe('Personal pickup in {{ count }} days:3');
+            expect(mockT).toHaveBeenCalledWith('Personal pickup in {{ count }} days', { count: 3 });
+        });
+
+        test('should return personal pickup message with weeks for pickup over week', () => {
+            const result = getDeliveryMessage(10, true, mockT);
+
+            expect(result).toBe('Personal pickup in {{count}} weeks:2');
+            expect(mockT).toHaveBeenCalledWith('Personal pickup in {{count}} weeks', { count: 2 });
+        });
+
+        test('should return personal pickup message with weeks for exactly 7 days', () => {
+            const result = getDeliveryMessage(7, true, mockT);
+
+            expect(result).toBe('Personal pickup in {{count}} weeks:1');
+            expect(mockT).toHaveBeenCalledWith('Personal pickup in {{count}} weeks', { count: 1 });
+        });
+
+        test('should return personal pickup message with weeks for 14 days', () => {
+            const result = getDeliveryMessage(14, true, mockT);
+
+            expect(result).toBe('Personal pickup in {{count}} weeks:2');
+            expect(mockT).toHaveBeenCalledWith('Personal pickup in {{count}} weeks', { count: 2 });
+        });
+
+        test('should round up weeks correctly for personal pickup', () => {
+            const result = getDeliveryMessage(8, true, mockT);
+
+            expect(result).toBe('Personal pickup in {{count}} weeks:2');
+            expect(mockT).toHaveBeenCalledWith('Personal pickup in {{count}} weeks', { count: 2 });
+        });
+    });
+
+    describe('Regular delivery messages', () => {
+        test('should return "Delivery today" for same day delivery', () => {
+            const result = getDeliveryMessage(0, false, mockT);
+
+            expect(result).toBe('Delivery today');
+            expect(mockT).toHaveBeenCalledWith('Delivery today');
+        });
+
+        test('should return delivery message with days for delivery within week', () => {
+            const result = getDeliveryMessage(5, false, mockT);
+
+            expect(result).toBe('Delivery in {{count}} days:5');
+            expect(mockT).toHaveBeenCalledWith('Delivery in {{count}} days', { count: 5 });
+        });
+
+        test('should return delivery message with weeks for delivery over week', () => {
+            const result = getDeliveryMessage(10, false, mockT);
+
+            expect(result).toBe('Delivery in {{count}} weeks:2');
+            expect(mockT).toHaveBeenCalledWith('Delivery in {{count}} weeks', { count: 2 });
+        });
+
+        test('should return delivery message with weeks for exactly 7 days', () => {
+            const result = getDeliveryMessage(7, false, mockT);
+
+            expect(result).toBe('Delivery in {{count}} weeks:1');
+            expect(mockT).toHaveBeenCalledWith('Delivery in {{count}} weeks', { count: 1 });
+        });
+
+        test('should round up weeks correctly for regular delivery', () => {
+            const result = getDeliveryMessage(9, false, mockT);
+
+            expect(result).toBe('Delivery in {{count}} weeks:2');
+            expect(mockT).toHaveBeenCalledWith('Delivery in {{count}} weeks', { count: 2 });
+        });
+    });
+
+    describe('Edge cases', () => {
+        test('should handle negative days as passed value', () => {
+            const result = getDeliveryMessage(-1, false, mockT);
+
+            expect(result).toBe('Delivery in {{count}} days:-1');
+            expect(mockT).toHaveBeenCalledWith('Delivery in {{count}} days', { count: -1 });
+        });
+
+        test('should handle very large number of days', () => {
+            const result = getDeliveryMessage(100, false, mockT);
+
+            expect(result).toBe('Delivery in {{count}} weeks:15');
+            expect(mockT).toHaveBeenCalledWith('Delivery in {{count}} weeks', { count: 15 });
+        });
+    });
+});

--- a/project-base/storefront/vitest/utils/orderValidation/getIsGoPayBankTransferPayment.test.ts
+++ b/project-base/storefront/vitest/utils/orderValidation/getIsGoPayBankTransferPayment.test.ts
@@ -1,0 +1,194 @@
+import { getIsGoPayBankTransferPayment } from 'components/Pages/Order/TransportAndPayment/transportAndPaymentUtils';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('next/config', () => ({
+    default: () => ({
+        serverRuntimeConfig: { internalGraphqlEndpoint: 'https://test.ts/graphql/' },
+        publicRuntimeConfig: {
+            errorDebuggingLevel: 'no-debug',
+            domains: [{ url: 'https://test.ts/' }, { url: 'https://test.ts/' }],
+        },
+    }),
+}));
+
+describe('getIsGoPayBankTransferPayment', () => {
+    describe('GoPay bank transfer payment detection', () => {
+        test('should return true for GoPay bank transfer payment', () => {
+            const payment = {
+                uuid: 'payment-uuid-1',
+                name: 'GoPay Bank Transfer',
+                goPayPaymentMethod: {
+                    identifier: 'BANK_ACCOUNT',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(true);
+        });
+
+        test('should return false for GoPay payment with different method', () => {
+            const payment = {
+                uuid: 'payment-uuid-2',
+                name: 'GoPay Card Payment',
+                goPayPaymentMethod: {
+                    identifier: 'CARD',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for GoPay payment with null method', () => {
+            const payment = {
+                uuid: 'payment-uuid-3',
+                name: 'GoPay Payment',
+                goPayPaymentMethod: null,
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for non-GoPay payment', () => {
+            const payment = {
+                uuid: 'payment-uuid-4',
+                name: 'Card Payment',
+                goPayPaymentMethod: null,
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Edge cases', () => {
+        test('should return false for null payment', () => {
+            const result = getIsGoPayBankTransferPayment(null);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for undefined payment', () => {
+            const result = getIsGoPayBankTransferPayment(undefined as any);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for payment with undefined goPayPaymentMethod', () => {
+            const payment = {
+                uuid: 'payment-uuid-5',
+                name: 'Some Payment',
+                goPayPaymentMethod: undefined,
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for payment with goPayPaymentMethod without identifier', () => {
+            const payment = {
+                uuid: 'payment-uuid-6',
+                name: 'GoPay Payment',
+                goPayPaymentMethod: {
+                    // identifier missing
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for payment with empty identifier', () => {
+            const payment = {
+                uuid: 'payment-uuid-7',
+                name: 'GoPay Payment',
+                goPayPaymentMethod: {
+                    identifier: '',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should handle case sensitivity correctly', () => {
+            const payment = {
+                uuid: 'payment-uuid-8',
+                name: 'GoPay Payment',
+                goPayPaymentMethod: {
+                    identifier: 'bank_account', // lowercase
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should handle whitespace in identifier', () => {
+            const payment = {
+                uuid: 'payment-uuid-9',
+                name: 'GoPay Payment',
+                goPayPaymentMethod: {
+                    identifier: ' BANK_ACCOUNT ',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('Different GoPay payment methods', () => {
+        test('should return false for GoPay wallet payment', () => {
+            const payment = {
+                uuid: 'payment-uuid-10',
+                name: 'GoPay Wallet',
+                goPayPaymentMethod: {
+                    identifier: 'WALLET',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for GoPay PayPal payment', () => {
+            const payment = {
+                uuid: 'payment-uuid-11',
+                name: 'GoPay PayPal',
+                goPayPaymentMethod: {
+                    identifier: 'PAYPAL',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+
+        test('should return false for any other GoPay method', () => {
+            const payment = {
+                uuid: 'payment-uuid-12',
+                name: 'GoPay Other',
+                goPayPaymentMethod: {
+                    identifier: 'OTHER_METHOD',
+                },
+            } as any;
+
+            const result = getIsGoPayBankTransferPayment(payment);
+
+            expect(result).toBe(false);
+        });
+    });
+});

--- a/project-base/storefront/vitest/utils/orderValidation/getTransportAndPaymentValidationMessages.test.ts
+++ b/project-base/storefront/vitest/utils/orderValidation/getTransportAndPaymentValidationMessages.test.ts
@@ -1,0 +1,159 @@
+import { getTransportAndPaymentValidationMessages } from 'components/Pages/Order/TransportAndPayment/transportAndPaymentUtils';
+import { TypeTransportTypeEnum } from 'graphql/types';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('next/config', () => ({
+    default: () => ({
+        serverRuntimeConfig: { internalGraphqlEndpoint: 'https://test.ts/graphql/' },
+        publicRuntimeConfig: {
+            errorDebuggingLevel: 'no-debug',
+            domains: [{ url: 'https://test.ts/' }, { url: 'https://test.ts/' }],
+        },
+    }),
+}));
+
+// Mock the translate function to match Translate type
+const mockT = vi.fn((key: string) => key) as any;
+
+// Mock transport data - using partial mocks to avoid complex GraphQL type issues
+const mockTransport = {
+    uuid: 'transport-uuid-1',
+    name: 'Test Transport',
+    isPersonalPickup: false,
+    transportTypeCode: TypeTransportTypeEnum.Common,
+} as any;
+
+const mockPersonalPickupTransport = {
+    uuid: 'transport-uuid-2',
+    name: 'Personal Pickup Transport',
+    isPersonalPickup: true,
+    transportTypeCode: TypeTransportTypeEnum.PersonalPickup,
+} as any;
+
+// Mock payment data
+const mockPayment = {
+    uuid: 'payment-uuid-1',
+    name: 'Test Payment',
+    goPayPaymentMethod: null,
+} as any;
+
+// Mock pickup place data
+const mockPickupPlace = {
+    identifier: 'pickup-place-1',
+    name: 'Test Pickup Place',
+} as any;
+
+describe('getTransportAndPaymentValidationMessages test', () => {
+    test('should return transport error when transport is not selected', () => {
+        const result = getTransportAndPaymentValidationMessages(null, null, mockPayment, null, mockT);
+
+        expect(result).toEqual({
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport',
+            },
+        });
+        expect(mockT).toHaveBeenCalledWith('Choose transport');
+        expect(mockT).toHaveBeenCalledWith('Please select transport');
+    });
+
+    test('should return payment error when payment is not selected', () => {
+        const result = getTransportAndPaymentValidationMessages(mockTransport, null, null, null, mockT);
+
+        expect(result).toEqual({
+            payment: {
+                name: 'payment',
+                label: 'Choose payment',
+                errorMessage: 'Please select payment',
+            },
+        });
+        expect(mockT).toHaveBeenCalledWith('Choose payment');
+        expect(mockT).toHaveBeenCalledWith('Please select payment');
+    });
+
+    test('should return transport error when personal pickup is selected without pickup place', () => {
+        const result = getTransportAndPaymentValidationMessages(
+            mockPersonalPickupTransport,
+            null,
+            mockPayment,
+            null,
+            mockT,
+        );
+
+        expect(result).toEqual({
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport with a personal pickup place',
+            },
+        });
+        expect(mockT).toHaveBeenCalledWith('Please select transport with a personal pickup place');
+    });
+
+    test('should return both transport and payment errors when neither is selected', () => {
+        const result = getTransportAndPaymentValidationMessages(null, null, null, null, mockT);
+
+        expect(result).toEqual({
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport',
+            },
+        });
+        // When transport is null, function returns early with only transport error
+    });
+
+    test('should return no errors when valid transport and payment are selected', () => {
+        const result = getTransportAndPaymentValidationMessages(mockTransport, null, mockPayment, null, mockT);
+
+        expect(result).toEqual({});
+    });
+
+    test('should return no errors when personal pickup transport has valid pickup place', () => {
+        const result = getTransportAndPaymentValidationMessages(
+            mockPersonalPickupTransport,
+            mockPickupPlace,
+            mockPayment,
+            null,
+            mockT,
+        );
+
+        expect(result).toEqual({});
+    });
+
+    test('should handle pickup place with empty identifier', () => {
+        const emptyPickupPlace = {
+            ...mockPickupPlace,
+            identifier: '',
+        };
+
+        const result = getTransportAndPaymentValidationMessages(
+            mockPersonalPickupTransport,
+            emptyPickupPlace,
+            mockPayment,
+            null,
+            mockT,
+        );
+
+        expect(result).toEqual({
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport with a personal pickup place',
+            },
+        });
+    });
+
+    test('should handle undefined values gracefully', () => {
+        const result = getTransportAndPaymentValidationMessages(null, null, null, null, mockT);
+
+        expect(result).toEqual({
+            transport: {
+                name: 'transport',
+                label: 'Choose transport',
+                errorMessage: 'Please select transport',
+            },
+        });
+    });
+});

--- a/upgrade-notes/storefront_20250702_130004.md
+++ b/upgrade-notes/storefront_20250702_130004.md
@@ -1,0 +1,5 @@
+#### Add comprehensive unit tests for order process utility functions ([#4060](https://github.com/shopsys/shopsys/pull/4060))
+
+- extracted pickup place functions from internal locations and moved them to `utils/cart/pickupPlaceCalculations.ts`
+- added 7 comprehensive test files significantly increasing test coverage for order process utilities
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
In this PR I have added unit tests for util functions in order creation process.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-utils-unit-tests-ssp-2380.odin.shopsys.cloud
  - https://cz.jm-utils-unit-tests-ssp-2380.odin.shopsys.cloud
<!-- Replace -->
