### PR TITLE
fixed order of registering extended routes

### DIFF
--- a/project-base/app/config/routes/shopsys_admin.yaml
+++ b/project-base/app/config/routes/shopsys_admin.yaml
@@ -1,4 +1,14 @@
-shopsys_shop_admin:
+shopsys_administration:
+    prefix: /%admin_url%
+    resource: "@ShopsysAdministrationBundle/config/routing.yaml"
+
+shopsys_framework:
+    prefix: /%admin_url%
+    resource: "@ShopsysFrameworkBundle/Controller/Admin"
+    type: attribute
+
+# has to be last to properly override routes from bundles above
+shopsys_project_base:
     prefix: /%admin_url%
     resource: "../../src/Controller/Admin/"
     type: attribute

--- a/project-base/app/config/routes/shopsys_framework.yaml
+++ b/project-base/app/config/routes/shopsys_framework.yaml
@@ -1,8 +1,0 @@
-shopsys_administration:
-    prefix: /%admin_url%
-    resource: "@ShopsysAdministrationBundle/config/routing.yaml"
-
-shopsys_framework:
-    prefix: /%admin_url%
-    resource: "@ShopsysFrameworkBundle/Controller/Admin"
-    type: attribute

--- a/upgrade-notes/backend_20250829_124729.md
+++ b/upgrade-notes/backend_20250829_124729.md
@@ -1,0 +1,3 @@
+#### fixed order of registering extended routes ([#4164](https://github.com/shopsys/shopsys/pull/4164))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

When the controller from shopsys/framework or shopsys/administration is extended, the route now has proper `_controller` attribute set, so it's safe to bind any features to it.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-extended-controller-router.odin.shopsys.cloud
  - https://cz.mg-extended-controller-router.odin.shopsys.cloud
<!-- Replace -->
