### PR TITLE
Fix announcing page title for screen readers

### DIFF
--- a/project-base/storefront/components/Basic/RangeSlider/RangeSlider.tsx
+++ b/project-base/storefront/components/Basic/RangeSlider/RangeSlider.tsx
@@ -54,10 +54,10 @@ export const RangeSlider: FC<RangeSliderProps> = ({
     const { t } = useTranslation();
     const step = useMemo(() => getStep(min, max), [min, max]);
 
-    const [minValueInput, setMinValueInput] = useState(min);
+    const [minValueInput, setMinValueInput] = useState<number | ''>(min);
     const [minValueThumb, setMinValueThumb] = useState(min);
 
-    const [maxValueInput, setMaxValueInput] = useState(max);
+    const [maxValueInput, setMaxValueInput] = useState<number | ''>(max);
     const [maxValueThumb, setMaxValueThumb] = useState(max);
 
     const range = useRef<HTMLDivElement>(null);
@@ -137,11 +137,15 @@ export const RangeSlider: FC<RangeSliderProps> = ({
         window.getSelection()?.removeAllRanges();
     };
 
-    const onChangeMaxInputHandler: ChangeEventHandler<HTMLInputElement> = (event) =>
-        setMaxValueInput(parseFloat(event.currentTarget.value));
+    const onChangeMaxInputHandler: ChangeEventHandler<HTMLInputElement> = (event) => {
+        const value = event.currentTarget.value;
+        setMaxValueInput(value === '' ? '' : parseFloat(value));
+    };
 
-    const onChangeMinInputHandler: ChangeEventHandler<HTMLInputElement> = (event) =>
-        setMinValueInput(parseFloat(event.currentTarget.value));
+    const onChangeMinInputHandler: ChangeEventHandler<HTMLInputElement> = (event) => {
+        const value = event.currentTarget.value;
+        setMinValueInput(value === '' ? '' : parseFloat(value));
+    };
 
     const onEnterKeyDownHandler: KeyboardEventHandler<HTMLInputElement> = (event) =>
         event.key === 'Enter' && event.currentTarget.blur();

--- a/project-base/storefront/components/Basic/RangeSlider/RangeSlider.tsx
+++ b/project-base/storefront/components/Basic/RangeSlider/RangeSlider.tsx
@@ -200,6 +200,7 @@ export const RangeSlider: FC<RangeSliderProps> = ({
             <div className="flex gap-x-2">
                 <div className="w-1/2">
                     <TextInput
+                        aria-hidden
                         aria-label={t('Filter by minimum value')}
                         disabled={isDisabled}
                         id={`${title} - from`}
@@ -213,6 +214,7 @@ export const RangeSlider: FC<RangeSliderProps> = ({
                 </div>
                 <div className="w-1/2">
                     <TextInput
+                        aria-hidden
                         aria-label={t('Filter by maximum value')}
                         disabled={isDisabled}
                         id={`${title} - to`}

--- a/project-base/storefront/components/Blocks/Skeleton/SkeletonManager.tsx
+++ b/project-base/storefront/components/Blocks/Skeleton/SkeletonManager.tsx
@@ -29,7 +29,7 @@ import { SkeletonPageStores } from './SkeletonPageStores';
 import { SkeletonPageTransportAndPayment } from './SkeletonPageTransportAndPayment';
 import { SkeletonPageUserConsent } from './SkeletonPageUserConsent';
 import { SkeletonPageWishlist } from './SkeletonPageWishlist';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { PageType } from 'store/slices/createPageLoadingStateSlice';
 import { useSessionStore } from 'store/useSessionStore';
 import { SkeletonEnum } from 'types/skeletons';
@@ -49,6 +49,7 @@ export const SkeletonManager: FC<SkeletonManagerProps> = ({
     const redirectPageType = useSessionStore((s) => s.redirectPageType);
     const updatePageLoadingState = useSessionStore((s) => s.updatePageLoadingState);
     const pageType = redirectPageType ?? pageTypeOverride;
+    const [showSkeleton, setShowSkeleton] = useState(false);
 
     useEffect(() => {
         if (pageTypeOverride) {
@@ -59,10 +60,13 @@ export const SkeletonManager: FC<SkeletonManagerProps> = ({
     useEffect(() => {
         if (isPageLoading) {
             window.scrollTo({ top: 0 });
+            setShowSkeleton(true);
+        } else {
+            setShowSkeleton(false);
         }
     }, [isPageLoading]);
 
-    if (!isPageLoading && !isFetchingData) {
+    if (!showSkeleton && !isFetchingData) {
         return <>{children}</>;
     }
 

--- a/project-base/storefront/components/Forms/Spinbox/Spinbox.tsx
+++ b/project-base/storefront/components/Forms/Spinbox/Spinbox.tsx
@@ -227,6 +227,7 @@ export const Spinbox = forwardRef<HTMLInputElement, SpinboxProps>(
                 </SpinboxButton>
 
                 <input
+                    aria-hidden
                     aria-describedby="quantity-input-description"
                     aria-label={t('Quantity')}
                     data-tid={TIDs.spinbox_input}

--- a/project-base/storefront/components/Forms/TextInput/TextInput.tsx
+++ b/project-base/storefront/components/Forms/TextInput/TextInput.tsx
@@ -19,6 +19,7 @@ type NativeProps = ExtractNativePropsFromDefault<
     | 'inputMode'
     | 'aria-label'
     | 'aria-labelledby'
+    | 'aria-hidden'
 >;
 
 export type TextInputProps = NativeProps & {
@@ -49,11 +50,13 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             inputMode,
             'aria-label': ariaLabel,
             'aria-labelledby': ariaLabelledby,
+            'aria-hidden': ariaHidden,
         },
         textInputForwarderRef,
     ) => (
         <LabelWrapper className={className} htmlFor={id} inputType="text-input" label={label} required={required}>
             <input
+                aria-hidden={ariaHidden}
                 aria-label={ariaLabel}
                 aria-labelledby={ariaLabelledby}
                 autoComplete={autoComplete}

--- a/project-base/storefront/components/Layout/Header/AccessibilityNavigation/AccessibilityNavigation.tsx
+++ b/project-base/storefront/components/Layout/Header/AccessibilityNavigation/AccessibilityNavigation.tsx
@@ -1,7 +1,5 @@
 import { AccessibleLink } from 'components/Basic/AccessibleLink/AccessibleLink';
 import useTranslation from 'next-translate/useTranslation';
-import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
 
 type AccessibilityNavigationProps = {
     simpleHeader?: boolean;
@@ -9,65 +7,24 @@ type AccessibilityNavigationProps = {
 
 export const AccessibilityNavigation: FC<AccessibilityNavigationProps> = ({ simpleHeader }) => {
     const { t } = useTranslation();
-    const router = useRouter();
-    const accessibilityLinksRef = useRef<HTMLDivElement>(null);
-    const previousRouteRef = useRef<string>('');
-    const [pageTitle, setPageTitle] = useState('');
-
-    // reset focus to accessibility menu only on actual route changes
-    useEffect(() => {
-        const handleRouteChangeComplete = (url: string) => {
-            const newPathname = url.split('?')[0];
-
-            // only focus if it's a different route (not just query param changes) AND not a link click
-            if (newPathname !== previousRouteRef.current) {
-                if (accessibilityLinksRef.current) {
-                    accessibilityLinksRef.current.focus();
-                }
-            }
-
-            previousRouteRef.current = newPathname;
-        };
-
-        previousRouteRef.current = router.asPath.split('?')[0];
-
-        router.events.on('routeChangeComplete', handleRouteChangeComplete);
-
-        return () => {
-            router.events.off('routeChangeComplete', handleRouteChangeComplete);
-        };
-    }, [router.events]);
-
-    // set page title after hydration to avoid hydration mismatch
-    useEffect(() => {
-        setPageTitle(document.title || '');
-    }, []);
-
-    const announceText = pageTitle ? t('You are on {{pageTitle}} page', { pageTitle }) : '';
 
     return (
-        <>
-            <span aria-atomic="true" aria-live="polite" className="sr-only" ref={accessibilityLinksRef} tabIndex={-1}>
-                {announceText}
-            </span>
-
-            <nav aria-label={t('Skip navigation')}>
-                <ul>
-                    <li>
-                        <AccessibleLink href="#main-content" title={t('Skip to main content')} />
-                    </li>
-                    {!simpleHeader && (
-                        <>
-                            <li>
-                                <AccessibleLink href="#search-input" title={t('Skip to search')} />
-                            </li>
-                            <li>
-                                <AccessibleLink href="#main-navigation" title={t('Skip to navigation')} />
-                            </li>
-                        </>
-                    )}
-                </ul>
-            </nav>
-        </>
+        <nav aria-label={t('Skip navigation')}>
+            <ul>
+                <li>
+                    <AccessibleLink href="#main-content" title={t('Skip to main content')} />
+                </li>
+                {!simpleHeader && (
+                    <>
+                        <li>
+                            <AccessibleLink href="#search-input" title={t('Skip to search')} />
+                        </li>
+                        <li>
+                            <AccessibleLink href="#main-navigation" title={t('Skip to navigation')} />
+                        </li>
+                    </>
+                )}
+            </ul>
+        </nav>
     );
 };

--- a/project-base/storefront/components/Layout/RouteAccessibilityManager.tsx
+++ b/project-base/storefront/components/Layout/RouteAccessibilityManager.tsx
@@ -1,0 +1,68 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, ReactNode } from 'react';
+import { useSessionStore } from 'store/useSessionStore';
+
+export const RouteAccessibilityManager: FC<{ children: ReactNode }> = ({ children }) => {
+    const router = useRouter();
+    const updatePageLoadingState = useSessionStore((s) => s.updatePageLoadingState);
+
+    const handleRouteChangeStart = useCallback(
+        (url: string, options: { shallow: boolean }) => {
+            const { shallow } = options;
+
+            if (shallow) {
+                return;
+            }
+
+            updatePageLoadingState({
+                hadClientSideNavigation: true,
+                isPageLoading: true,
+            });
+        },
+        [updatePageLoadingState],
+    );
+
+    const handleRouteChangeComplete = useCallback(
+        (url: string, options: { shallow: boolean }) => {
+            const { shallow } = options;
+
+            if (shallow) {
+                return;
+            }
+
+            updatePageLoadingState({
+                isPageLoading: false,
+            });
+        },
+        [updatePageLoadingState],
+    );
+
+    const handleRouteChangeError = useCallback(
+        (err: Error, url: string, options: { shallow: boolean }) => {
+            const { shallow } = options;
+
+            if (shallow) {
+                return;
+            }
+
+            updatePageLoadingState({
+                isPageLoading: false,
+            });
+        },
+        [updatePageLoadingState],
+    );
+
+    useEffect(() => {
+        router.events.on('routeChangeStart', handleRouteChangeStart);
+        router.events.on('routeChangeComplete', handleRouteChangeComplete);
+        router.events.on('routeChangeError', handleRouteChangeError);
+
+        return () => {
+            router.events.off('routeChangeStart', handleRouteChangeStart);
+            router.events.off('routeChangeComplete', handleRouteChangeComplete);
+            router.events.off('routeChangeError', handleRouteChangeError);
+        };
+    }, [router.events, handleRouteChangeStart, handleRouteChangeComplete, handleRouteChangeError]);
+
+    return <>{children}</>;
+};

--- a/project-base/storefront/components/Layout/RouteAnnouncer.tsx
+++ b/project-base/storefront/components/Layout/RouteAnnouncer.tsx
@@ -1,0 +1,162 @@
+import useTranslation from 'next-translate/useTranslation';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSessionStore } from 'store/useSessionStore';
+
+const ANNOUNCEMENT_MAX_WAIT_MS = 4000;
+const ANNOUNCEMENT_POLL_INTERVAL_MS = 80;
+const ANNOUNCEMENT_EARLY_REPEAT_THRESHOLD_MS = 400;
+
+const readDocumentTitle = (): string => {
+    const titleFromHead = document.head.querySelector('title')?.textContent ?? '';
+    const fallbackTitle = document.title;
+    return (titleFromHead || fallbackTitle).replace(/\s+/g, ' ').trim();
+};
+
+type AnnounceOptions = {
+    forceRepeat?: boolean;
+    formatter?: (normalizedTitle: string) => string;
+};
+
+export const RouteAnnouncer: FC = () => {
+    const { t } = useTranslation();
+    const router = useRouter();
+    const { hadClientSideNavigation, isPageLoading } = useSessionStore(
+        useCallback(
+            (state) => ({
+                hadClientSideNavigation: state.hadClientSideNavigation,
+                isPageLoading: state.isPageLoading,
+            }),
+            [],
+        ),
+    );
+
+    const [message, setMessage] = useState<string>('');
+    const lastAnnouncedRef = useRef<string>('');
+    const pendingPollRef = useRef<number | null>(null);
+    const pendingDeferredAnnouncementRef = useRef<number | null>(null);
+    const loadingTitleRef = useRef<string | null>(null);
+
+    const clearTimers = useCallback(() => {
+        if (pendingPollRef.current) {
+            window.clearTimeout(pendingPollRef.current);
+            pendingPollRef.current = null;
+        }
+        if (pendingDeferredAnnouncementRef.current) {
+            window.clearTimeout(pendingDeferredAnnouncementRef.current);
+            pendingDeferredAnnouncementRef.current = null;
+        }
+    }, []);
+
+    const announceTitle = useCallback(
+        (title: string, options: AnnounceOptions = {}) => {
+            const normalized = title.trim();
+
+            if (!normalized) {
+                return;
+            }
+
+            if (!options.forceRepeat && normalized === lastAnnouncedRef.current) {
+                return;
+            }
+
+            pendingDeferredAnnouncementRef.current = window.setTimeout(() => {
+                lastAnnouncedRef.current = normalized;
+                const resolvedMessage = options.formatter
+                    ? options.formatter(normalized)
+                    : t('You are on {{pageTitle}} page', { pageTitle: normalized });
+                setMessage(resolvedMessage);
+            }, 50);
+        },
+        [t],
+    );
+
+    const scheduleTitleAnnouncement = useCallback(
+        (options: { forceRepeat?: boolean } = {}) => {
+            clearTimers();
+
+            const startedAt = performance.now();
+            const initialTitle = readDocumentTitle();
+
+            const pollForTitle = () => {
+                const currentTitle = readDocumentTitle();
+                const titleChanged = currentTitle && currentTitle !== initialTitle;
+                const elapsed = performance.now() - startedAt;
+                const timedOut = performance.now() - startedAt >= ANNOUNCEMENT_MAX_WAIT_MS;
+                const exceedEarlyRepeatThreshold =
+                    !titleChanged && elapsed >= ANNOUNCEMENT_EARLY_REPEAT_THRESHOLD_MS && !!currentTitle;
+
+                if (titleChanged || exceedEarlyRepeatThreshold || timedOut) {
+                    const candidateTitle = currentTitle || initialTitle;
+                    const shouldUseLoadingFormatter =
+                        loadingTitleRef.current !== null && candidateTitle === loadingTitleRef.current;
+
+                    announceTitle(candidateTitle, {
+                        forceRepeat: options.forceRepeat || exceedEarlyRepeatThreshold || timedOut,
+                        formatter: shouldUseLoadingFormatter
+                            ? () => loadingTitleRef.current ?? candidateTitle
+                            : undefined,
+                    });
+
+                    if (titleChanged) {
+                        loadingTitleRef.current = null;
+                    }
+
+                    return;
+                }
+
+                pendingPollRef.current = window.setTimeout(pollForTitle, ANNOUNCEMENT_POLL_INTERVAL_MS);
+            };
+
+            pendingPollRef.current = window.setTimeout(pollForTitle, ANNOUNCEMENT_POLL_INTERVAL_MS);
+        },
+        [announceTitle, clearTimers],
+    );
+
+    useEffect(() => {
+        // Announce the server-rendered title after hydration.
+        announceTitle(readDocumentTitle(), { forceRepeat: true });
+    }, [announceTitle]);
+
+    useEffect(() => {
+        if (!hadClientSideNavigation) {
+            return undefined;
+        }
+
+        if (isPageLoading) {
+            clearTimers();
+            return undefined;
+        }
+
+        scheduleTitleAnnouncement({ forceRepeat: true });
+
+        return clearTimers;
+    }, [clearTimers, hadClientSideNavigation, isPageLoading, scheduleTitleAnnouncement]);
+
+    useEffect(() => {
+        const handleRouteChangeStart = () => {
+            clearTimers();
+            lastAnnouncedRef.current = '';
+
+            const loadingText = t('Page loading');
+            loadingTitleRef.current = loadingText;
+            document.title = loadingText;
+            announceTitle(loadingText, {
+                forceRepeat: true,
+                formatter: () => loadingText,
+            });
+        };
+
+        router.events.on('routeChangeStart', handleRouteChangeStart);
+
+        return () => {
+            router.events.off('routeChangeStart', handleRouteChangeStart);
+        };
+    }, [announceTitle, clearTimers, router.events, t]);
+
+    return (
+        <div aria-atomic="true" aria-live="polite" className="sr-only" role="status">
+            {message}
+        </div>
+    );
+};

--- a/project-base/storefront/pages/_app.tsx
+++ b/project-base/storefront/pages/_app.tsx
@@ -1,3 +1,5 @@
+import { RouteAccessibilityManager } from 'components/Layout/RouteAccessibilityManager';
+import { RouteAnnouncer } from 'components/Layout/RouteAnnouncer';
 import { AuthorizationProvider } from 'components/providers/AuthorizationProvider';
 import { CookiesStoreProvider } from 'components/providers/CookiesStoreProvider';
 import { DomainConfigProvider } from 'components/providers/DomainConfigProvider';
@@ -71,7 +73,10 @@ function MyApp({ Component, pageProps }: AppProps): ReactElement | null {
                             <GtmProvider>
                                 <MotionConfig reducedMotion="user">
                                     <LazyMotion features={framerMotionPlugins}>
-                                        <AppPageContent Component={Component} pageProps={pageProps} />
+                                        <RouteAccessibilityManager>
+                                            <RouteAnnouncer />
+                                            <AppPageContent Component={Component} pageProps={pageProps} />
+                                        </RouteAccessibilityManager>
                                     </LazyMotion>
                                 </MotionConfig>
                             </GtmProvider>

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -401,6 +401,7 @@
     "Overview": "Přehled",
     "page {{ currentPage }} from {{ totalPages }}": "stránka {{ currentPage }} z {{ totalPages }}",
     "page {{ currentPage }} to {{ currentPageWithLoadMore }} from {{ totalPages }}": "page {{ currentPage }} to {{ currentPageWithLoadMore }} from {{ totalPages }}",
+    "Page loading": "Načítání stránky",
     "Pagination navigation": "Navigace stránek",
     "Paid": "Zaplaceno",
     "Parameters": "Parametry",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -385,6 +385,7 @@
     "Overview": "Overview",
     "page {{ currentPage }} from {{ totalPages }}": "page {{ currentPage }} from {{ totalPages }}",
     "page {{ currentPage }} to {{ currentPageWithLoadMore }} from {{ totalPages }}": "page {{ currentPage }} to {{ currentPageWithLoadMore }} from {{ totalPages }}",
+    "Page loading": "Page loading",
     "Pagination navigation": "Pagination navigation",
     "Paid": "Paid",
     "Parameters": "Parameters",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -401,6 +401,7 @@
     "Overview": "Prehľad",
     "page {{ currentPage }} from {{ totalPages }}": "stránka {{ currentPage }} z {{ totalPages }}",
     "page {{ currentPage }} to {{ currentPageWithLoadMore }} from {{ totalPages }}": "page {{ currentPage }} to {{ currentPageWithLoadMore }} from {{ totalPages }}",
+    "Page loading": "Načítanie stránky",
     "Pagination navigation": "Navigace stránkování",
     "Paid": "Zaplatené",
     "Parameters": "Parametry",

--- a/project-base/storefront/utils/app/usePageLoader.ts
+++ b/project-base/storefront/utils/app/usePageLoader.ts
@@ -15,6 +15,7 @@ export const usePageLoader = () => {
             Nprogress.start();
         }
     };
+
     const onRouteChangeStop = (_targetUrl: string, { shallow }: { shallow: boolean }) => {
         updatePageLoadingState({ isPageLoading: false });
 

--- a/project-base/storefront/vitest/components/Blocks/Product/Filter/FilterGroupParameters.test.tsx
+++ b/project-base/storefront/vitest/components/Blocks/Product/Filter/FilterGroupParameters.test.tsx
@@ -54,14 +54,18 @@ vi.mock('store/useSessionStore', () => ({
 
 vi.mock('framer-motion', async () => {
     const actual = (await vi.importActual('framer-motion')) as any;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const MotionDiv = ({ children, layout, layoutId, animate, exit, initial, transition, ...props }: any) => (
+        <div {...props}>{children}</div>
+    );
     return {
         ...(actual || {}),
         AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
         motion: {
-            div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+            div: MotionDiv,
         },
         m: {
-            div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+            div: MotionDiv,
         },
     };
 });
@@ -405,14 +409,14 @@ describe('FilterGroupParameters', () => {
         test('renders slider parameter', () => {
             render(<FilterGroupParameters {...defaultSliderProps} />);
 
-            const numberInputs = screen.getAllByRole('spinbutton');
+            const numberInputs = screen.getAllByRole('spinbutton', { hidden: true });
             expect(numberInputs).toHaveLength(2);
         });
 
         test('renders slider with correct current values', () => {
             render(<FilterGroupParameters {...defaultSliderProps} />);
 
-            const numberInputs = screen.getAllByRole('spinbutton');
+            const numberInputs = screen.getAllByRole('spinbutton', { hidden: true });
             expect(numberInputs[0]).toHaveValue(10);
         });
 
@@ -421,7 +425,7 @@ describe('FilterGroupParameters', () => {
 
             render(<FilterGroupParameters {...defaultSliderProps} />);
 
-            const numberInputs = screen.getAllByRole('spinbutton');
+            const numberInputs = screen.getAllByRole('spinbutton', { hidden: true });
             const minInput = numberInputs[0];
 
             await user.clear(minInput);
@@ -436,7 +440,7 @@ describe('FilterGroupParameters', () => {
 
             render(<FilterGroupParameters {...defaultSliderProps} />);
 
-            const numberInputs = screen.getAllByRole('spinbutton');
+            const numberInputs = screen.getAllByRole('spinbutton', { hidden: true });
             const maxInput = numberInputs[1];
 
             await user.clear(maxInput);
@@ -454,7 +458,7 @@ describe('FilterGroupParameters', () => {
 
             render(<FilterGroupParameters {...sliderWithoutUnit} />);
 
-            const numberInputs = screen.getAllByRole('spinbutton');
+            const numberInputs = screen.getAllByRole('spinbutton', { hidden: true });
             expect(numberInputs).toHaveLength(2);
         });
     });
@@ -707,7 +711,7 @@ describe('FilterGroupParameters', () => {
 
             render(<FilterGroupParameters {...defaultSliderProps} />);
 
-            const numberInputs = screen.getAllByRole('spinbutton');
+            const numberInputs = screen.getAllByRole('spinbutton', { hidden: true });
             const minInput = numberInputs[0];
             const maxInput = numberInputs[1];
 

--- a/project-base/storefront/vitest/components/Layout/RouteAnnouncer.test.tsx
+++ b/project-base/storefront/vitest/components/Layout/RouteAnnouncer.test.tsx
@@ -1,0 +1,165 @@
+import { act, render, screen } from '@testing-library/react';
+import { RouteAnnouncer } from 'components/Layout/RouteAnnouncer';
+import { useSessionStore } from 'store/useSessionStore';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+
+type EventCallback = (...args: any[]) => void;
+
+const createRouterEvents = () => {
+    const listeners = new Map<string, Set<EventCallback>>();
+
+    return {
+        on: (event: string, cb: EventCallback) => {
+            if (!listeners.has(event)) {
+                listeners.set(event, new Set());
+            }
+            listeners.get(event)!.add(cb);
+        },
+        off: (event: string, cb: EventCallback) => {
+            listeners.get(event)?.delete(cb);
+        },
+        emit: (event: string, ...payload: any[]) => {
+            listeners.get(event)?.forEach((cb) => cb(...payload));
+        },
+        clearAll: () => listeners.clear(),
+    };
+};
+
+const routerEvents = createRouterEvents();
+
+vi.mock('next/router', () => ({
+    useRouter: () => ({
+        events: routerEvents,
+    }),
+}));
+
+vi.mock('next-translate/useTranslation', () => ({
+    __esModule: true,
+    default: () => ({
+        t: (key: string, params?: { pageTitle: string }) => {
+            if (key === 'Page loading') {
+                return 'Page loading';
+            }
+
+            if (params?.pageTitle) {
+                return `You are on ${params.pageTitle} page`;
+            }
+
+            return key;
+        },
+    }),
+}));
+
+const resetSessionStore = () => {
+    act(() => {
+        useSessionStore.setState({
+            hadClientSideNavigation: false,
+            isPageLoading: false,
+        });
+    });
+};
+
+const advanceTimersBy = (ms: number) => {
+    act(() => {
+        vi.advanceTimersByTime(ms);
+    });
+};
+
+const waitForAnnouncement = (expected: string, stepMs = 80, maxIterations = 120) => {
+    let lastText = '';
+    for (let iteration = 0; iteration < maxIterations; iteration += 1) {
+        lastText = screen.getByRole('status').textContent ?? '';
+        if (lastText.includes(expected)) {
+            return lastText;
+        }
+
+        advanceTimersBy(stepMs);
+    }
+
+    return lastText;
+};
+
+describe('RouteAnnouncer', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetSessionStore();
+        routerEvents.clearAll();
+        document.title = 'Initial Page Title';
+    });
+
+    afterEach(() => {
+        act(() => {
+            vi.runOnlyPendingTimers();
+        });
+        vi.useRealTimers();
+        resetSessionStore();
+    });
+
+    const renderAnnouncer = () => {
+        let utils: ReturnType<typeof render> | undefined;
+        act(() => {
+            utils = render(<RouteAnnouncer />);
+        });
+        return utils!;
+    };
+
+    test('announces server-rendered title after hydration', () => {
+        renderAnnouncer();
+
+        advanceTimersBy(60);
+
+        expect(screen.getByRole('status')).toHaveTextContent('You are on Initial Page Title page');
+    });
+
+    test('suppresses announcements during loading state', () => {
+        renderAnnouncer();
+        advanceTimersBy(60);
+
+        expect(screen.getByRole('status')).toHaveTextContent('You are on Initial Page Title page');
+
+        act(() => {
+            routerEvents.emit('routeChangeStart', '/next', { shallow: false });
+        });
+
+        act(() => {
+            useSessionStore.setState({ hadClientSideNavigation: true, isPageLoading: true });
+        });
+
+        const loadingMessage = waitForAnnouncement('Page loading');
+
+        expect(loadingMessage).toBe('Page loading');
+        expect(document.title).toBe('Page loading');
+
+        advanceTimersBy(500);
+
+        expect(screen.getByRole('status')).toHaveTextContent('Page loading');
+    });
+
+    test('announces new page title once loading completes', () => {
+        renderAnnouncer();
+        advanceTimersBy(60);
+
+        act(() => {
+            routerEvents.emit('routeChangeStart', '/next', { shallow: false });
+        });
+
+        act(() => {
+            useSessionStore.setState({ hadClientSideNavigation: true, isPageLoading: true });
+        });
+        const loadingMessage = waitForAnnouncement('Page loading');
+        expect(loadingMessage).toBe('Page loading');
+        expect(document.title).toBe('Page loading');
+
+        act(() => {
+            useSessionStore.setState({ isPageLoading: false });
+        });
+
+        advanceTimersBy(80);
+
+        document.title = 'Product Detail - New Title';
+
+        const finalMessage = waitForAnnouncement('Product Detail - New Title');
+
+        expect(finalMessage).toContain('You are on Product Detail - New Title page');
+    });
+});

--- a/upgrade-notes/storefront_20250831_121500.md
+++ b/upgrade-notes/storefront_20250831_121500.md
@@ -1,0 +1,6 @@
+#### fix announcing page title for screen readers ([#4166](https://github.com/shopsys/shopsys/pull/4166))
+
+- re-enabled `RouteAccessibilityManager` + `RouteAnnouncer` and introduced a localized “Page loading” announcement so VoiceOver no longer speaks the stale title (sometimes)
+- `<RouteAnnouncer>` now waits for SeoMeta to finish, announces the loading state, then voices the final page title once; keep the new translations (`Page loading`) in sync across locales
+- added `vitest/components/Layout/RouteAnnouncer.test.tsx` to lock in the behaviour
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed issue that after announcing old title, the new one was never announced after. Now, it gets announced every time after next page is loaded.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-accessibility-voice-over-page-title-ssp-3490.odin.shopsys.cloud
  - https://cz.jm-accessibility-voice-over-page-title-ssp-3490.odin.shopsys.cloud
<!-- Replace -->
