### PR TITLE
fix product videos association updates

### DIFF
--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -277,7 +277,7 @@ class ProductDataFactory
     protected function fillProductVideosByProductId(ProductData $productData, Product $product): void
     {
         foreach ($this->productVideoRepository->findByProductId($product->getId()) as $video) {
-            $productData->productVideosData[$video->getid()] = $this->productVideoDataFactory->createFromProductVideo($video);
+            $productData->productVideosData[] = $this->productVideoDataFactory->createFromProductVideo($video);
         }
     }
 }

--- a/packages/framework/src/Model/ProductVideo/ProductVideoFacade.php
+++ b/packages/framework/src/Model/ProductVideo/ProductVideoFacade.php
@@ -37,35 +37,45 @@ class ProductVideoFacade
      */
     public function saveProductVideosToProduct(Product $product, array $productVideoDataList): void
     {
-        $productVideos = $this->productVideoRepository->findByProductId($product->getId());
+        $existingProductVideos = $this->productVideoRepository->findByProductId($product->getId());
 
-        $videoDataListToUpdate = array_filter($productVideoDataList, function (ProductVideoData $productVideoData) {
-            return (bool)$productVideoData->id;
-        });
+        // Separate videos by whether they have IDs (existing) or not (new)
+        $videoDataToUpdateById = [];
+        $videoDataListToCreate = [];
 
-        $videoDataListToCreate = array_filter($productVideoDataList, function (ProductVideoData $productVideoData) {
-            return (bool)$productVideoData->id !== true;
-        });
-
-        $productVideosToRemove = [];
-
-        foreach ($productVideos as $productVideo) {
-            if (array_key_exists($productVideo->getId(), $videoDataListToUpdate)) {
-                $productVideo->setVideoToken(
-                    str_replace(self::YOUTUBE_LINKS_ARRAY, '', ($videoDataListToUpdate[$productVideo->getId()])->videoToken),
-                );
-                $this->cleanProductVideoTranslationsForProductVideo($productVideo);
-                $this->persistVideoTranslations($videoDataListToUpdate[$productVideo->getId()], $productVideo);
+        foreach ($productVideoDataList as $videoData) {
+            if ($videoData->id !== null) {
+                $videoDataToUpdateById[$videoData->id] = $videoData;
             } else {
-                $productVideosToRemove[] = $productVideo;
+                $videoDataListToCreate[] = $videoData;
             }
         }
 
+        // Determine which existing videos to remove (not present in update data)
+        $productVideosToRemove = [];
+
+        foreach ($existingProductVideos as $existingVideo) {
+            if (array_key_exists($existingVideo->getId(), $videoDataToUpdateById)) {
+                // Update existing video
+                $updateData = $videoDataToUpdateById[$existingVideo->getId()];
+                $existingVideo->setVideoToken(
+                    str_replace(self::YOUTUBE_LINKS_ARRAY, '', $updateData->videoToken),
+                );
+                $this->cleanProductVideoTranslationsForProductVideo($existingVideo);
+                $this->persistVideoTranslations($updateData, $existingVideo);
+            } else {
+                // Mark for removal - video not present in form data
+                $productVideosToRemove[] = $existingVideo;
+            }
+        }
+
+        // Remove videos that are no longer present
         foreach ($productVideosToRemove as $productVideoToRemove) {
             $this->cleanProductVideoTranslationsForProductVideo($productVideoToRemove);
             $this->em->remove($productVideoToRemove);
         }
 
+        // Create new videos
         foreach ($videoDataListToCreate as $videoDataToCreate) {
             $productVideoEntity = $this->productVideoFactory->create($videoDataToCreate);
             $productVideoEntity->setProduct($product);
@@ -74,6 +84,7 @@ class ProductVideoFacade
 
             $this->persistVideoTranslations($videoDataToCreate, $productVideoEntity);
         }
+
         $this->em->flush();
     }
 


### PR DESCRIPTION
#### Description, the reason for the PR
When updating an existing product video's description AND adding a new video simultaneously, the existing video's updated data would be lost and overwritten with the new video's data.

Root Cause - Array key collision in form data processing:

1. `ProductDataFactory::fillProductVideosByProductId()` was indexing video data by video ID:
`$productData->productVideosData[$video->getId()] = $videoData;` // e.g., [2 => existingVideoData]
2. Form Processing: When adding new videos, Symfony's CollectionType would assign sequential indices starting
from existing count so new video gets index 2 because it's the 2nd video total - `productVideosData[2] = newVideoData`
3. Key Collision: The new video data at index 2 would overwrite the existing video data that was also at key 2.
4. `ProductVideoFacade::saveProductVideosToProduct()` would receive only the new video's data with the existing video's index, causing it to UPDATE the existing video with new video data instead of creating a new video.

The buggy behavior video:

[Screencast from 2025-08-03 10-14-59.webm](https://github.com/user-attachments/assets/4dda74a4-297e-4ef9-a4e1-9ef446570dac)


<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-video.odin.shopsys.cloud
  - https://cz.rv-fix-video.odin.shopsys.cloud
<!-- Replace -->
