### PR TITLE
SF: html lang is now properly set for all domains

### DIFF
--- a/project-base/storefront/components/Pages/App/Loaders.tsx
+++ b/project-base/storefront/components/Pages/App/Loaders.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useAfterUserEntry } from 'utils/app/useAfterUserEntry';
 import { useAuthLoader } from 'utils/app/useAuthLoader';
+import { useHtmlLangLoader } from 'utils/app/useHtmlLangLoader';
 import { usePageLoader } from 'utils/app/usePageLoader';
 import { useReloadCart } from 'utils/cart/useReloadCart';
 import { useRefetchComparedProducts } from 'utils/productLists/comparison/useRefetchComparedProducts';
@@ -16,6 +17,7 @@ export const Loaders = () => {
     useAfterUserEntry();
     useRefetchComparedProducts();
     useRefetchWishedProducts();
+    useHtmlLangLoader();
     useBroadcastChannel('reloadPage', () => {
         router.reload();
     });

--- a/project-base/storefront/pages/_document.tsx
+++ b/project-base/storefront/pages/_document.tsx
@@ -1,0 +1,47 @@
+import { Head, Html, Main, NextScript } from 'next/document';
+import Document, { DocumentContext, DocumentInitialProps } from 'next/document';
+import { getDomainConfig } from 'utils/domain/domainConfig';
+import { logException } from 'utils/errors/logException';
+
+interface MyDocumentInitialProps extends DocumentInitialProps {
+    htmlLang: string;
+}
+
+class MyDocument extends Document<MyDocumentInitialProps> {
+    static async getInitialProps(context: DocumentContext): Promise<MyDocumentInitialProps> {
+        const initialProps = await Document.getInitialProps(context);
+
+        let htmlLang = 'en';
+
+        try {
+            const host = context.req?.headers.host;
+
+            if (!host) {
+                throw new Error('host was not found in the request headers');
+            }
+
+            const domainConfig = getDomainConfig(host);
+            htmlLang = domainConfig.defaultLocale;
+        } catch (error) {
+            logException(error);
+        }
+
+        return { ...initialProps, htmlLang };
+    }
+
+    render() {
+        const { htmlLang } = this.props;
+
+        return (
+            <Html lang={htmlLang}>
+                <Head />
+                <body>
+                    <Main />
+                    <NextScript />
+                </body>
+            </Html>
+        );
+    }
+}
+
+export default MyDocument;

--- a/project-base/storefront/utils/app/useHtmlLangLoader.ts
+++ b/project-base/storefront/utils/app/useHtmlLangLoader.ts
@@ -1,0 +1,22 @@
+import { useDomainConfig } from 'components/providers/DomainConfigProvider';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export const useHtmlLangLoader = () => {
+    const { defaultLocale } = useDomainConfig();
+    const router = useRouter();
+
+    useEffect(() => {
+        const updateHtmlLang = () => {
+            document.documentElement.lang = defaultLocale;
+        };
+
+        updateHtmlLang();
+
+        router.events.on('routeChangeComplete', updateHtmlLang);
+
+        return () => {
+            router.events.off('routeChangeComplete', updateHtmlLang);
+        };
+    }, [defaultLocale, router.events]);
+};

--- a/upgrade-notes/storefront_20250825_135158.md
+++ b/upgrade-notes/storefront_20250825_135158.md
@@ -1,0 +1,4 @@
+#### HTML lang is now properly set for all domains ([#4160](https://github.com/shopsys/shopsys/pull/4160))
+
+- HTML lang attribute takes its value from the domain configuration instead of using the default locale from i18n configuration
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
At the moment, we use "en" as a default locale configuration for Next. (See https://github.com/shopsys/shopsys/blob/17.0/project-base/storefront/i18n.js#L37). The problem is, as we do not use explicit locale in path, the default locale is used for html lang for all domains. See https://cz.17-0.odin.shopsys.cloud/ - it has Czech locale, however, in the html lang attribute, there is `<html lang="en">`. 

This PR fixes that by setting the proper locale from the domain config into the HTML lang attribute.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-html-lang.odin.shopsys.cloud
  - https://cz.rv-fix-html-lang.odin.shopsys.cloud
<!-- Replace -->
