### PR TITLE
AdminContext now includes elfinder routes

### DIFF
--- a/packages/framework/src/Component/Context/AdminContext.php
+++ b/packages/framework/src/Component/Context/AdminContext.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Context;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Utils\Utils;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 final class AdminContext extends AbstractContext
 {
     /**
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @param string[] $adminRoutePrefixes
      */
     public function __construct(
         private readonly RequestStack $requestStack,
+        private readonly array $adminRoutePrefixes = [],
     ) {
     }
 
@@ -40,6 +43,6 @@ final class AdminContext extends AbstractContext
 
         $route = $request->attributes->get('_route', '');
 
-        return is_string($route) && str_starts_with($route, 'admin_');
+        return is_string($route) && Utils::strStartsWithAny($route, $this->adminRoutePrefixes);
     }
 }

--- a/packages/framework/src/Component/Utils/Utils.php
+++ b/packages/framework/src/Component/Utils/Utils.php
@@ -7,6 +7,22 @@ namespace Shopsys\FrameworkBundle\Component\Utils;
 class Utils
 {
     /**
+     * @param string $haystack
+     * @param string[] $needles
+     * @return bool
+     */
+    public static function strStartsWithAny(string $haystack, array $needles): bool
+    {
+        foreach ($needles as $needle) {
+            if (str_starts_with($haystack, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param mixed $testVariable
      * @param mixed $default
      * @return mixed

--- a/packages/framework/src/DependencyInjection/Configuration.php
+++ b/packages/framework/src/DependencyInjection/Configuration.php
@@ -27,6 +27,9 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('admin_context_route_prefixes')
+                    ->scalarPrototype()->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\DependencyInjection;
 
 use Override;
 use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
 use Shopsys\FrameworkBundle\Component\EntityLog\ChangeSet\DataTypeResolver\DataTypeResolverInterface;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface;
@@ -88,6 +89,8 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
 
         $container->registerForAutoconfiguration(CategoryAutomatedFilterInterface::class)
             ->addTag('shopsys.category_automated_filter');
+
+        $this->setAdminContextRoutePrefixes($config['admin_context_route_prefixes'], $container);
     }
 
     /**
@@ -131,5 +134,15 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
 
         $container->getDefinition(OrderProcessingStack::class)
             ->setArgument('$processingMiddlewares', $middlewareReferences);
+    }
+
+    /**
+     * @param string[] $adminRoutePrefixes
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    protected function setAdminContextRoutePrefixes(array $adminRoutePrefixes, ContainerBuilder $container): void
+    {
+        $container->getDefinition(AdminContext::class)
+            ->setArgument('$adminRoutePrefixes', $adminRoutePrefixes);
     }
 }

--- a/packages/framework/tests/Unit/Component/UtilsTest.php
+++ b/packages/framework/tests/Unit/Component/UtilsTest.php
@@ -68,4 +68,17 @@ class UtilsTest extends TestCase
         $value = ['1', 3, []];
         $this->assertSame($value, Utils::mixedToArray($value));
     }
+
+    public function testStrStartsWithAny(): void
+    {
+        $utils = new Utils();
+
+        $this->assertTrue($utils::strStartsWithAny('test', ['test', 'example']));
+        $this->assertTrue($utils::strStartsWithAny('example', ['test', 'example']));
+        $this->assertTrue($utils::strStartsWithAny('example', ['exa', 'example']));
+
+        $this->assertFalse($utils::strStartsWithAny('test', []));
+        $this->assertFalse($utils::strStartsWithAny('example', ['test', 'sample']));
+        $this->assertFalse($utils::strStartsWithAny('sample', ['test', 'example']));
+    }
 }

--- a/project-base/app/config/packages/shopsys_framework.yaml
+++ b/project-base/app/config/packages/shopsys_framework.yaml
@@ -1,4 +1,9 @@
 shopsys_framework:
+    admin_context_route_prefixes:
+        - 'admin_'
+        - 'ef_connect'
+        - 'ef_main_js'
+        - 'elfinder'
     order:
         processing_middlewares:
             - 'Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\SetCustomerUserMiddleware'

--- a/upgrade-notes/backend_20250807_103134.md
+++ b/upgrade-notes/backend_20250807_103134.md
@@ -1,0 +1,3 @@
+#### AdminContext now includes elfinder routes ([#4134](https://github.com/shopsys/shopsys/pull/4134))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Without these routes, the wysiwyg was not properly translated to the selected locale of the current administrator.

Moreover, introduced `shopsys.admin_context_route_prefixes` parameter for easy future extension
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-elfinder-localization.odin.shopsys.cloud
  - https://cz.rv-fix-elfinder-localization.odin.shopsys.cloud
<!-- Replace -->
