### PR TITLE
Name is no longer mandatory for Category, Blog Category and Blog Article

### DIFF
--- a/packages/administration/templates/content/blog/article/listGrid.html.twig
+++ b/packages/administration/templates/content/blog/article/listGrid.html.twig
@@ -1,5 +1,9 @@
 {% extends '@ShopsysAdministration/datagrid/grid.html.twig' %}
 
+{% block grid_value_cell_id_name %}
+    {{ value|nameWithFallbackOnEmpty }}
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No blog articles found.'|trans }}
 {% endblock %}

--- a/packages/administration/templates/content/blog/category/list.html.twig
+++ b/packages/administration/templates/content/blog/category/list.html.twig
@@ -16,24 +16,42 @@
 {% block main_content %}
     {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainFilterController::domainFilterTabsAction', { namespace: domainFilterNamespace })) }}
 
-    {% macro blogCategoryTreeItem(blogCategoriesWithPreloadedChildren, isFirstLevel, isForAllDomains) %}
+    {% macro blogCategoryTreeItem(blogCategoriesWithPreloadedChildren, isFirstLevel, isForAllDomains, visibilityOfBlogCategoriesIndexedById) %}
         {% import _self as self %}
         <ul class="js-category-tree-items js-protect-root {{ isFirstLevel ? 'tree' : 'tree-group' }}">
             {% for blogCategoryWithPreloadedChildren in blogCategoriesWithPreloadedChildren %}
-                <li class="js-category-tree-item tree-item" id="js-category-tree-{{ blogCategoryWithPreloadedChildren.blogCategory.id }}">
+                {% set blogCategoryId = blogCategoryWithPreloadedChildren.blogCategory.id %}
+                <li class="js-category-tree-item tree-item" id="js-category-tree-{{ blogCategoryId }}">
                     <div class="tree-item-content js-category-tree-item-line">
                         <div class="js-category-tree-item-line js-category-tree-item-handle tree-item-label text-truncate{% if isForAllDomains %} cursor-grab{% endif %}">
-                            {{ blogCategoryWithPreloadedChildren.blogCategory.name }}
+                            {{ blogCategoryWithPreloadedChildren.blogCategory.name|nameWithFallbackOnEmpty }}
                         </div>
 
                         <div class="tree-item-actions">
-                            <a href="{{ url('admin_blogcategory_edit', {id: blogCategoryWithPreloadedChildren.blogCategory.id}) }}"
+                            {% if visibilityOfBlogCategoriesIndexedById is not null %}
+                                {% if visibilityOfBlogCategoriesIndexedById[blogCategoryId] is defined %}
+                                    {% if visibilityOfBlogCategoriesIndexedById[blogCategoryId] is same as('all') %}
+                                        <span class="text-success" title="{{ 'Blog category is visible on all domains'|trans }}">
+                                            {{ ux_icon('visible') }}
+                                        </span>
+                                    {% else %}
+                                        <span class="text-warning" title="{{ 'Blog category is visible on some domains'|trans }}">
+                                            {{ ux_icon('visible') }}
+                                        </span>
+                                    {% endif %}
+                                {% else %}
+                                    <span title="{{ 'Blog category is hidden on all domains'|trans }}">
+                                        {{ ux_icon('invisible') }}
+                                    </span>
+                                {% endif %}
+                            {% endif %}
+                            <a href="{{ url('admin_blogcategory_edit', {id: blogCategoryId}) }}"
                                class="link-secondary"
                             >{{ ux_icon('pencil') }}</a>
 
                             {% set csrfTokenId = constant('Shopsys\\FrameworkBundle\\Component\\Router\\Security\\RouteCsrfProtector::CSRF_TOKEN_ID_PREFIX') ~ 'admin_blogcategory_delete' %}
                         {% set blogCategoryDeleteUrl = url('admin_blogcategory_delete', {
-                            id: blogCategoryWithPreloadedChildren.blogCategory.id,
+                            id: blogCategoryId,
                             (constant('Shopsys\\FrameworkBundle\\Component\\Router\\Security\\RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER')): csrf_token(csrfTokenId)
                         }) %}
                         {% if blogCategoryWithPreloadedChildren.blogCategory.level is not same as(0) %}
@@ -46,7 +64,7 @@
                         </div>
                     </div>
 
-                    {{ self.blogCategoryTreeItem(blogCategoryWithPreloadedChildren.children, false, isForAllDomains) }}
+                    {{ self.blogCategoryTreeItem(blogCategoryWithPreloadedChildren.children, false, isForAllDomains, visibilityOfBlogCategoriesIndexedById) }}
                 </li>
             {% endfor %}
         </ul>
@@ -56,7 +74,7 @@
         <div class="card-body">
             {% if isForAllDomains %}
                 <div id="js-category-tree-sorting">
-                    {{ self.blogCategoryTreeItem(blogCategoriesWithPreloadedChildren, true, isForAllDomains) }}
+                    {{ self.blogCategoryTreeItem(blogCategoriesWithPreloadedChildren, true, isForAllDomains, visibilityOfBlogCategoriesIndexedById) }}
                 </div>
 
                 {% if can_edit(constant('Shopsys\\FrameworkBundle\\Component\\Security\\Role\\AdminRoleConstant::ROLE_BLOG_CATEGORY')) %}
@@ -79,7 +97,7 @@
                     {{ 'It is not possible to update order and indentation of blog categories on specific domain tab. Please go to the category detail or blog category overview for all domains'|trans }}
                 </div>
 
-                {{ self.blogCategoryTreeItem(blogCategoriesWithPreloadedChildren, true, isForAllDomains) }}
+                {{ self.blogCategoryTreeItem(blogCategoriesWithPreloadedChildren, true, isForAllDomains, visibilityOfBlogCategoriesIndexedById) }}
             {% endif %}
         </div>
     </div>

--- a/packages/administration/templates/content/category/list.html.twig
+++ b/packages/administration/templates/content/category/list.html.twig
@@ -27,7 +27,7 @@
                 <li class="js-category-tree-item tree-item" id="js-category-tree-{{ categoryWithPreloadedChildren.category.id }}">
                     <div class="tree-item-content{{ disabledFormFields ? '' : ' js-category-tree-item-line' }}">
                         <div class="js-category-tree-item-line js-category-tree-item-handle tree-item-label text-truncate{% if isForAllDomains %} cursor-grab{% endif %}">
-                            {{ categoryWithPreloadedChildren.category.name }}
+                            {{ categoryWithPreloadedChildren.category.name|nameWithFallbackOnEmpty }}
                         </div>
 
                         <div class="tree-item-actions">

--- a/packages/administration/templates/content/product/listGrid.html.twig
+++ b/packages/administration/templates/content/product/listGrid.html.twig
@@ -33,7 +33,7 @@
         </span>
     {% endif %}
     {% block grid_value_cell_id_name_product_name %}
-        <a href="{{ url('admin_product_edit', { id: row.id }) }}">{{ row.name|productListDisplayNameByName }}</a>
+        <a href="{{ url('admin_product_edit', { id: row.id }) }}">{{ row.name|nameWithFallbackOnEmpty }}</a>
     {% endblock %}
 {% endblock %}
 

--- a/packages/administration/templates/content/productPicker/listGrid.html.twig
+++ b/packages/administration/templates/content/productPicker/listGrid.html.twig
@@ -3,7 +3,7 @@
 {% block grid_action_cell_type_edit %}{% endblock %}
 
 {% block grid_value_cell_id_name_product_name %}
-    {{ row.name|productListDisplayNameByName }}
+    {{ row.name|nameWithFallbackOnEmpty }}
 {% endblock %}
 
 {% block grid_value_cell_id_select %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -226,6 +226,15 @@ msgstr "Rubriky blogu"
 msgid "Blog category"
 msgstr "Rubrika blogu"
 
+msgid "Blog category is hidden on all domains"
+msgstr "Rubrika blogu je skrytá na všech doménách"
+
+msgid "Blog category is visible on all domains"
+msgstr "Rubrika blogu je viditelná na všech doménách"
+
+msgid "Blog category is visible on some domains"
+msgstr "Rubrika blogu je viditelná na některých doménách"
+
 msgid "Brand"
 msgstr "Značka"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -226,6 +226,15 @@ msgstr ""
 msgid "Blog category"
 msgstr ""
 
+msgid "Blog category is hidden on all domains"
+msgstr ""
+
+msgid "Blog category is visible on all domains"
+msgstr ""
+
+msgid "Blog category is visible on some domains"
+msgstr ""
+
 msgid "Brand"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -226,6 +226,15 @@ msgstr "Blogové kategórie"
 msgid "Blog category"
 msgstr "Blogová kategória"
 
+msgid "Blog category is hidden on all domains"
+msgstr "Kategória blogu je skrytá na všetkých doménach"
+
+msgid "Blog category is visible on all domains"
+msgstr "Kategória blogu je viditeľná na všetkých doménach"
+
+msgid "Blog category is visible on some domains"
+msgstr "Kategória blogu je viditeľná na niektorých doménach"
+
 msgid "Brand"
 msgstr "Značka"
 

--- a/packages/framework/src/Controller/Admin/BlogArticleController.php
+++ b/packages/framework/src/Controller/Admin/BlogArticleController.php
@@ -22,6 +22,7 @@ use Shopsys\FrameworkBundle\Model\Article\Exception\ArticleNotFoundException;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleDataFactory;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleFacade;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleGridFactory;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -36,6 +37,7 @@ class BlogArticleController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Component\ConfirmDelete\ConfirmDeleteResponseFactory $confirmDeleteResponseFactory
      * @param \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleGridFactory $blogArticleGridFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly BlogArticleFacade $blogArticleFacade,
@@ -44,6 +46,7 @@ class BlogArticleController extends AdminBaseController
         protected readonly ConfirmDeleteResponseFactory $confirmDeleteResponseFactory,
         protected readonly BlogArticleGridFactory $blogArticleGridFactory,
         protected readonly AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -65,6 +68,7 @@ class BlogArticleController extends AdminBaseController
         $queryBuilder = $this->blogArticleFacade->getQueryBuilderForQuickSearch(
             $selectedDomainId,
             $quickSearchForm->getData(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
         );
 
         $grid = $this->blogArticleGridFactory->create($queryBuilder);

--- a/packages/framework/src/Controller/Admin/BlogCategoryController.php
+++ b/packages/framework/src/Controller/Admin/BlogCategoryController.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Nette\Utils\Json;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanCreate;
@@ -34,6 +35,7 @@ class BlogCategoryController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
         protected readonly BlogCategoryFacade $blogCategoryFacade,
@@ -41,6 +43,7 @@ class BlogCategoryController extends AdminBaseController
         protected readonly BreadcrumbOverrider $breadcrumbOverrider,
         protected readonly AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade,
         protected readonly Localization $localization,
+        protected readonly Domain $domain,
     ) {
     }
 
@@ -153,6 +156,7 @@ class BlogCategoryController extends AdminBaseController
             'blogCategoriesWithPreloadedChildren' => $blogCategoriesWithPreloadedChildren,
             'isForAllDomains' => ($selectedDomainId === null),
             'domainFilterNamespace' => $domainFilterNamespace,
+            'visibilityOfBlogCategoriesIndexedById' => $selectedDomainId === null ? $this->getVisibleBlogCategoryIdsForAllDomains() : null,
         ]);
     }
 
@@ -228,5 +232,15 @@ class BlogCategoryController extends AdminBaseController
         }
 
         return $this->json($blogCategoriesData);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getVisibleBlogCategoryIdsForAllDomains(): array
+    {
+        $domainsCount = count($this->domain->getAll());
+
+        return $this->blogCategoryFacade->getVisibilityOfBlogCategoriesIndexedById($domainsCount);
     }
 }

--- a/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
@@ -170,9 +170,7 @@ final class BlogArticleFormType extends AbstractType
 
         $builderSettingsGroup
             ->add('names', LocalizedType::class, [
-                'main_constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
-                ],
+                'required' => false,
                 'entry_options' => [
                     'required' => false,
                     'constraints' => [

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -124,9 +124,7 @@ final class BlogCategoryFormType extends AbstractType
 
         $builderSettingsGroup
             ->add('names', LocalizedType::class, [
-                'main_constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
-                ],
+                'required' => false,
                 'entry_options' => [
                     'required' => false,
                     'constraints' => [

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -119,9 +119,7 @@ final class CategoryFormType extends AbstractType
 
         $builderSettingsGroup
             ->add('name', LocalizedType::class, [
-                'main_constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
-                ],
+                'required' => false,
                 'entry_options' => [
                     'required' => false,
                     'constraints' => [

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -109,7 +109,7 @@ final class PaymentFormType extends AbstractType
                 'required' => false,
                 'choices' => $this->transportFacade->getAll(),
                 'choice_label' => function (Transport $transport) {
-                    return $transport->getName() ?? t('Name in default language is not entered') . ' (ID: ' . $transport->getId() . ')';
+                    return $transport->getName() ?? t('Name has not been entered in your current language') . ' (ID: ' . $transport->getId() . ')';
                 },
                 'choice_value' => 'id',
                 'multiple' => true,

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -95,7 +95,7 @@ final class TransportFormType extends AbstractType
                 'required' => false,
                 'choices' => $this->paymentFacade->getAll(),
                 'choice_label' => function (Payment $payment) {
-                    return $payment->getName() ?? t('Name in default language is not entered') . ' (ID: ' . $payment->getId() . ')';
+                    return $payment->getName() ?? t('Name has not been entered in your current language') . ' (ID: ' . $payment->getId() . ')';
                 },
                 'choice_value' => 'id',
                 'multiple' => true,

--- a/packages/framework/src/Model/Blog/Article/BlogArticleFacade.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleFacade.php
@@ -166,12 +166,14 @@ class BlogArticleFacade
     /**
      * @param int|null $selectedDomainId
      * @param \Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData $searchData
+     * @param string $locale
      * @return \Doctrine\ORM\QueryBuilder
      */
     public function getQueryBuilderForQuickSearch(
         ?int $selectedDomainId,
         QuickSearchFormData $searchData,
+        string $locale,
     ): QueryBuilder {
-        return $this->blogArticleRepository->getQueryBuilderForQuickSearch($selectedDomainId, $searchData);
+        return $this->blogArticleRepository->getQueryBuilderForQuickSearch($selectedDomainId, $searchData, $locale);
     }
 }

--- a/packages/framework/src/Model/Blog/Article/BlogArticleRepository.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleRepository.php
@@ -110,15 +110,17 @@ class BlogArticleRepository
     /**
      * @param int|null $domainId
      * @param \Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData $searchData
+     * @param string $locale
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getQueryBuilderForQuickSearch(?int $domainId, QuickSearchFormData $searchData): QueryBuilder
-    {
+    public function getQueryBuilderForQuickSearch(
+        ?int $domainId,
+        QuickSearchFormData $searchData,
+        string $locale,
+    ): QueryBuilder {
         if ($domainId === null) {
-            $locale = $this->localization->getCurrentLocaleForTranslatableEntities();
             $queryBuilder = $this->getAllBlogArticlesByLocaleQueryBuilder($locale);
         } else {
-            $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
             $queryBuilder = $this->getBlogArticlesByDomainIdAndLocaleQueryBuilderIfInBlogCategory($domainId, $locale);
         }
 

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
@@ -345,4 +345,13 @@ class BlogCategoryFacade
     {
         return $this->blogCategoryRepository->findVisibleMainBlogCategoryIdOnDomain($this->domain->getId());
     }
+
+    /**
+     * @param int $domainsCount
+     * @return array<int, string>
+     */
+    public function getVisibilityOfBlogCategoriesIndexedById(int $domainsCount): array
+    {
+        return $this->blogCategoryRepository->getVisibilityOfBlogCategoriesIndexedById($domainsCount);
+    }
 }

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -362,4 +362,27 @@ class BlogCategoryRepository extends NestedTreeRepository
             return null;
         }
     }
+
+    /**
+     * @param int $domainCount
+     * @return array<int, string>
+     */
+    public function getVisibilityOfBlogCategoriesIndexedById(int $domainCount): array
+    {
+        $visibilityOfBlogCategoriesIndexedById = [];
+
+        $result = $this->getAllQueryBuilder()
+            ->select('bc.id, COUNT(bcd.domainId) AS domainCount')
+            ->join(BlogCategoryDomain::class, 'bcd', Join::WITH, 'bcd.blogCategory = bc')
+            ->andWhere('bcd.visible = TRUE')
+            ->groupBy('bc.id')
+            ->getQuery()
+            ->getArrayResult();
+
+        foreach ($result as $row) {
+            $visibilityOfBlogCategoriesIndexedById[$row['id']] = $row['domainCount'] === $domainCount ? 'all' : 'partial';
+        }
+
+        return $visibilityOfBlogCategoriesIndexedById;
+    }
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -424,15 +424,6 @@ msgstr "Rubrika blogu <strong><a href=\"{{ url }}\">{{ name }}</a></strong> byla
 msgid "Blog category <strong>{{ name }}</strong> has been removed"
 msgstr "Rubrika blogu <strong>{{ name }}</strong> byla smazána"
 
-msgid "Blog category is hidden on all domains"
-msgstr "Rubrika blogu je skrytá na všech doménách"
-
-msgid "Blog category is visible on all domains"
-msgstr "Rubrika blogu je viditelná na všech doménách"
-
-msgid "Blog category is visible on some domains"
-msgstr "Rubrika blogu je viditelná na některých doménách"
-
 msgid "Brand"
 msgstr "Značka"
 
@@ -2640,12 +2631,6 @@ msgstr "Produkt je variantou"
 
 msgid "Product name"
 msgstr "Název produktu"
-
-msgid "Product name in default language is not entered"
-msgstr "Název zboží ve výchozím jazyce není vyplněn"
-
-msgid "Product not in e-shop."
-msgstr "Zboží se nenachází v eshopu."
 
 msgid "Product saved in order"
 msgstr "Zboží bylo uloženo do objednávky"

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -424,6 +424,15 @@ msgstr "Rubrika blogu <strong><a href=\"{{ url }}\">{{ name }}</a></strong> byla
 msgid "Blog category <strong>{{ name }}</strong> has been removed"
 msgstr "Rubrika blogu <strong>{{ name }}</strong> byla smazána"
 
+msgid "Blog category is hidden on all domains"
+msgstr "Rubrika blogu je skrytá na všech doménách"
+
+msgid "Blog category is visible on all domains"
+msgstr "Rubrika blogu je viditelná na všech doménách"
+
+msgid "Blog category is visible on some domains"
+msgstr "Rubrika blogu je viditelná na některých doménách"
+
 msgid "Brand"
 msgstr "Značka"
 

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2008,8 +2008,8 @@ msgstr "Název"
 msgid "Name %locale%"
 msgstr "Název %locale%"
 
-msgid "Name in default language is not entered"
-msgstr "Název ve výchozím jazyce není vyplněn"
+msgid "Name has not been entered in your current language"
+msgstr "Název ve vašem aktuálním jazyce není vyplněn"
 
 msgid "Name in the corresponding locale must be filled-in in order to display the file on the storefront"
 msgstr "Pro zobrazení souboru na doméně musí být vyplněn název v odpovídajícím jazyce"
@@ -2634,6 +2634,9 @@ msgstr "Název produktu"
 
 msgid "Product name in default language is not entered"
 msgstr "Název zboží ve výchozím jazyce není vyplněn"
+
+msgid "Product not in e-shop."
+msgstr "Zboží se nenachází v eshopu."
 
 msgid "Product saved in order"
 msgstr "Zboží bylo uloženo do objednávky"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2008,9 +2008,6 @@ msgstr ""
 msgid "Name %locale%"
 msgstr ""
 
-msgid "Name in default language is not entered"
-msgstr ""
-
 msgid "Name in the corresponding locale must be filled-in in order to display the file on the storefront"
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -424,15 +424,6 @@ msgstr ""
 msgid "Blog category <strong>{{ name }}</strong> has been removed"
 msgstr ""
 
-msgid "Blog category is hidden on all domains"
-msgstr ""
-
-msgid "Blog category is visible on all domains"
-msgstr ""
-
-msgid "Blog category is visible on some domains"
-msgstr ""
-
 msgid "Brand"
 msgstr ""
 
@@ -2639,12 +2630,6 @@ msgid "Product is variant"
 msgstr ""
 
 msgid "Product name"
-msgstr ""
-
-msgid "Product name in default language is not entered"
-msgstr ""
-
-msgid "Product not in e-shop."
 msgstr ""
 
 msgid "Product saved in order"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -424,6 +424,15 @@ msgstr ""
 msgid "Blog category <strong>{{ name }}</strong> has been removed"
 msgstr ""
 
+msgid "Blog category is hidden on all domains"
+msgstr ""
+
+msgid "Blog category is visible on all domains"
+msgstr ""
+
+msgid "Blog category is visible on some domains"
+msgstr ""
+
 msgid "Brand"
 msgstr ""
 
@@ -2008,6 +2017,9 @@ msgstr ""
 msgid "Name %locale%"
 msgstr ""
 
+msgid "Name has not been entered in your current language"
+msgstr ""
+
 msgid "Name in the corresponding locale must be filled-in in order to display the file on the storefront"
 msgstr ""
 
@@ -2630,6 +2642,9 @@ msgid "Product name"
 msgstr ""
 
 msgid "Product name in default language is not entered"
+msgstr ""
+
+msgid "Product not in e-shop."
 msgstr ""
 
 msgid "Product saved in order"

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -2008,8 +2008,8 @@ msgstr "Názov"
 msgid "Name %locale%"
 msgstr "Názov %locale%"
 
-msgid "Name in default language is not entered"
-msgstr "Názov v predvolenom jazyku nie je zadaný"
+msgid "Name has not been entered in your current language"
+msgstr "Názov nebol vyplnený vo vašom aktuálnom jazyke"
 
 msgid "Name in the corresponding locale must be filled-in in order to display the file on the storefront"
 msgstr "Názov v príslušnom jazyku musí byť vyplnený, aby sa súbor zobrazil v obchode"
@@ -2631,9 +2631,6 @@ msgstr "Produkt je varianta"
 
 msgid "Product name"
 msgstr "Názov produktu"
-
-msgid "Product name in default language is not entered"
-msgstr "Názov produktu v predvolenom jazyku nie je zadaný"
 
 msgid "Product saved in order"
 msgstr "Produkt uložený v objednávke"

--- a/packages/framework/src/Twig/NameFallbackExtension.php
+++ b/packages/framework/src/Twig/NameFallbackExtension.php
@@ -33,7 +33,7 @@ class NameFallbackExtension extends AbstractExtension
         }
 
         if ($value === null || $value === '') {
-            return t('Name in default language is not entered');
+            return t('Name has not been entered in your current language');
         }
 
         return $value;

--- a/packages/framework/src/Twig/ProductExtension.php
+++ b/packages/framework/src/Twig/ProductExtension.php
@@ -32,7 +32,6 @@ class ProductExtension extends AbstractExtension
     {
         return [
             new TwigFilter('productDisplayName', $this->getProductDisplayName(...)),
-            new TwigFilter('productListDisplayNameByName', $this->getProductListDisplayNameByName(...)),
         ];
     }
 
@@ -83,19 +82,6 @@ class ProductExtension extends AbstractExtension
         }
 
         return $product->getName();
-    }
-
-    /**
-     * @param string|null $name
-     * @return string
-     */
-    public function getProductListDisplayNameByName(?string $name): string
-    {
-        if ($name === null) {
-            return t('Product name in default language is not entered');
-        }
-
-        return $name;
     }
 
     /**

--- a/upgrade-notes/backend_20251002_092325.md
+++ b/upgrade-notes/backend_20251002_092325.md
@@ -1,0 +1,3 @@
+#### Name is no longer mandatory for Category, Blog Category and Blog Article ([#4209](https://github.com/shopsys/shopsys/pull/4209))
+
+- Twig filter `productListDisplayNameByName` has been removed, use `nameWithFallbackOnEmpty` instead


### PR DESCRIPTION
#### Description, the reason for the PR

- We had weird behavior where some form required name for entities but by current locale of administratort. This behavior has been now unified and all such entities now no longer require name, but are not visible in such case.

- Blog categories now have same visibility icons as product categories.

- Blog category visibility is now also calculated for root categories, that until now has always been visible.

- Unified displaying of information, about missing translation for current locale of all entities.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-requiring-name.odin.shopsys.cloud
  - https://cz.tl-fix-requiring-name.odin.shopsys.cloud
  - https://tl-fix-requiring-name.odin.shopsys.cloud/sk
<!-- Replace -->
