### PR TITLE
admin: enhance "Email allowed recipients" page

### DIFF
--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -263,7 +263,7 @@ class SideMenuBuilder
             static::MAIL_ALLOWED_RECIPIENTS,
             [
                 'route' => 'admin_mailallowedrecipient_list',
-                'label' => t('Email allowed recipients'),
+                'label' => t('Email allowed recipients (whitelist)'),
                 'display' => false,
             ],
         );

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -4924,6 +4924,9 @@ msgstr "Můžete si zapnout dvoufaktorové ověření pouze pro sebe."
 msgid "You are not allowed to access the requested page. Please ask your administrator to grant you access to the requested page."
 msgstr "Nemáte přístup k požadované stránce. Požádejte správce, aby vám udělil přístup."
 
+msgid "You can change the settings <a href=\"%linkUrl%\">here</a>."
+msgstr "Nastavení můžete změnit <a href=\"%linkUrl%\">zde</a>."
+
 msgid "You can drag additional content here."
 msgstr "Zde můžete přetáhnout další obsah."
 

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1852,8 +1852,8 @@ msgstr "Editace skladu - %name%"
 msgid "Email"
 msgstr "E-mail"
 
-msgid "Email allowed recipients"
-msgstr "Povolení příjemci e-mailů"
+msgid "Email allowed recipients (whitelist)"
+msgstr "Povolení příjemci e-mailů (whitelist)"
 
 msgid "Email name"
 msgstr "Jméno k e-mailu"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1852,7 +1852,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-msgid "Email allowed recipients"
+msgid "Email allowed recipients (whitelist)"
 msgstr ""
 
 msgid "Email name"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -4924,6 +4924,9 @@ msgstr ""
 msgid "You are not allowed to access the requested page. Please ask your administrator to grant you access to the requested page."
 msgstr ""
 
+msgid "You can change the settings <a href=\"%linkUrl%\">here</a>."
+msgstr ""
+
 msgid "You can drag additional content here."
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Content/MailAllowedRecipient/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/MailAllowedRecipient/list.html.twig
@@ -46,4 +46,10 @@
         <h2>Email allowed recipients (whitelist)</h2>
         <p><strong>No email patterns configured.</strong> All outgoing emails are currently blocked.</p>
     {% endif %}
+    {% if is_granted(constant('\\Shopsys\\FrameworkBundle\\Model\\Security\\Roles::ROLE_SUPER_ADMIN')) %}
+        <div class="margin-top-25">
+            {{ ux_icon('info') }}
+            {{ 'You can change the settings <a href="%linkUrl%">here</a>.'|trans({ '%linkUrl%': url('admin_superadmin_mailwhitelist') })|raw }}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/MailAllowedRecipient/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/MailAllowedRecipient/list.html.twig
@@ -1,7 +1,7 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
 
-{% block title %}- {{ 'Email allowed recipients'|trans }}{% endblock %}
-{% block h1 %}{{ 'Email allowed recipients'|trans }}{% endblock %}
+{% block title %}- {{ 'Email allowed recipients (whitelist)'|trans }}{% endblock %}
+{% block h1 %}{{ 'Email allowed recipients (whitelist)'|trans }}{% endblock %}
 
 {% block main_content %}
     {% if isDeliveryDisabled %}
@@ -43,7 +43,7 @@
             </div>
         {% endfor %}
     {% else %}
-        <h2>Email Allowed Recipients</h2>
+        <h2>Email allowed recipients (whitelist)</h2>
         <p><strong>No email patterns configured.</strong> All outgoing emails are currently blocked.</p>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
#### Description, the reason for the PR
Based on the feedback, we have added "whitelist" keyword for better UX (e.g. when searching in admin), plus for superadmins, the overview page now contains a link to the whitelist settings page
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-enhance-whitelist-page.odin.shopsys.cloud
  - https://cz.rv-enhance-whitelist-page.odin.shopsys.cloud
<!-- Replace -->
