### PR TITLE
fixed biome-config require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,6 @@
         "phpstan/phpstan-symfony": "^2.0.6",
         "phpunit/phpunit": "^11.2.1",
         "psr/event-dispatcher": "^1.0.0",
-        "shopsys/biome-config": "17.0.x-dev",
         "slevomat/coding-standard": "^8.13.1",
         "squizlabs/php_codesniffer": "^3.6.2",
         "sspooky13/yaml-standards": "^9.0",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -127,6 +127,7 @@
         "phpstan/phpstan-symfony": "^2.0.6",
         "phpunit/phpunit": "^11.2.1",
         "psr/event-dispatcher": "^1.0.0",
+        "shopsys/biome-config": "17.0.x-dev",
         "shopsys/coding-standards": "17.0.x-dev",
         "sspooky13/yaml-standards": "^9.0",
         "symfony/maker-bundle": "^1.62" ,


### PR DESCRIPTION
#### Description, the reason for the PR

In the previous commit, the requirement for biome-config was placed in the wrong composer.json file.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-biome.odin.shopsys.cloud
  - https://cz.mg-fix-biome.odin.shopsys.cloud
<!-- Replace -->
