### PR TITLE
admin: fix templates for single domain app

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Content/Product/edit.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/edit.html.twig
@@ -31,7 +31,7 @@
         </span>
     {% else %}
         {% if isVisibleForDefaultPricingGroupOnEachDomain(product) %}
-            <a href="{{ findUrlByDomainId('front_product_detail', { id: product.id }, getDomain().id) }}">
+            <a href="{{ findUrlByDomainId('front_product_detail', { id: product.id }, getFirstDomain().id) }}">
                 <span class="in-icon in-icon--visible">{{ ux_icon('visible') }}</span>
             </a>
         {% else %}

--- a/packages/framework/src/Resources/views/Admin/Content/Product/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/listGrid.html.twig
@@ -48,7 +48,7 @@
     {% else %}
         {% if row.isVisible %}
             {% apply spaceless %}
-                <a href="{{ findUrlByDomainId('front_product_detail', { id: row.id }, getDomain().id) }}">
+                <a href="{{ findUrlByDomainId('front_product_detail', { id: row.id }, getFirstDomain().id) }}">
                     <span class="in-icon in-icon--visible">{{ ux_icon('visible') }}</span>
                 </a>
             {% endapply %}

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -973,8 +973,8 @@
                         {% endfor %}
                     </select>
             {% else %}
-                <strong class="form-line__label">{{ getDomain().url }}</strong>
-                <input type="hidden" {{ block('widget_attributes') }} value="{{ getDomain().id }}" />
+                <strong class="form-line__label">{{ getFirstDomain().url }}</strong>
+                <input type="hidden" {{ block('widget_attributes') }} value="{{ getFirstDomain().id }}" />
             {% endif %}
         </div>
     </div>

--- a/packages/framework/src/Twig/DomainExtension.php
+++ b/packages/framework/src/Twig/DomainExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Twig;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\DomainFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
@@ -43,6 +44,7 @@ class DomainExtension extends AbstractExtension
             new TwigFunction('domainIcon', $this->getDomainIconHtml(...), ['is_safe' => ['html']]),
             new TwigFunction('isMultidomain', $this->isMultidomain(...)),
             new TwigFunction('getDomainUrlByLocale', $this->getDomainUrlByLocale(...)),
+            new TwigFunction('getFirstDomain', $this->getFirstDomainConfig(...)),
         ];
     }
 
@@ -126,5 +128,13 @@ class DomainExtension extends AbstractExtension
         }
 
         throw new NoDomainSelectedException('Domain for locale `' . $locale . '` not found;');
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
+     */
+    public function getFirstDomainConfig(): DomainConfig
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID);
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

Since https://github.com/shopsys/shopsys/pull/4113, there is no current domain config in admin anymore.

The single-domain application was broken because of a few places, where the current domain was still accessed within the admin, see https://github.com/shopsys/project-base/actions/runs/18276603764/job/52030048552

Fixed build should be seen here - https://github.com/shopsys/project-base/actions/runs/18304772257/job/52119463534

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-singledomain.odin.shopsys.cloud
  - https://cz.rv-fix-singledomain.odin.shopsys.cloud
  - https://rv-fix-singledomain.odin.shopsys.cloud/sk
<!-- Replace -->
