### PR TITLE
fixed path parameter values

### DIFF
--- a/project-base/app/config/packages/paths.yaml
+++ b/project-base/app/config/packages/paths.yaml
@@ -11,7 +11,6 @@ parameters:
     shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
     shopsys.domain_urls_config_filepath: '%kernel.project_dir%/config/domains_urls.yaml'
     shopsys.elasticsearch.structure_dir: '%shopsys.resources_dir%/definition/'
-    shopsys.error_pages_dir: '/var/errorPages/'
     shopsys.feed_dir: '/web%shopsys.feed_url_prefix%'
     shopsys.feed_url_prefix: '/%shopsys.content_dir_name%/feeds/'
     shopsys.filemanager_upload_dir: '%shopsys.web_dir%/%shopsys.filemanager_upload_web_dir%'

--- a/project-base/app/config/packages/paths.yaml
+++ b/project-base/app/config/packages/paths.yaml
@@ -32,6 +32,6 @@ parameters:
     shopsys.uploaded_file_config_filepath: '%kernel.project_dir%/config/uploaded_files.yaml'
     shopsys.uploaded_file_dir: '/web%shopsys.uploaded_file_url_prefix%'
     shopsys.uploaded_file_url_prefix: '/%shopsys.content_dir_name%/uploadedFiles/'
-    shopsys.var_dir: '/var'
+    shopsys.var_dir: '%kernel.project_dir%/var'
     shopsys.vendor_dir: '%kernel.project_dir%/vendor'
     shopsys.web_dir: '%kernel.project_dir%/web'


### PR DESCRIPTION
#### Description, the reason for the PR

`shopsys.error_pages_dir` is not used since #3827 

The value of `shopsys.var_dir` was resolved as a root `/var` instead of `.../project/app/var`. That could cause a few problems with file uploads.
For example, the filename of an uploaded file was not displayed after submission with a validation error.

https://github.com/user-attachments/assets/971321ae-dce4-4c8d-b130-4a5b838706b2



<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-var.odin.shopsys.cloud
  - https://cz.mg-fix-var.odin.shopsys.cloud
<!-- Replace -->
