### PR TITLE
fixed customer info in order detail

### DIFF
--- a/project-base/storefront/components/Blocks/OrderCustomerInfo/OrderCustomerInfo.tsx
+++ b/project-base/storefront/components/Blocks/OrderCustomerInfo/OrderCustomerInfo.tsx
@@ -66,7 +66,7 @@ export const OrderCustomerInfo: FC<OrderCustomerInfoProps> = ({ order }) => {
                     {order.city}, {order.postcode}
                 </span>
 
-                <span>{order.deliveryCountry?.name}</span>
+                <span>{order.country.name}</span>
 
                 <span>{order.companyNumber && `${t('Company number')}: ${order.companyNumber}`}</span>
 

--- a/project-base/storefront/utils/user/useCurrentUserContactInformation.ts
+++ b/project-base/storefront/utils/user/useCurrentUserContactInformation.ts
@@ -50,6 +50,11 @@ const mergeContactInformation = (
             continue;
         }
 
+        const isCountryField = key === 'country' || key === 'deliveryCountry';
+        if (isCountryField && !isUndefined && !isEmptyString) {
+            continue;
+        }
+
         const isFilledFromStorefront = !!contactInformationFromStore[key as keyof ContactInformation];
 
         if (((isUndefined || isEmptyString) && key in contactInformationFromApi) || isFilledFromStorefront) {
@@ -78,12 +83,17 @@ const assertCustomer = (contactInformation: ContactInformation) => {
 
 const assertCountries = (contactInformation: ContactInformation, countriesAsSelectOptions: SelectOptionType[]) => {
     if (countriesAsSelectOptions.length > 0) {
-        contactInformation.country =
-            contactInformation.country.value.length > 0 ? contactInformation.country : countriesAsSelectOptions[0];
-        contactInformation.deliveryCountry =
-            contactInformation.deliveryCountry.value.length > 0
-                ? contactInformation.deliveryCountry
-                : countriesAsSelectOptions[0];
+        const currentCountryExists = countriesAsSelectOptions.some(
+            (option) => option.value === contactInformation.country.value,
+        );
+        contactInformation.country = currentCountryExists ? contactInformation.country : countriesAsSelectOptions[0];
+
+        const currentDeliveryCountryExists = countriesAsSelectOptions.some(
+            (option) => option.value === contactInformation.deliveryCountry.value,
+        );
+        contactInformation.deliveryCountry = currentDeliveryCountryExists
+            ? contactInformation.deliveryCountry
+            : countriesAsSelectOptions[0];
     }
 };
 

--- a/upgrade-notes/storefront_20250724_080631.md
+++ b/upgrade-notes/storefront_20250724_080631.md
@@ -1,0 +1,5 @@
+#### Fix customer info in order detail ([#4116](https://github.com/shopsys/shopsys/pull/4116))
+
+- customer info is now showing correct address in order detail
+- billing address in order process now showing correct country
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Customer info is now showing correct country in order detail.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3510-fix-order-detail-customer-info.odin.shopsys.cloud
  - https://cz.tc-ssp-3510-fix-order-detail-customer-info.odin.shopsys.cloud
<!-- Replace -->
