### PR TITLE
fixed sales representative name without image

### DIFF
--- a/project-base/storefront/components/Layout/Header/MenuIconic/SalesRepresentative.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/SalesRepresentative.tsx
@@ -34,7 +34,7 @@ export const SalesRepresentative: FC = () => {
                         width={100}
                     />
                 )}
-                <div>
+                <div className="flex flex-col">
                     {fullName && <span className="h5">{fullName}</span>}
                     <span className="h6 text-text-less">{t('Your sales representative')}</span>
                 </div>

--- a/upgrade-notes/storefront_20250724_083828.md
+++ b/upgrade-notes/storefront_20250724_083828.md
@@ -1,0 +1,4 @@
+#### Fix sales representatives ([#4117](https://github.com/shopsys/shopsys/pull/4117))
+
+- sales represenatives is now showing correctly without image
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Sales represenatives is now showing correctly without image.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3497-fix-sales-representatives.odin.shopsys.cloud
  - https://cz.tc-ssp-3497-fix-sales-representatives.odin.shopsys.cloud
<!-- Replace -->
