### PR TITLE
mirror to gitlab is now initiated by github action

### DIFF
--- a/project-base/.github/workflows/initiate_mirror.yml
+++ b/project-base/.github/workflows/initiate_mirror.yml
@@ -1,0 +1,33 @@
+name: Initiate mirror to GitLab
+on:
+    push:
+        branches:
+            - '[0-9]+.[0-9]+'
+            - 'alpha'
+jobs:
+    trigger_gitlab_pipeline:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Trigger GitLab Mirror Pipeline
+                run: |
+                    echo "Triggering GitLab mirror pipeline..."
+                    response=$(curl -s -X POST \
+                      -F token=$GITLAB_TRIGGER_TOKEN \
+                      -F ref=devel \
+                      -F "variables[MIRROR_ONLY]=true" \
+                      $GITLAB_TRIGGER_URL)
+                    if [ $? -ne 0 ]; then
+                        echo "❌ Failed to trigger pipeline"
+                        exit 1
+                    fi
+                    status=$(echo "$response" | jq -r '.status // "unknown"')
+                    if [ "$status" = "created" ]; then
+                        echo "✅ Pipeline triggered successfully"
+                    else
+                        echo "❌ Pipeline trigger failed with status: $status"
+                        echo "Response: $response"
+                        exit 1
+                    fi
+                env:
+                    GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+                    GITLAB_TRIGGER_URL: ${{ vars.GITLAB_TRIGGER_URL }}


### PR DESCRIPTION
#### Description, the reason for the PR

Mirroring Github -> Gitlab migrated from webhook to Github Actions. 
Webhook always sends the whole payload, which Gitlab tries to use as an ENV variable. If a payload is bigger than 128kB, mirroring failed on Gitlab because it's not possible to create such a big variable.

Github Action mirror examples:

Example of working mirror trigger:
<img width="501" height="230" alt="Snímek obrazovky 2025-09-15 v 15 37 42" src="https://github.com/user-attachments/assets/14e98eb4-3c26-4b50-9394-b7dc1906f3b6" />

Example of failed mirror trigger:
<img width="501" height="343" alt="Snímek obrazovky 2025-09-15 v 15 34 41" src="https://github.com/user-attachments/assets/a8d2d7c0-ce59-4b31-bee4-5304fee324bf" />

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-trigger-mirror-change.odin.shopsys.cloud
  - https://cz.mg-trigger-mirror-change.odin.shopsys.cloud
<!-- Replace -->
