### PR TITLE
set homepage SEO page slug to "/" to fix 404 links to non-existent "/homepage"

### DIFF
--- a/packages/framework/src/Migrations/Version20250825101232.php
+++ b/packages/framework/src/Migrations/Version20250825101232.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20250825101232 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('UPDATE seo_page_domains SET page_slug = \'/\' WHERE page_slug = \'homepage\'');
+    }
+}

--- a/packages/framework/src/Model/Seo/HreflangLinksFacade.php
+++ b/packages/framework/src/Model/Seo/HreflangLinksFacade.php
@@ -256,7 +256,12 @@ class HreflangLinksFacade
     protected function createHreflangLinkForSeoPage(int $domainId, SeoPage $seoPage, bool $absoluteUrl): HreflangLink
     {
         $domainConfig = $this->domain->getDomainConfigById($domainId);
-        $href = ($absoluteUrl === true ? $domainConfig->getUrl() : '') . '/' . $seoPage->getPageSlug($domainId);
+        $href = ($absoluteUrl === true ? $domainConfig->getUrl() : '') . '/';
+        $pageSlug = $seoPage->getPageSlug($domainId);
+
+        if ($pageSlug !== SeoPage::SEO_PAGE_HOMEPAGE_SLUG) {
+            $href .= $pageSlug;
+        }
 
         return new HreflangLink(
             $domainConfig->getLocale(),

--- a/packages/framework/src/Model/Seo/Page/SeoPage.php
+++ b/packages/framework/src/Model/Seo/Page/SeoPage.php
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Model\Seo\Page\Exception\SeoPageDomainNotFoundExcept
  */
 class SeoPage
 {
-    public const SEO_PAGE_HOMEPAGE_SLUG = 'homepage';
+    public const string SEO_PAGE_HOMEPAGE_SLUG = '/';
 
     /**
      * @var int

--- a/upgrade-notes/backend_20250827_151948.md
+++ b/upgrade-notes/backend_20250827_151948.md
@@ -1,0 +1,3 @@
+#### set homepage SEO page slug to "/" to fix 404 links to non-existent "/homepage" ([#4159](https://github.com/shopsys/shopsys/pull/4159))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

At the moment, at homepage, you see the following links that lead to 404:
```
<link href="https://17-0.odin.shopsys.cloud/homepage" hreflang="en" rel="alternate" data-next-head="">
```

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-seo-homepage.odin.shopsys.cloud
  - https://cz.rv-seo-homepage.odin.shopsys.cloud
<!-- Replace -->
