### PR TITLE
Enable storefront offline mode

### DIFF
--- a/project-base/storefront/components/Blocks/Product/DeferredRecommendedProducts.tsx
+++ b/project-base/storefront/components/Blocks/Product/DeferredRecommendedProducts.tsx
@@ -7,7 +7,7 @@ import { TypeRecommendationType } from 'graphql/types';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { ReactElement } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { useCookiesStore } from 'store/useCookiesStore';
 import { getRecommenderClientIdentifier } from 'utils/recommender/getRecommenderClientIdentifier';
 import { useDeferredRender } from 'utils/useDeferredRender';
@@ -30,6 +30,7 @@ export const DeferredRecommendedProducts: FC<DeferredRecommendedProductsProps> =
     const userIdentifier = useCookiesStore((store) => store.userIdentifier);
     const { isLuigisBoxActive } = useDomainConfig();
     const { pathname } = useRouter();
+    const [isClientMounted, setIsClientMounted] = useState(false);
     const [{ data: recommendedProductsData, fetching: areRecommendedProductsFetching }] = useRecommendedProductsQuery({
         variables: {
             itemUuids,
@@ -40,14 +41,22 @@ export const DeferredRecommendedProducts: FC<DeferredRecommendedProductsProps> =
         },
         pause: !isLuigisBoxActive,
     });
-    const shouldRender = useDeferredRender('recommended_products');
 
-    if (areRecommendedProductsFetching) {
+    const shouldRender = useDeferredRender('recommended_products');
+    const isBasketPopup = recommendationType === TypeRecommendationType.BasketPopup;
+
+    useEffect(() => {
+        setIsClientMounted(true);
+    }, []);
+
+    const shouldShowSkeleton =
+        (isClientMounted && areRecommendedProductsFetching) ||
+        (isBasketPopup && !recommendedProductsData?.recommendedProducts.length && areRecommendedProductsFetching);
+
+    if (shouldShowSkeleton) {
         return (
             <Webline>
-                <SkeletonModuleProductSlider
-                    isWithSimpleCards={recommendationType === TypeRecommendationType.BasketPopup}
-                />
+                <SkeletonModuleProductSlider isWithSimpleCards={isBasketPopup} />
             </Webline>
         );
     }

--- a/project-base/storefront/components/Pages/App/Fonts.tsx
+++ b/project-base/storefront/components/Pages/App/Fonts.tsx
@@ -4,19 +4,49 @@ const interFont = Inter({
     weight: ['400', '500', '600', '700'],
     subsets: ['latin-ext', 'latin'],
     variable: '--font-inter',
+    display: 'swap',
+    fallback: [
+        '-apple-system',
+        'BlinkMacSystemFont',
+        '"Segoe UI"',
+        'Roboto',
+        '"Helvetica Neue"',
+        'Arial',
+        'system-ui',
+        'sans-serif',
+    ],
 });
 
-export const ralewayFont = Raleway({
+const ralewayFont = Raleway({
     weight: ['400', '500', '600', '700'],
     subsets: ['latin-ext', 'latin'],
     variable: '--font-raleway',
+    display: 'swap',
+    fallback: [
+        '-apple-system',
+        'BlinkMacSystemFont',
+        '"Segoe UI"',
+        'Roboto',
+        '"Helvetica Neue"',
+        'Arial',
+        'system-ui',
+        'sans-serif',
+    ],
 });
 
-export const Fonts: FC = () => {
+export { ralewayFont };
+
+export const Fonts = () => {
     return (
         <style global jsx>{`
             html {
                 font-family: ${interFont.style.fontFamily};
+            }
+            :root {
+                --font-inter-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+                    system-ui, sans-serif;
+                --font-raleway-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+                    system-ui, sans-serif;
             }
         `}</style>
     );

--- a/upgrade-notes/storefront_20250704_130830.md
+++ b/upgrade-notes/storefront_20250704_130830.md
@@ -1,0 +1,12 @@
+#### Fix storefront offline mode with font fallbacks and hydration error ([#4063](https://github.com/shopsys/shopsys/pull/4063))
+
+- enabled storefront offline mode to improve development experience
+- added comprehensive font fallbacks to Google Fonts (Inter and Raleway) configuration in `Fonts.tsx`
+    - configured `fallback` arrays with system fonts: `-apple-system`, `BlinkMacSystemFont`, `"Segoe UI"`, `Roboto`, `"Helvetica Neue"`, `Arial`, `system-ui`, `sans-serif`
+    - added CSS variables `--font-inter-fallback` and `--font-raleway-fallback` for consistent fallback reference
+    - ensures fonts display properly even when Google Fonts are unavailable
+- fixed hydration warning in `DeferredRecommendedProducts` component caused by server-client mismatch
+    - the issue occurred when GraphQL query state differed between server (not fetching) and client (briefly fetching), causing skeleton to appear only on client
+    - added `useEffect` hook to track client mount state and only show loading skeleton after client hydration
+    - ensures server and client render identical content initially, preventing React hydration mismatches
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
In this PR, storefront is enabled for an offline mode. Once installed and all dependancies are downloaded, if you stop the container and then run it again with `[docker/mutagen]-compose up -d storefront`, it is now running with fallback fonts and occasional hydration error (edge case for some compontens), but it does the trick.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-build-storefront-offline-ssp-2590.odin.shopsys.cloud
  - https://cz.jm-build-storefront-offline-ssp-2590.odin.shopsys.cloud
<!-- Replace -->
