### PR TITLE
Add special article page (about) GTM type

### DIFF
--- a/docs/storefront/gtm/objects.md
+++ b/docs/storefront/gtm/objects.md
@@ -181,3 +181,52 @@ export type GtmShippingInfoType = {
   transportExtra: string[]; // array of extra transport details
 };
 ```
+
+## SPECIAL_ARTICLE_GTM_TYPES
+
+Configuration object that maps specific article slugs to their corresponding GTM page types. This is used for articles that require special GTM tracking beyond the default `article_detail` type.
+
+```ts
+export const SPECIAL_ARTICLE_GTM_TYPES = Object.freeze({
+  '/about-us': GtmPageType.about, // English "About Us" page
+  '/o-nas': GtmPageType.about,    // Czech "About Us" page
+} as const);
+```
+
+### Usage
+
+The configuration is used by `getSpecialArticleGtmType()` function to determine if an article slug corresponds to a special GTM page type:
+
+```ts
+const gtmType = getSpecialArticleGtmType('/about-us'); // Returns GtmPageType.about
+const gtmType = getSpecialArticleGtmType('/regular-article'); // Returns null
+```
+
+### Current Mappings
+
+| Article Slug | GTM Page Type | Description |
+|-------------|---------------|-------------|
+| `/about-us` | `about` | English "About Us" page |
+| `/o-nas` | `about` | Czech "About Us" page |
+
+### For Administrators
+
+⚠️ **Important**: When you change article slugs in the admin interface, you **must** contact your developer to update this configuration to maintain correct GTM tracking.
+
+#### Steps when changing article slugs:
+
+1. **Before changing** - Note down the current slug
+2. **After changing** - Contact developer with:
+   - Old slug (e.g., `/about-us`)
+   - New slug (e.g., `/about-company`)
+   - Required GTM type (e.g., `about`)
+
+### For Developers
+
+#### Adding new special article types:
+
+1. Add the GTM page type to `GtmPageType` enum (if not already present)
+2. Add the mapping to `SPECIAL_ARTICLE_GTM_TYPES` in `gtm/types/objects.ts`
+3. Test the integration on both domains/languages
+4. Update this documentation
+

--- a/project-base/storefront/gtm/enums/GtmPageType.ts
+++ b/project-base/storefront/gtm/enums/GtmPageType.ts
@@ -15,6 +15,7 @@ export enum GtmPageType {
     flag_detail = 'flag detail',
     brand_detail = 'brand detail',
     article_detail = 'article detail',
+    about = 'about',
     payment_fail = 'payment fail',
     payment_success = 'payment success',
     payment_in_process = 'payment in process',

--- a/project-base/storefront/gtm/types/objects.ts
+++ b/project-base/storefront/gtm/types/objects.ts
@@ -5,6 +5,11 @@ import { GtmPageType } from 'gtm/enums/GtmPageType';
 import { GtmUserStatus } from 'gtm/enums/GtmUserStatus';
 import { GtmUserType } from 'gtm/enums/GtmUserType';
 
+export const SPECIAL_ARTICLE_GTM_TYPES = Object.freeze({
+    '/about-us': GtmPageType.about,
+    '/o-nas': GtmPageType.about,
+} as const);
+
 export type GtmReviewConsentsType = {
     seznam: boolean;
     google: boolean;

--- a/project-base/storefront/gtm/utils/getGtmPageInfoTypeForFriendlyUrl.ts
+++ b/project-base/storefront/gtm/utils/getGtmPageInfoTypeForFriendlyUrl.ts
@@ -5,12 +5,13 @@ import { TypeBrandDetailFragment } from 'graphql/requests/brands/fragments/Brand
 import { TypeCategoryDetailFragment } from 'graphql/requests/categories/fragments/CategoryDetailFragment.generated';
 import { GtmPageType } from 'gtm/enums/GtmPageType';
 import {
-    GtmPageInfoType,
-    GtmPageInfoInterface,
-    GtmCategoryDetailPageInfoType,
     GtmBlogArticleDetailPageInfoType,
     GtmBrandDetailPageInfoType,
+    GtmCategoryDetailPageInfoType,
+    GtmPageInfoInterface,
+    GtmPageInfoType,
 } from 'gtm/types/objects';
+import { getSpecialArticleGtmType } from 'gtm/utils/getSpecialArticleGtmTypes';
 import { FriendlyUrlPageType } from 'types/friendlyUrl';
 
 export const getGtmPageInfoTypeForFriendlyUrl = (
@@ -33,9 +34,11 @@ export const getGtmPageInfoTypeForFriendlyUrl = (
         case 'Store':
             pageInfo.type = GtmPageType.store_detail;
             break;
-        case 'ArticleSite':
-            pageInfo.type = GtmPageType.article_detail;
+        case 'ArticleSite': {
+            const specialGtmType = getSpecialArticleGtmType(friendlyUrlPageData.slug);
+            pageInfo.type = specialGtmType ?? GtmPageType.article_detail;
             break;
+        }
         case 'BlogArticle':
             pageInfo = getPageInfoForBlogArticleDetailPage(pageInfo, friendlyUrlPageData);
             break;

--- a/project-base/storefront/gtm/utils/getSpecialArticleGtmTypes.ts
+++ b/project-base/storefront/gtm/utils/getSpecialArticleGtmTypes.ts
@@ -1,0 +1,15 @@
+import { GtmPageType } from 'gtm/enums/GtmPageType';
+import { SPECIAL_ARTICLE_GTM_TYPES } from 'gtm/types/objects';
+
+/**
+ * Determines if an article slug corresponds to a special GTM page type.
+ *
+ * @param slug - The article slug to check (e.g., '/about-us', '/o-nas')
+ * @returns The corresponding GTM page type if found, otherwise null
+ */
+export const getSpecialArticleGtmType = (slug: string): GtmPageType | null => {
+    if (slug && typeof slug === 'string' && slug in SPECIAL_ARTICLE_GTM_TYPES) {
+        return SPECIAL_ARTICLE_GTM_TYPES[slug as keyof typeof SPECIAL_ARTICLE_GTM_TYPES];
+    }
+    return null;
+};

--- a/project-base/storefront/vitest/gtm/specialArticleGtmTypes.test.ts
+++ b/project-base/storefront/vitest/gtm/specialArticleGtmTypes.test.ts
@@ -1,0 +1,61 @@
+import { GtmPageType } from 'gtm/enums/GtmPageType';
+import { SPECIAL_ARTICLE_GTM_TYPES } from 'gtm/types/objects';
+import { getSpecialArticleGtmType } from 'gtm/utils/getSpecialArticleGtmTypes';
+import { describe, expect, test } from 'vitest';
+
+describe('specialArticleGtmTypes', () => {
+    describe('SPECIAL_ARTICLE_GTM_TYPES configuration', () => {
+        test('should contain mappings for about us pages in different languages', () => {
+            expect(SPECIAL_ARTICLE_GTM_TYPES['/about-us']).toBe(GtmPageType.about);
+            expect(SPECIAL_ARTICLE_GTM_TYPES['/o-nas']).toBe(GtmPageType.about);
+        });
+
+        test('should be a frozen object to prevent accidental modifications', () => {
+            expect(() => {
+                (SPECIAL_ARTICLE_GTM_TYPES as any)['/test'] = GtmPageType.other;
+            }).toThrow();
+        });
+    });
+
+    describe('getSpecialArticleGtmType', () => {
+        test('should return correct GTM type for English about us page', () => {
+            const result = getSpecialArticleGtmType('/about-us');
+            expect(result).toBe(GtmPageType.about);
+        });
+
+        test('should return correct GTM type for Czech about us page', () => {
+            const result = getSpecialArticleGtmType('/o-nas');
+            expect(result).toBe(GtmPageType.about);
+        });
+
+        test('should return null for unknown article slugs', () => {
+            const result = getSpecialArticleGtmType('/unknown-article');
+            expect(result).toBeNull();
+        });
+
+        test('should return null for empty slug', () => {
+            const result = getSpecialArticleGtmType('');
+            expect(result).toBeNull();
+        });
+
+        test('should return null for non-string parameters', () => {
+            const result1 = getSpecialArticleGtmType(null as any);
+            const result2 = getSpecialArticleGtmType(undefined as any);
+            const result3 = getSpecialArticleGtmType(123 as any);
+
+            expect(result1).toBeNull();
+            expect(result2).toBeNull();
+            expect(result3).toBeNull();
+        });
+
+        test('should handle case-sensitive slugs correctly', () => {
+            const result = getSpecialArticleGtmType('/About-Us');
+            expect(result).toBeNull(); // Should be case-sensitive
+        });
+
+        test('should handle slugs with trailing slashes', () => {
+            const result = getSpecialArticleGtmType('/about-us/');
+            expect(result).toBeNull(); // Exact match required
+        });
+    });
+});

--- a/upgrade-notes/storefront_20250909_142418.md
+++ b/upgrade-notes/storefront_20250909_142418.md
@@ -1,0 +1,13 @@
+#### Add special article page (about) GTM type ([#4184](https://github.com/shopsys/shopsys/pull/4184))
+
+- added new `about` GTM page type for special article tracking instead of generic `article_detail`
+- added `SPECIAL_ARTICLE_GTM_TYPES` configuration object in `gtm/types/objects.ts` mapping article slugs to GTM types
+    - configured default mappings: `/about-us` (EN) and `/o-nas` (CS) → `GtmPageType.about`
+    - configuration is immutable (Object.freeze) to prevent accidental modifications
+- added `getSpecialArticleGtmType()` utility function
+- modified `getGtmPageInfoTypeForFriendlyUrl()` to check article slugs against configuration before falling back to default `article_detail` type
+- added comprehensive test coverage and documentation for administrators and developers
+
+**⚠️ CRITICAL: Project developers must update `SPECIAL_ARTICLE_GTM_TYPES` configuration when administrators change article slugs in the admin interface to maintain correct GTM tracking. The configuration maps exact slug matches to GTM page types.**
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
To track events on about us page, new GTM type was introduced. However, since the about us page is dynamic article page, the url and other properties can be edited by administrators. Therefore, the responsibility to update the url slug of GTM type switching is on each project developer.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-about-us-gtm-type.odin.shopsys.cloud
  - https://cz.jm-about-us-gtm-type.odin.shopsys.cloud
<!-- Replace -->
