### PR TITLE
Heureka categories for SK domains

### DIFF
--- a/docs/extensibility/extending-form-from-plugin.md
+++ b/docs/extensibility/extending-form-from-plugin.md
@@ -76,7 +76,7 @@ class HeurekaProductCrudExtension implements PluginCrudExtensionInterface
      */
     public function getFormLabel()
     {
-        return $this->translator->trans('Heureka.cz product feed');
+        return $this->translator->trans('Heureka product feed');
     }
 
     /**

--- a/packages/administration/templates/form/type/MultidomainType.html.twig
+++ b/packages/administration/templates/form/type/MultidomainType.html.twig
@@ -9,7 +9,7 @@
             {% set itemCount = form|length %}
             {% set columnClass = itemCount == 1 ? 'col-12' : (itemCount == 2 ? 'col-12 col-xl-6' : 'col-12 col-xl-4') %}
             {% set columnSpacing = itemCount > 1 ? ' mb-3 mb-xl-0' : '' %}
-            
+
             <div class="row">
                 {% for child in form %}
                     <div class="{{ display_mode == 'columns' ? columnClass ~ columnSpacing : 'col-12 mb-3' }}">
@@ -22,7 +22,7 @@
             {% set itemCount = form|length %}
             {% set columnClass = itemCount == 1 ? 'col-12' : (itemCount == 2 ? 'col-12 col-xl-6' : 'col-12 col-xl-4') %}
             {% set columnSpacing = itemCount > 1 ? ' mb-3 mb-xl-0' : '' %}
-            
+
             <div class="row">
                 {% for child in form %}
                     {% set childContent = form_row(child, {row_attr: {class: "mb-0"}})|trim %}
@@ -40,7 +40,6 @@
                                     </div>
                                     <div class="card-body">
                                         {{- childContent|raw -}}
-                                        {{- form_errors(child) -}}
                                     </div>
                                 </div>
                             {% else %}
@@ -54,7 +53,6 @@
                                     </div>
                                     <div class="card-body">
                                         {{- childContent|raw -}}
-                                        {{- form_errors(child) -}}
                                     </div>
                                 </div>
                             {% endif %}

--- a/packages/framework/src/Component/Domain/Domain.php
+++ b/packages/framework/src/Component/Domain/Domain.php
@@ -321,4 +321,9 @@ class Domain implements DomainIdsProviderInterface
 
         return true;
     }
+
+    public function anyDomainHasLocale(string $locale): bool
+    {
+        return in_array($locale, $this->getAllLocales(), true);
+    }
 }

--- a/packages/framework/src/Migrations/Version20260223133152.php
+++ b/packages/framework/src/Migrations/Version20260223133152.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20260223133152 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE heureka_category ADD locale VARCHAR(255) NOT NULL DEFAULT \'cs\'');
+        $this->sql('ALTER TABLE heureka_category ALTER locale DROP DEFAULT');
+
+        $this->sql('ALTER TABLE heureka_category ADD heureka_id INT NOT NULL DEFAULT 0');
+        $this->sql('ALTER TABLE heureka_category ALTER heureka_id DROP DEFAULT');
+        $this->sql('UPDATE heureka_category SET heureka_id = id');
+
+        $this->sql('CREATE SEQUENCE heureka_category_id_seq');
+        $this->sql('SELECT setval(\'heureka_category_id_seq\', (SELECT MAX(id) FROM heureka_category))');
+        $this->sql('ALTER TABLE heureka_category ALTER id SET DEFAULT nextval(\'heureka_category_id_seq\')');
+
+        $this->sql('DROP INDEX uniq_fe112a6912469de2;');
+
+        $this->sql('CREATE UNIQUE INDEX uq_heureka_category_heureka_id_locale ON heureka_category (locale, heureka_id)');
+        $this->sql('CREATE INDEX IDX_FE112A6912469DE2 ON heureka_category_categories (category_id)');
+    }
+}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
@@ -73,7 +73,6 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
                 return $padding . $category->getName();
             },
             'choice_value' => 'id',
-            'attr' => ['class' => 'js-autocomplete-selectbox'],
         ];
     }
 

--- a/packages/product-feed-heureka/src/DataFixtures/HeurekaCategoryDataFixture.php
+++ b/packages/product-feed-heureka/src/DataFixtures/HeurekaCategoryDataFixture.php
@@ -30,55 +30,70 @@ class HeurekaCategoryDataFixture implements PluginDataFixtureInterface
     #[Override]
     public function load(): void
     {
+        $czechLocale = 'cs';
         $heurekaCategoriesData = [];
 
-        $firsHeurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-        $firsHeurekaCategoryData->id = static::HEUREKA_CATEGORY_ID_FIRST;
-        $firsHeurekaCategoryData->name = 'Autobaterie';
-        $firsHeurekaCategoryData->fullName = 'Heureka.cz | Auto-moto | Autodoplňky | Autobaterie';
+        $firstHeurekaCategoryData = $this->heurekaCategoryDataFactory->create($czechLocale);
+        $firstHeurekaCategoryData->heurekaId = static::HEUREKA_CATEGORY_ID_FIRST;
+        $firstHeurekaCategoryData->name = 'Autobaterie';
+        $firstHeurekaCategoryData->fullName = 'Heureka.cz | Auto-moto | Autodoplňky | Autobaterie';
 
-        $heurekaCategoriesData[] = $firsHeurekaCategoryData;
+        $heurekaCategoriesData[] = $firstHeurekaCategoryData;
 
-        $secondHeurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-        $secondHeurekaCategoryData->id = static::HEUREKA_CATEGORY_ID_SECOND;
+        $secondHeurekaCategoryData = $this->heurekaCategoryDataFactory->create($czechLocale);
+        $secondHeurekaCategoryData->heurekaId = static::HEUREKA_CATEGORY_ID_SECOND;
         $secondHeurekaCategoryData->name = 'Bublifuky';
         $secondHeurekaCategoryData->fullName = 'Heureka.cz | Dětské zboží | Hračky | Hry na zahradu | Bublifuky';
 
         $heurekaCategoriesData[] = $secondHeurekaCategoryData;
 
-        $thirdHeurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-        $thirdHeurekaCategoryData->id = static::HEUREKA_CATEGORY_ID_THIRD;
+        $thirdHeurekaCategoryData = $this->heurekaCategoryDataFactory->create($czechLocale);
+        $thirdHeurekaCategoryData->heurekaId = static::HEUREKA_CATEGORY_ID_THIRD;
         $thirdHeurekaCategoryData->name = 'Cukřenky';
         $thirdHeurekaCategoryData->fullName = 'Heureka.cz | Dům a zahrada | Domácnost | Kuchyně | Stolování | Cukřenky';
 
         $heurekaCategoriesData[] = $thirdHeurekaCategoryData;
 
-        $this->heurekaCategoryFacade->saveHeurekaCategories($heurekaCategoriesData);
+        $this->heurekaCategoryFacade->saveHeurekaCategories($heurekaCategoriesData, $czechLocale);
 
-        $heurekaCategoryFirst = $this->heurekaCategoryFacade->getOneById(static::HEUREKA_CATEGORY_ID_FIRST);
+        $heurekaCategoryFirst = $this->heurekaCategoryFacade->getOneByHeurekaIdAndLocale(
+            static::HEUREKA_CATEGORY_ID_FIRST,
+            $czechLocale,
+        );
         $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(
             static::CATEGORY_ID_FIRST,
             $heurekaCategoryFirst,
+            $czechLocale,
         );
 
-        $heurekaCategorySecond = $this->heurekaCategoryFacade->getOneById(static::HEUREKA_CATEGORY_ID_SECOND);
+        $heurekaCategorySecond = $this->heurekaCategoryFacade->getOneByHeurekaIdAndLocale(
+            static::HEUREKA_CATEGORY_ID_SECOND,
+            $czechLocale,
+        );
         $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(
             static::CATEGORY_ID_SECOND,
             $heurekaCategorySecond,
+            $czechLocale,
         );
         $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(
             static::CATEGORY_ID_THIRD,
             $heurekaCategorySecond,
+            $czechLocale,
         );
 
-        $heurekaCategoryThird = $this->heurekaCategoryFacade->getOneById(static::HEUREKA_CATEGORY_ID_THIRD);
+        $heurekaCategoryThird = $this->heurekaCategoryFacade->getOneByHeurekaIdAndLocale(
+            static::HEUREKA_CATEGORY_ID_THIRD,
+            $czechLocale,
+        );
         $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(
             static::CATEGORY_ID_FOURTH,
             $heurekaCategoryThird,
+            $czechLocale,
         );
         $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(
             static::CATEGORY_ID_FIFTH,
             $heurekaCategoryThird,
+            $czechLocale,
         );
     }
 }

--- a/packages/product-feed-heureka/src/Form/CategoryCrudExtension.php
+++ b/packages/product-feed-heureka/src/Form/CategoryCrudExtension.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\ProductFeed\HeurekaBundle\Form;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\Plugin\PluginCrudExtensionInterface;
 use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategory;
+use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader;
 use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacade;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -15,6 +17,8 @@ class CategoryCrudExtension implements PluginCrudExtensionInterface
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly HeurekaCategoryFacade $heurekaCategoryFacade,
+        private readonly Domain $domain,
+        private readonly HeurekaCategoryDownloader $heurekaCategoryDownloader,
     ) {
     }
 
@@ -27,18 +31,24 @@ class CategoryCrudExtension implements PluginCrudExtensionInterface
     #[Override]
     public function getFormLabel(): string
     {
-        return $this->translator->trans('Heureka.cz product feed');
+        return $this->translator->trans('Heureka product feed');
     }
 
     #[Override]
     public function getData(int $categoryId): array
     {
-        $heurekaCategory = $this->heurekaCategoryFacade->findByCategoryId($categoryId);
-
         $pluginData = [];
 
-        if ($heurekaCategory !== null) {
-            $pluginData['heureka_category'] = $heurekaCategory;
+        foreach ($this->heurekaCategoryDownloader->getSupportedLocales() as $locale) {
+            if (!$this->domain->anyDomainHasLocale($locale)) {
+                continue;
+            }
+
+            $heurekaCategory = $this->heurekaCategoryFacade->findByCategoryIdAndLocale($categoryId, $locale);
+
+            if ($heurekaCategory !== null) {
+                $pluginData[self::createFormFieldKeyByLocale($locale)] = $heurekaCategory;
+            }
         }
 
         return $pluginData;
@@ -47,16 +57,31 @@ class CategoryCrudExtension implements PluginCrudExtensionInterface
     #[Override]
     public function saveData(int $categoryId, mixed $data): void
     {
-        if (isset($data['heureka_category']) && $data['heureka_category'] instanceof HeurekaCategory) {
-            $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId($categoryId, $data['heureka_category']);
-        } else {
-            $this->heurekaCategoryFacade->removeHeurekaCategoryForCategoryId($categoryId);
+        foreach ($this->heurekaCategoryDownloader->getSupportedLocales() as $locale) {
+            if (!$this->domain->anyDomainHasLocale($locale)) {
+                continue;
+            }
+
+            $key = self::createFormFieldKeyByLocale($locale);
+
+            if (isset($data[$key]) && $data[$key] instanceof HeurekaCategory) {
+                $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId($categoryId, $data[$key], $locale);
+            } else {
+                $this->heurekaCategoryFacade->removeHeurekaCategoryForCategoryId($categoryId, $locale);
+            }
         }
     }
 
     #[Override]
     public function removeData(int $categoryId): void
     {
-        $this->heurekaCategoryFacade->removeHeurekaCategoryForCategoryId($categoryId);
+        foreach ($this->heurekaCategoryDownloader->getSupportedLocales() as $locale) {
+            $this->heurekaCategoryFacade->removeHeurekaCategoryForCategoryId($categoryId, $locale);
+        }
+    }
+
+    public static function createFormFieldKeyByLocale(string $locale): string
+    {
+        return 'heureka_' . $locale . '_category';
     }
 }

--- a/packages/product-feed-heureka/src/Form/CategoryFormType.php
+++ b/packages/product-feed-heureka/src/Form/CategoryFormType.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\ProductFeed\HeurekaBundle\Form;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader;
 use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -16,22 +18,36 @@ final class CategoryFormType extends AbstractType
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly HeurekaCategoryFacade $heurekaCategoryFacade,
+        private readonly Domain $domain,
+        private readonly HeurekaCategoryDownloader $heurekaCategoryDownloader,
     ) {
     }
 
     #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $heurekaCategories = $this->heurekaCategoryFacade->getAllIndexedById();
+        foreach ($this->heurekaCategoryDownloader->getSupportedLocales() as $locale) {
+            if (!$this->domain->anyDomainHasLocale($locale)) {
+                continue;
+            }
 
-        $builder->add('heureka_category', ChoiceType::class, [
-            'label' => $this->translator->trans('Heureka category'),
-            'choices' => $heurekaCategories,
-            'required' => false,
-            'attr' => [
-                'class' => 'js-autocomplete-selectbox',
-            ],
-            'choice_label' => 'getName',
-        ]);
+            $heurekaCategories = $this->heurekaCategoryFacade->getAllIndexedByHeurekaId($locale);
+            $builder->add(CategoryCrudExtension::createFormFieldKeyByLocale($locale), ChoiceType::class, [
+                'label' => $this->getLabelForLocale($locale),
+                'translation_domain' => false,
+                'choices' => $heurekaCategories,
+                'required' => false,
+                'choice_label' => 'getName',
+            ]);
+        }
+    }
+
+    private function getLabelForLocale(string $locale): string
+    {
+        return match ($locale) {
+            'cs' => $this->translator->trans('Heureka.cz category'),
+            'sk' => $this->translator->trans('Heureka.sk category'),
+            default => $this->translator->trans('Heureka category'),
+        };
     }
 }

--- a/packages/product-feed-heureka/src/Form/HeurekaProductCrudExtension.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaProductCrudExtension.php
@@ -28,7 +28,7 @@ class HeurekaProductCrudExtension implements PluginCrudExtensionInterface
     #[Override]
     public function getFormLabel(): string
     {
-        return $this->translator->trans('Heureka.cz product feed');
+        return $this->translator->trans('Heureka product feed');
     }
 
     /**

--- a/packages/product-feed-heureka/src/Form/HeurekaProductFormType.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaProductFormType.php
@@ -6,8 +6,10 @@ namespace Shopsys\ProductFeed\HeurekaBundle\Form;
 
 use Override;
 use Shopsys\FormTypesBundle\MultidomainType;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Form\Constraints\MoneyRange;
+use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -15,28 +17,60 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class HeurekaProductFormType extends AbstractType
 {
-    public function __construct(private readonly TranslatorInterface $translator)
-    {
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+        private readonly HeurekaCategoryDownloader $heurekaCategoryDownloader,
+        private readonly Domain $domain,
+    ) {
     }
 
     #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $defaultOptionsByLocale = [
+            'cs' => [
+                'currency' => 'CZK',
+                'constraints' => [
+                    new MoneyRange(
+                        min: Money::zero(),
+                        max: Money::create(1000),
+                    ),
+                ],
+            ],
+            'sk' => [
+                'currency' => 'EUR',
+                'constraints' => [
+                    new MoneyRange(
+                        min: Money::zero(),
+                        max: Money::create(50),
+                    ),
+                ],
+            ],
+        ];
+
+        $supportedLocales = $this->heurekaCategoryDownloader->getSupportedLocales();
+        $optionsByDomainId = [];
+
+        foreach ($this->domain->getAll() as $domainConfig) {
+            $locale = $domainConfig->getLocale();
+
+            if (in_array($locale, $supportedLocales, true)) {
+                $optionsByDomainId[$domainConfig->getId()] = $defaultOptionsByLocale[$locale] ?? [];
+            } else {
+                $optionsByDomainId[$domainConfig->getId()] = [
+                    'disabled' => true,
+                    'help' => $this->translator->trans('Heureka is not available for this domain locale'),
+                ];
+            }
+        }
+
         $builder->add('cpc', MultidomainType::class, [
             'label' => $this->translator->trans('Maximum price per click'),
             'entry_type' => MoneyType::class,
             'required' => false,
             'layout' => 'block',
             'display_mode' => 'columns',
-            'entry_options' => [
-                'currency' => 'CZK',
-                'constraints' => [
-                    new MoneyRange(
-                        min: Money::zero(),
-                        max: Money::create(500),
-                    ),
-                ],
-            ],
+            'options_by_domain_id' => $optionsByDomainId,
         ]);
     }
 }

--- a/packages/product-feed-heureka/src/Model/FeedItem/HeurekaFeedItemFactory.php
+++ b/packages/product-feed-heureka/src/Model/FeedItem/HeurekaFeedItemFactory.php
@@ -71,28 +71,29 @@ class HeurekaFeedItemFactory
         $mainCategory = $this->categoryFacade->findProductMainCategoryByDomainId($product, $domainConfig->getId());
 
         if ($mainCategory !== null) {
-            return $this->findHeurekaCategoryFullNameByCategoryIdUsingCache($mainCategory->getId());
+            return $this->findHeurekaCategoryFullNameByCategoryIdUsingCache($mainCategory->getId(), $domainConfig->getLocale());
         }
 
         return null;
     }
 
-    protected function findHeurekaCategoryFullNameByCategoryIdUsingCache(int $categoryId): ?string
+    protected function findHeurekaCategoryFullNameByCategoryIdUsingCache(int $categoryId, string $locale): ?string
     {
-        $key = (string)$categoryId;
+        $key = $categoryId . '_' . $locale;
 
         return $this->inMemoryCache->getOrSaveValue(
             static::HEUREKA_CATEGORY_FULL_NAMES_CACHE_NAMESPACE,
             fn () => $this->findHeurekaCategoryFullNameByCategoryId(
                 $categoryId,
+                $locale,
             ),
             $key,
         );
     }
 
-    protected function findHeurekaCategoryFullNameByCategoryId(int $categoryId): ?string
+    protected function findHeurekaCategoryFullNameByCategoryId(int $categoryId, string $locale): ?string
     {
-        $heurekaCategory = $this->heurekaCategoryFacade->findByCategoryId($categoryId);
+        $heurekaCategory = $this->heurekaCategoryFacade->findByCategoryIdAndLocale($categoryId, $locale);
 
         return $heurekaCategory !== null ? $heurekaCategory->getFullName() : null;
     }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 
 #[ORM\Table(name: 'heureka_category')]
+#[ORM\UniqueConstraint(name: 'uq_heureka_category_heureka_id_locale', columns: ['locale', 'heureka_id'])]
 #[ORM\Entity]
 class HeurekaCategory
 {
@@ -17,6 +18,7 @@ class HeurekaCategory
      */
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
 
     /**
@@ -36,13 +38,25 @@ class HeurekaCategory
      */
     #[ORM\JoinTable(name: 'heureka_category_categories')]
     #[ORM\JoinColumn(name: 'heureka_category_id', referencedColumnName: 'id')]
-    #[ORM\InverseJoinColumn(name: 'category_id', referencedColumnName: 'id', unique: true)]
+    #[ORM\InverseJoinColumn(name: 'category_id', referencedColumnName: 'id')]
     #[ORM\ManyToMany(targetEntity: Category::class)]
     protected $categories;
 
+    /**
+     * @var string
+     */
+    #[ORM\Column(type: 'string')]
+    protected $locale;
+
+    /**
+     * @var int
+     */
+    #[ORM\Column(type: 'integer')]
+    protected $heurekaId;
+
     public function __construct(HeurekaCategoryData $heurekaCategoryData)
     {
-        $this->id = $heurekaCategoryData->id;
+        $this->heurekaId = $heurekaCategoryData->heurekaId;
         $this->categories = new ArrayCollection($heurekaCategoryData->categories);
         $this->setData($heurekaCategoryData);
     }
@@ -57,6 +71,7 @@ class HeurekaCategory
     {
         $this->name = $heurekaCategoryData->name;
         $this->fullName = $heurekaCategoryData->fullName;
+        $this->locale = $heurekaCategoryData->locale;
     }
 
     /**
@@ -87,6 +102,14 @@ class HeurekaCategory
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeurekaId()
+    {
+        return $this->heurekaId;
     }
 
     /**

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
@@ -6,6 +6,7 @@ namespace Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory;
 
 use Monolog\Logger;
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 
 class HeurekaCategoryCronModule implements SimpleCronModuleInterface
@@ -15,27 +16,28 @@ class HeurekaCategoryCronModule implements SimpleCronModuleInterface
     public function __construct(
         protected readonly HeurekaCategoryDownloader $heurekaCategoryDownloader,
         protected readonly HeurekaCategoryFacade $heurekaCategoryFacade,
+        protected readonly Domain $domain,
     ) {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     #[Override]
     public function setLogger(Logger $logger): void
     {
         $this->logger = $logger;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     #[Override]
     public function run(): void
     {
         try {
-            $heurekaCategoriesData = $this->heurekaCategoryDownloader->getHeurekaCategories();
-            $this->heurekaCategoryFacade->saveHeurekaCategories($heurekaCategoriesData);
+            foreach ($this->heurekaCategoryDownloader->getSupportedLocales() as $locale) {
+                if (!$this->domain->anyDomainHasLocale($locale)) {
+                    continue;
+                }
+
+                $heurekaCategoriesData = $this->heurekaCategoryDownloader->getHeurekaCategories($locale);
+                $this->heurekaCategoryFacade->saveHeurekaCategories($heurekaCategoriesData, $locale);
+            }
         } catch (HeurekaCategoryDownloadFailedException $e) {
             $this->logger->error($e->getMessage());
         }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryData.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryData.php
@@ -9,7 +9,7 @@ class HeurekaCategoryData
     /**
      * @var int|null
      */
-    public $id;
+    public $heurekaId;
 
     /**
      * @var string|null
@@ -25,6 +25,11 @@ class HeurekaCategoryData
      * @var \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
     public $categories;
+
+    /**
+     * @var string
+     */
+    public $locale;
 
     public function __construct()
     {

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDataFactory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDataFactory.php
@@ -11,8 +11,11 @@ class HeurekaCategoryDataFactory
         return new HeurekaCategoryData();
     }
 
-    public function create(): HeurekaCategoryData
+    public function create(string $locale): HeurekaCategoryData
     {
-        return $this->createInstance();
+        $heurekaCategoryData = $this->createInstance();
+        $heurekaCategoryData->locale = $locale;
+
+        return $heurekaCategoryData;
     }
 }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
@@ -9,26 +9,38 @@ use SimpleXMLElement;
 
 class HeurekaCategoryDownloader
 {
+    /**
+     * @param array<string, string> $feedUrlsByLocale
+     */
     public function __construct(
-        protected string $heurekaCategoryFeedUrl,
+        protected readonly array $feedUrlsByLocale,
         protected readonly HeurekaCategoryDataFactory $heurekaCategoryDataFactory,
     ) {
     }
 
     /**
-     * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[]
+     * @return string[]
      */
-    public function getHeurekaCategories(): array
+    public function getSupportedLocales(): array
     {
-        $xmlCategoryDataObjects = $this->loadXml()->xpath('/HEUREKA//CATEGORY[CATEGORY_FULLNAME]');
-
-        return $this->convertToHeurekaCategoriesData($xmlCategoryDataObjects);
+        return array_keys($this->feedUrlsByLocale);
     }
 
-    protected function loadXml(): SimpleXMLElement
+    /**
+     * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[]
+     */
+    public function getHeurekaCategories(string $locale): array
+    {
+        $url = $this->feedUrlsByLocale[$locale];
+        $xmlCategoryDataObjects = $this->loadXml($url)->xpath('/HEUREKA//CATEGORY[CATEGORY_FULLNAME]');
+
+        return $this->convertToHeurekaCategoriesData($xmlCategoryDataObjects, $locale);
+    }
+
+    protected function loadXml(string $url): SimpleXMLElement
     {
         try {
-            return new SimpleXMLElement($this->heurekaCategoryFeedUrl, LIBXML_NOERROR | LIBXML_NOWARNING, true);
+            return new SimpleXMLElement($url, LIBXML_NOERROR | LIBXML_NOWARNING, true);
         } catch (Exception $e) {
             throw new HeurekaCategoryDownloadFailedException($e);
         }
@@ -38,15 +50,15 @@ class HeurekaCategoryDownloader
      * @param \SimpleXMLElement[] $xmlCategoryDataObjects
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[]
      */
-    protected function convertToHeurekaCategoriesData(array $xmlCategoryDataObjects): array
+    protected function convertToHeurekaCategoriesData(array $xmlCategoryDataObjects, string $locale): array
     {
         $heurekaCategoriesData = [];
 
         foreach ($xmlCategoryDataObjects as $xmlCategoryDataObject) {
             $categoryId = (int)$xmlCategoryDataObject->CATEGORY_ID;
 
-            $heurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-            $heurekaCategoryData->id = $categoryId;
+            $heurekaCategoryData = $this->heurekaCategoryDataFactory->create($locale);
+            $heurekaCategoryData->heurekaId = $categoryId;
             $heurekaCategoryData->name = (string)$xmlCategoryDataObject->CATEGORY_NAME;
             $heurekaCategoryData->fullName = (string)$xmlCategoryDataObject->CATEGORY_FULLNAME;
 

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFacade.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFacade.php
@@ -20,18 +20,18 @@ class HeurekaCategoryFacade
     /**
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[] $newHeurekaCategoriesData
      */
-    public function saveHeurekaCategories(array $newHeurekaCategoriesData): void
+    public function saveHeurekaCategories(array $newHeurekaCategoriesData, string $locale): void
     {
-        $existingHeurekaCategories = $this->heurekaCategoryRepository->getAllIndexedById();
+        $existingHeurekaCategories = $this->heurekaCategoryRepository->getAllIndexedByHeurekaId($locale);
 
         $this->removeOldHeurekaCategories($newHeurekaCategoriesData, $existingHeurekaCategories);
 
         foreach ($newHeurekaCategoriesData as $newHeurekaCategoryData) {
-            if (!array_key_exists($newHeurekaCategoryData->id, $existingHeurekaCategories)) {
+            if (!array_key_exists($newHeurekaCategoryData->heurekaId, $existingHeurekaCategories)) {
                 $newHeurekaCategory = $this->heurekaCategoryFactory->create($newHeurekaCategoryData);
                 $this->em->persist($newHeurekaCategory);
             } else {
-                $existingHeurekaCategory = $existingHeurekaCategories[$newHeurekaCategoryData->id];
+                $existingHeurekaCategory = $existingHeurekaCategories[$newHeurekaCategoryData->heurekaId];
                 $newHeurekaCategoryData->categories = $existingHeurekaCategory->getCategories();
                 $existingHeurekaCategory->edit($newHeurekaCategoryData);
             }
@@ -53,7 +53,7 @@ class HeurekaCategoryFacade
         $newHeurekaCategoriesIds = [];
 
         foreach ($newHeurekaCategoriesData as $newHeurekaCategoryData) {
-            $newHeurekaCategoriesIds[] = $newHeurekaCategoryData->id;
+            $newHeurekaCategoriesIds[] = $newHeurekaCategoryData->heurekaId;
         }
 
         $categoryIdsToDelete = array_diff($existingHeurekaCategoriesIds, $newHeurekaCategoriesIds);
@@ -63,15 +63,18 @@ class HeurekaCategoryFacade
         }
     }
 
-    public function changeHeurekaCategoryForCategoryId(int $categoryId, HeurekaCategory $heurekaCategory): void
-    {
-        $oldHeurekaCategoryByCategoryId = $this->heurekaCategoryRepository->findByCategoryId($categoryId);
+    public function changeHeurekaCategoryForCategoryId(
+        int $categoryId,
+        HeurekaCategory $heurekaCategory,
+        string $locale,
+    ): void {
+        $oldHeurekaCategoryByCategoryId = $this->heurekaCategoryRepository->findByCategoryIdAndLocale($categoryId, $locale);
 
         $category = $this->categoryRepository->getById($categoryId);
 
         if ($oldHeurekaCategoryByCategoryId === null) {
             $heurekaCategory->addCategory($category);
-        } elseif ($oldHeurekaCategoryByCategoryId->getId() !== $heurekaCategory->getId()) {
+        } elseif ($oldHeurekaCategoryByCategoryId->getHeurekaId() !== $heurekaCategory->getHeurekaId()) {
             $oldHeurekaCategoryByCategoryId->removeCategory($category);
             $heurekaCategory->addCategory($category);
         }
@@ -79,15 +82,14 @@ class HeurekaCategoryFacade
         $this->em->flush();
     }
 
-    public function findByCategoryId(
-        int $categoryId,
-    ): ?HeurekaCategory {
-        return $this->heurekaCategoryRepository->findByCategoryId($categoryId);
+    public function findByCategoryIdAndLocale(int $categoryId, string $locale): ?HeurekaCategory
+    {
+        return $this->heurekaCategoryRepository->findByCategoryIdAndLocale($categoryId, $locale);
     }
 
-    public function removeHeurekaCategoryForCategoryId(int $categoryId): void
+    public function removeHeurekaCategoryForCategoryId(int $categoryId, string $locale): void
     {
-        $heurekaCategory = $this->heurekaCategoryRepository->findByCategoryId($categoryId);
+        $heurekaCategory = $this->heurekaCategoryRepository->findByCategoryIdAndLocale($categoryId, $locale);
 
         if ($heurekaCategory === null) {
             return;
@@ -99,16 +101,16 @@ class HeurekaCategoryFacade
         $this->em->flush();
     }
 
-    public function getOneById(int $id): HeurekaCategory
+    public function getOneByHeurekaIdAndLocale(int $heurekaId, string $locale): HeurekaCategory
     {
-        return $this->heurekaCategoryRepository->getOneById($id);
+        return $this->heurekaCategoryRepository->getOneByHeurekaIdAndLocale($heurekaId, $locale);
     }
 
     /**
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategory[]
      */
-    public function getAllIndexedById(): array
+    public function getAllIndexedByHeurekaId(string $locale): array
     {
-        return $this->heurekaCategoryRepository->getAllIndexedById();
+        return $this->heurekaCategoryRepository->getAllIndexedByHeurekaId($locale);
     }
 }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryRepository.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryRepository.php
@@ -21,40 +21,46 @@ class HeurekaCategoryRepository
     /**
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategory[]
      */
-    public function getAllIndexedById(): array
+    public function getAllIndexedByHeurekaId(string $locale): array
     {
         $queryBuilder = $this->em->createQueryBuilder()
             ->select('hc')
-            ->from(HeurekaCategory::class, 'hc', 'hc.id');
+            ->from(HeurekaCategory::class, 'hc', 'hc.heurekaId')
+            ->where('hc.locale = :locale')
+            ->setParameter('locale', $locale);
 
         return $queryBuilder->getQuery()
             ->execute();
     }
 
-    public function findByCategoryId(int $categoryId): ?HeurekaCategory
+    public function findByCategoryIdAndLocale(int $categoryId, string $locale): ?HeurekaCategory
     {
         $queryBuilder = $this->em->createQueryBuilder()
             ->select('hc')
             ->from(HeurekaCategory::class, 'hc')
             ->join('hc.categories', 'hcc')
-            ->andWhere('hcc = :categoriesId')
-            ->setParameter('categoriesId', $categoryId);
+            ->andWhere('hcc = :categoryId')
+            ->andWhere('hc.locale = :locale')
+            ->setParameter('categoryId', $categoryId)
+            ->setParameter('locale', $locale);
 
         return $queryBuilder->getQuery()
             ->getOneOrNullResult();
     }
 
-    public function getOneById(int $id): HeurekaCategory
+    public function getOneByHeurekaIdAndLocale(int $heurekaId, string $locale): HeurekaCategory
     {
         $queryBuilder = $this->getHeurekaCategoryRepository()
             ->createQueryBuilder('hc')
-            ->andWhere('hc.id = :id')
-            ->setParameter('id', $id);
+            ->andWhere('hc.heurekaId = :heurekaId')
+            ->andWhere('hc.locale = :locale')
+            ->setParameter('heurekaId', $heurekaId)
+            ->setParameter('locale', $locale);
         $heurekaCategory = $queryBuilder->getQuery()->getOneOrNullResult();
 
         if ($heurekaCategory === null) {
             throw new HeurekaCategoryNotFoundException(
-                'Heureka category with ID ' . $id . ' does not exist.',
+                'Heureka category with ID ' . $heurekaId . ' and locale ' . $locale . ' does not exist.',
             );
         }
 

--- a/packages/product-feed-heureka/src/Resources/config/paths.yaml
+++ b/packages/product-feed-heureka/src/Resources/config/paths.yaml
@@ -1,2 +1,3 @@
 parameters:
-    shopsys.product_feed.heureka_bundle.heureka_category_feed_url: http://www.heureka.cz/direct/xml-export/shops/heureka-sekce.xml
+    shopsys.product_feed.heureka_bundle.heureka_category_feed_cz_url: https://www.heureka.cz/direct/xml-export/shops/heureka-sekce.xml
+    shopsys.product_feed.heureka_bundle.heureka_category_feed_sk_url: https://www.heureka.sk/direct/xml-export/shops/heureka-sekce.xml

--- a/packages/product-feed-heureka/src/Resources/config/services.yaml
+++ b/packages/product-feed-heureka/src/Resources/config/services.yaml
@@ -30,4 +30,6 @@ services:
 
     Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader:
         arguments:
-            - '%shopsys.product_feed.heureka_bundle.heureka_category_feed_url%'
+            $feedUrlsByLocale:
+                cs: '%shopsys.product_feed.heureka_bundle.heureka_category_feed_cz_url%'
+                sk: '%shopsys.product_feed.heureka_bundle.heureka_category_feed_sk_url%'

--- a/packages/product-feed-heureka/src/Resources/translations/messages.cs.po
+++ b/packages/product-feed-heureka/src/Resources/translations/messages.cs.po
@@ -10,8 +10,17 @@ msgstr "Nastavení XML feedu Heureka"
 msgid "Heureka category"
 msgstr "Heureka kategorie"
 
-msgid "Heureka.cz product feed"
-msgstr "XML feed Heureka.cz"
+msgid "Heureka is not available for this domain locale"
+msgstr "Heureka není dostupná pro tento jazyk domény"
+
+msgid "Heureka product feed"
+msgstr "XML feed Heureka"
+
+msgid "Heureka.cz category"
+msgstr "Heureka.cz kategorie"
+
+msgid "Heureka.sk category"
+msgstr "Heureka.sk kategorie"
 
 msgid "Maximum price per click"
 msgstr "Maximální cena za proklik"

--- a/packages/product-feed-heureka/src/Resources/translations/messages.en.po
+++ b/packages/product-feed-heureka/src/Resources/translations/messages.en.po
@@ -8,13 +8,22 @@ msgid "Heureka XML feed settings"
 msgstr ""
 
 msgid "Heureka category"
-msgstr "Heureka category"
+msgstr ""
 
-msgid "Heureka.cz product feed"
-msgstr "Heureka.cz product feed"
+msgid "Heureka is not available for this domain locale"
+msgstr ""
+
+msgid "Heureka product feed"
+msgstr ""
+
+msgid "Heureka.cz category"
+msgstr ""
+
+msgid "Heureka.sk category"
+msgstr ""
 
 msgid "Maximum price per click"
-msgstr "Maximum price per click"
+msgstr ""
 
 msgid "Number of delivery days for out of stock products for Heureka XML feed"
 msgstr ""

--- a/packages/product-feed-heureka/src/Resources/translations/messages.sk.po
+++ b/packages/product-feed-heureka/src/Resources/translations/messages.sk.po
@@ -10,8 +10,17 @@ msgstr "Nastavenia Heureka XML feedu"
 msgid "Heureka category"
 msgstr "Heureka kategória"
 
-msgid "Heureka.cz product feed"
-msgstr "Feed produktov pre Heureka.cz"
+msgid "Heureka is not available for this domain locale"
+msgstr "Heureka nie je dostupná pre tento jazyk domény"
+
+msgid "Heureka product feed"
+msgstr "Heureka produktový feed"
+
+msgid "Heureka.cz category"
+msgstr "Heureka.cz kategória"
+
+msgid "Heureka.sk category"
+msgstr "Heureka.sk kategória"
 
 msgid "Maximum price per click"
 msgstr "Maximálna cena za klik"

--- a/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
+++ b/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
@@ -155,9 +155,9 @@ class HeurekaFeedItemTest extends TestCase
                 [$this->defaultProduct, $this->defaultDomain->getId(), $categoryStub],
             ]);
 
-        $this->heurekaCategoryFacadeStub->method('findByCategoryId')
+        $this->heurekaCategoryFacadeStub->method('findByCategoryIdAndLocale')
             ->willReturnMap([
-                [1, $heurekaCategoryStub],
+                [1, 'cs', $heurekaCategoryStub],
             ]);
 
         $heurekaFeedItem = $this->heurekaFeedItemFactory->create($this->defaultProduct, $this->defaultDomain);

--- a/upgrade-notes/backend_20260304_104032.md
+++ b/upgrade-notes/backend_20260304_104032.md
@@ -1,0 +1,15 @@
+#### Heureka categories for SK domains ([#4216](https://github.com/shopsys/shopsys/pull/4216))
+
+- `Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData::$id` property was renamed to `$heurekaId`
+- `Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacade` methods have been updated to support multiple locales:
+    - `findByCategoryId(int $categoryId)` was removed, use `findByCategoryIdAndLocale(int $categoryId, string $locale)` instead
+    - `getOneById(int $id)` was removed, use `getOneByHeurekaIdAndLocale(int $heurekaId, string $locale)` instead
+    - `getAllIndexedById()` was removed, use `getAllIndexedByHeurekaId(string $locale)` instead
+    - `saveHeurekaCategories()`, `changeHeurekaCategoryForCategoryId()`, and `removeHeurekaCategoryForCategoryId()` now require a new `string $locale` parameter
+- `Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryRepository` methods were updated similarly:
+    - `getAllIndexedById()` was removed, use `getAllIndexedByHeurekaId(string $locale)` instead
+    - `findByCategoryId(int $categoryId)` was removed, use `findByCategoryIdAndLocale(int $categoryId, string $locale)` instead
+    - `getOneById(int $id)` was removed, use `getOneByHeurekaIdAndLocale(int $heurekaId, string $locale)` instead
+- `Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader::getHeurekaCategories()` now requires a new `string $locale` parameter
+- if you have extended `Shopsys\ProductFeed\HeurekaBundle\Model\FeedItem\HeurekaFeedItemFactory` and overridden `findHeurekaCategoryFullNameByCategoryIdUsingCache()` or `findHeurekaCategoryFullNameByCategoryId()`, update their signatures to include the new `string $locale` parameter
+- the `shopsys.product_feed.heureka_bundle.heureka_category_feed_url` configuration parameter was removed; if you override it in your project, replace it with `shopsys.product_feed.heureka_bundle.heureka_category_feed_cz_url` and `shopsys.product_feed.heureka_bundle.heureka_category_feed_sk_url`


### PR DESCRIPTION
#### Description, the reason for the PR
I implemented Heureka categories for SK domains, where these categories should be downloaded from [SK Heureka](https://www.heureka.sk/direct/xml-export/shops/heureka-sekce.xml) instead of [CZ Heureka](https://www.heureka.cz/direct/xml-export/shops/heureka-sekce.xml). Logic is separated from CZ heureka categories, and admin can set SK heureka categories if eshop has at least one SK domain

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















----
:globe_with_meridians: Live Preview:
  - https://pt-heureka-categories.odin.shopsys.cloud
  - https://cz.pt-heureka-categories.odin.shopsys.cloud
  - https://pt-heureka-categories.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772622650.166039 -->