### PR TITLE
upgrade postgreSQL version to 18.x

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -14,7 +14,7 @@ services:
     #        <<: *blackfire_environments
 
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -17,17 +17,17 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
-            - postgres-data:/var/lib/postgresql/data
+            - ./project-base/app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf:delegated
+            - postgres-data:/var/lib/postgresql
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
 
     webserver:
         image: nginx:1.27-alpine

--- a/docker/conf/docker-compose.github-actions.cypress.yml.dist
+++ b/docker/conf/docker-compose.github-actions.cypress.yml.dist
@@ -3,17 +3,17 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - postgres-data:/var/lib/postgresql/data:rw
-            - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf
+            - postgres-data:/var/lib/postgresql:rw
+            - ./project-base/app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
         healthcheck:
             test: ["CMD", "pg_isready"]
             start_period: 10s

--- a/docker/conf/docker-compose.github-actions.cypress.yml.dist
+++ b/docker/conf/docker-compose.github-actions.cypress.yml.dist
@@ -1,6 +1,6 @@
 services:
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - postgres-data:/var/lib/postgresql/data:rw

--- a/docker/conf/docker-compose.github-actions.review.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.yml.dist
@@ -1,7 +1,7 @@
 services:
     postgres:
         restart: always
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         volumes:
             - postgres-conf:/var/lib/postgresql/conf
         environment:

--- a/docker/conf/docker-compose.github-actions.review.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.yml.dist
@@ -190,6 +190,11 @@ services:
                 hard: 65536
         environment:
             - discovery.type=single-node
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        deploy:
+            resources:
+                limits:
+                    memory: 1G
         networks:
             - default
         labels:

--- a/docker/conf/docker-compose.github-actions.yml.dist
+++ b/docker/conf/docker-compose.github-actions.yml.dist
@@ -3,16 +3,16 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf
+            - ./project-base/app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
 
     webserver:
         image: nginx:1.27-alpine

--- a/docker/conf/docker-compose.github-actions.yml.dist
+++ b/docker/conf/docker-compose.github-actions.yml.dist
@@ -1,6 +1,6 @@
 services:
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -17,17 +17,17 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf
-            - ./project-base/app/var/postgres-data:/var/lib/postgresql/data
+            - ./project-base/app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf
+            - ./project-base/app/var/postgres-data:/var/lib/postgresql
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
 
     webserver:
         image: nginx:1.27-alpine

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -14,7 +14,7 @@ services:
     #        <<: *blackfire_environments
 
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - ./project-base/app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf

--- a/docs/installation/application-requirements.md
+++ b/docs/installation/application-requirements.md
@@ -5,7 +5,7 @@ To be able to install, develop and run Shopsys Platform, the system should have 
 ## Linux / macOS / WSL
 
 - [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [PostgreSQL 17.4](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
+- [PostgreSQL 18](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
 - [PHP 8.3 or higher](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 - [Composer](https://getcomposer.org/doc/00-intro.md#globally)
 - [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
@@ -24,7 +24,7 @@ To be able to install, develop and run Shopsys Platform, the system should have 
         ```bash
         git config --system core.longpaths true
         ```
-- [PostgreSQL 17.4](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
+- [PostgreSQL 18](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
 - [PHP 8.3 or higher](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 - [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows)
 - [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)

--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -453,7 +453,7 @@ These images and packages are configured in `docker-compose.yml` and in `Dockerf
 
 ### Postgres
 
-Image: `postgres:17.4-alpine`  
+Image: `postgres:18-alpine`  
 License: PostgreSQL License  
 https://www.postgresql.org/about/licence/
 

--- a/packages/php-image/Dockerfile
+++ b/packages/php-image/Dockerfile
@@ -89,7 +89,7 @@ RUN apk add --no-cache --virtual .build-deps \
         nano \
         openssl \
         patch \
-        postgresql17-client \
+        postgresql18-client \
         rabbitmq-c \
         vim
 
@@ -113,8 +113,8 @@ COPY ./docker-php-entrypoint /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-php-entrypoint
 
 # Cachetool for opcache management
-RUN curl -sL https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar -o /usr/local/bin/cachetool \
-    && chmod +x /usr/local/bin/cachetool
+RUN curl -sL https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar -o /usr/local/bin/cachetool && \
+    chmod +x /usr/local/bin/cachetool
 
 RUN chown -R www-data:www-data /var/www/html
 

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -4,7 +4,7 @@ parameters:
     container.autowiring.strict_mode: true
     container.dumper.inline_class_loader: true
     database_driver: pdo_pgsql
-    database_server_version: 17.4
+    database_server_version: 18
     # Symfony's FrameworkBundle sets throw_at (error_reporting) to 0 in production by default
     debug.error_handler.throw_at: -1
     env(ADMIN_URL): 'admin'

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -17,7 +17,7 @@ services:
     #        <<: *blackfire_environments
 
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - ./app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -20,17 +20,17 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - ./app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
-            - postgres-data:/var/lib/postgresql/data
+            - ./app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf:delegated
+            - postgres-data:/var/lib/postgresql
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
 
     webserver:
         image: nginx:1.27-alpine

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -17,7 +17,7 @@ services:
     #        <<: *blackfire_environments
 
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - ./app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -20,17 +20,17 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - ./app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf
-            - postgres-data:/var/lib/postgresql/data
+            - ./app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf
+            - postgres-data:/var/lib/postgresql
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
 
     webserver:
         image: nginx:1.27-alpine

--- a/project-base/gitlab/docker-compose-ci.yml
+++ b/project-base/gitlab/docker-compose-ci.yml
@@ -3,17 +3,17 @@ services:
         image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
-            - postgres-data:/var/lib/postgresql/data:rw
-            - ./app/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf
+            - postgres-data:/var/lib/postgresql:rw
+            - ./app/docker/postgres/postgres.conf:/etc/postgresql/postgresql.conf
         environment:
-            - PGDATA=/var/lib/postgresql/data/pgdata
+            - PGDATA=/var/lib/postgresql/18/docker
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
             - postgres
             - -c
-            - config_file=/var/lib/postgresql/data/postgresql.conf
+            - config_file=/etc/postgresql/postgresql.conf
 
     webserver:
         image: nginx:1.27-alpine

--- a/project-base/gitlab/docker-compose-ci.yml
+++ b/project-base/gitlab/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
     postgres:
-        image: postgres:17.4-alpine
+        image: postgres:18-alpine
         container_name: shopsys-framework-postgres
         volumes:
             - postgres-data:/var/lib/postgresql/data:rw

--- a/upgrade-notes/backend_20260114_101820.md
+++ b/upgrade-notes/backend_20260114_101820.md
@@ -1,0 +1,3 @@
+#### upgrade postgreSQL version to 18.x ([#4149](https://github.com/shopsys/shopsys/pull/4149))
+
+- see #project-base-diff to update your project

--- a/utils/license-acknowledgements-generator/template.md
+++ b/utils/license-acknowledgements-generator/template.md
@@ -26,7 +26,7 @@ You can check all the dependencies using the instructions from the section Libra
 These images and packages are configured in `docker-compose.yml` and in `Dockerfile`. We do not redistribute these packages, we are only referencing them to download, user agrees to download these images by pulling and building images done by `docker compose up` or `docker build`.
 
 ### Postgres
-Image: `postgres:17.4-alpine`  
+Image: `postgres:18-alpine`  
 License: PostgreSQL License  
 https://www.postgresql.org/about/licence/
 


### PR DESCRIPTION
#### Description, the reason for the PR
The new is always better :slightly_smiling_face: :rocket: 

For keeping the Postgres version fresh, we now use  `postgres:18-alpine` image without specifying the minor version, to get the minor upgrades automatically when available.

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











----
:globe_with_meridians: Live Preview:
  - https://rv-update-postgres.odin.shopsys.cloud
  - https://cz.rv-update-postgres.odin.shopsys.cloud
  - https://rv-update-postgres.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770098887.895439 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-update-postgres.odin.shopsys.cloud
  - https://cz.rv-update-postgres.odin.shopsys.cloud
  - https://rv-update-postgres.odin.shopsys.cloud/sk
<!-- Replace -->
