### PR TITLE
Fix payment transactions ordering in Order entity

### DIFF
--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -323,6 +323,7 @@ class Order
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransaction>
      * @ORM\OneToMany(targetEntity="Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransaction", mappedBy="order", cascade={"persist"})
+     * @ORM\OrderBy({"id" = "ASC"})
      */
     protected $paymentTransactions;
 


### PR DESCRIPTION
#### Description, the reason for the PR
Payment transactions were not ordered, causing unpredictable results when accessing `$paymentTransactions`.

Added OrderBy annotation to sort payment transactions by ID in ascending order.

This ensures consistent ordering when accessing payment transaction collections.

#### Fixes issues

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
