### PR TITLE
fixed recalculation of deleted regular product

### DIFF
--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationFacade.php
@@ -57,7 +57,7 @@ class ProductRecalculationFacade
         $exportScopesIndexedByProductId = $this->productRecalculationDeduplicationFacade->getScopesIndexedByProductId($productIds, $priority);
 
         foreach ($this->groupProductIdsWithSameScopes($exportScopesIndexedByProductId) as $productIdsWithScopes) {
-            $idsToRecalculate = $this->productRecalculationRepository->getIdsToRecalculateByMainVariantIds(
+            $idsToRecalculate = $this->productRecalculationRepository->getRelevantIdsToRecalculate(
                 $productIdsWithScopes[self::KEY_PRODUCT_IDS],
             );
 

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationRepository.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationRepository.php
@@ -41,16 +41,18 @@ class ProductRecalculationRepository
     }
 
     /**
-     * @param int[] $mainVariantsIds
+     * @param int[] $inputProductIds
      * @return int[]
      */
-    public function getIdsToRecalculateByMainVariantIds(array $mainVariantsIds): array
+    public function getRelevantIdsToRecalculate(array $inputProductIds): array
     {
         $ids = $this->em
             ->createQuery('SELECT p.id FROM ' . Product::class . ' p WHERE p.mainVariant IN (:productIds) OR p.id IN (:productIds)')
-            ->setParameter('productIds', $mainVariantsIds)
+            ->setParameter('productIds', $inputProductIds)
             ->getArrayResult();
 
-        return array_column($ids, 'id');
+        $ids = array_column($ids, 'id');
+
+        return array_unique([...$ids, ...$inputProductIds]);
     }
 }

--- a/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationRepositoryTest.php
@@ -22,7 +22,7 @@ class ProductRecalculationRepositoryTest extends TransactionFunctionalTestCase
     #[DataProvider('getProductsForRecalculationProvider')]
     public function testProperIdsAreReturned(array $inputIds, array $expectedIds): void
     {
-        $calculatedIds = $this->productRecalculationRepository->getIdsToRecalculateByMainVariantIds($inputIds);
+        $calculatedIds = $this->productRecalculationRepository->getRelevantIdsToRecalculate($inputIds);
 
         $this->assertEqualsCanonicalizing($expectedIds, $calculatedIds);
     }

--- a/upgrade-notes/backend_20250821_130824.md
+++ b/upgrade-notes/backend_20250821_130824.md
@@ -1,0 +1,4 @@
+#### fix recalculation of deleted regular product ([#4151](https://github.com/shopsys/shopsys/pull/4151))
+
+- method `\Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationRepository::getIdsToRecalculateByMainVariantIds()` was renamed to `getRelevantIdsToRecalculate()`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

When a regular product was deleted, the `\Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationRepository::getIdsToRecalculateByMainVariantIds()` was not able to get the proper ID to recalculate (because it was not in the database anymore). 
That caused an error during recalculations, and the product was not removed from the Elastic (it was still present on the storefront). 

This is fixed now.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-delete-product.odin.shopsys.cloud
  - https://cz.mg-fix-delete-product.odin.shopsys.cloud
<!-- Replace -->
