### PR TITLE
updated filled email in order after log

### DIFF
--- a/project-base/storefront/utils/user/useCurrentUserContactInformation.ts
+++ b/project-base/storefront/utils/user/useCurrentUserContactInformation.ts
@@ -55,6 +55,11 @@ const mergeContactInformation = (
             continue;
         }
 
+        const isEmailField = key === 'email';
+        if (isEmailField && !isUndefined && !isEmptyString) {
+            continue;
+        }
+
         const isFilledFromStorefront = !!contactInformationFromStore[key as keyof ContactInformation];
 
         if (((isUndefined || isEmptyString) && key in contactInformationFromApi) || isFilledFromStorefront) {
@@ -106,6 +111,7 @@ const mapCurrentCustomerContactInformationApiData = (
 
     return {
         ...apiCurrentCustomerUserData,
+        email: apiCurrentCustomerUserData.email,
         firstName: apiCurrentCustomerUserData.firstName ?? '',
         lastName: apiCurrentCustomerUserData.lastName ?? '',
         street: apiCurrentCustomerUserData.street ?? '',

--- a/upgrade-notes/storefront_20250925_105527.md
+++ b/upgrade-notes/storefront_20250925_105527.md
@@ -1,0 +1,4 @@
+#### Filled email in order process ([#4199](https://github.com/shopsys/shopsys/pull/4199))
+
+- this update fixes an issue where, during the order process, if a public user entered an email, then navigated to the homepage and logged in with a different email, the previously entered email would still appear in the disabled email input under contact information
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
This update fixes an issue where, during the order process, if a public user entered an email, then navigated to the homepage and logged in with a different email, the previously entered email would still appear in the disabled email input under contact information.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3583-fix-email-in-order.odin.shopsys.cloud
  - https://cz.tc-ssp-3583-fix-email-in-order.odin.shopsys.cloud
<!-- Replace -->
