### PR TITLE
updated transport and payment select for single option

### DIFF
--- a/project-base/storefront/components/Basic/Animations/AnimateCollapseDiv.tsx
+++ b/project-base/storefront/components/Basic/Animations/AnimateCollapseDiv.tsx
@@ -2,13 +2,9 @@ import { TIDs } from 'cypress/tids';
 import { HTMLMotionProps, m } from 'framer-motion';
 import { collapseExpandAnimation } from 'utils/animations/animationVariants';
 
-export const AnimateCollapseDiv: FC<HTMLMotionProps<'div'> & { tid?: TIDs; keyName?: string }> = ({
-    children,
-    className,
-    keyName,
-    tid,
-    ...props
-}) => (
+export const AnimateCollapseDiv: FC<
+    HTMLMotionProps<'div'> & { tid?: TIDs; keyName?: string; disableAnimation?: boolean }
+> = ({ children, className, keyName, tid, disableAnimation, ...props }) => (
     <m.div
         key={keyName}
         animate="open"
@@ -16,7 +12,7 @@ export const AnimateCollapseDiv: FC<HTMLMotionProps<'div'> & { tid?: TIDs; keyNa
         data-tid={tid}
         exit="closed"
         initial="closed"
-        variants={collapseExpandAnimation}
+        variants={disableAnimation ? undefined : collapseExpandAnimation}
         {...props}
     >
         {children}

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
@@ -54,7 +54,11 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                         <legend className="sr-only">{t('Choose transport type')}</legend>
                         <AnimatePresence initial={false}>
                             {!!transport && (
-                                <AnimateCollapseDiv className="relative !block" keyName="transport-selected">
+                                <AnimateCollapseDiv
+                                    className="relative !block"
+                                    disableAnimation={transports.length === 1 ? true : false}
+                                    keyName="transport-selected"
+                                >
                                     <TransportListItem
                                         isActive
                                         changeTransport={changeTransport}
@@ -68,7 +72,11 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
 
                         <AnimatePresence initial={false}>
                             {!transport && (
-                                <AnimateCollapseDiv className="relative !block" keyName="transport-list">
+                                <AnimateCollapseDiv
+                                    className="relative !block"
+                                    disableAnimation={transports.length === 1 ? true : false}
+                                    keyName="transport-list"
+                                >
                                     {transports.map((transportItem) => (
                                         <TransportListItem
                                             key={transportItem.uuid}
@@ -84,7 +92,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                 </ul>
 
                 <AnimatePresence initial={false}>
-                    {!!transport && (
+                    {!!transport && transports.length > 1 && (
                         <AnimateCollapseDiv className="relative !flex flex-col" keyName="transport-reset">
                             <ResetButton
                                 text={t('Change transport type')}
@@ -113,7 +121,11 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                             <legend className="sr-only">{t('Choose payment type')}</legend>
                             <AnimatePresence initial={false}>
                                 {!!payment && (
-                                    <AnimateCollapseDiv className="relative !block" keyName="payment-selected">
+                                    <AnimateCollapseDiv
+                                        className="relative !block"
+                                        disableAnimation={transport.payments.length === 1 ? true : false}
+                                        keyName="payment-selected"
+                                    >
                                         <PaymentListItem isActive changePayment={changePayment} payment={payment} />
                                     </AnimateCollapseDiv>
                                 )}
@@ -121,7 +133,11 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
 
                             <AnimatePresence initial={false}>
                                 {!payment && (
-                                    <AnimateCollapseDiv className="relative !block" keyName="payment-list">
+                                    <AnimateCollapseDiv
+                                        className="relative !block"
+                                        disableAnimation={transport.payments.length === 1 ? true : false}
+                                        keyName="payment-list"
+                                    >
                                         {transport.payments.map((paymentItem) => (
                                             <PaymentListItem
                                                 key={paymentItem.uuid}
@@ -135,7 +151,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                         </fieldset>
 
                         <AnimatePresence initial={false}>
-                            {payment !== null && (
+                            {payment !== null && transport.payments.length > 1 && (
                                 <AnimateCollapseDiv className="relative !flex flex-col" keyName="payment-reset">
                                     <ResetButton
                                         text={t('Change payment type')}

--- a/upgrade-notes/storefront_20250908_081304.md
+++ b/upgrade-notes/storefront_20250908_081304.md
@@ -1,0 +1,4 @@
+#### Transport and payment single-option ([#4177](https://github.com/shopsys/shopsys/pull/4177))
+
+- removed unnecessary reset button for transport and payment single-option
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Removed unnecessary reset button for transport and payment single-option.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2877-transport-and-payment-select.odin.shopsys.cloud
  - https://cz.tc-ssp-2877-transport-and-payment-select.odin.shopsys.cloud
<!-- Replace -->
