### PR TITLE
customer social login registration: normalize empty strings to null

### DIFF
--- a/packages/framework/tests/Unit/Component/UtilsTest.php
+++ b/packages/framework/tests/Unit/Component/UtilsTest.php
@@ -9,14 +9,14 @@ use Shopsys\FrameworkBundle\Component\Utils\Utils;
 
 class UtilsTest extends TestCase
 {
-    public function testIfNull()
+    public function testIfNull(): void
     {
         $this->assertTrue(Utils::ifNull(null, true));
         $this->assertFalse(Utils::ifNull(false, true));
         $this->assertTrue(Utils::ifNull(true, false));
     }
 
-    public function testSetArrayDefaultValueExists()
+    public function testSetArrayDefaultValueExists(): void
     {
         $array = [
             'key' => 'value',
@@ -27,7 +27,7 @@ class UtilsTest extends TestCase
         $this->assertSame($expectedArray, $array);
     }
 
-    public function testSetArrayDefaultValueExistsNull()
+    public function testSetArrayDefaultValueExistsNull(): void
     {
         $array = [
             'key' => null,
@@ -38,7 +38,7 @@ class UtilsTest extends TestCase
         $this->assertSame($expectedArray, $array);
     }
 
-    public function testSetArrayDefaultValueNotExist()
+    public function testSetArrayDefaultValueNotExist(): void
     {
         $array = [
             'key' => null,
@@ -52,18 +52,18 @@ class UtilsTest extends TestCase
         $this->assertSame($expectedArray, $array);
     }
 
-    public function testMixedToArrayIfNull()
+    public function testMixedToArrayIfNull(): void
     {
         $this->assertSame([], Utils::mixedToArray(null));
     }
 
-    public function testMixedToArrayIfNotArray()
+    public function testMixedToArrayIfNotArray(): void
     {
         $value = 'I am not array';
         $this->assertSame([$value], Utils::mixedToArray($value));
     }
 
-    public function testMixedToArrayIfArray()
+    public function testMixedToArrayIfArray(): void
     {
         $value = ['1', 3, []];
         $this->assertSame($value, Utils::mixedToArray($value));

--- a/packages/frontend-api/src/Model/Customer/User/RegistrationDataFactory.php
+++ b/packages/frontend-api/src/Model/Customer/User/RegistrationDataFactory.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrontendApiBundle\Model\Customer\User;
 use Hybridauth\User\Profile;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\FrameworkBundle\Model\Country\CountryFacade;
 
 class RegistrationDataFactory
@@ -71,9 +72,9 @@ class RegistrationDataFactory
     {
         $registrationData = $this->createForDomainId($this->domain->getId());
 
-        $registrationData->firstName = $profile->firstName;
-        $registrationData->lastName = $profile->lastName;
-        $registrationData->email = $profile->email;
+        $registrationData->firstName = TransformStringHelper::getTrimmedStringOrNullOnEmpty($profile->firstName);
+        $registrationData->lastName = TransformStringHelper::getTrimmedStringOrNullOnEmpty($profile->lastName);
+        $registrationData->email = TransformStringHelper::getTrimmedStringOrNullOnEmpty($profile->email);
 
         return $registrationData;
     }


### PR DESCRIPTION
#### Description, the reason for the PR
When a user creates a registration using a social profile (facebook, google, ...), we can not be sure about the format of incoming data. As we prefer `null` values over empty strings in the application, we should rather normalize the data this way to avoid unexpected behavior. E.g., the customer user data (such as name and surname) are updated from his first order if they are `null` after registration - this breaks when they are empty strings, actually.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-social-registration-data.odin.shopsys.cloud
  - https://cz.rv-social-registration-data.odin.shopsys.cloud
<!-- Replace -->
