### PR TITLE
fixed back to overview link color

### DIFF
--- a/packages/framework/assets/styles/admin/components/window/fixed-bar.less
+++ b/packages/framework/assets/styles/admin/components/window/fixed-bar.less
@@ -111,7 +111,7 @@
                 padding-right: 5px;
             }
 
-            a {
+            .window-fixed-bar--top & a {
                 color: #add8ff;
 
                 &:hover {


### PR DESCRIPTION
#### Description, the reason for the PR

`Back to overview` link had wrong color since #4114. This is fixed now.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-backlink-color.odin.shopsys.cloud
  - https://cz.mg-fix-backlink-color.odin.shopsys.cloud
<!-- Replace -->
