### PR TITLE
add generate_upgrade_notes Claude slash command

### DIFF
--- a/.claude/agents/pull_request_diff_fetcher.md
+++ b/.claude/agents/pull_request_diff_fetcher.md
@@ -1,0 +1,177 @@
+---
+name: pr-diff-fetcher
+description: Fetches pull request data including diff, metadata, and commits
+tools: Bash, WebFetch, Read
+---
+
+# PR Diff Fetcher
+
+This helper is responsible for fetching pull request data including diff, metadata, and commits.
+
+## Input
+
+You will receive ONE of:
+- PR URL (e.g., `https://github.com/shopsys/shopsys/pull/4183`)
+- PR number (e.g., `4183`)
+- String "current-branch" (analyze current git branch)
+
+## Your Task
+
+Fetch complete PR data using the best available method and return structured information.
+
+## Method Priority: gh CLI → WebFetch → Local Git
+
+### Method 1: GitHub CLI (gh) - PREFERRED
+
+**Step 1: Check gh availability**
+
+1. Check installation: `gh --version`
+   - If not installed → Skip to Method 2 (WebFetch)
+2. Check authentication: `gh auth status`
+   - If not authenticated → Skip to Method 2 (WebFetch)
+   - If authenticated → ✅ Use gh for everything
+
+**Step 2: Fetch PR data using gh**
+
+1. **Extract PR metadata and BASE branch** (CRITICAL):
+   ```bash
+   gh pr view {PR_NUMBER} --json baseRefName,title,body,labels
+   ```
+   - Extract: `baseRefName` (this is your BASE branch - store it!)
+   - Extract: `title`, `body`, `labels`
+
+2. **Get complete diff** (PRIMARY DATA SOURCE):
+   ```bash
+   gh pr diff {PR_NUMBER}
+   ```
+   - **⚠️ CRITICAL: Verify the diff is COMPLETE before proceeding!**
+   - No size limits with gh CLI
+
+3. **Get commits** (for movement detection):
+   ```bash
+   gh pr view {PR_NUMBER} --json commits
+   ```
+   - Look for movement keywords: "move", "moved", "moving" + "from project-base" or "to package"
+
+**Return to main command with:**
+- Method used: "gh"
+- Base branch: {extracted from baseRefName}
+- PR title, body, labels
+- Complete diff content
+- Commit messages
+- Success: true
+
+### Method 2: WebFetch (fallback if gh not available)
+
+**Step 1: Extract PR metadata**
+
+```
+WebFetch: https://github.com/shopsys/shopsys/pull/{PR_NUMBER}
+Prompt: "Extract the base branch name from 'wants to merge X commits into [BASE_BRANCH] from [HEAD_BRANCH]'. Also extract PR title, description, and labels."
+```
+
+Store the BASE branch - you'll need it if diff is large.
+
+**Step 2: Get complete diff**
+
+```
+WebFetch: https://patch-diff.githubusercontent.com/raw/shopsys/shopsys/pull/{PR_NUMBER}.diff
+Prompt: "Return the complete diff content exactly as-is"
+```
+
+**Step 3: Get commits**
+
+```
+WebFetch: https://github.com/shopsys/shopsys/pull/{PR_NUMBER}/commits
+Prompt: "Extract commit messages, looking for keywords: 'move', 'moved', 'moving' combined with 'from project-base' or 'to package'"
+```
+
+**Step 4: Decide if local git needed**
+
+- Estimate diff size from WebFetch response
+- If diff < 500KB → Use only WebFetch data
+- If diff > 500KB OR appears truncated → Need local git
+
+If local git needed, ask main command to confirm with user: "The diff is large. I'll use local git for analysis. Current branch is {branch}. Is the base branch '{extracted_base_branch}'?"
+
+Then use: `git diff {base_branch}...HEAD`
+
+**Return to main command with:**
+- Method used: "webfetch" or "webfetch+git"
+- Base branch: {extracted}
+- PR title, body, labels
+- Complete diff content
+- Commit messages
+- Success: true
+
+### Method 3: Local Git (when no PR provided)
+
+**When input is "current-branch":**
+
+1. Get current branch:
+   ```bash
+   git branch --show-current
+   ```
+
+2. Return to main command with request:
+   - "No PR provided. Current branch is {branch}. Please ask user for base branch."
+
+3. After receiving base branch from main command:
+   ```bash
+   git log {base_branch}...HEAD --oneline
+   git diff {base_branch}...HEAD
+   ```
+
+**Return to main command with:**
+- Method used: "local-git"
+- Base branch: {provided by user}
+- Current branch: {detected}
+- Complete diff content
+- Commit messages from log
+- Success: true
+
+## Error Handling
+
+If any method fails:
+- Try next method in priority order
+- If all methods fail, return:
+  - Success: false
+  - Error: {description}
+  - Suggestion: {what user should do}
+
+## Output Format
+
+Always return a structured summary in this format:
+
+```markdown
+## PR Data Fetch Results
+
+**Method used:** {gh|webfetch|webfetch+git|local-git}
+**PR Number:** {number or "N/A"}
+**Base Branch:** {branch name}
+**PR Title:** {title}
+
+**Diff size:** {approximate size or "complete"}
+**Commits analyzed:** {count}
+**Movement indicators found:** {yes/no + details}
+
+**Status:** ✅ Success | ❌ Failed
+
+### Metadata
+{JSON structure with all extracted data}
+
+### Diff Content
+{First 100 lines of diff as preview}
+[Full diff available in metadata]
+
+### Commit Messages
+{List of commit messages with movement indicators highlighted}
+```
+
+## Important Notes
+
+- **ALWAYS extract and store the BASE branch** - never assume it's "main" or hardcode branch names
+- **Verify diff completeness** - incomplete diff = missed changes
+- **Check commits for movement keywords** BEFORE returning
+- **Prefer gh CLI** - it has no size limits and is most reliable
+- **Never make assumptions** - if data is unclear, note it in the output

--- a/.claude/agents/upgrade_notes_analyzer.md
+++ b/.claude/agents/upgrade_notes_analyzer.md
@@ -1,0 +1,261 @@
+---
+name: upgrade-notes-analyzer
+description: Analyzes PR diffs to identify breaking changes, feature movements, and scope
+tools: Read, Grep
+---
+
+# Upgrade Notes Analyzer
+
+Analyzes PR diffs to identify breaking changes, feature movements, and scope.
+
+## Input
+
+- Complete diff content & commit messages (from pr-diff-fetcher)
+- PR metadata (title, base branch, labels)
+- User-specified scope (optional: backend|storefront|both)
+
+## Analysis Order (CRITICAL)
+
+### ⚠️ STEP 1: MOVEMENTS FIRST
+
+**A deletion in `/project-base/` + addition in `/packages/` = MOVEMENT, not removal!**
+
+**Detection:**
+1. Check commit messages for: "move", "moved", "moving" + "project-base"/"packages"
+2. Cross-reference every `/project-base/src/` deletion with `/packages/` additions:
+   - Same class name + namespace change (`App\*` → `Shopsys\FrameworkBundle\*`) = MOVEMENT
+   - Similar path structure = likely MOVEMENT
+
+**Output:**
+```markdown
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the {package} package:
+    - {description} ({new FQCN from packages})
+```
+
+### STEP 2: DELETIONS (only after ruling out movements)
+
+**Always BC breaks:**
+- Methods removed from `/packages/` classes
+- Classes/interfaces removed entirely (no corresponding addition)
+- GraphQL queries/mutations/fields removed
+- Configuration options removed
+
+**Output:**
+```markdown
+- method `{methodName}` in `{FQCN}` was removed - use `{replacement}` instead
+- GraphQL field `{Type}#{field}` has been removed
+```
+
+### STEP 3: MODIFICATIONS
+
+**Constructor Changes (CRITICAL RULE):**
+- ❌ **SKIP** autowired services (facades, repositories, factories) - DI handles automatically
+- ✅ **INCLUDE** manually instantiated classes (with `new`): FilterQuery, DataObject, form types, validators
+
+**Identify manually instantiated:** Search diff for `new ClassName()` usage
+
+**Other modifications:**
+- Method signature changes (parameters, types)
+- Property/interface changes
+- GraphQL schema changes (field types, arguments)
+- Configuration structure changes
+
+**Output:**
+```markdown
+- `{FQCN}` constructor now has new required `$param` parameter
+  - this class is manually instantiated, update all `new {ClassName}()` calls
+```
+
+### STEP 4: ADDITIONS (mostly skip)
+
+**SKIP:**
+- ❌ New methods/properties/classes in `/packages/`
+- ❌ New migrations (auto-executed)
+- ❌ Constructor params in autowired services
+
+**INCLUDE:**
+- ✅ Corresponds to project-base deletion (it's a MOVEMENT - see Step 1)
+- ✅ Manual setup required (database extensions, SQL)
+- ✅ Constructor params in manually instantiated classes
+
+### STEP 5: SCOPE
+
+**Infer from paths:**
+- **backend**: `/packages/`, `/project-base/app/`, `/project-base/templates/`
+- **storefront**: `/project-base/storefront/`
+- **both**: GraphQL schema changes (`*.types.yaml`, `*Query.php`) + storefront usage
+
+## Output Format
+
+```markdown
+## Analysis Results
+
+### Scope
+**Determined scope:** {backend|storefront|both}
+**Confidence:** {high|medium|low}
+**Reasoning:** {brief explanation}
+
+### Movements Detected
+{count} movements from project-base to packages:
+- **{Feature}**: `{old}` → `{new FQCN}` ({package})
+
+### Breaking Changes ({total count})
+
+#### Removals ({count})
+- `{FQCN}::{method}` removed → use `{replacement}`
+
+#### Modifications ({count})
+- `{FQCN}` constructor: new required `$param` (manually instantiated)
+
+#### GraphQL ({count})
+- Field `{Type}#{field}` removed
+
+#### Configuration ({count})
+- Parameter `{old}` renamed to `{new}`
+
+### Content for Upgrade Notes
+
+#### {PR Title} ([#{PR_NUMBER}](https://github.com/shopsys/shopsys/pull/{PR_NUMBER}))
+
+- {actionable instruction 1}
+- {actionable instruction 2}
+- see #project-base-diff to update your project
+```
+
+## Writing Rules
+
+**INCLUDE:**
+- Methods/properties/classes removed → show replacement
+- Signatures changed → show before/after
+- Manual actions required (DB extensions, etc.)
+- Feature movements to packages
+
+**EXCLUDE:**
+- New entities/classes/methods
+- New migrations
+- Constructor changes in autowired services
+- Feature explanations
+
+**Style:**
+- Action verbs: "use", "replace", "update"
+- Always use FQCN
+- Focus on WHAT to do, not WHY
+- Key test: "Will code break without manual changes?" → YES = include
+
+**Critical:**
+- MOVEMENTS FIRST - never mark movement as "removed"
+- FQCN ALWAYS
+- #project-base-diff - if ANY project-base files changed
+- Constructor changes - ONLY for `new ClassName()`, NOT autowired
+
+**Real-World Example Patterns:**
+
+**Pattern 1: Simple project-base only (no BC breaks)**
+```markdown
+#### Upgrade postgreSQL version to 17.4 ([#3659](https://github.com/shopsys/shopsys/pull/3659))
+
+- see #project-base-diff to update your project
+```
+
+**Pattern 2: Method/property removal with replacement**
+```markdown
+#### Admin Grid performance improvements ([#2460](https://github.com/shopsys/shopsys/pull/2460))
+
+- Twig filter `getProductListDisplayName` from `ProductExtension` is removed. Use `getProductListDisplayNameByName` instead.
+- method `getStoresCountByDomainId` in `StoreFacade` and `StoreRepository` in framework package was removed
+- see #project-base-diff to update your project
+```
+
+**Pattern 3: Constructor/method signature changes**
+```markdown
+#### enable domain configuration with path fragment ([#4113](https://github.com/shopsys/shopsys/pull/4113))
+
+- `Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig` constructor now has new required `$baseUrl` and optional `$postfix` parameters
+    - `DomainConfig::getUrl()` method returns the whole URL including the postfix, if you need just the host part, use `DomainConfig::getBaseUrl()` method instead
+- `Shopsys\FrameworkBundle\Twig\ImageExtension::getImageUrl()` method now requires `int $domainId` parameter
+- see #project-base-diff to update your project
+```
+
+**Pattern 4: Feature movement from project-base to packages**
+```markdown
+#### movements of features from project-base to packages ([#3735](https://github.com/shopsys/shopsys/pull/3735))
+
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the framework package:
+    - `CspHeaderController` and all the related logic (see the usages of `Setting::CSP_HEADER` constant)
+    - `FlagController` - `editAction`, `newAction`, `deleteAction`, `deleteConfirmAction`, and all the related logic
+    - whole language constant agenda in admin (see `LanguageConstantController`)
+    - `Product::$productVideos` property, `ProductVideo` entity, and all the related logic
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the frontend-api package:
+    - `Breadcrumb` interface graphql type (`BreadcrumbDecorator.types.yaml`)
+    - language constant types and query (`LanguageConstantQuery` and `LanguageConstantDecorator.types.yaml`)
+- see #project-base-diff to update your project
+```
+
+**Pattern 5: Conditional instructions (if you have X)**
+```markdown
+#### Grids ordering by administrator language ([#4135](https://github.com/shopsys/shopsys/pull/4135))
+
+- added new factories for all DataSource types to ensure consistent instantiation
+- if you are using custom grid implementations with direct DataSource instantiation, use the new factory classes for consistent collation behavior
+- see #project-base-diff to update your project
+```
+
+**Pattern 6: Database/infrastructure manual actions**
+```markdown
+#### Admin Grid performance improvements ([#2460](https://github.com/shopsys/shopsys/pull/2460))
+
+- add to `pg_trgm` extension to your postgreSQL database
+    - you need to install the extension before running the migration `Version20241205144230`
+    - for your production and devel environment, you need to install the extension manually (`CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA pg_catalog`)
+    - localhost and CI is covered by `db-create` target
+- check your code for usages of the `NORMALIZED(columnName) LIKE NORMALIZED(:text)` and create the indexes for corresponding columns
+- see #project-base-diff to update your project
+```
+
+**Pattern 7: GraphQL schema changes**
+```markdown
+#### remove linked categories ([#3718](https://github.com/shopsys/shopsys/pull/3718))
+
+- Frontend API field `Category#linkedCategories` has been removed along with its loader
+- if your project uses this functionality
+    - skip the migration `Shopsys\FrameworkBundle\Migrations\Version20250324141622`
+    - skip removing the code
+    - add the field `linkedCategories` to the `Category` type in your project in Frontend API schema
+- see #project-base-diff to update your project
+```
+
+**Pattern 8: Storefront changes (components, hooks, types)**
+```markdown
+#### enable domain configuration with path fragment ([#4113](https://github.com/shopsys/shopsys/pull/4113))
+
+- **`getDomainConfig()` function signature changed**
+    - before: `getDomainConfig(domainUrl: string): DomainConfigType`
+    - after: `getDomainConfig(context: GetServerSidePropsContext | NextPageContext): DomainConfigType`
+- **`createClient()` function signature changed**
+    - before: accepts `publicGraphqlEndpoint: string` parameter
+    - after: accepts `domainConfig: DomainConfigType` parameter instead
+- see #project-base-diff to update your project
+```
+
+**Pattern 9: Configuration changes**
+```markdown
+#### enable domain configuration with path fragment ([#4113](https://github.com/shopsys/shopsys/pull/4113))
+
+- `Shopsys\FrameworkBundle\Component\Context\AdminContext` constructor parameter `$adminRoutePrefixes` has been renamed to `$additionalAdminPathPrefixes`
+    - the meaning of the parameter has changed, it now represents additional path prefixes instead of the original route names
+    - the configuration parameter name has changed from `admin_context_route_prefixes` to `admin_context_additional_path_prefixes`
+- see #project-base-diff to update your project
+```
+
+**Pattern 10: Multiple related changes**
+```markdown
+#### Implement store features ([#3413](https://github.com/shopsys/shopsys/pull/3413))
+
+- `StoresQuery` class now uses new `StoreFacade` class from frontend-api package
+    - Instead of `getStoresByDomainId` method, use `getFilteredStores` method
+    - Instead of `getStoresCountByDomainId` method, use `getFilteredStoresCount` method
+- attribute `Store::$contactInfo` was removed. If you still want to use it, you need to implement it by yourself
+- new attributes `Store::$email`, `Store::$phone` and `Store::$directions` were introduced
+- `StoreFormType` form was refactored into multiple groups. Look into the `StoreFormType` class to see the changes
+- see #project-base-diff to update your project
+```

--- a/.claude/commands/generate_upgrade_notes.md
+++ b/.claude/commands/generate_upgrade_notes.md
@@ -1,0 +1,278 @@
+# Generate Upgrade Notes
+
+Generates upgrade notes for Shopsys Platform features when creating pull requests. Analyzes code changes and creates structured upgrade note files following project conventions.
+
+## Initial Setup
+
+When invoked, respond:
+```
+I'm ready to generate upgrade notes. Please provide:
+1. Link to the pull request (or I can analyze current branch changes)
+2. Scope: backend, storefront, or both (or I can infer from changes)
+```
+
+Then wait for user input.
+
+## Command Arguments
+
+- **[link-to-pull-request]** (optional): GitHub PR URL or number (e.g., `4183` or `https://github.com/shopsys/shopsys/pull/4183`)
+- **[backend|storefront|both]** (optional): Scope of changes - will be inferred if not provided
+
+## Workflow After Receiving User Input
+
+Use TodoWrite to track: fetching PR data → analyzing changes → generating files → user review
+
+### Step 1: Parse User Input
+
+Extract from user input:
+- **PR identifier**: URL, number, or "current-branch"
+- **Scope** (optional): backend, storefront, or both
+
+### Step 2: Fetch PR Data (Using Subagent)
+
+**Launch the pr-diff-fetcher subagent:**
+
+Use the Task tool with general-purpose agent:
+
+```
+Description: "Fetch PR diff and metadata"
+
+Prompt: "You are the PR Diff Fetcher subagent. Read the specification at .claude/agents/pull_request_diff_fetcher.md and follow it exactly.
+
+Input: {PR_URL or PR_NUMBER or 'current-branch'}
+
+Your task: Fetch complete PR data (diff, metadata, commits) using the best available method (gh CLI → WebFetch → local git) as specified in the helper documentation.
+
+Return structured results following the output format in the specification."
+```
+
+**Wait for subagent results.**
+
+If subagent requests user input (e.g., "What is the base branch?"), relay the question to user and pass answer back.
+
+### Step 3: Analyze Changes (Using Subagent)
+
+**Launch the upgrade-notes-analyzer subagent:**
+
+Use the Task tool with general-purpose agent:
+
+```
+Description: "Analyze BC breaks and movements"
+
+Prompt: "You are the Upgrade Notes Analyzer subagent. Read the specification at .claude/agents/upgrade_notes_analyzer.md and follow it exactly.
+
+Input:
+- Complete diff content: {from pr-diff-fetcher}
+- Commit messages: {from pr-diff-fetcher}
+- PR metadata: {from pr-diff-fetcher}
+- User-specified scope: {user input or 'infer'}
+
+Your task: Analyze the diff following the critical three-step process:
+1. Detect movements FIRST
+2. Identify true deletions (not movements)
+3. Find modifications and BC breaks
+
+Return structured analysis following the output format in the specification, including ready-to-use upgrade note content."
+```
+
+**Wait for subagent results.**
+
+### Step 4: Generate Upgrade Note Content
+
+Based on analyzer output, prepare the upgrade note file content:
+
+**File naming:**
+- Format: `{scope}_YYYYMMDD_HHmmss.md`
+- Get timestamp: `date +"%Y%m%d_%H%M%S"`
+
+**Content structure:**
+```markdown
+#### {PR Title} ([#{PR_NUMBER}](https://github.com/shopsys/shopsys/pull/{PR_NUMBER}))
+
+{Content from analyzer subagent - already formatted}
+
+```
+
+**Decision tree for content:**
+1. **BC breaks found** → Use detailed content from analyzer
+2. **No BC breaks BUT project-base changed** → Minimal note: title + "see #project-base-diff"
+3. **No BC breaks AND no project-base changes** → Minimal note: title only
+
+**Files to create:**
+- **backend scope** → `upgrade-notes/backend_YYYYMMDD_HHmmss.md`
+- **storefront scope** → `upgrade-notes/storefront_YYYYMMDD_HHmmss.md`
+- **both scope** → Create BOTH files with scope-specific content
+
+### Step 5: Present to User for Review
+
+**Show comprehensive summary:**
+
+```markdown
+## Analysis Summary
+
+**PR:** #{PR_NUMBER} - {title}
+**Base branch:** {branch}
+**Method used:** {gh|webfetch|local-git}
+
+### Changes Detected
+- **Files changed:** {count}
+- **Feature movements:** {count} (project-base → packages)
+- **Breaking changes:** {count}
+- **Project-base changes:** {yes/no}
+
+### Movements Found
+{list movements if any}
+
+### Breaking Changes Found
+{list BC breaks if any, or "No breaking changes detected"}
+
+### Scope
+**Determined scope:** {backend|storefront|both}
+{reasoning if inferred}
+
+---
+
+## Generated Upgrade Notes
+
+### File: upgrade-notes/{scope}_YYYYMMDD_HHmmss.md
+
+```markdown
+{show complete file content}
+```
+
+{if both scope, show second file}
+
+---
+
+Would you like me to:
+1. Save this as-is
+2. Make edits (please specify changes)
+3. Cancel
+```
+
+### Step 6: Handle User Response
+
+**If user requests edits:**
+- Make requested changes
+- Show updated content
+- Ask for confirmation again
+
+**If user approves:**
+- Proceed to Step 7
+
+**If user cancels:**
+- Confirm cancellation
+- Do not create files
+
+### Step 7: Save the Files
+
+After user confirms:
+
+1. Create file(s) using Write tool in `upgrade-notes/` directory
+2. Confirm successful creation
+
+**Final message:**
+```
+✓ Created upgrade notes:
+  - upgrade-notes/{scope}_YYYYMMDD_HHmmss.md
+  {- upgrade-notes/{scope2}_YYYYMMDD_HHmmss.md if both}
+
+Ready for inclusion in your PR. These will be combined into UPGRADE-{version}.md during release.
+```
+
+## Subagent Architecture
+
+This command uses two specialized subagents (via general-purpose agent with detailed prompts):
+
+### 1. PR Diff Fetcher (`pull_request_diff_fetcher.md`)
+**Responsibilities:**
+- Check gh CLI availability and authentication
+- Fetch PR metadata (base branch, title, labels)
+- Get complete diff using best method (gh → WebFetch → local git)
+- Fetch commit messages
+- Handle fallback logic
+
+### 2. Upgrade Notes Analyzer (`upgrade_notes_analyzer.md`)
+**Responsibilities:**
+- Detect feature movements (FIRST!)
+- Identify true deletions vs movements
+- Find BC breaks (removals, modifications)
+- Determine scope
+- Generate ready-to-use upgrade note content
+
+## Error Handling
+
+**If pr-diff-fetcher fails:**
+- Show error from subagent
+- Suggest alternatives (try different method, check authentication, etc.)
+- Allow user to retry or cancel
+
+**If upgrade-notes-analyzer finds issues:**
+- Show warnings/concerns from analyzer
+- Ask user for clarification if needed
+- Proceed with best-effort analysis
+
+**General errors:**
+- Invalid PR link → Ask user to verify
+- No changes detected → Inform user, ask to verify
+- Unable to determine scope → Ask user to specify
+- Diff too large/truncated → Warn user, use best available data
+
+## Architecture Awareness
+
+**Package-first development:**
+- Core logic in `/packages/`
+- Configuration in `/project-base/`
+- Feature movements from project-base to packages are significant architectural changes
+
+**Key file locations:**
+- Backend: `/packages/framework/`, `/packages/frontend-api/`, `/project-base/app/src/`
+- Storefront: `/project-base/storefront/`
+- Config: `/project-base/app/config/`
+
+## Quality Checks
+
+- Focus on breaking changes requiring manual action
+- Avoid documenting changes caught by static analysis
+- Always include `#project-base-diff` phrase when project-base changes
+- Use FQCN (Fully Qualified Class Names) everywhere
+- Keep instructions clear and actionable
+
+## Example Real-World Patterns
+
+The analyzer subagent has comprehensive examples of upgrade note patterns. Key patterns include:
+
+1. **Simple project-base only** (no BC breaks)
+2. **Method/property removal** with replacement
+3. **Constructor/method signature changes**
+4. **Feature movements** from project-base to packages
+5. **Conditional instructions** ("if you have X")
+6. **Database/infrastructure** manual actions
+7. **GraphQL schema changes**
+8. **Storefront changes** (components, hooks, types)
+9. **Configuration changes**
+10. **Multiple related changes**
+
+See `.claude/agents/upgrade_notes_analyzer.md` for detailed examples.
+
+## Example Usage Scenarios
+
+**With PR link and scope:**
+```
+User: /generate-upgrade-notes https://github.com/shopsys/shopsys/pull/4183 backend
+```
+
+**With just PR number:**
+```
+User: /generate-upgrade-notes 4169
+```
+
+**Current branch analysis:**
+```
+User: /generate-upgrade-notes
+```
+
+**Both scopes:**
+```
+User: /generate-upgrade-notes 4135 both
+```

--- a/docs/contributing/guidelines-for-writing-upgrade.md
+++ b/docs/contributing/guidelines-for-writing-upgrade.md
@@ -2,6 +2,9 @@
 
 Keep in mind that upgrade instructions are written for users who might not understand our system well, so the more clear they are, the more helpful they are.
 
+- If you are using Claude Code, you can leverage `/generate-upgrade-notes` slash command to generate the upgrade notes, however, make sure to review and edit the generated content as needed.
+    - The best practice is to create the pull request first and then use the command as it uses the pull request link to analyze the changes.
+    - The command works best with `gh` CLI tool ([installation guide](https://github.com/cli/cli#installation)) as the primary method, but also works without it via GitHub web API, or can analyze local branch changes as a fallback.
 - Our users work in a clone of project-base, and even when they do the upgrade, their project-base still needs to be upgraded.
   Every time you change/add anything in the project-base, write upgrade instruction how to repeat this work.
     - for anything with docker, phing, frontend, config, etc.
@@ -15,3 +18,4 @@ Keep in mind that upgrade instructions are written for users who might not under
     - describe all the BC breaks and provide information on how to handle them
         - e.g. _"Method MyClass::oldMethod() was removed, use MyClass::newMethod() instead"_
         - you do not need to explicitly mention changes that are easily discoverable by the standard checks or static analysis, e.g., adding a new dependency into a class constructor.
+        - also, it is not the purpose of the upgrade notes to describe the feature itself (developers can read that in the linked pull request), only the changes that need to be done in the project

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,10 @@ If you are not able to find the desired information here, you can always ask us 
 If you are struggling with Docker, [Docker Troubleshooting](./docker/docker-troubleshooting.md) might help you.
 
 ## What is new and how to upgrade
-* In `CHANGELOG` file you can find the list of all important changes in all repositories maintained in [shopsys/shopsys monorepo](https://github.com/shopsys/shopsys/)
 * For step-by-step upgrade instructions, see the particular `UPGRADE` file
+    * it is important to switch the [shopsys/shopsys monorepo](https://github.com/shopsys/shopsys/) repository to the proper branch that corresponds to the version you are upgrading to
+        *  e.g., for upgrading to version `v17.0.0`, you find [the upgrading instructions](https://github.com/shopsys/shopsys/blob/17.0/UPGRADE-17.0.md) in the `17.0` branch, while for upgrading to version `v16.0.0`, you find [the upgrading instructions](https://github.com/shopsys/shopsys/blob/16.0/UPGRADE-16.0.md) in the `16.0` branch, etc.
+* In `CHANGELOG` file you can find the list of all important changes in all repositories maintained in [shopsys/shopsys monorepo](https://github.com/shopsys/shopsys/)
 * Thanks to our [Backward Compatibility Promise](./contributing/backward-compatibility-promise.md), it should be clear to which versions you can upgrade safely and how we plan to maintain the code in the future
 
 ## Table of Contents

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -220,3 +220,8 @@ The installation script automatically configures the `LOCAL_PATH_TO_PROJECT_ROOT
 For macOS and Windows users, no further configuration is needed. Linux requires additional installation of [phpstorm-url-handler](https://github.com/sanduhrs/phpstorm-url-handler) as stated in the [Symfony docs](https://symfony.com/doc/current/reference/configuration/framework.html#ide).
 
 If you're using a different IDE than PHPStorm, you need to update environment variables `SYMFONY_IDE_URL_FORMAT` and `TRACY_DEBUGGER_IDE_URL_FORMAT` in your `.env.local` file to match your IDE's URL format.
+
+## Where can I find upgrading notes for a specific version?
+
+Each version of Shopsys Platform has its own upgrading notes file located in the [root of the repository](https://github.com/shopsys/shopsys) in the `UPGRADE-x.y.md` file.
+To find the desired version, you need to switch to the proper branch, see [What is new and how to upgrade](../index.md#what-is-new-and-how-to-upgrade) section for more information.


### PR DESCRIPTION
#### Description, the reason for the PR
The new command should help Shopsys Platform developers and contributors with writing upgrade notes for their features. 

Moreover, the docs were improved to emphasise where the particular upgrade notes for the particular versions could be found.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-upgrade-notes.odin.shopsys.cloud
  - https://cz.rv-upgrade-notes.odin.shopsys.cloud
  - https://rv-upgrade-notes.odin.shopsys.cloud/sk
<!-- Replace -->
