### PR TITLE
added support for IDE URLs to the profiler and blue screen error page

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -108,6 +108,7 @@ services:
             - ~/.gitconfig:/home/www-data/.gitconfig
         environment:
             <<: *blackfire_environments
+            LOCAL_PATH_TO_PROJECT_ROOT: /var/www/html
         ports:
             - "35729:35729"
 

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -112,6 +112,7 @@ services:
             - .:/var/www/html
         environment:
             <<: *blackfire_environments
+            LOCAL_PATH_TO_PROJECT_ROOT: /var/www/html
         ports:
             - "35729:35729"
 

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -210,3 +210,12 @@ The default is `selling_price` which displays the price using setting of the sel
 ```bash
 git config --system core.longpaths true
 ```
+
+## How can I make file paths in error pages clickable in my IDE?
+
+Shopsys Platform supports clickable file paths in error pages (Blue Screen of Death) and Symfony profiler that open directly in your PHPStorm.
+This feature automatically maps Docker container file paths to your local project paths.
+
+The installation script automatically configures the `LOCAL_PATH_TO_PROJECT_ROOT` environment variable with your current working directory in your `docker-compose.yml` file.
+
+If you're using a different IDE than PHPStorm, you need to update environment variables `SYMFONY_IDE_URL_FORMAT` and `TRACY_DEBUGGER_IDE_URL_FORMAT` in your `.env.local` file to match your IDE's URL format.

--- a/packages/framework/src/Component/Error/BlueScreenErrorRenderer.php
+++ b/packages/framework/src/Component/Error/BlueScreenErrorRenderer.php
@@ -18,11 +18,15 @@ final class BlueScreenErrorRenderer implements ErrorRendererInterface
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      * @param \Symfony\Component\ErrorHandler\ErrorRenderer\ErrorRendererInterface $fallbackErrorRenderer
      * @param bool $isDebug
+     * @param string $localPathToProjectRoot
+     * @param string $tracyDebuggerIdeUrlFormat
      */
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly ErrorRendererInterface $fallbackErrorRenderer,
         private readonly bool $isDebug,
+        private readonly string $localPathToProjectRoot,
+        private readonly string $tracyDebuggerIdeUrlFormat,
     ) {
     }
 
@@ -38,6 +42,10 @@ final class BlueScreenErrorRenderer implements ErrorRendererInterface
         }
 
         Debugger::$time = time();
+        Debugger::$editor = $this->tracyDebuggerIdeUrlFormat;
+        Debugger::$editorMapping = [
+            '/var/www/html/' => $this->localPathToProjectRoot . '/',
+        ];
         $blueScreen = new BlueScreen();
 
         ob_start();

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -857,6 +857,8 @@ services:
         arguments:
             $fallbackErrorRenderer: '@twig.error_renderer.html'
             $isDebug: '%kernel.debug%'
+            $localPathToProjectRoot: '%env(LOCAL_PATH_TO_PROJECT_ROOT)%'
+            $tracyDebuggerIdeUrlFormat: '%env(TRACY_DEBUGGER_IDE_URL_FORMAT)%'
         class: Shopsys\FrameworkBundle\Component\Error\BlueScreenErrorRenderer
 
     fragment.handler:

--- a/project-base/app/.env
+++ b/project-base/app/.env
@@ -76,3 +76,7 @@ SEZNAM_CLIENT_SECRET=secret
 
 USERSNAP_PROJECT_API_KEY=
 MAKER_PHP_CS_FIXER_CONFIG_PATH=vendor/shopsys/maker/config/maker-php-cs-fixer.config.php
+
+LOCAL_PATH_TO_PROJECT_ROOT=/var/www/html
+SYMFONY_IDE_URL_FORMAT=phpstorm://open?file=%f&line=%l
+TRACY_DEBUGGER_IDE_URL_FORMAT=phpstorm://%action/?file=%file&line=%line&search=%search&replace=%replace

--- a/project-base/app/config/packages/framework.yaml
+++ b/project-base/app/config/packages/framework.yaml
@@ -10,6 +10,7 @@ framework:
         legacy_error_messages: false
     fragments: ~
     http_method_override: true
+    ide: '%env(SYMFONY_IDE_URL_FORMAT)%&/var/www/html/>%env(LOCAL_PATH_TO_PROJECT_ROOT)%/'
     profiler:
         collect: false
         enabled: false

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -108,6 +108,7 @@ services:
             - ./.npm-global:/var/www/html/.npm-global
         environment:
             <<: *blackfire_environments
+            LOCAL_PATH_TO_PROJECT_ROOT: /var/www/html
         ports:
             - "35729:35729"
 

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -112,6 +112,7 @@ services:
             - ./app/:/var/www/html
         environment:
             <<: *blackfire_environments
+            LOCAL_PATH_TO_PROJECT_ROOT: /var/www/html
         ports:
             - "35729:35729"
 

--- a/project-base/scripts/configure.sh
+++ b/project-base/scripts/configure.sh
@@ -48,6 +48,7 @@ case "$operatingSystem" in
         sed -i -r "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
         sed -i -r "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
         sed -i -r "s#node_uid: [0-9]+#node_uid: $(id -u)#" ./docker-compose.yml
+        sed -i -r "s#LOCAL_PATH_TO_PROJECT_ROOT: .*#LOCAL_PATH_TO_PROJECT_ROOT: $(pwd)#" ./docker-compose.yml
 
         echo "Starting docker compose"
         docker compose up -d --build --force-recreate
@@ -58,6 +59,7 @@ case "$operatingSystem" in
         sed -i '' -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
         sed -i '' -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
         sed -i '' -E "s#defaultOwner: \"id:501\"+#defaultOwner: \"id:$(id -u)\"#" ./docker-compose.yml
+        sed -i '' -E "s#LOCAL_PATH_TO_PROJECT_ROOT: .*#LOCAL_PATH_TO_PROJECT_ROOT: $(pwd)#" ./docker-compose.yml
 
         if [[ $1 != --skip-aliasing ]]; then
             echo "You will be asked to enter sudo password in case to allow second domain alias in your system config"

--- a/upgrade-notes/backend_20250811_140532.md
+++ b/upgrade-notes/backend_20250811_140532.md
@@ -1,0 +1,3 @@
+#### Added support for IDE URLs to the profiler and blue screen error page ([#4138](https://github.com/shopsys/shopsys/pull/4138))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Developers now can click on file links in the browser and those files will be opened in their IDE.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-ide-urls.odin.shopsys.cloud
  - https://cz.tl-ide-urls.odin.shopsys.cloud
<!-- Replace -->
