### PR TITLE
fixed warnings in storefront Dockerfile

### DIFF
--- a/project-base/storefront/docker/Dockerfile
+++ b/project-base/storefront/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine3.17 AS base
 RUN corepack enable
 RUN corepack prepare --activate pnpm@9.6.0
 
-FROM base as dependencies
+FROM base AS dependencies
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
@@ -20,9 +20,9 @@ ARG SENTRY_ORG
 ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_PROJECT
 
-ENV APP_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
-ENV SENTRY_RELEASE $SENTRY_RELEASE
+ENV APP_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 RUN pnpm run build
 RUN pnpm prune --prod
@@ -36,8 +36,8 @@ USER node
 ARG APP_DIR=/home/node/app
 WORKDIR $APP_DIR
 
-ENV APP_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV APP_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY --from=dependencies --chown=node:node /tmp/build $APP_DIR
 

--- a/project-base/storefront/docker/ci.Dockerfile
+++ b/project-base/storefront/docker/ci.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.17 as development
+FROM node:20-alpine3.17 AS development
 
 RUN corepack enable
 RUN corepack prepare --activate pnpm@9.0.5
@@ -6,8 +6,8 @@ RUN corepack prepare --activate pnpm@9.0.5
 ARG APP_DIR=/home/node/app
 WORKDIR $APP_DIR
 
-ENV APP_ENV development
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV APP_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY docker/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.17 as development
+FROM node:20-alpine3.17 AS development
 
 RUN corepack enable
 RUN corepack prepare --activate pnpm@9.6.0
@@ -15,8 +15,8 @@ RUN if [[ -n "$node_uid" && "$node_uid" -ne 1000 ]]; then usermod -u $node_uid n
 USER node
 WORKDIR $APP_DIR
 
-ENV APP_ENV development
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV APP_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY docker/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/upgrade-notes/backend_20250910_185013.md
+++ b/upgrade-notes/backend_20250910_185013.md
@@ -1,0 +1,3 @@
+#### fix warnings in storefront Dockerfiles ([#4188](https://github.com/shopsys/shopsys/pull/4188))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Docker no longer warns about deprecated usage of certain instructions.

List of checks - https://docs.docker.com/reference/build-checks/
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-dockerfiles-fix.odin.shopsys.cloud
  - https://cz.mg-dockerfiles-fix.odin.shopsys.cloud
<!-- Replace -->
