### PR TITLE
Clean elastic indices on review cancel

### DIFF
--- a/.github/cancel-review.sh
+++ b/.github/cancel-review.sh
@@ -6,6 +6,7 @@ if [ -n "$BRANCH_NAME" ]; then
     docker exec github-runner-postgres-1 psql -d postgres -c "DROP DATABASE IF EXISTS \"${BRANCH_NAME}\";"
     docker exec github-runner-redis-1 redis-cli --scan --pattern "${BRANCH_NAME}:*" | xargs -r docker exec github-runner-redis-1 redis-cli del
     docker exec github-runner-rabbitmq-1 rabbitmqctl delete_vhost "${BRANCH_NAME}" || true
+    docker exec github-runner-elasticsearch-1 curl -X DELETE "localhost:9200/${BRANCH_NAME}_*" 2>/dev/null || true
 
     BASE_DIR="/home/github-runner/actions-runner/_work/shopsys/shopsys"
 


### PR DESCRIPTION
#### Description, the reason for the PR
To prevent elastic indices bloat, automatic cleanup of closed review branches was added in this PR.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-clean-elastic-indicies-ssp-3500.odin.shopsys.cloud
  - https://cz.jm-clean-elastic-indicies-ssp-3500.odin.shopsys.cloud
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cleanup process to also remove Elasticsearch indices related to a cancelled branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->