### PR TITLE
Improve cypress gql error handling

### DIFF
--- a/docs/storefront/cypress.md
+++ b/docs/storefront/cypress.md
@@ -26,6 +26,86 @@ Here you can put various global helpers, such as custom cypress commands, or sim
 
 You can put all commands or support functions related to API (such as manual mutations or queries) in `/support/api.ts`.
 
+#### GraphQL requests and `checkGQL`
+
+For GraphQL requests, prefer the `checkGQL` child command defined in `project-base/storefront/cypress/support/api.ts`. It makes requests fail fast with a helpful error message instead of timing out when `body.data.*` is missing.
+
+- Always set `failOnStatusCode: false` on `cy.request` so the error payload can be read even on HTTP 4xx/5xx.
+- Call `.checkGQL('<OperationName>')` right after the request. The operation name must be explicit.
+- On success, `checkGQL` yields `body.data` so you can chain `.its('...')` or `.then(...)` directly.
+- On error, the command throws with a rich message: `[GQL] <Operation> failed: <message> (status <code>[, code <extCode>[, userCode <userCode>]])`.
+    - If GraphQL returns `extensions.validation`, it is flattened under a `Validation:` section with the `input.` prefix removed from field names.
+- Logging: `checkGQL` writes a `cy.log` entry before throwing so the GUI log always shows what failed.
+
+Usage examples
+
+- Success path (example: add to cart):
+
+```
+cy.request({
+  method: 'POST',
+  url: 'graphql/',
+  headers: { 'Content-Type': 'application/json', /* optionally: 'X-Auth-Token': `Bearer ${accessToken}` */ },
+  body: JSON.stringify({
+    operationName: 'AddToCartMutation',
+    query: `mutation AddToCartMutation($input: AddToCartInput!) { AddToCart(input: $input) { cart { uuid } } }`,
+    variables: { input: { cartUuid, productUuid, quantity: 1 } },
+  }),
+  failOnStatusCode: false,
+})
+  .checkGQL('AddToCartMutation')
+  .its('AddToCart.cart.uuid')
+  .then((uuid) => { /* assertions */ });
+```
+
+- Negative/validation scenario (two options):
+    - Prefer asserting on the thrown message using `Cypress.once('fail', ...)` (keeps the command consistent and still fail-fast):
+
+```
+Cypress.once('fail', (err) => {
+  expect(String(err.message)).to.contain('RegistrationMutation failed');
+  expect(String(err.message)).to.match(/Validation:/);
+  expect(String(err.message)).not.to.contain('input.');
+  return false; // prevent the test from failing after verifying the error
+});
+
+cy.request({ /* ... invalid input ... */, failOnStatusCode: false })
+  .checkGQL('RegistrationMutation');
+```
+
+- Or, if you need to inspect `errors` without throwing, skip `checkGQL` and assert on `response.body.errors` manually:
+
+```
+cy.request({ /* ... */, failOnStatusCode: false }).then((res) => {
+  const body = typeof res.body === 'string' ? JSON.parse(res.body) : res.body;
+  expect(body.errors).to.be.an('array').and.not.empty;
+  // further assertions
+});
+```
+
+Migration from `.its('body.data.*')`
+
+- Before:
+    - `cy.request(...).its('body.data.Product')`
+- After:
+    - `cy.request({ ..., failOnStatusCode: false }).checkGQL('ProductQuery').its('Product')`
+
+Headers and auth
+
+- Many helpers in `support/api.ts` take care of auth cookies/headers for you. If writing raw requests:
+    - Set `Content-Type: application/json`.
+    - When needed, add `'X-Auth-Token': 'Bearer ' + accessToken` (read from `cy.getCookie('accessToken')`).
+
+JSON envelope
+
+- Prefer sending the GraphQL envelope as a JSON string via `body: JSON.stringify({ operationName, query, variables })` for consistency and to avoid payload-type mismatches.
+
+Type definitions
+
+- `cypress/cypress.d.ts` declares the `checkGQL` command as returning the `body.data` shape:
+    - `checkGQL<T = any>(operationName: string): Cypress.Chainable<T>`
+    - After `checkGQL`, you can safely chain `.its('...')` on `data`.
+
 ### TIDs.ts
 
 Here you should put all data test IDs (TIDs) used in the app. Having them in a single TS file which can be globally referenced is helpful for maintenance and keeping track of used or unused IDs.

--- a/project-base/storefront/cypress/cypress.d.ts
+++ b/project-base/storefront/cypress/cypress.d.ts
@@ -5,6 +5,7 @@ import { TIDs } from 'tids';
 declare global {
     namespace Cypress {
         interface Chainable<Subject = any> {
+            checkGQL<T = any>(operationName: string): Cypress.Chainable<T>;
             getByTID(
                 value: ([TIDs, number | string] | TIDs)[],
                 options?:
@@ -18,18 +19,15 @@ declare global {
             waitForHydration(): Cypress.Chainable<void>;
             addProductToCartForTest(productUuid?: string, quantity?: number): Cypress.Chainable<any>;
             addPromoCodeToCartForTest(promoCode: string): Cypress.Chainable<any>;
-            preselectTransportForTest(
-                transportUuid: string,
-                pickupPlaceIdentifier?: string,
-            ): Cypress.Chainable<Cypress.Response<any>>;
-            preselectPaymentForTest(paymentUuid: string): Cypress.Chainable<Cypress.Response<any>>;
-            login(email?: string, password?: string): Cypress.Chainable<Cypress.Response<any>>;
-            logout(): Cypress.Chainable<Cypress.Response<any>>;
+            preselectTransportForTest(transportUuid: string, pickupPlaceIdentifier?: string): Cypress.Chainable<any>;
+            preselectPaymentForTest(paymentUuid: string): Cypress.Chainable<any>;
+            login(email?: string, password?: string): Cypress.Chainable<any>;
+            logout(): Cypress.Chainable<any>;
             createOrder(createOrderInput: CreateOrderMutationVariables): Cypress.Chainable<{ urlHash: string }>;
             registerAsNewUser(
                 registrationInput: RegistrationDataInputApi,
                 shouldLogin?: boolean,
-            ): Cypress.Chainable<Cypress.Response<any>>;
+            ): Cypress.Chainable<any>;
 
             setDevicePixelRatio(
                 pixelRatio: number,

--- a/project-base/storefront/cypress/e2e/graphql/graphQLErrorHandling.cy.ts
+++ b/project-base/storefront/cypress/e2e/graphql/graphQLErrorHandling.cy.ts
@@ -1,0 +1,61 @@
+import { generateCustomerRegistrationData } from 'fixtures/generators';
+import { initializePersistStoreInLocalStorageToDefaultValues } from 'support';
+
+describe('GraphQL error handling', () => {
+    it('surfaces schema errors (unknown field)', () => {
+        cy.request({
+            method: 'POST',
+            url: 'graphql/',
+            headers: { 'Content-Type': 'application/json' },
+            body: { query: 'query { nonExistingField }' },
+            failOnStatusCode: false,
+        }).then((response) => {
+            const body = typeof response.body === 'string' ? JSON.parse(response.body) : response.body;
+            expect(body.errors?.[0]?.message || '').to.not.equal('');
+        });
+
+        Cypress.once('fail', (err) => {
+            expect(String(err.message)).to.contain('InvalidQuery failed');
+            return false;
+        });
+
+        cy.request({
+            method: 'POST',
+            url: 'graphql/',
+            headers: { 'Content-Type': 'application/json' },
+            body: { query: 'query { nonExistingField }' },
+            failOnStatusCode: false,
+        }).checkGQL('InvalidQuery');
+    });
+
+    it('flattens validation errors with input. prefix removed', () => {
+        initializePersistStoreInLocalStorageToDefaultValues();
+        const validInput = generateCustomerRegistrationData('commonCustomer');
+        const invalidInput = { ...validInput, email: 'not-an-email' };
+        const body = {
+            operationName: 'RegistrationMutation',
+            query: `mutation RegistrationMutation($input: RegistrationDataInput!) {
+                Register(input: $input) { tokens { accessToken } }
+            }`,
+            variables: {
+                input: invalidInput,
+            },
+        };
+
+        Cypress.once('fail', (err) => {
+            const msg = String(err.message);
+            expect(msg).to.contain('RegistrationMutation failed');
+            expect(msg).to.match(/Validation:/);
+            expect(msg).not.to.contain('input.');
+            return false;
+        });
+
+        cy.request({
+            method: 'POST',
+            url: 'graphql/',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            failOnStatusCode: false,
+        }).checkGQL('RegistrationMutation');
+    });
+});

--- a/project-base/storefront/cypress/support/api.ts
+++ b/project-base/storefront/cypress/support/api.ts
@@ -3,6 +3,102 @@ import { TypePromoCode, TypeRegistrationDataInput } from '../../graphql/types';
 import 'cypress-real-events';
 import { PERSIST_STORE_NAME, products, user } from 'fixtures/demodata';
 
+Cypress.Commands.add('checkGQL', { prevSubject: true }, (subject: Cypress.Response<any>, operationName: string) => {
+    // Defer all work into Cypress chain so cy.log entries render in GUI before any throw
+    return cy.wrap(subject, { log: false }).then((response) => {
+        // Normalize body to object
+        let body: any = response?.body;
+        if (typeof body === 'string') {
+            try {
+                body = JSON.parse(body);
+            } catch (e) {
+                cy.log(`[GQL] ${operationName} non-JSON response (status ${response.status})`);
+                return cy.then(() => {
+                    throw new Error(
+                        `[GQL] ${operationName} failed: response body is not valid JSON (status ${response.status})`,
+                    );
+                });
+            }
+        }
+
+        const errors = body?.errors as
+            | Array<{
+                  message: string;
+                  path?: (string | number)[];
+                  extensions?:
+                      | (Record<string, unknown> & {
+                            code?: number | string;
+                            userCode?: string | null;
+                            validation?: Record<string, Array<{ code?: string; message?: string } | string>>;
+                        })
+                      | undefined;
+              }>
+            | undefined;
+        const data = body?.data;
+
+        if (Array.isArray(errors) && errors.length > 0) {
+            const first = errors[0];
+            const pathStr = first.path ? first.path.join('.') : undefined;
+
+            const validation = first.extensions?.validation;
+            const validationMessages: string[] = [];
+            if (validation && typeof validation === 'object') {
+                Object.entries(validation).forEach(([field, issues]) => {
+                    const cleanField = field.startsWith('input.') ? field.replace(/^input\./, '') : field;
+                    if (Array.isArray(issues)) {
+                        for (const issue of issues) {
+                            if (issue && typeof issue === 'object') {
+                                const code = (issue as any).code ? ` [${(issue as any).code}]` : '';
+                                const message = (issue as any).message ?? String(issue);
+                                validationMessages.push(`${cleanField}: ${message}${code}`);
+                            } else {
+                                validationMessages.push(`${cleanField}: ${String(issue)}`);
+                            }
+                        }
+                    }
+                });
+            }
+
+            const extCode = first.extensions && (first.extensions as any).code;
+            const userCode = first.extensions && (first.extensions as any).userCode;
+
+            let detailedMessage = `${first.message}`;
+            if (validationMessages.length > 0) {
+                detailedMessage += `\nValidation:\n- ${validationMessages.join('\n- ')}`;
+            }
+            const summary = `${detailedMessage}${pathStr ? ` @ ${pathStr}` : ''}`;
+
+            cy.log(
+                `[GQL] ${operationName} failed (status ${response.status}${
+                    extCode || userCode ? `, code ${extCode ?? ''}${userCode ? `, userCode ${userCode}` : ''}` : ''
+                }):`,
+            );
+            if (validationMessages.length > 0) {
+                cy.log(`Validation:\n- ${validationMessages.join('\n- ')}`);
+            } else {
+                cy.log(first.message);
+            }
+
+            return cy.then(() => {
+                const codeInfo =
+                    extCode || userCode ? `, code ${extCode ?? ''}${userCode ? `, userCode ${userCode}` : ''}` : '';
+                throw new Error(`[GQL] ${operationName} failed: ${summary} (status ${response.status}${codeInfo})`);
+            });
+        }
+
+        if (typeof data === 'undefined') {
+            cy.log(`[GQL] ${operationName} missing both data and errors (status ${response.status})`);
+            return cy.then(() => {
+                throw new Error(
+                    `[GQL] ${operationName} failed: missing both data and errors (status ${response.status})`,
+                );
+            });
+        }
+
+        return data;
+    });
+});
+
 Cypress.Commands.add('addProductToCartForTest', (productUuid?: string, quantity?: number) => {
     const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
 
@@ -39,8 +135,10 @@ Cypress.Commands.add('addProductToCartForTest', (productUuid?: string, quantity?
                     'Content-Type': 'application/json',
                     ...(accessToken ? { 'X-Auth-Token': 'Bearer ' + accessToken } : {}),
                 },
+                failOnStatusCode: false,
             })
-            .its('body.data.AddToCart.cart');
+            .checkGQL('AddToCartMutation')
+            .its('AddToCart.cart');
     });
 });
 
@@ -80,8 +178,10 @@ Cypress.Commands.add('addPromoCodeToCartForTest', (promoCode: string) => {
                     'Content-Type': 'application/json',
                     ...(accessToken ? { 'X-Auth-Token': 'Bearer ' + accessToken } : {}),
                 },
+                failOnStatusCode: false,
             })
-            .its('body.data.ApplyPromoCodeToCart')
+            .checkGQL('ApplyPromoCodeToCartMutation')
+            .its('ApplyPromoCodeToCart')
             .then((cart) => {
                 expect(cart.uuid).equal(cartUuid);
                 const responsePromoCode = cart.promoCodes.find(
@@ -135,8 +235,10 @@ Cypress.Commands.add('preselectTransportForTest', (transportUuid: string, pickup
                     'Content-Type': 'application/json',
                     ...(accessToken ? { 'X-Auth-Token': 'Bearer ' + accessToken } : {}),
                 },
+                failOnStatusCode: false,
             })
-            .its('body.data.ChangeTransportInCart')
+            .checkGQL('ChangeTransportInCartMutation')
+            .its('ChangeTransportInCart')
             .then((cart) => {
                 expect(cart.uuid).equal(cartUuid);
                 expect(cart.transport.uuid).equal(transportUuid);
@@ -188,8 +290,10 @@ Cypress.Commands.add('preselectPaymentForTest', (paymentUuid: string) => {
                     'Content-Type': 'application/json',
                     ...(accessToken ? { 'X-Auth-Token': 'Bearer ' + accessToken } : {}),
                 },
+                failOnStatusCode: false,
             })
-            .its('body.data.ChangePaymentInCart')
+            .checkGQL('ChangePaymentInCartMutation')
+            .its('ChangePaymentInCart')
             .then((cart) => {
                 expect(cart.uuid).equal(cartUuid);
                 expect(cart.payment.uuid).equal(paymentUuid);
@@ -219,8 +323,10 @@ Cypress.Commands.add('registerAsNewUser', (registrationInput: TypeRegistrationDa
             headers: {
                 'Content-Type': 'application/json',
             },
+            failOnStatusCode: false,
         })
-        .its('body.data.Register')
+        .checkGQL('RegistrationMutation')
+        .its('Register')
         .then((registrationResponse) => {
             if (shouldLogin) {
                 expect(registrationResponse.tokens.accessToken).to.be.a('string').and.not.be.empty;
@@ -266,12 +372,12 @@ Cypress.Commands.add('login', (email = user.email, password = user.password) => 
                     productListsUuids: [],
                 },
             },
+            failOnStatusCode: false,
         })
-            // .its('body.data')
-            .then((res) => {
-                console.log(res);
-                accessToken = res.body.data.Login.tokens.accessToken;
-                refreshToken = res.body.data.Login.tokens.refreshToken;
+            .checkGQL('LoginMutation')
+            .then((data) => {
+                accessToken = data.Login.tokens.accessToken;
+                refreshToken = data.Login.tokens.refreshToken;
 
                 cy.log('Customer login - ' + user.email);
                 if (accessToken) {
@@ -316,9 +422,11 @@ Cypress.Commands.add('logout', () => {
                     'Content-Type': 'application/json',
                     ...(accessToken ? { 'X-Auth-Token': 'Bearer ' + accessToken } : {}),
                 },
+                failOnStatusCode: false,
             })
-            .then((logoutResponse) => {
-                expect(logoutResponse.body.data.Logout).to.be.true;
+            .checkGQL('LogoutMutation')
+            .then((data) => {
+                expect(data.Logout).to.be.true;
                 cy.clearCookie('accessToken-1');
                 cy.clearCookie('refreshToken-1');
             });
@@ -416,7 +524,9 @@ Cypress.Commands.add('createOrder', (createOrderVariables: TypeCreateOrderMutati
                     'Content-Type': 'application/json',
                     ...(accessToken ? { 'X-Auth-Token': 'Bearer ' + accessToken } : {}),
                 },
+                failOnStatusCode: false,
             })
-            .its('body.data.CreateOrder.order');
+            .checkGQL('CreateOrderMutation')
+            .its('CreateOrder.order');
     });
 });

--- a/upgrade-notes/storefront_20251007_164440.md
+++ b/upgrade-notes/storefront_20251007_164440.md
@@ -1,0 +1,7 @@
+#### Improve cypress gql error handling ([#4220](https://github.com/shopsys/shopsys/pull/4220))
+
+- **New Cypress command `checkGQL<T>(operationName: string)` added** for GraphQL error handling
+    - use this command to validate GraphQL responses and get detailed error messages
+    - replaces the pattern `.its('body.data.X')` with `.checkGQL('OperationName').its('X')`
+- if you have custom Cypress test helpers that directly access GraphQL responses, update them to use the new `checkGQL()` command for better error reporting
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
In order to capture GQL request errors in Cypress tests, new error handling was introduced. Now, instead of failing on timeout in case of failed GQL request, the developer is informed about the actual error by throwing an error and logging comprehensive error log to Cypress & console logs (could be inspected via GUI with `make open-acceptance-tests-base`).
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-cypress-gql-errors-ssp-3579.odin.shopsys.cloud
  - https://cz.jm-cypress-gql-errors-ssp-3579.odin.shopsys.cloud
  - https://jm-cypress-gql-errors-ssp-3579.odin.shopsys.cloud/sk
<!-- Replace -->
