### PR TITLE
fix hreflang links for SEO pages

### DIFF
--- a/packages/framework/src/Model/Seo/HreflangLinksFacade.php
+++ b/packages/framework/src/Model/Seo/HreflangLinksFacade.php
@@ -255,10 +255,11 @@ class HreflangLinksFacade
      */
     protected function createHreflangLinkForSeoPage(int $domainId, SeoPage $seoPage, bool $absoluteUrl): HreflangLink
     {
-        $href = ($absoluteUrl === true ? $this->domain->getUrl() : '') . '/' . $seoPage->getPageSlug($domainId);
+        $domainConfig = $this->domain->getDomainConfigById($domainId);
+        $href = ($absoluteUrl === true ? $domainConfig->getUrl() : '') . '/' . $seoPage->getPageSlug($domainId);
 
         return new HreflangLink(
-            $this->domain->getDomainConfigById($domainId)->getLocale(),
+            $domainConfig->getLocale(),
             $href,
             $domainId,
         );

--- a/project-base/app/tests/FrontendApiBundle/Functional/Hreflang/HreflangLinksTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Hreflang/HreflangLinksTest.php
@@ -205,7 +205,7 @@ class HreflangLinksTest extends GraphQlTestCase
     private function getUrlByRouteNameAndEntityId(string $routeName, int $domainId, object $entity): string
     {
         if ($entity instanceof SeoPage) {
-            return $this->domain->getUrl() . '/' . $entity->getPageSlug($domainId);
+            return $this->domain->getDomainConfigById($domainId)->getUrl() . '/' . $entity->getPageSlug($domainId);
         }
 
         return $this->friendlyUrlFacade->getAbsoluteUrlByRouteNameAndEntityId(

--- a/upgrade-notes/backend_20250824_062740.md
+++ b/upgrade-notes/backend_20250824_062740.md
@@ -1,0 +1,3 @@
+#### fix hreflang links for SEO pages ([#4157](https://github.com/shopsys/shopsys/pull/4157))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The current domain was used to generate hreflangs, leading to broken links in the `<link>` tags. E.g. when you enter https://17-0.odin.shopsys.cloud/brands-overview, you will see:

```
<link href="https://17-0.odin.shopsys.cloud/brands-overview" hreflang="en" rel="alternate" data-next-head="">
<link href="https://17-0.odin.shopsys.cloud/prehled-znacek" hreflang="cs" rel="alternate" data-next-head="">
```

The second link is broken, it should be actually https://cz.17-0.odin.shopsys.cloud/prehled-znacek
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-hreflang.odin.shopsys.cloud
  - https://cz.rv-hreflang.odin.shopsys.cloud
<!-- Replace -->
