### PR TITLE
updated scroll above heading in orders and complaints in customer layout

### DIFF
--- a/project-base/storefront/components/Forms/validationRules.ts
+++ b/project-base/storefront/components/Forms/validationRules.ts
@@ -79,7 +79,7 @@ export const validateStreet = (t: Translate): Schema => {
     return Yup.string()
         .required(t('Please enter street'))
         .matches(
-            /^[a-zA-Z].*\s\d+(\/\d+)?[a-zA-Z]?$|^\d+(\/\d+)?[a-zA-Z]?\s.*[a-zA-Z]$/,
+            /^[\u00C0-\u017Fa-zA-Z].*\s\d+(\/\d+)?[\u00C0-\u017Fa-zA-Z]?$|^\d+(\/\d+)?[\u00C0-\u017Fa-zA-Z]?\s.*[\u00C0-\u017Fa-zA-Z]$/,
             t('Please enter a valid street. Examples: Street 123, Street 123/4'),
         )
         .max(

--- a/project-base/storefront/components/Layout/CustomerLayout.tsx
+++ b/project-base/storefront/components/Layout/CustomerLayout.tsx
@@ -3,12 +3,16 @@ import { VerticalStack } from './VerticalStack/VerticalStack';
 import { UserNavigation } from 'components/Blocks/UserNavigation/UserNavigation';
 import { CommonLayout, CommonLayoutProps } from 'components/Layout/CommonLayout';
 import { Webline } from 'components/Layout/Webline/Webline';
+import { PaginationProvider } from 'components/providers/PaginationProvider';
+import { useRef } from 'react';
 
 type CustomerLayoutProps = {
     pageHeading?: string;
 } & CommonLayoutProps;
 
 export const CustomerLayout: FC<CustomerLayoutProps> = ({ pageHeading, children, breadcrumbs, ...props }) => {
+    const paginationScrollTargetRef = useRef<HTMLHeadingElement>(null);
+
     return (
         <CommonLayout {...props}>
             <Breadcrumbs key="breadcrumb" breadcrumbs={breadcrumbs ?? []} type={props.breadcrumbsType} />
@@ -18,8 +22,14 @@ export const CustomerLayout: FC<CustomerLayoutProps> = ({ pageHeading, children,
                     <UserNavigation />
 
                     <VerticalStack gap="sm">
-                        {pageHeading && <h1>{pageHeading}</h1>}
-                        {children}
+                        <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
+                            {pageHeading && (
+                                <h1 className="scroll-mt-4" ref={paginationScrollTargetRef}>
+                                    {pageHeading}
+                                </h1>
+                            )}
+                            {children}
+                        </PaginationProvider>
                     </VerticalStack>
                 </div>
             </Webline>

--- a/project-base/storefront/components/Pages/Customer/Complaints/ComplaintsContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/Complaints/ComplaintsContent.tsx
@@ -2,11 +2,9 @@ import { ComplaintItem } from './ComplaintItem';
 import { InfoIcon } from 'components/Basic/Icon/InfoIcon';
 import { Pagination } from 'components/Blocks/Pagination/Pagination';
 import { SkeletonModuleCustomerComplaints } from 'components/Blocks/Skeleton/SkeletonModuleCustomerComplaints';
-import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { DEFAULT_ORDERS_SIZE } from 'config/constants';
 import { TypeComplaintDetailFragment } from 'graphql/requests/complaints/fragments/ComplaintDetailFragment.generated';
 import useTranslation from 'next-translate/useTranslation';
-import { useRef } from 'react';
 
 type ComplaintsContentProps = {
     areComplaintsFetching: boolean;
@@ -21,7 +19,6 @@ export const ComplaintsContent: FC<ComplaintsContentProps> = ({
     totalCount,
     hasNextPage,
 }) => {
-    const paginationScrollTargetRef = useRef<HTMLDivElement>(null);
     const { t } = useTranslation();
 
     if (!items?.length && !areComplaintsFetching) {
@@ -34,7 +31,7 @@ export const ComplaintsContent: FC<ComplaintsContentProps> = ({
     }
 
     return (
-        <div className="scroll-mt-5" ref={paginationScrollTargetRef}>
+        <>
             {areComplaintsFetching ? (
                 <SkeletonModuleCustomerComplaints />
             ) : (
@@ -43,9 +40,7 @@ export const ComplaintsContent: FC<ComplaintsContentProps> = ({
                 </div>
             )}
 
-            <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
-                <Pagination hasNextPage={hasNextPage} pageSize={DEFAULT_ORDERS_SIZE} totalCount={totalCount || 0} />
-            </PaginationProvider>
-        </div>
+            <Pagination hasNextPage={hasNextPage} pageSize={DEFAULT_ORDERS_SIZE} totalCount={totalCount || 0} />
+        </>
     );
 };

--- a/project-base/storefront/components/Pages/Customer/Orders/OrdersContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/Orders/OrdersContent.tsx
@@ -2,11 +2,9 @@ import { OrderItem } from './OrderItem';
 import { InfoIcon } from 'components/Basic/Icon/InfoIcon';
 import { Pagination } from 'components/Blocks/Pagination/Pagination';
 import { SkeletonModuleCustomerOrders } from 'components/Blocks/Skeleton/SkeletonModuleCustomerOrders';
-import { PaginationProvider } from 'components/providers/PaginationProvider';
 import { DEFAULT_ORDERS_SIZE } from 'config/constants';
 import { TypeListedOrderFragment } from 'graphql/requests/orders/fragments/ListedOrderFragment.generated';
 import useTranslation from 'next-translate/useTranslation';
-import { useRef } from 'react';
 import { useAddOrderItemsToCart } from 'utils/cart/useAddOrderItemsToCart';
 
 type OrdersContentProps = {
@@ -17,7 +15,6 @@ type OrdersContentProps = {
 };
 
 export const OrdersContent: FC<OrdersContentProps> = ({ areOrdersFetching, orders, totalCount, hasNextPage }) => {
-    const paginationScrollTargetRef = useRef<HTMLDivElement>(null);
     const addOrderItemsToEmptyCart = useAddOrderItemsToCart();
     const { t } = useTranslation();
 
@@ -31,7 +28,7 @@ export const OrdersContent: FC<OrdersContentProps> = ({ areOrdersFetching, order
     }
 
     return (
-        <div className="scroll-mt-5" ref={paginationScrollTargetRef}>
+        <>
             {areOrdersFetching ? (
                 <SkeletonModuleCustomerOrders />
             ) : (
@@ -47,9 +44,7 @@ export const OrdersContent: FC<OrdersContentProps> = ({ areOrdersFetching, order
                 </div>
             )}
 
-            <PaginationProvider paginationScrollTargetRef={paginationScrollTargetRef}>
-                <Pagination hasNextPage={hasNextPage} pageSize={DEFAULT_ORDERS_SIZE} totalCount={totalCount || 0} />
-            </PaginationProvider>
-        </div>
+            <Pagination hasNextPage={hasNextPage} pageSize={DEFAULT_ORDERS_SIZE} totalCount={totalCount || 0} />
+        </>
     );
 };

--- a/project-base/storefront/components/providers/PaginationProvider.tsx
+++ b/project-base/storefront/components/providers/PaginationProvider.tsx
@@ -2,12 +2,12 @@ import { createContext, useContext } from 'react';
 import { RefObject } from 'react';
 
 type PaginationContextType = {
-    paginationScrollTargetRef: RefObject<HTMLDivElement> | null;
+    paginationScrollTargetRef: RefObject<HTMLElement> | null;
 };
 export const PaginationContext = createContext<PaginationContextType | null>(null);
 
 type PaginationProviderProps = {
-    paginationScrollTargetRef: RefObject<HTMLDivElement> | null;
+    paginationScrollTargetRef: RefObject<HTMLElement> | null;
 };
 
 export const PaginationProvider: FC<PaginationProviderProps> = ({ paginationScrollTargetRef, children }) => {

--- a/project-base/storefront/utils/ui/useScrollRestoration.ts
+++ b/project-base/storefront/utils/ui/useScrollRestoration.ts
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { RefObject, useEffect, useRef } from 'react';
 
 type MutuallyExcludedProps = {
-    scrollTargetRef: RefObject<HTMLDivElement> | null;
+    scrollTargetRef: RefObject<HTMLElement> | null;
     scrollY: number;
 };
 

--- a/upgrade-notes/storefront_20250912_063228.md
+++ b/upgrade-notes/storefront_20250912_063228.md
@@ -1,0 +1,4 @@
+#### Fix customer orders/complaints pagination scroll ([#4189](https://github.com/shopsys/shopsys/pull/4189))
+
+- pagination scroll destination is right above heading in Customer Layout for Complaints and Orders
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Pagination scroll destination is right above heading in Customer Layout for Complaints and Orders.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3578-scroll-above-heading.odin.shopsys.cloud
  - https://cz.tc-ssp-3578-scroll-above-heading.odin.shopsys.cloud
<!-- Replace -->
