### PR TITLE
improve annotations in (Image/UploadedFile)Config + Loader classes to fix phpstan errors

### DIFF
--- a/packages/framework/src/Component/Image/Config/ImageConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfig.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageTypeNotFoundEx
 class ImageConfig
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[]
+     * @var array<class-string, \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig>
      */
     protected array $imageEntityConfigsByClass;
 

--- a/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
@@ -17,7 +17,7 @@ use Symfony\Component\Yaml\Parser;
 class ImageConfigLoader
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[]
+     * @var array<class-string, \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig>
      */
     protected array $foundEntityConfigs;
 

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfig.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfig.php
@@ -10,7 +10,7 @@ use Shopsys\FrameworkBundle\Component\UploadedFile\Config\Exception\UploadedFile
 class UploadedFileConfig implements UploadedFileConfigInterface
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig[] $uploadedFileEntityConfigsByClass
+     * @param array<class-string, \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig> $uploadedFileEntityConfigsByClass
      */
     public function __construct(protected readonly array $uploadedFileEntityConfigsByClass)
     {

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigLoader.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigLoader.php
@@ -17,7 +17,7 @@ use Symfony\Component\Yaml\Parser;
 class UploadedFileConfigLoader
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig[]
+     * @var array<class-string, \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig>
      */
     protected array $uploadedFileEntityConfigsByClass;
 


### PR DESCRIPTION
#### Description, the reason for the PR
PHPStan was not familiar with the keys of the referenced arrays, so it reported issues, see e.g. https://github.com/shopsys/shopsys/actions/runs/17613751938/job/50041852465?pr=4153#step:4:460 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-phpstan.odin.shopsys.cloud
  - https://cz.rv-fix-phpstan.odin.shopsys.cloud
<!-- Replace -->
