### PR TITLE
admin forms: add some missing labels

### DIFF
--- a/docs/introduction/using-form-types.md
+++ b/docs/introduction/using-form-types.md
@@ -435,7 +435,7 @@ $actionBar = $builder->create('actionBar', ActionBarType::class, [
 ]);
 
 $actionBar->add('createAndDownloadCsv', SubmitType::class, [
-    'label' => t('Create and download CSV'),
+    'label' => 'Create and download CSV',
     'position' => [
         'before' => 'save',
     ],

--- a/packages/administration/templates/form/type/GroupType.html.twig
+++ b/packages/administration/templates/form/type/GroupType.html.twig
@@ -2,7 +2,7 @@
     {%- set row_class = (row_attr.class|default('') ~ ' card mb-3')|trim -%}
     <div {% with {attr: row_attr|merge({class: row_class})} %}{{ block('attributes') }}{% endwith %}>
         <div class="card-header">
-            <h3 class="card-title">{{ form.vars.label }}</h3>
+            <h3 class="card-title">{{ form.vars.label|trans }}</h3>
         </div>
         <div class="card-body">
             {{ form_widget(form) }}

--- a/packages/framework/src/Form/Admin/Administrator/AdminDomainsFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdminDomainsFormType.php
@@ -44,7 +44,7 @@ final class AdminDomainsFormType extends AbstractType
         $builder
             ->add($domainsGroup)
             ->add('apply', SubmitType::class, [
-                'label' => t('Apply'),
+                'label' => 'Apply',
             ]);
 
         $builder->addModelTransformer(new CallbackTransformer(

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -56,7 +56,7 @@ final class AdministratorFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null $adminToEdit */
@@ -66,7 +66,7 @@ final class AdministratorFormType extends AbstractType
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $adminToEdit->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ]);
         }
 
@@ -84,7 +84,7 @@ final class AdministratorFormType extends AbstractType
                         'entityName' => Administrator::class,
                     ]),
                 ],
-                'label' => t('Login name'),
+                'label' => 'Login name',
             ])
             ->add('realName', TextType::class, [
                 'constraints' => [
@@ -93,7 +93,7 @@ final class AdministratorFormType extends AbstractType
                         ['max' => 100, 'maxMessage' => 'Full name cannot be longer than {{ limit }} characters'],
                     ),
                 ],
-                'label' => t('Full name'),
+                'label' => 'Full name',
             ])
             ->add('email', EmailType::class, [
                 'required' => true,
@@ -110,7 +110,7 @@ final class AdministratorFormType extends AbstractType
                         'entityName' => Administrator::class,
                     ]),
                 ],
-                'label' => t('Email'),
+                'label' => 'Email',
             ]);
 
         if ($options['scenario'] === self::SCENARIO_EDIT) {
@@ -123,7 +123,7 @@ final class AdministratorFormType extends AbstractType
                             'admin_administrator_send-reset-password',
                         ),
                     ],
-                    'label' => t('Password'),
+                    'label' => 'Password',
                     'route_label' => t('Send reset password email'),
                     'link_target' => '_self',
                 ]);
@@ -133,9 +133,9 @@ final class AdministratorFormType extends AbstractType
             $builderSettingsGroup->add('roleGroup', ChoiceType::class, [
                 'required' => false,
                 'choices' => $this->administratorRoleGroupFacade->getAll(),
-                'placeholder' => t('Custom'),
+                'placeholder' => 'Custom',
                 'multiple' => false,
-                'label' => t('Role Group'),
+                'label' => 'Role Group',
                 'choice_label' => function (AdministratorRoleGroup $administratorRoleGroup) {
                     return $administratorRoleGroup->getName();
                 },
@@ -145,7 +145,7 @@ final class AdministratorFormType extends AbstractType
             ]);
 
             $builderSettingsGroup->add('roles', RolesType::class, [
-                'label' => t('Role'),
+                'label' => 'Role',
                 'context' => AdminContext::class,
                 'row_attr' => [
                     'data-js-role-group-custom' => null,

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorResetPasswordFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorResetPasswordFormType.php
@@ -34,7 +34,7 @@ final class AdministratorResetPasswordFormType extends AbstractType
                     ],
                 ],
                 'first_options' => [
-                    'label' => t('Password'),
+                    'label' => 'Password',
                     'constraints' => [
                         new Constraints\Regex(['pattern' => '/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{10,}$/', 'message' => '']),
                         new Constraints\NotBlank(['message' => '']),
@@ -51,10 +51,10 @@ final class AdministratorResetPasswordFormType extends AbstractType
                     ),
                 ],
                 'second_options' => [
-                    'label' => t('Password again'),
+                    'label' => 'Password again',
                 ],
                 'invalid_message' => 'Passwords do not match',
-                'label' => t('Password'),
+                'label' => 'Password',
             ])
             ->add('save', SubmitType::class);
     }

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorRoleGroupFormType.php
@@ -32,7 +32,7 @@ final class AdministratorRoleGroupFormType extends AbstractType
                     ['max' => 100, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
                 ),
             ],
-            'label' => t('Role name'),
+            'label' => 'Role name',
         ]);
         $builder->add('roles', RolesType::class, [
             'label' => 'Roles',

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -53,20 +53,20 @@ final class AdvertFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
             ->add('domain', DisplayOnlyType::class, [
                 'data' => $this->adminDomainTabsFacade->getSelectedDomainConfig()->getName(),
-                'label' => t('Domain'),
+                'label' => 'Domain',
             ]);
 
         if ($options['scenario'] === self::SCENARIO_EDIT) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $options['advert']->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ]);
         }
 
@@ -76,7 +76,7 @@ final class AdvertFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter name of advertisement area']),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
                 'help' => t('Name serves only for internal use within the administration.'),
             ])
             ->add('type', ChoiceType::class, [
@@ -90,30 +90,30 @@ final class AdvertFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please choose advertisement type']),
                 ],
-                'label' => t('Type'),
+                'label' => 'Type',
             ])
             ->add('positionName', ChoiceType::class, [
                 'required' => true,
                 'choices' => array_flip($this->advertPositionRegistry->getAllLabelsIndexedByNames()),
-                'placeholder' => t('-- Choose area --'),
+                'placeholder' => '-- Choose area --',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please choose advertisement area']),
                 ],
-                'label' => t('Area'),
+                'label' => 'Area',
             ])
             ->add('categories', CategoriesType::class, [
                 'required' => false,
                 'domain_id' => $this->adminDomainTabsFacade->getSelectedDomainId(),
-                'label' => t('Assign to category'),
+                'label' => 'Assign to category',
                 'row_attr' => [
                     'data-js-advert-categories' => null,
                 ],
             ])
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hide advertisement'),
+                'label' => 'Hide advertisement',
             ])
             ->add('code', TextareaType::class, [
-                'label' => t('Code'),
+                'label' => 'Code',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -127,7 +127,7 @@ final class AdvertFormType extends AbstractType
             ]);
 
         $builderImageGroup = $builder->create('image_group', GroupType::class, [
-            'label' => t('Images'),
+            'label' => 'Images',
             'row_attr' => [
                 'data-js-advert-type-content' => 'image',
             ],
@@ -136,7 +136,7 @@ final class AdvertFormType extends AbstractType
         $builderImageGroup
             ->add('link', TextType::class, [
                 'required' => false,
-                'label' => t('Link'),
+                'label' => 'Link',
             ]);
 
         $imageConstraints = [
@@ -161,7 +161,7 @@ final class AdvertFormType extends AbstractType
                     ]),
                 ],
                 'constraints' => ($options['web_image_exists'] ? [] : $imageConstraints),
-                'label' => t('Upload new image'),
+                'label' => 'Upload new image',
                 'entity' => $options['advert'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
@@ -181,7 +181,7 @@ final class AdvertFormType extends AbstractType
                     ]),
                 ],
                 'constraints' => ($options['mobile_image_exists'] ? [] : $imageConstraints),
-                'label' => t('Upload image for mobile devices'),
+                'label' => 'Upload image for mobile devices',
                 'entity' => $options['advert'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
@@ -191,11 +191,11 @@ final class AdvertFormType extends AbstractType
             ->add($builderImageGroup)
             ->add('datetimeVisibleFrom', DatePickerType::class, [
                 'required' => false,
-                'label' => t('Display date FROM'),
+                'label' => 'Display date FROM',
             ])
             ->add('datetimeVisibleTo', DatePickerType::class, [
                 'required' => false,
-                'label' => t('Display date TO'),
+                'label' => 'Display date TO',
             ])
             ->add('actionBar', ActionBarType::class, [
                 'back_route' => 'admin_advert_list',

--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -59,7 +59,7 @@ final class ArticleFormType extends AbstractType
         $seoMetaDescriptionAttributes = $this->getSeoMetaDescriptionAttributes($options);
 
         $builderArticleData = $builder->create('articleData', GroupType::class, [
-            'label' => t('Article data'),
+            'label' => 'Article data',
         ]);
 
         if ($article === null) {
@@ -67,26 +67,26 @@ final class ArticleFormType extends AbstractType
                 ->add('domainId', DomainType::class, [
                     'required' => true,
                     'data' => $options['domain_id'],
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                 ])
                 ->add('placement', ChoiceType::class, [
                     'required' => true,
                     'choices' => $this->articleFacade->getAvailablePlacementChoices(),
-                    'placeholder' => t('-- Choose article position --'),
+                    'placeholder' => '-- Choose article position --',
                     'constraints' => [
                         new Constraints\NotBlank(['message' => 'Please choose article placement']),
                     ],
-                    'label' => t('Location'),
+                    'label' => 'Location',
                 ]);
         } else {
             $builderArticleData
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $article->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ])
                 ->add('domain', DisplayOnlyType::class, [
                     'data' => $this->domain->getDomainConfigById($article->getDomainId())->getName(),
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                 ]);
         }
         $builderArticleData
@@ -95,13 +95,13 @@ final class ArticleFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter article name']),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hide'),
+                'label' => 'Hide',
             ])
             ->add('external', YesNoType::class, [
-                'label' => t('Open in new window'),
+                'label' => 'Open in new window',
             ])
             ->add('type', ChoiceType::class, [
                 'required' => true,
@@ -111,7 +111,7 @@ final class ArticleFormType extends AbstractType
                 ],
                 'expanded' => true,
                 'multiple' => false,
-                'label' => t('Type'),
+                'label' => 'Type',
             ])
             ->add('url', UrlType::class, [
                 'required' => true,
@@ -121,7 +121,7 @@ final class ArticleFormType extends AbstractType
                         'groups' => [self::VALIDATION_GROUP_TYPE_LINK],
                     ]),
                 ],
-                'label' => t('URL'),
+                'label' => 'URL',
                 'trim' => true,
                 'row_attr' => [
                     'data-js-article-type-content' => 'link',
@@ -136,7 +136,7 @@ final class ArticleFormType extends AbstractType
                         'groups' => [self::VALIDATION_GROUP_TYPE_SITE],
                     ]),
                 ],
-                'label' => t('Content'),
+                'label' => 'Content',
                 'row_attr' => [
                     'data-js-article-type-content' => 'site',
                 ],
@@ -146,14 +146,14 @@ final class ArticleFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter date of creation']),
                 ],
-                'label' => t('Creation date'),
+                'label' => 'Creation date',
                 'row_attr' => [
                     'data-js-article-type-content' => 'site',
                 ],
             ]);
 
         $builderSeoData = $builder->create('seo', GroupType::class, [
-            'label' => t('SEO'),
+            'label' => 'SEO',
             'row_attr' => [
                 'data-js-article-type-content' => 'site',
             ],
@@ -166,25 +166,25 @@ final class ArticleFormType extends AbstractType
                     'data-js-recommended-length' => 60,
                     'data-js-placeholder-source-input-id' => 'article_form_articleData_name',
                 ],
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescription', TextareaType::class, [
                 'required' => false,
                 'attr' => $seoMetaDescriptionAttributes,
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('seoH1', TextType::class, [
                 'required' => false,
                 'attr' => [
                     'data-js-placeholder-source-input-id' => 'article_form_articleData_name',
                 ],
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
             ]);
 
         if ($article !== null) {
             $builderSeoData
                 ->add('urls', UrlListType::class, [
-                    'label' => t('URL addresses'),
+                    'label' => 'URL addresses',
                     'route_name' => 'front_article_detail',
                     'entity_id' => $article->getId(),
                     'limit_domains_by_ids' => [$article->getDomainId()],

--- a/packages/framework/src/Form/Admin/Autocomplete/AutocompleteFavoriteFormType.php
+++ b/packages/framework/src/Form/Admin/Autocomplete/AutocompleteFavoriteFormType.php
@@ -56,7 +56,7 @@ final class AutocompleteFavoriteFormType extends AbstractType
         }
 
         $productsGroup = $builder->create('productsGroup', GroupType::class, [
-            'label' => t('Favorite Products'),
+            'label' => 'Favorite Products',
         ]);
         $productsGroup->add(
             $builder->create('products', ProductsType::class, [
@@ -64,7 +64,7 @@ final class AutocompleteFavoriteFormType extends AbstractType
                 'sortable' => true,
                 'allow_variants' => false,
                 'attr' => [
-                    'placeholder' => t('Search and select products...'),
+                    'placeholder' => 'Search and select products...',
                 ],
             ])->addModelTransformer(
                 $this->removeDuplicatesFromArrayTransformer,
@@ -72,7 +72,7 @@ final class AutocompleteFavoriteFormType extends AbstractType
         );
 
         $categoriesGroup = $builder->create('categoriesGroup', GroupType::class, [
-            'label' => t('Favorite Categories'),
+            'label' => 'Favorite Categories',
         ]);
         $categoriesGroup->add(
             $builder->create('categories', SortableValuesType::class, [
@@ -86,7 +86,7 @@ final class AutocompleteFavoriteFormType extends AbstractType
         );
 
         $brandsGroup = $builder->create('brandsGroup', GroupType::class, [
-            'label' => t('Favorite Brands'),
+            'label' => 'Favorite Brands',
         ]);
         $brandsGroup->add(
             $builder->create('brands', SortableValuesType::class, [

--- a/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
+++ b/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
@@ -25,7 +25,7 @@ final class BestsellingProductFormType extends AbstractType
     {
         $builder
             ->add('products', GroupType::class, [
-                'label' => t('Bestselling products'),
+                'label' => 'Bestselling products',
                 'error_bubbling' => true,
                 'constraints' => [
                     new Constraints\UniqueCollection([

--- a/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
@@ -108,7 +108,7 @@ final class BlogArticleFormType extends AbstractType
         [$seoTitlesOptionsByDomainId, $seoMetaDescriptionsOptionsByDomainId, $seoH1OptionsByDomainId] = $this->prepareSeoData($blogArticle);
 
         $builderSeoGroup = $builder->create('seo', GroupType::class, [
-            'label' => t('Seo'),
+            'label' => 'Seo',
         ]);
 
         $builderSeoGroup
@@ -116,13 +116,13 @@ final class BlogArticleFormType extends AbstractType
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoTitlesOptionsByDomainId,
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescriptions', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoMetaDescriptionsOptionsByDomainId,
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('seoH1s', MultidomainType::class, [
                 'required' => false,
@@ -132,7 +132,7 @@ final class BlogArticleFormType extends AbstractType
                     ],
                 ],
                 'options_by_domain_id' => $seoH1OptionsByDomainId,
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
             ]);
 
         if ($blogArticle !== null) {
@@ -140,7 +140,7 @@ final class BlogArticleFormType extends AbstractType
                 ->add('urls', UrlListType::class, [
                     'route_name' => 'front_blogarticle_detail',
                     'entity_id' => $blogArticle->getId(),
-                    'label' => t('URL addresses'),
+                    'label' => 'URL addresses',
                 ]);
         }
 
@@ -157,7 +157,7 @@ final class BlogArticleFormType extends AbstractType
         ?BlogArticle $blogArticle,
     ): FormBuilderInterface {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $categoriesOptionsByDomainId = [];
@@ -179,26 +179,26 @@ final class BlogArticleFormType extends AbstractType
                         new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
                     ],
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('blogCategoriesByDomainId', MultidomainType::class, [
                 'required' => false,
                 'entry_type' => BlogCategoriesType::class,
                 'options_by_domain_id' => $categoriesOptionsByDomainId,
-                'label' => t('Assign to category'),
+                'label' => 'Assign to category',
             ])
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hide'),
+                'label' => 'Hide',
             ])
             ->add('visibleOnHomepage', YesNoType::class, [
-                'label' => t('Visible on homepage'),
+                'label' => 'Visible on homepage',
             ])
             ->add('publishDate', DatePickerType::class, [
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter date of creation']),
                 ],
-                'label' => t('Date of publication'),
+                'label' => 'Date of publication',
                 'data' => $blogArticle === null ? new DateTime() : $blogArticle->getPublishDate(),
             ]);
 
@@ -212,7 +212,7 @@ final class BlogArticleFormType extends AbstractType
     private function createDescriptionGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderDescriptionGroup = $builder->create('description', GroupType::class, [
-            'label' => t('Description'),
+            'label' => 'Description',
         ]);
 
         $builderDescriptionGroup
@@ -222,7 +222,7 @@ final class BlogArticleFormType extends AbstractType
                 'entry_options' => [
                     'allow_products' => true,
                 ],
-                'label' => t('Description'),
+                'label' => 'Description',
                 'required' => false,
             ]);
 
@@ -236,7 +236,7 @@ final class BlogArticleFormType extends AbstractType
     private function createPerexGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderDescriptionGroup = $builder->create('perex', GroupType::class, [
-            'label' => t('Perex'),
+            'label' => 'Perex',
         ]);
 
         $builderDescriptionGroup
@@ -245,7 +245,7 @@ final class BlogArticleFormType extends AbstractType
                 'entry_options' => [
                     'required' => false,
                 ],
-                'label' => t('Perex'),
+                'label' => 'Perex',
             ]);
 
         return $builderDescriptionGroup;
@@ -259,7 +259,7 @@ final class BlogArticleFormType extends AbstractType
     private function createImageGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup
@@ -276,7 +276,7 @@ final class BlogArticleFormType extends AbstractType
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
                     ]),
                 ],
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'entity' => $options['blogArticle'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -111,14 +111,14 @@ final class BlogCategoryFormType extends AbstractType
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         if ($options['blogCategory'] !== null) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $options['blogCategory']->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ]);
         }
 
@@ -133,7 +133,7 @@ final class BlogCategoryFormType extends AbstractType
                         new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
                     ],
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('parent', ChoiceType::class, [
                 'required' => true,
@@ -144,11 +144,11 @@ final class BlogCategoryFormType extends AbstractType
                     return $padding . $blogCategory->getName();
                 },
                 'choice_value' => 'id',
-                'label' => t('Ancestor category'),
+                'label' => 'Ancestor category',
             ])
             ->add('enabled', DomainsType::class, [
                 'required' => false,
-                'label' => t('Display on'),
+                'label' => 'Display on',
             ]);
 
         return $builderSettingsGroup;
@@ -201,7 +201,7 @@ final class BlogCategoryFormType extends AbstractType
         [$seoTitlesOptionsByDomainId, $seoMetaDescriptionsOptionsByDomainId, $seoH1OptionsByDomainId] = $this->prepareSeoData($options);
 
         $builderSeoGroup = $builder->create('seo', GroupType::class, [
-            'label' => t('Seo'),
+            'label' => 'Seo',
         ]);
 
         $builderSeoGroup
@@ -209,13 +209,13 @@ final class BlogCategoryFormType extends AbstractType
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoTitlesOptionsByDomainId,
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescriptions', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoMetaDescriptionsOptionsByDomainId,
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('seoH1s', MultidomainType::class, [
                 'required' => false,
@@ -225,7 +225,7 @@ final class BlogCategoryFormType extends AbstractType
                     ],
                 ],
                 'options_by_domain_id' => $seoH1OptionsByDomainId,
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
             ]);
 
         if ($options['blogCategory'] !== null) {
@@ -233,7 +233,7 @@ final class BlogCategoryFormType extends AbstractType
                 ->add('urls', UrlListType::class, [
                     'route_name' => 'front_blogcategory_detail',
                     'entity_id' => $this->getBlogCategoryId($options['blogCategory']),
-                    'label' => t('URL addresses'),
+                    'label' => 'URL addresses',
                 ]);
         }
 
@@ -260,13 +260,13 @@ final class BlogCategoryFormType extends AbstractType
     private function createDescriptionGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderDescriptionGroup = $builder->create('description', GroupType::class, [
-            'label' => t('Description'),
+            'label' => 'Description',
         ]);
 
         $builderDescriptionGroup
             ->add('descriptions', LocalizedType::class, [
                 'entry_type' => CKEditorType::class,
-                'label' => t('Description'),
+                'label' => 'Description',
                 'required' => false,
             ]);
 
@@ -281,7 +281,7 @@ final class BlogCategoryFormType extends AbstractType
     private function createImageGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup
@@ -296,7 +296,7 @@ final class BlogCategoryFormType extends AbstractType
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
                     ]),
                 ],
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'entity' => $options['blogCategory'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -104,14 +104,14 @@ final class CategoryFormType extends AbstractType
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         if ($options['scenario'] === self::SCENARIO_EDIT) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $options['category']->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ]);
         }
 
@@ -130,7 +130,7 @@ final class CategoryFormType extends AbstractType
                         ),
                     ],
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('parent', ChoiceType::class, [
                 'required' => false,
@@ -141,14 +141,14 @@ final class CategoryFormType extends AbstractType
                     return $padding . $category->getName();
                 },
                 'choice_value' => 'id',
-                'label' => t('Parent category'),
+                'label' => 'Parent category',
             ])
             ->add('enabled', DomainsType::class, [
                 'required' => false,
-                'label' => t('Display on'),
+                'label' => 'Display on',
             ])
             ->add('automatedFilters', ChoiceType::class, [
-                'label' => t('Automated filters'),
+                'label' => 'Automated filters',
                 'required' => false,
                 'multiple' => true,
                 'expanded' => true,
@@ -167,7 +167,7 @@ final class CategoryFormType extends AbstractType
             ]);
 
         $builderSeoGroup = $builder->create('seo', GroupType::class, [
-            'label' => t('SEO'),
+            'label' => 'SEO',
         ]);
 
         $builderSeoGroup
@@ -175,13 +175,13 @@ final class CategoryFormType extends AbstractType
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoTitlesOptionsByDomainId,
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescriptions', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoMetaDescriptionsOptionsByDomainId,
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('seoH1s', MultidomainType::class, [
                 'required' => false,
@@ -193,7 +193,7 @@ final class CategoryFormType extends AbstractType
                     ],
                 ],
                 'options_by_domain_id' => $seoH1OptionsByDomainId,
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
             ]);
 
         if ($options['scenario'] === self::SCENARIO_EDIT) {
@@ -201,12 +201,12 @@ final class CategoryFormType extends AbstractType
                 ->add('urls', UrlListType::class, [
                     'route_name' => 'front_product_list',
                     'entity_id' => $options['category']?->getId(),
-                    'label' => t('URL addresses'),
+                    'label' => 'URL addresses',
                 ]);
         }
 
         $builderDescriptionGroup = $builder->create('description', GroupType::class, [
-            'label' => t('Description'),
+            'label' => 'Description',
         ]);
 
         $builderDescriptionGroup
@@ -216,7 +216,7 @@ final class CategoryFormType extends AbstractType
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup
@@ -232,7 +232,7 @@ final class CategoryFormType extends AbstractType
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
                     ]),
                 ],
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'entity' => $options['category'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
@@ -304,13 +304,13 @@ final class CategoryFormType extends AbstractType
         $parametersFilterBuilder->add('parametersPosition', SortableValuesType::class, [
             'entry_type' => IntegerType::class,
             'labels_by_value' => $parameterNamesById,
-            'label' => t('Parameters order in category'),
+            'label' => 'Parameters order in category',
             'required' => false,
         ]);
 
         $parametersFilterBuilder->add('parametersCollapsed', ChoiceType::class, [
             'required' => false,
-            'label' => t('Filter parameters closed by default'),
+            'label' => 'Filter parameters closed by default',
             'choices' => $parametersUsedByProductsInCategory,
             'expanded' => true,
             'choice_label' => 'name',

--- a/packages/framework/src/Form/Admin/Category/TopCategory/TopCategoriesFormType.php
+++ b/packages/framework/src/Form/Admin/Category/TopCategory/TopCategoriesFormType.php
@@ -44,7 +44,7 @@ final class TopCategoriesFormType extends AbstractType
             ->add(
                 $builder
                     ->create('categories', SortableValuesType::class, [
-                        'label' => t('Category'),
+                        'label' => 'Category',
                         'labels_by_value' => $categoryPaths,
                         'required' => false,
                     ])

--- a/packages/framework/src/Form/Admin/CategorySeo/CategorySeoFilterFormType.php
+++ b/packages/framework/src/Form/Admin/CategorySeo/CategorySeoFilterFormType.php
@@ -39,11 +39,11 @@ final class CategorySeoFilterFormType extends AbstractType
 
         $builder
             ->add('useFlags', YesNoType::class, [
-                'label' => t('By flag'),
+                'label' => 'By flag',
                 'data' => false,
             ])
             ->add('parameters', ChoiceType::class, [
-                'label' => t('Products parameters of selected category'),
+                'label' => 'Products parameters of selected category',
                 'choices' => $this->categorySeoFacade->getParametersUsedByProductsInCategoryWithoutSlider($category, $domainId),
                 'choice_label' => 'name',
                 'choice_value' => 'id',

--- a/packages/framework/src/Form/Admin/CategorySeo/ReadyCategorySeoCombinationFormType.php
+++ b/packages/framework/src/Form/Admin/CategorySeo/ReadyCategorySeoCombinationFormType.php
@@ -35,36 +35,36 @@ final class ReadyCategorySeoCombinationFormType extends AbstractType
                 'required' => true,
                 'route_name' => 'front_category_seo',
                 'entity_id' => $readyCategorySeoMix?->getId(),
-                'label' => t('URL Settings'),
+                'label' => 'URL Settings',
                 'constraints' => [
                     new NotBlank(),
                 ],
             ])
             ->add('h1', TextType::class, [
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
                 'required' => true,
                 'constraints' => [
                     new NotBlank(),
                 ],
             ])
             ->add('showInCategory', YesNoType::class, [
-                'label' => t('Show in the category'),
+                'label' => 'Show in the category',
             ])
             ->add('shortDescription', TextareaType::class, [
-                'label' => t('Short description of category'),
+                'label' => 'Short description of category',
                 'required' => false,
             ])
             ->add('description', CKEditorType::class, [
-                'label' => t('Category description'),
+                'label' => 'Category description',
                 'required' => false,
             ])
             ->add('title', TextType::class, [
-                'label' => t('Page title'),
+                'label' => 'Page title',
                 'required' => false,
                 'attr' => ['data-js-recommended-length' => 60],
             ])
             ->add('metaDescription', TextareaType::class, [
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
                 'required' => false,
                 'attr' => ['data-js-recommended-length' => 155],
             ])

--- a/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
@@ -107,33 +107,33 @@ final class ComplaintFormType extends AbstractType
         Complaint $complaint,
     ): FormBuilderInterface {
         $builderBasicInformationGroup = $builder->create('basicInformationGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         $builderBasicInformationGroup
             ->add('id', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $complaint->getId(),
             ]);
 
         if ($this->domain->isMultidomain()) {
             $builderBasicInformationGroup
                 ->add('domainIcon', DisplayOnlyDomainIconType::class, [
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                     'data' => $complaint->getDomainId(),
                 ]);
         }
         $builderBasicInformationGroup
             ->add('number', DisplayOnlyType::class, [
-                'label' => t('Complaint number'),
+                'label' => 'Complaint number',
                 'data' => $complaint->getNumber(),
             ])
             ->add('dateOfCreation', DisplayOnlyType::class, [
-                'label' => t('Date of creation'),
+                'label' => 'Date of creation',
                 'data' => $this->dateTimeFormatterExtension->formatDateTime($complaint->getCreatedAt()),
             ])
             ->add('status', ChoiceType::class, [
-                'label' => t('Status'),
+                'label' => 'Status',
                 'required' => true,
                 'choices' => $this->complaintStatusFacade->getAll(),
                 'choice_label' => 'name',
@@ -142,7 +142,7 @@ final class ComplaintFormType extends AbstractType
                 'expanded' => false,
             ])
             ->add('resolution', ChoiceType::class, [
-                'label' => t('Resolution'),
+                'label' => 'Resolution',
                 'required' => true,
                 'choices' => $this->complaintResolutionEnum->getAllIndexedByTranslations(),
                 'multiple' => false,
@@ -152,7 +152,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('bankAccountNumber', TextType::class, [
-                'label' => t('Bank account number'),
+                'label' => 'Bank account number',
                 'constraints' => [
                     new Constraints\NotBlank([
                         'message' => 'Please enter bank account number',
@@ -174,16 +174,16 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('order', DisplayOnlyOrderType::class, [
-                'label' => t('Order or document number'),
+                'label' => 'Order or document number',
                 'order' => $complaint->getOrder(),
                 'manualDocumentNumber' => $complaint->getManualDocumentNumber(),
             ])
             ->add('user', DisplayOnlyCustomerType::class, [
-                'label' => t('Customer'),
+                'label' => 'Customer',
                 'user' => $complaint->getCustomerUser(),
             ])
             ->add('email', TextType::class, [
-                'label' => t('Email'),
+                'label' => 'Email',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter email']),
                     new Email(['message' => 'Please enter valid email']),
@@ -204,12 +204,12 @@ final class ComplaintFormType extends AbstractType
     private function createDeliveryAddressGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderDeliveryAddressGroup = $builder->create('deliveryAddressGroup', GroupType::class, [
-            'label' => t('Delivery address'),
+            'label' => 'Delivery address',
         ]);
 
         $builderDeliveryAddressGroup
             ->add('deliveryFirstName', TextType::class, [
-                'label' => t('First name'),
+                'label' => 'First name',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -222,7 +222,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryLastName', TextType::class, [
-                'label' => t('Last name'),
+                'label' => 'Last name',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -235,7 +235,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryCompanyName', TextType::class, [
-                'label' => t('Company'),
+                'label' => 'Company',
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length([
@@ -245,7 +245,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryTelephone', TextType::class, [
-                'label' => t('Telephone'),
+                'label' => 'Telephone',
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length([
@@ -255,7 +255,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryStreet', TextType::class, [
-                'label' => t('Street'),
+                'label' => 'Street',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -268,7 +268,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryCity', TextType::class, [
-                'label' => t('City'),
+                'label' => 'City',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -280,7 +280,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryPostcode', TextType::class, [
-                'label' => t('Postcode'),
+                'label' => 'Postcode',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -293,7 +293,7 @@ final class ComplaintFormType extends AbstractType
                 ],
             ])
             ->add('deliveryCountry', ChoiceType::class, [
-                'label' => t('Country'),
+                'label' => 'Country',
                 'required' => true,
                 'choices' => $this->countryFacade->getAll(),
                 'choice_label' => 'name',
@@ -313,7 +313,7 @@ final class ComplaintFormType extends AbstractType
     private function createItemsGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderItemsGroup = $builder->create('itemsGroup', GroupType::class, [
-            'label' => t('Complaint items'),
+            'label' => 'Complaint items',
         ]);
 
         $builderItemsGroup

--- a/packages/framework/src/Form/Admin/ContactForm/ContactFormSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/ContactForm/ContactFormSettingsFormType.php
@@ -23,7 +23,7 @@ final class ContactFormSettingsFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Main text'),
+            'label' => 'Main text',
         ]);
 
         $builderSettingsGroup

--- a/packages/framework/src/Form/Admin/Country/CountryFormType.php
+++ b/packages/framework/src/Form/Admin/Country/CountryFormType.php
@@ -43,7 +43,7 @@ final class CountryFormType extends AbstractType
 
         if ($this->country instanceof Country) {
             $builder->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $this->country->getId(),
             ]);
         }
@@ -60,7 +60,7 @@ final class CountryFormType extends AbstractType
                         ),
                     ],
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('code', TextType::class, [
                 'required' => true,
@@ -74,12 +74,12 @@ final class CountryFormType extends AbstractType
                         'message' => 'Country code with this code already exists',
                     ]),
                 ],
-                'label' => t('Code'),
+                'label' => 'Code',
                 'help' => t('Country code in ISO 3166-1 alpha-2'),
             ])
             ->add('enabled', DomainsType::class, [
                 'required' => false,
-                'label' => t('Display on'),
+                'label' => 'Display on',
             ])
             ->add('priority', MultidomainType::class, [
                 'entry_type' => IntegerType::class,
@@ -94,7 +94,7 @@ final class CountryFormType extends AbstractType
                     ],
                 ],
                 'required' => false,
-                'label' => t('Priority'),
+                'label' => 'Priority',
             ])
             ->add('actionBar', ActionBarType::class, [
                 'back_route' => 'admin_country_list',

--- a/packages/framework/src/Form/Admin/CspHeaderSetting/CspHeaderSettingFormType.php
+++ b/packages/framework/src/Form/Admin/CspHeaderSetting/CspHeaderSettingFormType.php
@@ -27,7 +27,7 @@ final class CspHeaderSettingFormType extends AbstractType
 
         $builder->add('cspHeader', TextareaType::class, [
             'required' => false,
-            'label' => t('Content-Security-Policy header'),
+            'label' => 'Content-Security-Policy header',
         ]);
         $builder->add('actionBar', ActionBarType::class, [
             'save_label' => t('Save changes'),

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -40,7 +40,7 @@ final class BillingAddressFormType extends AbstractType
         $countries = $this->countryFacade->getAllEnabledOnDomain($options['domain_id']);
 
         $builderCompanyDataGroup = $builder->create('companyData', GroupType::class, [
-            'label' => t('Company data'),
+            'label' => 'Company data',
         ]);
 
         $builderCompanyDataGroup
@@ -51,7 +51,7 @@ final class BillingAddressFormType extends AbstractType
                     'class' => 'js-checkbox-toggle',
                 ],
                 'disabled' => $options['disableCompanyCustomerCheckbox'],
-                'label' => t('I buy on company behalf'),
+                'label' => 'I buy on company behalf',
             ])
             ->add(
                 $builderCompanyDataGroup
@@ -75,7 +75,7 @@ final class BillingAddressFormType extends AbstractType
                                 'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                         ],
-                        'label' => t('Company'),
+                        'label' => 'Company',
                     ])
                     ->add('companyNumber', TextType::class, [
                         'required' => true,
@@ -90,7 +90,7 @@ final class BillingAddressFormType extends AbstractType
                                 'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                         ],
-                        'label' => t('Company number'),
+                        'label' => 'Company number',
                     ])
                     ->add('companyTaxNumber', TextType::class, [
                         'required' => false,
@@ -101,12 +101,12 @@ final class BillingAddressFormType extends AbstractType
                                 'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                         ],
-                        'label' => t('Tax number'),
+                        'label' => 'Tax number',
                     ]),
             );
 
         $builderAddressGroup = $builder->create('address', GroupType::class, [
-            'label' => t('Address'),
+            'label' => 'Address',
         ]);
 
         $builderAddressGroup
@@ -121,7 +121,7 @@ final class BillingAddressFormType extends AbstractType
                         'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Street'),
+                'label' => 'Street',
             ])
             ->add('city', TextType::class, [
                 'required' => true,
@@ -134,7 +134,7 @@ final class BillingAddressFormType extends AbstractType
                         'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('City'),
+                'label' => 'City',
             ])
             ->add('postcode', TextType::class, [
                 'required' => true,
@@ -147,7 +147,7 @@ final class BillingAddressFormType extends AbstractType
                         'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Postcode'),
+                'label' => 'Postcode',
             ])
             ->add('country', ChoiceType::class, [
                 'required' => true,
@@ -159,7 +159,7 @@ final class BillingAddressFormType extends AbstractType
                         'message' => 'Please choose country',
                     ]),
                 ],
-                'label' => t('Country'),
+                'label' => 'Country',
             ]);
 
         $builder

--- a/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
@@ -44,7 +44,7 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('First name'),
+                'label' => 'First name',
             ])
             ->add('lastName', TextType::class, [
                 'required' => true,
@@ -55,7 +55,7 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Last name'),
+                'label' => 'Last name',
             ])
             ->add('companyName', TextType::class, [
                 'required' => false,
@@ -65,7 +65,7 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'Company name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Company'),
+                'label' => 'Company',
             ])
             ->add('street', TextType::class, [
                 'required' => true,
@@ -76,7 +76,7 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Street'),
+                'label' => 'Street',
             ])
             ->add('city', TextType::class, [
                 'required' => true,
@@ -87,7 +87,7 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('City'),
+                'label' => 'City',
             ])
             ->add('postcode', TextType::class, [
                 'required' => true,
@@ -98,14 +98,14 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Postcode'),
+                'label' => 'Postcode',
             ])
             ->add('country', ChoiceType::class, [
                 'required' => true,
                 'choices' => $countries,
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'label' => t('Country'),
+                'label' => 'Country',
             ])
             ->add('telephone', TextType::class, [
                 'required' => false,
@@ -115,7 +115,7 @@ final class DeliveryAddressFormType extends AbstractType
                         'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Telephone'),
+                'label' => 'Telephone',
             ])
             ->add('actionBar', ActionBarType::class, [
                 'back_url' => $options['back_url'],

--- a/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
@@ -35,7 +35,7 @@ final class CustomerUserRoleGroupFormType extends AbstractType
     {
         $builder->add('names', LocalizedType::class, [
             'required' => true,
-            'label' => t('Role group name'),
+            'label' => 'Role group name',
             'entry_options' => [
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter role name']),
@@ -47,7 +47,7 @@ final class CustomerUserRoleGroupFormType extends AbstractType
         ]);
 
         $builder->add('roles', RolesType::class, [
-            'label' => t('Role'),
+            'label' => 'Role',
             'context' => FrontendApiContext::class,
         ]);
 

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -71,20 +71,20 @@ final class CustomerUserFormType extends AbstractType
         $domain = $this->domain->getDomainConfigById($options['domain_id']);
 
         $builderSystemDataGroup = $builder->create('systemData', GroupType::class, [
-            'label' => t('System data'),
+            'label' => 'System data',
         ]);
 
         if ($this->customerUser instanceof CustomerUser) {
             $builderSystemDataGroup->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $this->customerUser->getId(),
             ]);
             $builderSystemDataGroup->add('activated', DisplayOnlyType::class, [
-                'label' => t('Active'),
+                'label' => 'Active',
                 'data' => $this->customerUser->isActivated() ? t('Yes') : t('No'),
             ]);
             $builderSystemDataGroup->add('domainIcon', DisplayOnlyDomainIconType::class, [
-                'label' => t('Domain'),
+                'label' => 'Domain',
                 'data' => $this->customerUser->getDomainId(),
             ]);
             $pricingGroups = $this->pricingGroupFacade->getByDomainId($this->customerUser->getDomainId());
@@ -93,7 +93,7 @@ final class CustomerUserFormType extends AbstractType
                 ->add('domainId', DomainType::class, [
                     'required' => true,
                     'data' => $options['domain_id'],
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                     'attr' => [
                         'class' => 'js-toggle-opt-group-control',
                     ],
@@ -113,7 +113,7 @@ final class CustomerUserFormType extends AbstractType
                         'data-js-toggle-option' => $pricingGroup->getDomainId(),
                     ];
                 },
-                'label' => t('Pricing group'),
+                'label' => 'Pricing group',
                 'attr' => [
                     'data-js-toggle-opt-group-control' => '.js-toggle-opt-group-control',
                 ],
@@ -126,12 +126,12 @@ final class CustomerUserFormType extends AbstractType
                 'choices' => $this->salesRepresentativeFacade->getAll(),
                 'choice_label' => 'fullName',
                 'choice_value' => 'id',
-                'label' => t('Sales representative'),
+                'label' => 'Sales representative',
                 'disabled' => !$options['allowEditSystemData'],
             ]);
 
         $builderPersonalDataGroup = $builder->create('personalData', GroupType::class, [
-            'label' => t('Personal data'),
+            'label' => 'Personal data',
         ]);
 
         if (
@@ -145,7 +145,7 @@ final class CustomerUserFormType extends AbstractType
                     'choices' => $roleGroups,
                     'choice_label' => 'name',
                     'choice_value' => 'id',
-                    'label' => t('Role'),
+                    'label' => 'Role',
                 ]);
         }
 
@@ -158,7 +158,7 @@ final class CustomerUserFormType extends AbstractType
                         'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('First name'),
+                'label' => 'First name',
             ])
             ->add('lastName', TextType::class, [
                 'constraints' => [
@@ -168,7 +168,7 @@ final class CustomerUserFormType extends AbstractType
                         'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Last name'),
+                'label' => 'Last name',
             ])
             ->add('email', EmailType::class, [
                 'constraints' => [
@@ -180,13 +180,13 @@ final class CustomerUserFormType extends AbstractType
                     new Email(['message' => 'Please enter valid email']),
                     new Constraints\Callback([$this, 'validateUniqueEmail']),
                 ],
-                'label' => t('Email'),
+                'label' => 'Email',
             ]);
 
         if ($this->customerUser === null) {
             $builderPersonalDataGroup->add('sendRegistrationMail', CheckboxType::class, [
                 'required' => false,
-                'label' => t('Send confirmation email about registration to customer'),
+                'label' => 'Send confirmation email about registration to customer',
             ]);
         }
 
@@ -199,17 +199,17 @@ final class CustomerUserFormType extends AbstractType
                         'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Telephone'),
+                'label' => 'Telephone',
             ]);
 
         if ($this->customerUser instanceof CustomerUser) {
             $builderSystemDataGroup->add('createdAt', DisplayOnlyType::class, [
-                'label' => t('Date of registration and privacy policy agreement'),
+                'label' => 'Date of registration and privacy policy agreement',
                 'data' => $this->dateTimeFormatterExtension->formatDateTime($this->customerUser->getCreatedAt()),
             ]);
 
             $builderSystemDataGroup->add('lastLogin', DisplayOnlyType::class, [
-                'label' => t('Last login'),
+                'label' => 'Last login',
                 'data' => $this->customerUserLoginInformationProvider->getLastLogin($this->customerUser) !== null ? $this->dateTimeFormatterExtension->formatDateTime(
                     $this->customerUserLoginInformationProvider->getLastLogin($this->customerUser),
                 ) : t(
@@ -219,7 +219,7 @@ final class CustomerUserFormType extends AbstractType
 
             if ($this->customerUserLoginInformationProvider->getAdditionalLoginInfo($this->customerUser) !== null) {
                 $builderSystemDataGroup->add('additionalLoginInfo', DisplayOnlyType::class, [
-                    'label' => t('Additional login info'),
+                    'label' => 'Additional login info',
                     'data' => $this->customerUserLoginInformationProvider->getAdditionalLoginInfo($this->customerUser),
                 ]);
             }

--- a/packages/framework/src/Form/Admin/CustomerCommunication/CustomerUserCommunicationFormType.php
+++ b/packages/framework/src/Form/Admin/CustomerCommunication/CustomerUserCommunicationFormType.php
@@ -26,24 +26,24 @@ final class CustomerUserCommunicationFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
             ->add(self::ORDER_SENT_CONTENT_FIELD_NAME, CKEditorType::class, [
-                'label' => t('Order sent page content'),
+                'label' => 'Order sent page content',
                 'required' => false,
             ])
             ->add(self::PAYMENT_SUCCESSFUL_CONTENT_FIELD_NAME, CKEditorType::class, [
-                'label' => t('Payment successful page content'),
+                'label' => 'Payment successful page content',
                 'required' => false,
             ])
             ->add(self::PAYMENT_IN_PROCESS_CONTENT_FIELD_NAME, CKEditorType::class, [
-                'label' => t('Payment in process page content'),
+                'label' => 'Payment in process page content',
                 'required' => false,
             ])
             ->add(self::PAYMENT_FAILED_CONTENT_FIELD_NAME, CKEditorType::class, [
-                'label' => t('Payment failed page content'),
+                'label' => 'Payment failed page content',
                 'required' => false,
             ]);
 

--- a/packages/framework/src/Form/Admin/Domain/DomainFormType.php
+++ b/packages/framework/src/Form/Admin/Domain/DomainFormType.php
@@ -26,7 +26,7 @@ final class DomainFormType extends AbstractType
     {
         $builder
             ->add('domainIcon', DisplayOnlyDomainIconType::class, [
-                'label' => t('Existing icon'),
+                'label' => 'Existing icon',
                 'data' => $options['domain']->getId(),
                 'show_domain_name' => false,
             ])

--- a/packages/framework/src/Form/Admin/FriendlyUrl/FriendlyUrlFormType.php
+++ b/packages/framework/src/Form/Admin/FriendlyUrl/FriendlyUrlFormType.php
@@ -80,7 +80,7 @@ final class FriendlyUrlFormType extends AbstractType
                     'required' => false,
                     'multiple' => false,
                     'expanded' => true,
-                    'placeholder' => t('No redirect'),
+                    'placeholder' => 'No redirect',
                     'choices' => [
                         t('301 (Permanent redirect)') => 301,
                         t('302 (Temporary redirect)') => 302,

--- a/packages/framework/src/Form/Admin/GiftPlan/GiftPlanFormType.php
+++ b/packages/framework/src/Form/Admin/GiftPlan/GiftPlanFormType.php
@@ -45,25 +45,25 @@ final class GiftPlanFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         if ($options['giftPlan'] !== null) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $options['giftPlan']->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ])
                 ->add('domainId', DisplayOnlyType::class, [
                     'data' => $this->domain->getDomainConfigById($options['giftPlan']->getDomainId())->getName(),
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                 ]);
         } else {
             $builderSettingsGroup
                 ->add('domainId', DomainType::class, [
                     'required' => true,
                     'data' => $this->adminDomainTabsFacade->getSelectedDomainId(),
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                 ]);
         }
 
@@ -74,7 +74,7 @@ final class GiftPlanFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter name of gift plan']),
                     new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
                 'help' => t('Name serves only for internal use within the administration.'),
             ])
             ->add('giftProduct', ProductType::class, [
@@ -82,19 +82,19 @@ final class GiftPlanFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please choose gift product']),
                 ],
-                'label' => t('Gift product'),
+                'label' => 'Gift product',
             ])
             ->add('validFrom', DatePickerType::class, [
                 'required' => false,
-                'label' => t('Valid from'),
+                'label' => 'Valid from',
             ])
             ->add('validTo', DatePickerType::class, [
                 'required' => false,
-                'label' => t('Valid to'),
+                'label' => 'Valid to',
             ])
             ->add('mainProducts', ProductsType::class, [
                 'required' => false,
-                'label' => t('Main products'),
+                'label' => 'Main products',
             ]);
         $builderSettingsGroup->get('validTo')->addModelTransformer($this->endOfDayTransformer);
 

--- a/packages/framework/src/Form/Admin/GiftPlan/GiftPriceSettingFormType.php
+++ b/packages/framework/src/Form/Admin/GiftPlan/GiftPriceSettingFormType.php
@@ -30,11 +30,11 @@ final class GiftPriceSettingFormType extends AbstractType
                 new NotBlank(['message' => 'Please enter price']),
                 new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
             ],
-            'label' => t('Gift price (with VAT)'),
+            'label' => 'Gift price (with VAT)',
         ]);
         $builder
             ->add('save', SubmitType::class, [
-                'label' => t('Save gift price setting'),
+                'label' => 'Save gift price setting',
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
+++ b/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
@@ -24,7 +24,7 @@ final class HeurekaShopCertificationFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
@@ -37,12 +37,12 @@ final class HeurekaShopCertificationFormType extends AbstractType
                         'exactMessage' => 'Heureka API must be {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Code of service Heureka - Verified by Customer'),
+                'label' => 'Code of service Heureka - Verified by Customer',
                 'help' => t('Enter 32-digit code which will be sent to server') . ' ' . $options['server_name'],
             ])
             ->add('heurekaWidgetCode', TextareaType::class, [
                 'required' => false,
-                'label' => t('Heureka Widget code'),
+                'label' => 'Heureka Widget code',
             ]);
 
         $builder

--- a/packages/framework/src/Form/Admin/LanguageConstant/LanguageConstantFormType.php
+++ b/packages/framework/src/Form/Admin/LanguageConstant/LanguageConstantFormType.php
@@ -27,16 +27,16 @@ final class LanguageConstantFormType extends AbstractType
 
         $builder
             ->add('key', DisplayOnlyType::class, [
-                'label' => t('Key'),
+                'label' => 'Key',
                 'data' => $languageConstantData->key,
             ])
             ->add('originalTranslation', DisplayOnlyType::class, [
-                'label' => t('Original translation'),
+                'label' => 'Original translation',
                 'data' => $languageConstantData->originalTranslation,
             ])
             ->add('userTranslation', TextType::class, [
                 'required' => true,
-                'label' => t('User translation'),
+                'label' => 'User translation',
                 'constraints' => [
                     new Constraints\NotBlank(),
                 ],

--- a/packages/framework/src/Form/Admin/LegalConditions/PrivacyPolicySettingFormType.php
+++ b/packages/framework/src/Form/Admin/LegalConditions/PrivacyPolicySettingFormType.php
@@ -32,7 +32,7 @@ final class PrivacyPolicySettingFormType extends AbstractType
         $articles = $this->articleFacade->getAllByDomainId($options['domain_id']);
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
@@ -41,8 +41,8 @@ final class PrivacyPolicySettingFormType extends AbstractType
                 'choices' => $articles,
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'placeholder' => t('-- Choose article --'),
-                'label' => t('Privacy policy'),
+                'placeholder' => '-- Choose article --',
+                'label' => 'Privacy policy',
                 'help' => t('Choose article, which will serve as privacy policy with which the customer has to agree when creating order or registering user.'),
             ]);
 

--- a/packages/framework/src/Form/Admin/LegalConditions/TermsAndConditionsSettingFormType.php
+++ b/packages/framework/src/Form/Admin/LegalConditions/TermsAndConditionsSettingFormType.php
@@ -32,7 +32,7 @@ final class TermsAndConditionsSettingFormType extends AbstractType
         $articles = $this->articleFacade->getAllByDomainId($options['domain_id']);
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
@@ -41,8 +41,8 @@ final class TermsAndConditionsSettingFormType extends AbstractType
                 'choices' => $articles,
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'placeholder' => t('-- Choose article --'),
-                'label' => t('Terms and conditions'),
+                'placeholder' => '-- Choose article --',
+                'label' => 'Terms and conditions',
                 'help' => t('Choose article, which will serve as terms and conditions with which the customer has to agree when creating order.'),
             ]);
 

--- a/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
@@ -26,7 +26,7 @@ final class MailSettingFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
@@ -35,41 +35,41 @@ final class MailSettingFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter email']),
                     new Email(['message' => 'Please enter valid email']),
                 ],
-                'label' => t('Main administrator email'),
+                'label' => 'Main administrator email',
             ])
             ->add('name', TextType::class, [
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter full name']),
                 ],
-                'label' => t('Email name'),
+                'label' => 'Email name',
             ]);
 
         $footerGroup = $builder->create('footerGroup', GroupType::class, [
-            'label' => t('Footer'),
+            'label' => 'Footer',
         ]);
 
         $footerGroup->add('facebookUrl', TextType::class, [
-            'label' => t('Facebook URL'),
+            'label' => 'Facebook URL',
             'required' => false,
         ]);
         $footerGroup->add('instagramUrl', TextType::class, [
-            'label' => t('Instagram URL'),
+            'label' => 'Instagram URL',
             'required' => false,
         ]);
         $footerGroup->add('youtubeUrl', TextType::class, [
-            'label' => t('Youtube URL'),
+            'label' => 'Youtube URL',
             'required' => false,
         ]);
         $footerGroup->add('linkedinUrl', TextType::class, [
-            'label' => t('LinkedIn URL'),
+            'label' => 'LinkedIn URL',
             'required' => false,
         ]);
         $footerGroup->add('tiktokUrl', TextType::class, [
-            'label' => t('TikTok URL'),
+            'label' => 'TikTok URL',
             'required' => false,
         ]);
         $footerGroup->add('footerText', CKEditorType::class, [
-            'label' => t('Footer Text'),
+            'label' => 'Footer Text',
         ]);
 
         $builder

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
@@ -40,7 +40,7 @@ final class MailTemplateFormType extends AbstractType
 
         $builder
             ->add('subject', TextType::class, [
-                'label' => t('Subject'),
+                'label' => 'Subject',
                 'required' => true,
                 'constraints' => $this->getSubjectConstraints($options),
                 'label_attr' => [
@@ -48,7 +48,7 @@ final class MailTemplateFormType extends AbstractType
                 ],
             ])
             ->add('bccEmail', EmailType::class, [
-                'label' => t('Hidden copy'),
+                'label' => 'Hidden copy',
                 'required' => false,
                 'constraints' => [
                     new Email(),
@@ -60,7 +60,7 @@ final class MailTemplateFormType extends AbstractType
             ->add(
                 $builder
                     ->create('body', GrapesJsMailType::class, [
-                        'label' => t('Content'),
+                        'label' => 'Content',
                         'required' => true,
                         'body_variables' => $options['body_variables'],
                         'constraints' => $this->getBodyConstraints($options),
@@ -74,7 +74,7 @@ final class MailTemplateFormType extends AbstractType
                     ->addModelTransformer(new EmptyWysiwygTransformer()),
             )
             ->add('attachments', FileUploadType::class, [
-                'label' => t('Upload attachment'),
+                'label' => 'Upload attachment',
                 'required' => false,
                 'file_constraints' => [
                     new Constraints\File([
@@ -89,7 +89,7 @@ final class MailTemplateFormType extends AbstractType
 
         if ($options['allow_disable_sending']) {
             $builder->add('sendMail', CheckboxType::class, [
-                'label' => t('Send email about change to this status'),
+                'label' => 'Send email about change to this status',
                 'attr' => ['class' => 'js-send-mail-checkbox'],
                 'required' => false,
             ]);

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateSendFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateSendFormType.php
@@ -40,7 +40,7 @@ final class MailTemplateSendFormType extends AbstractType
         $labelForEntityIdentifier = $this->mailTemplateSenderFacade->getFormLabelForEntityIdentifier($options['mailTemplate']);
         $builder
             ->add('mailTo', TextType::class, [
-                'label' => t('Send mail to'),
+                'label' => 'Send mail to',
                 'required' => true,
                 'data' => $currentAdministrator->getEmail(),
                 'constraints' => [
@@ -60,7 +60,7 @@ final class MailTemplateSendFormType extends AbstractType
 
         $builder
             ->add('save', SubmitType::class, [
-                'label' => t('Send'),
+                'label' => 'Send',
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Module/ModulesFormType.php
+++ b/packages/framework/src/Form/Admin/Module/ModulesFormType.php
@@ -24,7 +24,7 @@ final class ModulesFormType extends AbstractType
     {
         $builder
             ->add('modules', GroupType::class, [
-                'label' => t('Modules'),
+                'label' => 'Modules',
             ])
             ->add('actionBar', ActionBarType::class, [
                 'save_label' => t('Save changes'),

--- a/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
+++ b/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
@@ -54,17 +54,17 @@ final class NavigationItemFormType extends AbstractType
         $builder
             ->add('domainId', DomainType::class, [
                 'required' => true,
-                'label' => t('Domain'),
+                'label' => 'Domain',
             ])
             ->add('name', TextType::class, [
-                'label' => t('Name'),
+                'label' => 'Name',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter navigation item name']),
                 ],
             ])
             ->add('url', TextType::class, [
-                'label' => t('Link URL'),
+                'label' => 'Link URL',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter link URL']),

--- a/packages/framework/src/Form/Admin/NotificationBar/NotificationBarFormType.php
+++ b/packages/framework/src/Form/Admin/NotificationBar/NotificationBarFormType.php
@@ -36,7 +36,7 @@ final class NotificationBarFormType extends AbstractType
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
             'required' => false,
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $domainIdAttributes = [];
@@ -47,38 +47,38 @@ final class NotificationBarFormType extends AbstractType
 
         $builderSettingsGroup
             ->add('domainId', DomainType::class, [
-                'label' => t('Domain'),
+                'label' => 'Domain',
                 'attr' => $domainIdAttributes,
             ])
             ->add('text', CKEditorType::class, [
                 'required' => false,
-                'label' => t('Content'),
+                'label' => 'Content',
                 'constraints' => [
                     new NotBlank(['message' => 'Please enter notification bar content']),
                 ],
             ])
             ->add('rgbColor', ColorPickerType::class, [
-                'label' => t('Background color'),
+                'label' => 'Background color',
                 'constraints' => [
                     new NotBlank(['message' => 'Please enter notification bar background color']),
                 ],
             ])
             ->add('validityFrom', DateTimeType::class, [
                 'required' => false,
-                'label' => t('Valid from'),
+                'label' => 'Valid from',
                 'attr' => [
                     'autocomplete' => 'off',
                 ],
             ])
             ->add('validityTo', DateTimeType::class, [
                 'required' => false,
-                'label' => t('Valid to'),
+                'label' => 'Valid to',
                 'attr' => [
                     'autocomplete' => 'off',
                 ],
             ])
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hide'),
+                'label' => 'Hide',
             ])
             ->add('image', ImageUploadType::class, [
                 'required' => false,
@@ -94,7 +94,7 @@ final class NotificationBarFormType extends AbstractType
                     ]),
                 ],
                 'entity' => $options['notification_bar'],
-                'label' => t('Upload new image'),
+                'label' => 'Upload new image',
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
 

--- a/packages/framework/src/Form/Admin/Order/OrderFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderFormType.php
@@ -119,16 +119,16 @@ final class OrderFormType extends AbstractType
     {
         $domainConfig = $this->domain->getDomainConfigById($order->getDomainId());
         $builderBasicInformationGroup = $builder->create('basicInformationGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         $builderBasicInformationGroup
             ->add('id', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $order->getId(),
             ])
             ->add('orderDetail', DisplayOnlyUrlType::class, [
-                'label' => t('Order detail'),
+                'label' => 'Order detail',
                 'route' => 'front_customer_order_detail_unregistered',
                 'route_params' => [
                     'urlHash' => $order->getUrlHash(),
@@ -139,22 +139,22 @@ final class OrderFormType extends AbstractType
         if ($this->domain->isMultidomain()) {
             $builderBasicInformationGroup
                 ->add('domainIcon', DisplayOnlyDomainIconType::class, [
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                     'data' => $order->getDomainId(),
                 ]);
         }
 
         $builderBasicInformationGroup
             ->add('orderNumber', DisplayOnlyType::class, [
-                'label' => t('Order number'),
+                'label' => 'Order number',
                 'data' => $order->getNumber(),
             ])
             ->add('dateOfCreation', DisplayOnlyType::class, [
-                'label' => t('Date of creation and privacy policy agreement'),
+                'label' => 'Date of creation and privacy policy agreement',
                 'data' => $this->dateTimeFormatterExtension->formatDateTime($order->getCreatedAt()),
             ])
             ->add('status', ChoiceType::class, [
-                'label' => t('Status'),
+                'label' => 'Status',
                 'required' => true,
                 'choices' => $this->orderStatusFacade->getAll(),
                 'choice_label' => 'name',
@@ -166,28 +166,28 @@ final class OrderFormType extends AbstractType
         if ($order->getCreatedAsAdministrator() || $order->getCreatedAsAdministratorName()) {
             $builderBasicInformationGroup
                 ->add('createdAsAdministrator', DisplayOnlyType::class, [
-                    'label' => t('Created by administrator'),
+                    'label' => 'Created by administrator',
                     'data' => $order->getCreatedAsAdministrator() === null ? $order->getCreatedAsAdministratorName() : $order->getCreatedAsAdministrator()->getRealName(),
                 ]);
         }
 
         $builderBasicInformationGroup
             ->add('user', DisplayOnlyCustomerType::class, [
-                'label' => t('Customer'),
+                'label' => 'Customer',
                 'user' => $order->getCustomerUser(),
             ]);
 
         if ($domainConfig->isB2b() && $order->getCustomer()?->getBillingAddress()->getCompanyNumber() !== null) {
             $builderBasicInformationGroup
                 ->add('company', DisplayOnlyCompanyNameType::class, [
-                    'label' => t('Company'),
+                    'label' => 'Company',
                     'customer' => $order->getCustomer(),
                 ]);
         }
 
         $builderBasicInformationGroup
             ->add('heurekaAgreement', DisplayOnlyType::class, [
-                'label' => t('Heureka agreement'),
+                'label' => 'Heureka agreement',
                 'data' => $order->isHeurekaAgreement() ? t('Yes') : t('No'),
             ]);
 
@@ -201,7 +201,7 @@ final class OrderFormType extends AbstractType
 
         $builderBasicInformationGroup
             ->add('payment', DisplayOnlyType::class, [
-                'label' => t('Payment type'),
+                'label' => 'Payment type',
                 'data' => $order->getPayment()->getName(),
             ]);
 
@@ -221,18 +221,18 @@ final class OrderFormType extends AbstractType
 
             $builderBasicInformationGroup
                 ->add('gopayStatus', DisplayOnlyType::class, [
-                    'label' => t('GoPay payment status'),
+                    'label' => 'GoPay payment status',
                     'data' => $translatedGoPayStatus,
                 ]);
         }
 
         $builderBasicInformationGroup
             ->add('transport', DisplayOnlyType::class, [
-                'label' => t('Transport type'),
+                'label' => 'Transport type',
                 'data' => $order->getTransport()->getName(),
             ])
             ->add('trackingNumber', TextType::class, [
-                'label' => t('Tracking number'),
+                'label' => 'Tracking number',
                 'required' => false,
                 'constraints' => [
                     new Length([
@@ -246,7 +246,7 @@ final class OrderFormType extends AbstractType
         if ($promoCode !== null) {
             $builderBasicInformationGroup
                 ->add('promoCode', DisplayOnlyType::class, [
-                    'label' => t('Promo code'),
+                    'label' => 'Promo code',
                     'data' => $promoCode,
                 ]);
         }
@@ -261,12 +261,12 @@ final class OrderFormType extends AbstractType
     private function createPersonalDataGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderPersonalDataGroup = $builder->create('personalDataGroup', GroupType::class, [
-            'label' => t('Personal data'),
+            'label' => 'Personal data',
         ]);
 
         $builderPersonalDataGroup
             ->add('firstName', TextType::class, [
-                'label' => t('First name'),
+                'label' => 'First name',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter first name']),
                     new Constraints\Length([
@@ -276,7 +276,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('lastName', TextType::class, [
-                'label' => t('Last name'),
+                'label' => 'Last name',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter last name']),
                     new Constraints\Length([
@@ -286,7 +286,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('email', EmailType::class, [
-                'label' => t('Email'),
+                'label' => 'Email',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter email']),
                     new Email(['message' => 'Please enter valid email']),
@@ -297,7 +297,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('telephone', TextType::class, [
-                'label' => t('Telephone'),
+                'label' => 'Telephone',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter telephone number']),
                     new Constraints\Length([
@@ -317,12 +317,12 @@ final class OrderFormType extends AbstractType
     private function createCompanyDataGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderCompanyDataGroup = $builder->create('companyDataGroup', GroupType::class, [
-            'label' => t('Company data'),
+            'label' => 'Company data',
         ]);
 
         $builderCompanyDataGroup
             ->add('companyName', TextType::class, [
-                'label' => t('Company name'),
+                'label' => 'Company name',
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length([
@@ -332,7 +332,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('companyNumber', TextType::class, [
-                'label' => t('Company number'),
+                'label' => 'Company number',
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length([
@@ -342,7 +342,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('companyTaxNumber', TextType::class, [
-                'label' => t('Tax number'),
+                'label' => 'Tax number',
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length([
@@ -363,12 +363,12 @@ final class OrderFormType extends AbstractType
     private function createBillingDataGroup(FormBuilderInterface $builder, array $countries): FormBuilderInterface
     {
         $builderBillingDataGroup = $builder->create('billingDataGroup', GroupType::class, [
-            'label' => t('Billing data'),
+            'label' => 'Billing data',
         ]);
 
         $builderBillingDataGroup
             ->add('street', TextType::class, [
-                'label' => t('Street'),
+                'label' => 'Street',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter street']),
                     new Constraints\Length([
@@ -378,7 +378,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('city', TextType::class, [
-                'label' => t('City'),
+                'label' => 'City',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter city']),
                     new Constraints\Length([
@@ -388,7 +388,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('postcode', TextType::class, [
-                'label' => t('Postcode'),
+                'label' => 'Postcode',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter zip code']),
                     new Constraints\Length([
@@ -398,7 +398,7 @@ final class OrderFormType extends AbstractType
                 ],
             ])
             ->add('country', ChoiceType::class, [
-                'label' => t('Country'),
+                'label' => 'Country',
                 'choices' => $countries,
                 'choice_label' => 'name',
                 'choice_value' => 'id',
@@ -418,12 +418,12 @@ final class OrderFormType extends AbstractType
     private function createShippingAddressGroup(FormBuilderInterface $builder, array $countries): FormBuilderInterface
     {
         $builderShippingAddressGroup = $builder->create('shippingAddressGroup', GroupType::class, [
-            'label' => t('Delivery address'),
+            'label' => 'Delivery address',
         ]);
 
         $builderShippingAddressGroup
             ->add('deliveryAddressSameAsBillingAddress', CheckboxType::class, [
-                'label' => t('Delivery address is the same as billing address'),
+                'label' => 'Delivery address is the same as billing address',
                 'required' => false,
                 'attr' => [
                     'data-checkbox-toggle-container-class' => 'js-delivery-address-fields',
@@ -440,7 +440,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryFirstName', TextType::class, [
-                        'label' => t('First name'),
+                        'label' => 'First name',
                         'required' => true,
                         'constraints' => [
                             new Constraints\NotBlank([
@@ -455,7 +455,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryLastName', TextType::class, [
-                        'label' => t('Last name'),
+                        'label' => 'Last name',
                         'required' => true,
                         'constraints' => [
                             new Constraints\NotBlank([
@@ -470,7 +470,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryCompanyName', TextType::class, [
-                        'label' => t('Company'),
+                        'label' => 'Company',
                         'required' => false,
                         'constraints' => [
                             new Constraints\Length([
@@ -481,7 +481,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryTelephone', TextType::class, [
-                        'label' => t('Telephone'),
+                        'label' => 'Telephone',
                         'required' => false,
                         'constraints' => [
                             new Constraints\Length([
@@ -492,7 +492,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryStreet', TextType::class, [
-                        'label' => t('Street'),
+                        'label' => 'Street',
                         'required' => true,
                         'constraints' => [
                             new Constraints\NotBlank([
@@ -507,7 +507,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryCity', TextType::class, [
-                        'label' => t('City'),
+                        'label' => 'City',
                         'required' => true,
                         'constraints' => [
                             new Constraints\NotBlank([
@@ -521,7 +521,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryPostcode', TextType::class, [
-                        'label' => t('Postcode'),
+                        'label' => 'Postcode',
                         'required' => true,
                         'constraints' => [
                             new Constraints\NotBlank([
@@ -536,7 +536,7 @@ final class OrderFormType extends AbstractType
                         ],
                     ])
                     ->add('deliveryCountry', ChoiceType::class, [
-                        'label' => t('Country'),
+                        'label' => 'Country',
                         'required' => true,
                         'choices' => $countries,
                         'choice_label' => 'name',
@@ -557,12 +557,12 @@ final class OrderFormType extends AbstractType
     private function createNoteGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderNoteGroup = $builder->create('noteGroup', GroupType::class, [
-            'label' => t('Note'),
+            'label' => 'Note',
         ]);
 
         $builderNoteGroup
             ->add('note', TextareaType::class, [
-                'label' => t('Contact us'),
+                'label' => 'Contact us',
                 'required' => false,
             ]);
 
@@ -577,7 +577,7 @@ final class OrderFormType extends AbstractType
     private function createPaymentTransactionsGroup(FormBuilderInterface $builder, Order $order): FormBuilderInterface
     {
         $builderPaymentGroup = $builder->create('paymentTransactionsGroup', GroupType::class, [
-            'label' => t('Payment transactions'),
+            'label' => 'Payment transactions',
         ]);
 
         $builderPaymentGroup->add('paymentTransactionRefunds', PaymentTransactionsType::class, [

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -68,12 +68,12 @@ final class PaymentFormType extends AbstractType
         /** @var \Shopsys\FrameworkBundle\Model\Payment\Payment|null $payment */
         $payment = $options['payment'];
         $builderBasicInformationGroup = $builder->create('basicInformation', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         if ($payment instanceof Payment) {
             $builderBasicInformationGroup->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $payment->getId(),
             ]);
         }
@@ -92,7 +92,7 @@ final class PaymentFormType extends AbstractType
             ])
             ->add('enabled', DomainsType::class, [
                 'required' => false,
-                'label' => t('Display on'),
+                'label' => 'Display on',
             ]);
 
         if ($payment !== null) {
@@ -103,7 +103,7 @@ final class PaymentFormType extends AbstractType
         }
 
         $builderBasicInformationGroup->add('hidden', YesNoType::class, [
-            'label' => t('Hidden'),
+            'label' => 'Hidden',
         ])
             ->add('transports', ChoiceType::class, [
                 'required' => false,
@@ -115,10 +115,10 @@ final class PaymentFormType extends AbstractType
                 'multiple' => true,
                 'expanded' => true,
                 'empty_message' => t('You have to create some shipping first.'),
-                'label' => t('Available shipping methods'),
+                'label' => 'Available shipping methods',
             ])
             ->add('type', ChoiceType::class, [
-                'label' => t('Type'),
+                'label' => 'Type',
                 'choices' => $this->paymentTypeProvider->getAllIndexedByTranslations(),
                 'multiple' => false,
                 'expanded' => false,
@@ -138,7 +138,7 @@ final class PaymentFormType extends AbstractType
                     'expanded' => false,
                     'required' => true,
                 ],
-                'label' => t('GoPay payment method'),
+                'label' => 'GoPay payment method',
                 'required' => true,
                 'row_attr' => [
                     'class' => 'js-payment-gopay-payment-method',
@@ -146,7 +146,7 @@ final class PaymentFormType extends AbstractType
             ])
             ->add('accountNumberByDomainId', MultidomainType::class, [
                 'entry_type' => TextType::class,
-                'label' => t('Account number'),
+                'label' => 'Account number',
                 'required' => true,
                 'row_attr' => [
                     'class' => 'js-payment-bank-transfer',
@@ -154,7 +154,7 @@ final class PaymentFormType extends AbstractType
             ])
             ->add('ibanByDomainId', MultidomainType::class, [
                 'entry_type' => TextType::class,
-                'label' => t('IBAN'),
+                'label' => 'IBAN',
                 'required' => true,
                 'row_attr' => [
                     'class' => 'js-payment-bank-transfer',
@@ -162,7 +162,7 @@ final class PaymentFormType extends AbstractType
             ])
             ->add('bicSwiftByDomainId', MultidomainType::class, [
                 'entry_type' => TextType::class,
-                'label' => t('BIC/Swift'),
+                'label' => 'BIC/Swift',
                 'required' => true,
                 'row_attr' => [
                     'class' => 'js-payment-bank-transfer',
@@ -170,12 +170,12 @@ final class PaymentFormType extends AbstractType
             ]);
 
         $builderPriceGroup = $builder->create('prices', GroupType::class, [
-            'label' => t('Prices'),
+            'label' => 'Prices',
         ]);
 
         $builderPriceGroup
             ->add('czkRounding', YesNoType::class, [
-                'label' => t('Order in CZK round to whole crowns'),
+                'label' => 'Order in CZK round to whole crowns',
                 'help' => t('Rounding item with 0 % VAT will be added to your order. It is used for payment in cash.'),
             ])
             ->add('pricesByDomains', PriceAndVatTableByDomainsType::class, [
@@ -185,19 +185,19 @@ final class PaymentFormType extends AbstractType
             ]);
 
         $builderAdditionalInformationGroup = $builder->create('additionalInformation', GroupType::class, [
-            'label' => t('Additional information'),
+            'label' => 'Additional information',
         ]);
 
         $builderAdditionalInformationGroup
             ->add('description', LocalizedType::class, [
                 'required' => false,
                 'entry_type' => TextareaType::class,
-                'label' => t('Description'),
+                'label' => 'Description',
             ])
             ->add('instructions', LocalizedType::class, [
                 'required' => false,
                 'entry_type' => CKEditorType::class,
-                'label' => t('Instructions'),
+                'label' => 'Instructions',
                 'entry_options' => [
                     'help' => $this->buildInstructionsHelpHtml(),
                     'help_html' => true,
@@ -205,12 +205,12 @@ final class PaymentFormType extends AbstractType
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
         $builderImageGroup
             ->add('image', ImageUploadType::class, [
                 'required' => false,
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'image_entity_class' => Payment::class,
                 'file_constraints' => [
                     new Constraints\Image([

--- a/packages/framework/src/Form/Admin/PriceList/ImportPriceListFormType.php
+++ b/packages/framework/src/Form/Admin/PriceList/ImportPriceListFormType.php
@@ -55,8 +55,8 @@ final class ImportPriceListFormType extends AbstractType
                     return $this->domain->getDomainConfigById($priceList->getDomainId())->getName();
                 },
                 'required' => false,
-                'placeholder' => t('-- Create new price list --'),
-                'label' => t('Overwrite Price list'),
+                'placeholder' => '-- Create new price list --',
+                'label' => 'Overwrite Price list',
                 'attr' => [
                     'class' => 'js-import-price-list-select-list',
                     'data-load-metadata-url' => $this->urlGenerator->generate('admin_pricelist_loadmetadata', ['id' => '0']),
@@ -64,13 +64,13 @@ final class ImportPriceListFormType extends AbstractType
             ])
             ->add('domainId', DomainType::class, [
                 'required' => true,
-                'label' => t('Domain'),
+                'label' => 'Domain',
                 'row_attr' => [
                     'data-js-import-price-list-domain-id' => null,
                 ],
             ])
             ->add('name', TextType::class, [
-                'label' => t('Name'),
+                'label' => 'Name',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter product list name']),
@@ -84,7 +84,7 @@ final class ImportPriceListFormType extends AbstractType
                 ],
             ])
             ->add('validFrom', DateTimeType::class, [
-                'label' => t('Valid from'),
+                'label' => 'Valid from',
                 'input' => 'datetime_immutable',
                 'required' => true,
                 'constraints' => [
@@ -95,7 +95,7 @@ final class ImportPriceListFormType extends AbstractType
                 ],
             ])
             ->add('validTo', DateTimeType::class, [
-                'label' => t('Valid to'),
+                'label' => 'Valid to',
                 'input' => 'datetime_immutable',
                 'required' => true,
                 'constraints' => [
@@ -121,7 +121,7 @@ final class ImportPriceListFormType extends AbstractType
                             . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
                     ]),
                 ],
-                'label' => t('CSV file'),
+                'label' => 'CSV file',
             ]);
 
         $builder->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Form/Admin/PriceList/PriceListFormType.php
+++ b/packages/framework/src/Form/Admin/PriceList/PriceListFormType.php
@@ -46,11 +46,11 @@ final class PriceListFormType extends AbstractType
         if ($priceList instanceof PriceList) {
             $builder
                 ->add('id', DisplayOnlyType::class, [
-                    'label' => t('ID'),
+                    'label' => 'ID',
                     'data' => $priceList->getId(),
                 ])
                 ->add('lastUpdate', DisplayOnlyType::class, [
-                    'label' => t('Last update'),
+                    'label' => 'Last update',
                     'data' => $this->dateTimeFormatterExtension->formatDateTime($priceList->getLastUpdate()),
                 ]);
         }
@@ -59,7 +59,7 @@ final class PriceListFormType extends AbstractType
 
         $builder
             ->add('name', TextType::class, [
-                'label' => t('Name'),
+                'label' => 'Name',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter product list name']),
                     new Constraints\Length([
@@ -69,7 +69,7 @@ final class PriceListFormType extends AbstractType
                 ],
             ])
             ->add('validFrom', DateTimeType::class, [
-                'label' => t('Valid from'),
+                'label' => 'Valid from',
                 'input' => 'datetime_immutable',
                 'required' => true,
                 'constraints' => [
@@ -77,7 +77,7 @@ final class PriceListFormType extends AbstractType
                 ],
             ])
             ->add('validTo', DateTimeType::class, [
-                'label' => t('Valid to'),
+                'label' => 'Valid to',
                 'input' => 'datetime_immutable',
                 'required' => true,
                 'constraints' => [
@@ -86,7 +86,7 @@ final class PriceListFormType extends AbstractType
             ])
             ->add('priceListProductPricesData', PriceListProductsPickerType::class, [
                 'required' => false,
-                'label' => t('Products'),
+                'label' => 'Products',
             ]);
 
         $builder->add('actionBar', ActionBarType::class, [
@@ -138,13 +138,13 @@ final class PriceListFormType extends AbstractType
 
         if ($priceList instanceof PriceList) {
             $builder->add('domainIcon', DisplayOnlyDomainIconType::class, [
-                'label' => t('Domain'),
+                'label' => 'Domain',
                 'data' => $priceList->getDomainId(),
             ]);
         } else {
             $builder->add('domainId', DomainType::class, [
                 'required' => true,
-                'label' => t('Domain'),
+                'label' => 'Domain',
                 'attr' => [
                     'class' => 'js-update-domain-id',
                 ],

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -88,7 +88,7 @@ final class CurrencyFormType extends AbstractType
                     t('To fifty hundredths (halfs)') => Currency::ROUNDING_TYPE_FIFTIES,
                     t('To whole numbers') => Currency::ROUNDING_TYPE_INTEGER,
                 ],
-                'label' => t('Price including VAT rounding'),
+                'label' => 'Price including VAT rounding',
             ])
             ->add('roundingPlacesPriceWithoutVat', NumberType::class, [
                 'required' => true,

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencySettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencySettingsFormType.php
@@ -54,7 +54,7 @@ final class CurrencySettingsFormType extends AbstractType
                 ],
             ])
             ->add('save', SubmitType::class, [
-                'label' => t('Save default currencies'),
+                'label' => 'Save default currencies',
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupSettingsFormType.php
@@ -42,7 +42,7 @@ final class PricingGroupSettingsFormType extends AbstractType
                 ],
             ])
             ->add('save', SubmitType::class, [
-                'label' => t('Save default pricing group'),
+                'label' => 'Save default pricing group',
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -74,13 +74,13 @@ final class BrandFormType extends AbstractType
         }
 
         $builderBasicInformationGroup = $builder->create('basicInformation', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         if ($brand !== null) {
             $builderBasicInformationGroup
                 ->add('id', DisplayOnlyType::class, [
-                    'label' => t('ID'),
+                    'label' => 'ID',
                     'data' => $brand->getId(),
                 ]);
         }
@@ -94,47 +94,47 @@ final class BrandFormType extends AbstractType
                         ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
                     ),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('descriptions', LocalizedType::class, [
                 'entry_type' => CKEditorType::class,
                 'required' => false,
-                'label' => t('Description'),
+                'label' => 'Description',
             ]);
 
         $builderSeoGroup = $builder->create('seo', GroupType::class, [
-            'label' => t('SEO'),
+            'label' => 'SEO',
         ]);
         $builderSeoGroup
             ->add('seoTitles', MultidomainType::class, [
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoTitlesOptionsByDomainId,
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescriptions', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoMetaDescriptionsOptionsByDomainId,
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('seoH1s', MultidomainType::class, [
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoH1sOptionsByDomainId,
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
             ]);
 
         if ($brand) {
             $builderSeoGroup->add('urls', UrlListType::class, [
                 'route_name' => 'front_brand_detail',
                 'entity_id' => $brand->getId(),
-                'label' => t('URL addresses'),
+                'label' => 'URL addresses',
             ]);
         }
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
         $builderImageGroup
             ->add('image', ImageUploadType::class, [
@@ -151,7 +151,7 @@ final class BrandFormType extends AbstractType
                 ],
                 'entity' => $brand,
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
             ]);
 
         $builder

--- a/packages/framework/src/Form/Admin/Product/Flag/FlagFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Flag/FlagFormType.php
@@ -29,7 +29,7 @@ final class FlagFormType extends AbstractType
     {
         $builder
             ->add('name', LocalizedType::class, [
-                'label' => t('Name'),
+                'label' => 'Name',
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [
@@ -42,32 +42,32 @@ final class FlagFormType extends AbstractType
             ]);
 
         $builderBasicInformationGroup = $builder->create('basicInformationGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         $builderBasicInformationGroup
             ->add('rgbColor', ColorPickerType::class, [
-                'label' => t('Color'),
+                'label' => 'Color',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter flag color']),
                 ],
             ])
             ->add('visible', YesNoType::class, [
-                'label' => t('Display'),
+                'label' => 'Display',
             ]);
 
         $builder->add($builderBasicInformationGroup);
 
         if ($options['flag'] !== null) {
             $builderSeoInformationGroup = $builder->create('seoGroup', GroupType::class, [
-                'label' => t('Seo'),
+                'label' => 'Seo',
             ]);
 
             $builderSeoInformationGroup
                 ->add('urls', UrlListType::class, [
                     'route_name' => 'front_flag_detail',
                     'entity_id' => $options['flag']->getId(),
-                    'label' => t('URL addresses'),
+                    'label' => 'URL addresses',
                 ]);
 
             $builder->add($builderSeoInformationGroup);

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
@@ -67,7 +67,7 @@ final class ParameterFormType extends AbstractType
                 'label' => 'Unit',
                 'required' => false,
                 'choices' => $this->unitFacade->getAll(),
-                'placeholder' => t('-- Choose unit --'),
+                'placeholder' => '-- Choose unit --',
                 'choice_label' => 'name',
                 'choice_value' => 'id',
             ])
@@ -83,7 +83,7 @@ final class ParameterFormType extends AbstractType
             ])
             ->add('group', ChoiceType::class, [
                 'label' => 'Group',
-                'placeholder' => t('-- Choose group --'),
+                'placeholder' => '-- Choose group --',
                 'required' => false,
                 'choices' => $this->parameterGroupFacade->getAll(),
                 'choice_label' => 'name',

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
@@ -47,6 +47,7 @@ final class ParameterFormType extends AbstractType
     {
         $builder
             ->add('name', LocalizedType::class, [
+                'label' => 'Name',
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [
@@ -58,10 +59,12 @@ final class ParameterFormType extends AbstractType
                 ],
             ])
             ->add('parameterType', ChoiceType::class, [
+                'label' => 'Parameter type',
                 'required' => true,
                 'choices' => Parameter::PARAMETER_TYPES,
             ])
             ->add('unit', ChoiceType::class, [
+                'label' => 'Unit',
                 'required' => false,
                 'choices' => $this->unitFacade->getAll(),
                 'placeholder' => t('-- Choose unit --'),
@@ -69,6 +72,7 @@ final class ParameterFormType extends AbstractType
                 'choice_value' => 'id',
             ])
             ->add('orderingPriority', NumberType::class, [
+                'label' => 'Ordering priority',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter parameter ordering priority']),
@@ -78,6 +82,7 @@ final class ParameterFormType extends AbstractType
                 ),
             ])
             ->add('group', ChoiceType::class, [
+                'label' => 'Group',
                 'placeholder' => t('-- Choose group --'),
                 'required' => false,
                 'choices' => $this->parameterGroupFacade->getAll(),

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
@@ -39,6 +39,7 @@ final class ParameterGroupFormType extends AbstractType
     {
         $builder
             ->add('name', LocalizedType::class, [
+                'label' => 'Name',
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueFormType.php
@@ -26,9 +26,9 @@ final class ParameterValueFormType extends AbstractType
     {
         $builder->add('rgbHex', ColorPickerType::class, [
             'required' => false,
-            'label' => t('RGB Hex'),
+            'label' => 'RGB Hex',
         ])->add('colourIcon', FileUploadType::class, [
-            'label' => t('Upload attachment'),
+            'label' => 'Upload attachment',
             'required' => false,
             'file_constraints' => [
                 new Constraints\File([

--- a/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
@@ -44,7 +44,7 @@ final class ProductPricesWithVatSelectType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
                 ],
-                'label' => t('VAT'),
+                'label' => 'VAT',
             ])
             ->add(
                 'manualInputPricesByPricingGroupId',

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -114,7 +114,7 @@ final class ProductFormType extends AbstractType
                         new Constraints\Length(['max' => 255, 'maxMessage' => 'Product prefix name cannot be longer than {{ limit }} characters']),
                     ],
                 ],
-                'label' => t('Name prefix'),
+                'label' => 'Name prefix',
             ])
             ->add('name', LocalizedType::class, [
                 'required' => false,
@@ -125,7 +125,7 @@ final class ProductFormType extends AbstractType
                         ),
                     ],
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('nameSuffix', LocalizedType::class, [
                 'required' => false,
@@ -134,7 +134,7 @@ final class ProductFormType extends AbstractType
                         new Constraints\Length(['max' => 255, 'maxMessage' => 'Product suffix name cannot be longer than {{ limit }} characters']),
                     ],
                 ],
-                'label' => t('Name suffix'),
+                'label' => 'Name suffix',
             ]);
 
         if ($this->isProductVariant($product) || $this->isProductMainVariant($product)) {
@@ -190,14 +190,14 @@ final class ProductFormType extends AbstractType
         array $disabledItemInMainVariantHelp = [],
     ): FormBuilderInterface {
         $builderBasicInformationGroup = $builder->create('basicInformationGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         if (!$this->isProductMainVariant($product)) {
             $builderBasicInformationGroup->add('productType', ChoiceType::class, [
                 'required' => true,
                 'choices' => $this->productTypeEnum->getAllIndexedByTranslations(),
-                'label' => t('Product type'),
+                'label' => 'Product type',
             ]);
         }
 
@@ -213,7 +213,7 @@ final class ProductFormType extends AbstractType
                 'data-unique-catnum-url' => $this->urlGenerator->generate('admin_product_catnumexists'),
                 'data-current-product-catnum' => $product !== null ? $product->getCatnum() : '',
             ],
-            'label' => t('Catalog number'),
+            'label' => 'Catalog number',
             ...$disabledItemInMainVariantHelp,
         ])
             ->add('partno', TextType::class, [
@@ -224,7 +224,7 @@ final class ProductFormType extends AbstractType
                     ),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
-                'label' => t('PartNo (serial number)'),
+                'label' => 'PartNo (serial number)',
                 ...$disabledItemInMainVariantHelp,
             ])
             ->add('ean', TextType::class, [
@@ -235,13 +235,13 @@ final class ProductFormType extends AbstractType
                     ),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
-                'label' => t('EAN'),
+                'label' => 'EAN',
                 ...$disabledItemInMainVariantHelp,
             ]);
 
         if ($product !== null) {
             $builderBasicInformationGroup->add('id', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $product->getId(),
             ]);
         }
@@ -257,18 +257,18 @@ final class ProductFormType extends AbstractType
                     'expanded' => true,
                 ],
                 'required' => false,
-                'label' => t('Flags'),
+                'label' => 'Flags',
             ])
             ->add('brand', ChoiceType::class, [
                 'required' => false,
                 'choices' => $this->brandFacade->getAll(),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'placeholder' => t('-- Choose brand --'),
-                'label' => t('Brand'),
+                'placeholder' => '-- Choose brand --',
+                'label' => 'Brand',
             ])
             ->add('weight', IntegerType::class, [
-                'label' => t('Weight (g)'),
+                'label' => 'Weight (g)',
                 'required' => false,
             ])
             ->add('excludedTransports', ChoiceType::class, [
@@ -277,7 +277,7 @@ final class ProductFormType extends AbstractType
                 'choice_label' => 'name',
                 'multiple' => true,
                 'expanded' => false,
-                'label' => t('Excluded transports'),
+                'label' => 'Excluded transports',
             ]);
 
         return $builderBasicInformationGroup;
@@ -293,7 +293,7 @@ final class ProductFormType extends AbstractType
         ?Product $product,
     ): FormBuilderInterface {
         $builderShortDescriptionGroup = $builder->create('shortDescriptionsGroup', GroupType::class, [
-            'label' => t('Short description'),
+            'label' => 'Short description',
         ]);
 
         if ($this->isProductVariant($product)) {
@@ -321,7 +321,7 @@ final class ProductFormType extends AbstractType
     private function createDescriptionsGroup(FormBuilderInterface $builder, ?Product $product): FormBuilderInterface
     {
         $builderDescriptionGroup = $builder->create('descriptionsGroup', GroupType::class, [
-            'label' => t('Description'),
+            'label' => 'Description',
         ]);
 
         if ($this->isProductVariant($product)) {
@@ -360,16 +360,16 @@ final class ProductFormType extends AbstractType
         }
 
         $builderDisplayAvailabilityGroup = $builder->create('displayAvailabilityGroup', GroupType::class, [
-            'label' => t('Display and availability'),
+            'label' => 'Display and availability',
         ]);
 
         $builderDisplayAvailabilityGroup
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hide product'),
+                'label' => 'Hide product',
             ]);
 
         $builderDisplayAvailabilityGroup->add('domainHidden', MultidomainType::class, [
-            'label' => t('Hide on domain'),
+            'label' => 'Hide on domain',
             'entry_type' => YesNoType::class,
         ]);
 
@@ -377,21 +377,21 @@ final class ProductFormType extends AbstractType
             ->add('sellingFrom', DatePickerType::class, [
                 'required' => false,
                 'invalid_message' => 'Enter date in DD.MM.YYYY format',
-                'label' => t('Selling start date'),
+                'label' => 'Selling start date',
             ])
             ->add('sellingTo', DatePickerType::class, [
                 'required' => false,
                 'invalid_message' => 'Enter date in DD.MM.YYYY format',
-                'label' => t('Selling end date'),
+                'label' => 'Selling end date',
             ])
             ->add('sellingDenied', YesNoType::class, [
-                'label' => t('Exclude from sale on whole eshop'),
+                'label' => 'Exclude from sale on whole eshop',
                 'help' => t(
                     'Products excluded from sale can\'t be displayed on lists and can\'t be searched. Product detail is available by direct access from the URL, but it is not possible to add product to cart.',
                 ),
             ])
             ->add('saleExclusion', MultidomainType::class, [
-                'label' => t('Exclude from sale on domains'),
+                'label' => 'Exclude from sale on domains',
                 'entry_type' => YesNoType::class,
             ]);
 
@@ -409,7 +409,7 @@ final class ProductFormType extends AbstractType
             $builderDisplayAvailabilityGroup
                 ->add('categoriesByDomainId', DisplayOnlyType::class, [
                     'data' => t('You can set the categories on product detail of the main variant'),
-                    'label' => t('Assign to category'),
+                    'label' => 'Assign to category',
                 ]);
         } else {
             $builderDisplayAvailabilityGroup
@@ -418,7 +418,7 @@ final class ProductFormType extends AbstractType
                     'entry_type' => CategoriesType::class,
                     'options_by_domain_id' => $categoriesOptionsByDomainId,
                     'disabled' => $this->isProductVariant($product),
-                    'label' => t('Assign to category'),
+                    'label' => 'Assign to category',
                 ]);
         }
         $builderDisplayAvailabilityGroup
@@ -432,7 +432,7 @@ final class ProductFormType extends AbstractType
                         'message' => 'Please choose unit',
                     ]),
                 ],
-                'label' => t('Unit'),
+                'label' => 'Unit',
             ]);
 
         $builderDisplayAvailabilityGroup
@@ -441,7 +441,7 @@ final class ProductFormType extends AbstractType
                 'entry_options' => [
                     'required' => true,
                 ],
-                'label' => t('Sorting priority'),
+                'label' => 'Sorting priority',
             ]);
 
         return $builderDisplayAvailabilityGroup;
@@ -455,7 +455,7 @@ final class ProductFormType extends AbstractType
     private function createStocksGroup(FormBuilderInterface $builder, ?Product $product): FormBuilderInterface
     {
         $stockGroupBuilder = $builder->create('stocksGroup', GroupType::class, [
-            'label' => t('Warehouses'),
+            'label' => 'Warehouses',
         ]);
 
         if ($this->isProductMainVariant($product)) {
@@ -467,7 +467,7 @@ final class ProductFormType extends AbstractType
         } else {
             $stockGroupBuilder->add('isAllowedNegativeStock', YesNoType::class, [
                 'required' => false,
-                'label' => t('Allow negative stock'),
+                'label' => 'Allow negative stock',
                 'help' => t('If you allow negative stock, it is possible to order more items than are currently in stock.'),
             ]);
 
@@ -488,7 +488,7 @@ final class ProductFormType extends AbstractType
     private function createPricesGroup(FormBuilderInterface $builder, ?Product $product): FormBuilderInterface
     {
         $builderPricesGroup = $builder->create('pricesGroup', GroupType::class, [
-            'label' => t('Prices'),
+            'label' => 'Prices',
         ]);
 
         if ($this->isProductMainVariant($product)) {
@@ -546,7 +546,7 @@ final class ProductFormType extends AbstractType
                     'priceListOverview',
                     MultidomainType::class,
                     [
-                        'label' => t('Price list overview'),
+                        'label' => 'Price list overview',
                         'entry_type' => PriceListOverviewType::class,
                         'required' => false,
                         'mapped' => false,
@@ -589,7 +589,7 @@ final class ProductFormType extends AbstractType
             $seoH1OptionsByDomainId[$domainId] = $seoTitlesOptionsByDomainId[$domainId];
         }
         $builderSeoGroup = $builder->create('seoGroup', GroupType::class, [
-            'label' => t('SEO'),
+            'label' => 'SEO',
         ]);
 
         $builderSeoGroup
@@ -597,26 +597,26 @@ final class ProductFormType extends AbstractType
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoTitlesOptionsByDomainId,
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescriptions', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoMetaDescriptionsOptionsByDomainId,
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('seoH1s', MultidomainType::class, [
                 'entry_type' => TextType::class,
                 'required' => false,
                 'options_by_domain_id' => $seoH1OptionsByDomainId,
-                'label' => t('Heading (H1)'),
+                'label' => 'Heading (H1)',
             ]);
 
         if ($product) {
             $builderSeoGroup->add('urls', UrlListType::class, [
                 'route_name' => 'front_product_detail',
                 'entity_id' => $product->getId(),
-                'label' => t('URL settings'),
+                'label' => 'URL settings',
             ]);
         }
 
@@ -637,7 +637,7 @@ final class ProductFormType extends AbstractType
 
         if ($this->isProductVariant($product)) {
             $variantGroup->add('mainVariantUrl', DisplayOnlyUrlType::class, [
-                'label' => t('Product is variant'),
+                'label' => 'Product is variant',
                 'route' => 'admin_product_edit',
                 'route_params' => [
                     'id' => $product->getMainVariant()->getId(),
@@ -654,7 +654,7 @@ final class ProductFormType extends AbstractType
                         ),
                     ],
                 ],
-                'label' => t('Variant alias'),
+                'label' => 'Variant alias',
             ]);
         }
 
@@ -665,7 +665,7 @@ final class ProductFormType extends AbstractType
                 'allow_main_variants' => false,
                 'allow_variants' => false,
                 'label_button_add' => t('Add variant'),
-                'label' => t('Variants'),
+                'label' => 'Variants',
                 'top_info_title' => t('Product is main variant.'),
             ]);
         }
@@ -708,7 +708,7 @@ final class ProductFormType extends AbstractType
     private function createParametersGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderParametersGroup = $builder->create('parametersGroup', GroupType::class, [
-            'label' => t('Parameters'),
+            'label' => 'Parameters',
         ]);
 
         $builderParametersGroup
@@ -738,7 +738,7 @@ final class ProductFormType extends AbstractType
     private function createImagesGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         $builderImageGroup = $builder->create('imageGroup', GroupType::class, [
-            'label' => t('Images'),
+            'label' => 'Images',
         ]);
         $builderImageGroup
             ->add('images', ImageUploadType::class, [
@@ -755,7 +755,7 @@ final class ProductFormType extends AbstractType
                 ],
                 'entity' => $options['product'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
-                'label' => t('Images'),
+                'label' => 'Images',
             ]);
 
         return $builderImageGroup;
@@ -773,7 +773,7 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'main_product' => $product,
                 'sortable' => true,
-                'label' => t('Accessories'),
+                'label' => 'Accessories',
             ])
             ->addViewTransformer($this->removeDuplicatesTransformer);
     }
@@ -785,7 +785,7 @@ final class ProductFormType extends AbstractType
     private function createShortDescriptionsUspGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderShortDescriptionsUspGroup = $builder->create('shortDescriptionsUspGroups', GroupType::class, [
-            'label' => t('Short description USP'),
+            'label' => 'Short description USP',
         ]);
 
         $builderShortDescriptionsUspGroup
@@ -834,7 +834,7 @@ final class ProductFormType extends AbstractType
     private function createFilesGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         $builderFileGroup = $builder->create('fileGroup', GroupType::class, [
-            'label' => t('Files'),
+            'label' => 'Files',
         ]);
 
         $builderFileGroup
@@ -849,7 +849,7 @@ final class ProductFormType extends AbstractType
                     ]),
                 ],
                 'entity' => $options['product'],
-                'label' => t('Files'),
+                'label' => 'Files',
             ]);
 
         return $builderFileGroup;
@@ -862,7 +862,7 @@ final class ProductFormType extends AbstractType
     private function createVideosGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $videosGroup = $builder->create('videosGroup', GroupType::class, [
-            'label' => t('Videos'),
+            'label' => 'Videos',
         ]);
         $videosGroup
             ->add(

--- a/packages/framework/src/Form/Admin/Product/TopProduct/TopProductsFormType.php
+++ b/packages/framework/src/Form/Admin/Product/TopProduct/TopProductsFormType.php
@@ -32,7 +32,7 @@ final class TopProductsFormType extends AbstractType
             ->add(
                 $builder
                     ->create('products', ProductsType::class, [
-                        'label' => t('Products'),
+                        'label' => 'Products',
                         'required' => false,
                         'sortable' => true,
                     ])

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitFormType.php
@@ -23,6 +23,7 @@ final class UnitFormType extends AbstractType
     {
         $builder
             ->add('name', LocalizedType::class, [
+                'label' => 'Name',
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
@@ -31,6 +31,7 @@ final class UnitSettingFormType extends AbstractType
     {
         $builder
             ->add('defaultUnit', ChoiceType::class, [
+                'label' => 'Default unit',
                 'placeholder' => t('-- Choose unit --'),
                 'required' => true,
                 'choices' => $this->unitFacade->getAll(),

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
@@ -32,7 +32,7 @@ final class UnitSettingFormType extends AbstractType
         $builder
             ->add('defaultUnit', ChoiceType::class, [
                 'label' => 'Default unit',
-                'placeholder' => t('-- Choose unit --'),
+                'placeholder' => '-- Choose unit --',
                 'required' => true,
                 'choices' => $this->unitFacade->getAll(),
                 'choice_label' => 'name',
@@ -43,7 +43,7 @@ final class UnitSettingFormType extends AbstractType
                 ],
             ])
             ->add('save', SubmitType::class, [
-                'label' => t('Save default unit'),
+                'label' => 'Save default unit',
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Product/VariantFormType.php
+++ b/packages/framework/src/Form/Admin/Product/VariantFormType.php
@@ -28,7 +28,7 @@ final class VariantFormType extends AbstractType
     {
         $builder
             ->add(self::MAIN_VARIANT, ProductType::class, [
-                'label' => t('Main variant'),
+                'label' => 'Main variant',
                 'allow_main_variants' => false,
                 'allow_variants' => false,
                 'constraints' => [
@@ -38,7 +38,7 @@ final class VariantFormType extends AbstractType
             ->add(
                 $builder
                     ->create(self::VARIANTS, ProductsType::class, [
-                        'label' => t('Variants'),
+                        'label' => 'Variants',
                         'allow_main_variants' => false,
                         'allow_variants' => false,
                         'constraints' => [

--- a/packages/framework/src/Form/Admin/Product/VideoTokenType.php
+++ b/packages/framework/src/Form/Admin/Product/VideoTokenType.php
@@ -29,7 +29,7 @@ final class VideoTokenType extends AbstractType
                     'message' => 'Please enter video ID',
                 ]),
             ],
-            'label' => t('Youtube ID'),
+            'label' => 'Youtube ID',
         ]);
 
         $builder->add('videoTokenDescriptions', LocalizedType::class, [
@@ -42,7 +42,7 @@ final class VideoTokenType extends AbstractType
                     ),
                 ],
             ],
-            'label' => t('Description'),
+            'label' => 'Description',
         ]);
     }
 

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
@@ -89,7 +89,7 @@ final class PromoCodeFormType extends AbstractType
 
         if ($options['mass_generate']) {
             $actionBar->add('saveAndDownloadCsv', SubmitType::class, [
-                'label' => t('Create and download CSV'),
+                'label' => 'Create and download CSV',
                 'position' => [
                     'before' => 'save',
                 ],
@@ -106,13 +106,13 @@ final class PromoCodeFormType extends AbstractType
     private function buildBaseGroup(FormBuilderInterface $builder, array $options): void
     {
         $baseGroup = $builder->create('baseGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         if (!$options['mass_generate']) {
             $baseGroup
                 ->add('code', TextType::class, [
-                    'label' => t('Promo code'),
+                    'label' => 'Promo code',
                     'required' => true,
                     'constraints' => [
                         new Constraints\NotBlank([
@@ -124,7 +124,7 @@ final class PromoCodeFormType extends AbstractType
 
         if ($this->promoCode instanceof PromoCode) {
             $baseGroup->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $this->promoCode->getId(),
             ]);
         }
@@ -134,24 +134,24 @@ final class PromoCodeFormType extends AbstractType
         ])
             ->add('shownDomainId', DomainType::class, [
                 'mapped' => false,
-                'label' => t('Domain'),
+                'label' => 'Domain',
                 'disabled' => true,
             ])
             ->add('discountType', ChoiceType::class, [
                 'expanded' => true,
                 'multiple' => false,
                 'choices' => $this->promoCodeTypeEnum->getAllIndexedByTranslations(),
-                'label' => t('Discount type'),
+                'label' => 'Discount type',
                 'attr' => [
                     'class' => 'js-promo-code-discount-type',
                 ],
             ])
             ->add('remainingUses', IntegerType::class, [
-                'label' => t('Remaining number of uses'),
+                'label' => 'Remaining number of uses',
                 'required' => false,
             ])
             ->add('enabled', YesNoType::class, [
-                'label' => t('Enabled'),
+                'label' => 'Enabled',
             ]);
 
         $builder->add($baseGroup);
@@ -176,11 +176,11 @@ final class PromoCodeFormType extends AbstractType
                 ]),
             ],
             'invalid_message' => 'Please enter number.',
-            'label' => t('Discount (%)'),
+            'label' => 'Discount (%)',
         ];
 
         $limitsGroup = $builder->create('limitsGroup', GroupType::class, [
-            'label' => t('Apply according to the total price of the order'),
+            'label' => 'Apply according to the total price of the order',
             'row_attr' => [
                 'data-js-promo-code-limits-group' => null,
             ],
@@ -214,15 +214,15 @@ final class PromoCodeFormType extends AbstractType
     private function buildTimeValidationFormGroup(FormBuilderInterface $builder): void
     {
         $timeValidationGroup = $builder->create('timeValidationGroup', GroupType::class, [
-            'label' => t('Apply according to date and time limit'),
+            'label' => 'Apply according to date and time limit',
         ]);
 
         $timeValidationGroup->add('datetimeValidFrom', DateTimeType::class, [
             'required' => false,
-            'label' => t('Valid from'),
+            'label' => 'Valid from',
         ])->add('datetimeValidTo', DateTimeType::class, [
             'required' => false,
-            'label' => t('Valid to'),
+            'label' => 'Valid to',
         ]);
 
         $builder->add($timeValidationGroup);
@@ -234,7 +234,7 @@ final class PromoCodeFormType extends AbstractType
     private function buildFlagsFormGroup(FormBuilderInterface $builder): void
     {
         $flagsGroup = $builder->create('flagsGroup', GroupType::class, [
-            'label' => t('Apply according to product flags'),
+            'label' => 'Apply according to product flags',
         ]);
 
         $flagsGroup->add('flags', PromoCodeFlagCollectionType::class, [
@@ -259,18 +259,18 @@ final class PromoCodeFormType extends AbstractType
     private function buildCustomersFormGroup(FormBuilderInterface $builder): void
     {
         $customersGroup = $builder->create('customersGroup', GroupType::class, [
-            'label' => t('Apply according to customer'),
+            'label' => 'Apply according to customer',
         ]);
         $builder->add($customersGroup);
         $customersGroup->add('registeredCustomerUserOnly', YesNoType::class, [
-            'label' => t('For registered customers only'),
+            'label' => 'For registered customers only',
         ])
             ->add('limitedPricingGroups', ChoiceType::class, [
                 'required' => false,
                 'choices' => $this->pricingGroupFacade->getByDomainId($this->adminDomainTabsFacade->getSelectedDomainId()),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'label' => t('Pricing groups'),
+                'label' => 'Pricing groups',
                 'multiple' => true,
             ]);
     }
@@ -284,7 +284,7 @@ final class PromoCodeFormType extends AbstractType
             ->add('productsWithSale', ProductsType::class, [
                 'required' => false,
                 'sortable' => true,
-                'label' => t('Apply to selected products'),
+                'label' => 'Apply to selected products',
             ]);
     }
 
@@ -294,7 +294,7 @@ final class PromoCodeFormType extends AbstractType
     private function buildCategoriesWithSaleFormGroup(FormBuilderInterface $builder): void
     {
         $displayCategoriesGroup = $builder->create('displayCategoriesGroup', GroupType::class, [
-            'label' => t('Apply to selected categories'),
+            'label' => 'Apply to selected categories',
         ]);
         $displayCategoriesGroup->add('categoriesWithSale', CategoriesType::class, [
             'required' => false,
@@ -310,7 +310,7 @@ final class PromoCodeFormType extends AbstractType
     private function buildBrandsWithSaleFormGroup(FormBuilderInterface $builder): void
     {
         $displayCategoriesGroup = $builder->create('displayBrandsGroup', GroupType::class, [
-            'label' => t('Apply to selected brands'),
+            'label' => 'Apply to selected brands',
         ]);
         $displayCategoriesGroup->add('brandsWithSale', ChoiceType::class, [
             'required' => false,
@@ -330,16 +330,16 @@ final class PromoCodeFormType extends AbstractType
     private function addMassGenerationGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderMassPromoCodeGroup = $builder->create('massPromoCodeGroup', GroupType::class, [
-            'label' => t('Bulk promo code generation'),
+            'label' => 'Bulk promo code generation',
         ]);
 
         $builderMassPromoCodeGroup
             ->add('prefix', TextType::class, [
-                'label' => t('Prefix (e.g. "SPRING_")'),
+                'label' => 'Prefix (e.g. "SPRING_")',
                 'required' => false,
             ])
             ->add('quantity', IntegerType::class, [
-                'label' => t('Number of generated promo codes'),
+                'label' => 'Number of generated promo codes',
                 'required' => true,
                 'constraints' => [
                     new NotBlank([

--- a/packages/framework/src/Form/Admin/SalesRepresentative/SalesRepresentativeFormType.php
+++ b/packages/framework/src/Form/Admin/SalesRepresentative/SalesRepresentativeFormType.php
@@ -33,11 +33,11 @@ final class SalesRepresentativeFormType extends AbstractType
 
         if ($salesRepresentative instanceof SalesRepresentative) {
             $builderSystemDataGroup = $builder->create('systemData', GroupType::class, [
-                'label' => t('System data'),
+                'label' => 'System data',
             ]);
 
             $builderSystemDataGroup->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $salesRepresentative->getId(),
             ]);
 
@@ -46,7 +46,7 @@ final class SalesRepresentativeFormType extends AbstractType
         }
 
         $builderPersonalDataGroup = $builder->create('personalData', GroupType::class, [
-            'label' => t('Personal data'),
+            'label' => 'Personal data',
         ]);
 
         $builderPersonalDataGroup
@@ -58,7 +58,7 @@ final class SalesRepresentativeFormType extends AbstractType
                         'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('First name'),
+                'label' => 'First name',
             ])
             ->add('lastName', TextType::class, [
                 'required' => false,
@@ -68,7 +68,7 @@ final class SalesRepresentativeFormType extends AbstractType
                         'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Last name'),
+                'label' => 'Last name',
             ])
             ->add('email', EmailType::class, [
                 'required' => false,
@@ -79,7 +79,7 @@ final class SalesRepresentativeFormType extends AbstractType
                     ]),
                     new Email(['message' => 'Please enter valid email']),
                 ],
-                'label' => t('Email'),
+                'label' => 'Email',
             ])
             ->add('telephone', TextType::class, [
                 'required' => false,
@@ -89,11 +89,11 @@ final class SalesRepresentativeFormType extends AbstractType
                         'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
                     ]),
                 ],
-                'label' => t('Telephone'),
+                'label' => 'Telephone',
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup
@@ -109,7 +109,7 @@ final class SalesRepresentativeFormType extends AbstractType
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
                     ]),
                 ],
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'entity' => $options['salesRepresentative'],
                 'info_text' => t('You can upload following formats: PNG, JPG'),
                 'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],

--- a/packages/framework/src/Form/Admin/Seo/HreflangSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/HreflangSettingFormType.php
@@ -49,7 +49,7 @@ final class HreflangSettingFormType extends AbstractType
             ])
             ->add(self::FIELD_HREFLANG_COLLECTION, CollectionType::class, [
                 'block_prefix' => 'hreflang_setting_collection',
-                'label' => t('Alternate language domains'),
+                'label' => 'Alternate language domains',
                 'entry_type' => ChoiceType::class,
                 'entry_options' => [
                     'required' => true,

--- a/packages/framework/src/Form/Admin/Seo/SeoPageFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoPageFormType.php
@@ -80,7 +80,7 @@ final class SeoPageFormType extends AbstractType
         ?SeoPage $seoPage,
     ): FormBuilderInterface {
         $group = $builder->create('basicInformationGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         $optionsByDomainId = [];
@@ -98,7 +98,7 @@ final class SeoPageFormType extends AbstractType
 
         $group
             ->add('pageName', TextType::class, [
-                'label' => t('Page name'),
+                'label' => 'Page name',
                 'required' => true,
                 'disabled' => $seoPage !== null,
                 'constraints' => [
@@ -109,7 +109,7 @@ final class SeoPageFormType extends AbstractType
                 'entry_type' => TextType::class,
                 'disabled' => $seoPage !== null,
                 'required' => true,
-                'label' => t('Page slug'),
+                'label' => 'Page slug',
                 'options_by_domain_id' => $optionsByDomainId,
                 'entry_options' => [
                     'constraints' => [
@@ -132,7 +132,7 @@ final class SeoPageFormType extends AbstractType
     private function createSeoAttributesGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $group = $builder->create('attributes', GroupType::class, [
-            'label' => t('SEO'),
+            'label' => 'SEO',
         ]);
 
         $group
@@ -142,7 +142,7 @@ final class SeoPageFormType extends AbstractType
                 'entry_options' => [
                     'attr' => ['data-js-recommended-length' => 60],
                 ],
-                'label' => t('Page title'),
+                'label' => 'Page title',
             ])
             ->add('seoMetaDescriptionsIndexedByDomainId', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
@@ -150,7 +150,7 @@ final class SeoPageFormType extends AbstractType
                 'entry_options' => [
                     'attr' => ['data-js-recommended-length' => 155],
                 ],
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ])
             ->add('canonicalUrlsIndexedByDomainId', MultidomainType::class, [
                 'entry_type' => UrlType::class,
@@ -160,7 +160,7 @@ final class SeoPageFormType extends AbstractType
                     ],
                 ],
                 'required' => false,
-                'label' => t('Canonical URL'),
+                'label' => 'Canonical URL',
             ])
             ->add('seoOgTitlesIndexedByDomainId', MultidomainType::class, [
                 'entry_type' => TextType::class,
@@ -168,7 +168,7 @@ final class SeoPageFormType extends AbstractType
                 'entry_options' => [
                     'attr' => ['data-js-recommended-length' => 60],
                 ],
-                'label' => t('Open Graph title'),
+                'label' => 'Open Graph title',
             ])
             ->add('seoOgDescriptionsIndexedByDomainId', MultidomainType::class, [
                 'entry_type' => TextareaType::class,
@@ -176,7 +176,7 @@ final class SeoPageFormType extends AbstractType
                 'entry_options' => [
                     'attr' => ['data-js-recommended-length' => 155],
                 ],
-                'label' => t('Open Graph description'),
+                'label' => 'Open Graph description',
             ]);
 
         return $group;
@@ -190,7 +190,7 @@ final class SeoPageFormType extends AbstractType
     private function createImageGroup(FormBuilderInterface $builder, ?SeoPage $seoPage): FormBuilderInterface
     {
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup

--- a/packages/framework/src/Form/Admin/Seo/SeoRobotsSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoRobotsSettingFormType.php
@@ -27,7 +27,7 @@ final class SeoRobotsSettingFormType extends AbstractType
             ])
             ->add('content', TextareaType::class, [
                 'required' => false,
-                'label' => t('File content'),
+                'label' => 'File content',
             ])
             ->add('actionBar', ActionBarType::class, [
                 'save_label' => t('Save changes'),

--- a/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
@@ -47,7 +47,7 @@ final class SeoSettingFormType extends AbstractType
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
@@ -59,7 +59,7 @@ final class SeoSettingFormType extends AbstractType
                         'message' => 'Same title is used on another domain',
                     ]),
                 ],
-                'label' => t('Headline'),
+                'label' => 'Headline',
             ])
             ->add('titleAddOn', TextType::class, [
                 'required' => false,
@@ -69,7 +69,7 @@ final class SeoSettingFormType extends AbstractType
                         'message' => 'Same title complement is used on another domain',
                     ]),
                 ],
-                'label' => t('Complement to title'),
+                'label' => 'Complement to title',
                 'help' => t(
                     'Complement to title will be set as suffix to all titles e.g. if complement is set “ | My shop” and product name is “iPhone 7” the result title for this products page will be “iPhone 7 | My shop”.',
                 ),
@@ -82,7 +82,7 @@ final class SeoSettingFormType extends AbstractType
                         'message' => 'Same description is used on another domain',
                     ]),
                 ],
-                'label' => t('Meta description'),
+                'label' => 'Meta description',
             ]);
 
         $builder

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -44,26 +44,26 @@ final class SliderItemFormType extends AbstractType
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         if ($options['scenario'] === self::SCENARIO_EDIT) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $options['slider_item']->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ])
                 ->add('domainId', DomainType::class, [
                     'required' => true,
                     'attr' => ['readonly' => 'readonly'],
-                    'label' => t('Domain'),
+                    'label' => 'Domain',
                 ]);
         }
 
         if ($options['scenario'] === self::SCENARIO_CREATE) {
             $builderSettingsGroup->add('domainId', DomainType::class, [
                 'required' => true,
-                'label' => t('Domain'),
+                'label' => 'Domain',
             ]);
         }
 
@@ -73,7 +73,7 @@ final class SliderItemFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter name']),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
                 'help' => t('Name serves only for internal use within the administration'),
             ])
             ->add('link', UrlType::class, [
@@ -82,18 +82,18 @@ final class SliderItemFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter link']),
                     new Constraints\Url(['message' => 'Link must be valid URL address']),
                 ],
-                'label' => t('Link'),
+                'label' => 'Link',
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,
-                'label' => t('Description'),
+                'label' => 'Description',
             ])
             ->add('rgbBackgroundColor', ColorPickerType::class, [
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter description box background color']),
                 ],
-                'label' => t('Description background color'),
+                'label' => 'Description background color',
             ])
             ->add('opacity', NumberSliderType::class, [
                 'required' => true,
@@ -106,14 +106,14 @@ final class SliderItemFormType extends AbstractType
                         'notInRangeMessage' => 'Opacity must be between {{ min }} and {{ max }}',
                     ]),
                 ],
-                'label' => t('Description opacity'),
+                'label' => 'Description opacity',
             ])
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hide'),
+                'label' => 'Hide',
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup
@@ -130,7 +130,7 @@ final class SliderItemFormType extends AbstractType
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
                     ]),
                 ],
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'entity' => $options['slider_item'],
                 'info_text' => t('You can upload following formats: PNG, JPG'),
                 'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],
@@ -142,11 +142,11 @@ final class SliderItemFormType extends AbstractType
             ->add($builderImageGroup)
             ->add('datetimeVisibleFrom', DatePickerType::class, [
                 'required' => false,
-                'label' => t('Display date FROM'),
+                'label' => 'Display date FROM',
             ])
             ->add('datetimeVisibleTo', DatePickerType::class, [
                 'required' => false,
-                'label' => t('Display date TO'),
+                'label' => 'Display date TO',
             ])
             ->add('actionBar', ActionBarType::class, [
                 'back_route' => 'admin_slider_list',

--- a/packages/framework/src/Form/Admin/Stock/StockFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/StockFormType.php
@@ -40,19 +40,19 @@ final class StockFormType extends AbstractType
         $this->stock = $options['stock'];
 
         $stockDataBuilder = $builder->create('stockData', GroupType::class, [
-            'label' => t('Warehouse'),
+            'label' => 'Warehouse',
         ]);
 
         if ($this->stock !== null) {
             $stockDataBuilder
                 ->add('stockId', DisplayOnlyType::class, [
-                    'label' => t('ID'),
+                    'label' => 'ID',
                     'data' => $this->stock->getId(),
                 ])
                 ->add('isDefault', DisplayOnlyType::class, [
                     'required' => false,
                     'data' => $this->stock->isDefault() ? t('Yes') : t('No'),
-                    'label' => t('Default warehouse'),
+                    'label' => 'Default warehouse',
                 ]);
         }
 
@@ -63,15 +63,15 @@ final class StockFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter warehouse name']),
                     new Constraints\Length(['max' => 255, 'maxMessage' => 'Warehouse name cannot be longer than {{ limit }} characters']),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('isEnabledByDomain', DomainsType::class, [
                 'required' => false,
-                'label' => t('Display on'),
+                'label' => 'Display on',
             ])
             ->add('externalId', TextType::class, [
                 'required' => false,
-                'label' => t('External bridge ID'),
+                'label' => 'External bridge ID',
                 'constraints' => [
                     new Constraints\Length(['max' => 255, 'maxMessage' => 'External bridge ID cannot be longer than {{ limit }} characters']),
                     new Constraints\Callback([$this, 'sameStockExternalIdValidation']),
@@ -79,7 +79,7 @@ final class StockFormType extends AbstractType
             ])
             ->add('note', TextType::class, [
                 'required' => false,
-                'label' => t('Internal note'),
+                'label' => 'Internal note',
             ]);
 
         $builder->add($stockDataBuilder);

--- a/packages/framework/src/Form/Admin/Stock/StockSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/StockSettingsFormType.php
@@ -37,12 +37,12 @@ final class StockSettingsFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builderStockSettingGroup = $builder->create('stockSettings', GroupType::class, [
-            'label' => t('Warehouse settings'),
+            'label' => 'Warehouse settings',
         ]);
 
         $builderStockSettingGroup
             ->add('transfer', TextType::class, [
-                'label' => t('Days for transfer between warehouses'),
+                'label' => 'Days for transfer between warehouses',
                 'constraints' => [
                     new Constraints\NotBlank(),
                     new Constraints\Regex(['pattern' => '/^\d+$/']),
@@ -51,12 +51,12 @@ final class StockSettingsFormType extends AbstractType
             ]);
 
         $builderFeedSettingGroup = $builder->create('feedSettings', GroupType::class, [
-            'label' => t('XML feeds settings'),
+            'label' => 'XML feeds settings',
         ]);
 
         $builderFeedSettingGroup
             ->add('feedDeliveryDaysForOutOfStockProducts', IntegerType::class, [
-                'label' => t('Number of delivery days for out of stock products in XML feeds'),
+                'label' => 'Number of delivery days for out of stock products in XML feeds',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotNull([

--- a/packages/framework/src/Form/Admin/Store/ClosedDayFormType.php
+++ b/packages/framework/src/Form/Admin/Store/ClosedDayFormType.php
@@ -39,7 +39,7 @@ final class ClosedDayFormType extends AbstractType
             ->add('date', DatePickerType::class, [
                 'required' => true,
                 'input' => 'datetime_immutable',
-                'label' => t('Date'),
+                'label' => 'Date',
                 'widget' => 'single_text',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter date']),
@@ -48,7 +48,7 @@ final class ClosedDayFormType extends AbstractType
             ])
             ->add('name', TextType::class, [
                 'required' => true,
-                'label' => t('Name'),
+                'label' => 'Name',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter name']),
                     new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
@@ -56,7 +56,7 @@ final class ClosedDayFormType extends AbstractType
             ])
             ->add('excludedStores', ChoiceType::class, [
                 'required' => false,
-                'label' => t('Excluded stores'),
+                'label' => 'Excluded stores',
                 'choices' => $this->storeFacade->getStoresByDomainId($domainId),
                 'choice_label' => static fn (Store $store) => $store->getName(),
                 'multiple' => true,

--- a/packages/framework/src/Form/Admin/Store/StoreFormType.php
+++ b/packages/framework/src/Form/Admin/Store/StoreFormType.php
@@ -80,24 +80,24 @@ final class StoreFormType extends AbstractType
     private function createBasicInformationGroup(FormBuilderInterface $builder, ?Store $store): FormBuilderInterface
     {
         $builderBasicInformationGroup = $builder->create('basicInformationGroup', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         if ($store !== null) {
             $builderBasicInformationGroup
                 ->add('id', DisplayOnlyType::class, [
                     'data' => $store->getId(),
-                    'label' => t('ID'),
+                    'label' => 'ID',
                 ])
                 ->add('isDefault', DisplayOnlyType::class, [
                     'required' => false,
                     'data' => $store->isDefault() ? t('Yes') : t('No'),
-                    'label' => t('Default store'),
+                    'label' => 'Default store',
                 ])
                 ->add('urls', UrlListType::class, [
                     'route_name' => StoreFriendlyUrlProvider::ROUTE_NAME,
                     'entity_id' => $store->getId(),
-                    'label' => t('URL settings'),
+                    'label' => 'URL settings',
                     'limit_domains_by_ids' => [$store->getDomainId()],
                 ]);
         }
@@ -111,11 +111,11 @@ final class StoreFormType extends AbstractType
                         ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
                     ),
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('domainId', DomainType::class, [
                 'required' => true,
-                'label' => t('Display on'),
+                'label' => 'Display on',
                 'disabled' => $store !== null,
             ])
             ->add('externalId', TextType::class, [
@@ -126,12 +126,12 @@ final class StoreFormType extends AbstractType
                     ),
                     new Constraints\Callback([$this, 'sameStoreExternalIdValidation']),
                 ],
-                'label' => t('External ID'),
+                'label' => 'External ID',
             ])
             ->add('stock', ChoiceType::class, [
                 'required' => false,
-                'label' => t('Warehouse'),
-                'placeholder' => t('No warehouse associated'),
+                'label' => 'Warehouse',
+                'placeholder' => 'No warehouse associated',
                 'choices' => $this->stockFacade->getAllStocks(),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
@@ -149,7 +149,7 @@ final class StoreFormType extends AbstractType
     private function createUserInformationGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderUserInformationGroup = $builder->create('userInformation', GroupType::class, [
-            'label' => t('Information for customers'),
+            'label' => 'Information for customers',
         ]);
 
         $builderUserInformationGroup
@@ -163,7 +163,7 @@ final class StoreFormType extends AbstractType
                 'required' => false,
             ])
             ->add('openingHours', CollectionType::class, [
-                'label' => t('Opening hours'),
+                'label' => 'Opening hours',
                 'help' => t('Enter in the store local time'),
                 'entry_type' => OpeningHoursRangeCollectionFormType::class,
                 'required' => false,
@@ -186,7 +186,7 @@ final class StoreFormType extends AbstractType
     private function createMapGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderMapGroup = $builder->create('map', GroupType::class, [
-            'label' => t('Map coordinates in decimal format'),
+            'label' => 'Map coordinates in decimal format',
         ]);
 
         $builderMapGroup
@@ -209,12 +209,12 @@ final class StoreFormType extends AbstractType
     private function createAddressGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderAddressGroup = $builder->create('address', GroupType::class, [
-            'label' => t('Address'),
+            'label' => 'Address',
         ]);
 
         $builderAddressGroup
             ->add('street', TextType::class, [
-                'label' => t('Street'),
+                'label' => 'Street',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter street']),
@@ -225,7 +225,7 @@ final class StoreFormType extends AbstractType
                 ],
             ])
             ->add('city', TextType::class, [
-                'label' => t('City'),
+                'label' => 'City',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter city']),
@@ -236,7 +236,7 @@ final class StoreFormType extends AbstractType
                 ],
             ])
             ->add('postcode', TextType::class, [
-                'label' => t('Postcode'),
+                'label' => 'Postcode',
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter zip code']),
@@ -247,7 +247,7 @@ final class StoreFormType extends AbstractType
                 ],
             ])
             ->add('country', ChoiceType::class, [
-                'label' => t('Country'),
+                'label' => 'Country',
                 'required' => true,
                 'choices' => $this->countryFacade->getAll(),
                 'choice_label' => 'name',
@@ -305,7 +305,7 @@ final class StoreFormType extends AbstractType
     private function createImagesGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         return $builder->create('imageGroup', GroupType::class, [
-            'label' => t('Images'),
+            'label' => 'Images',
         ])->add('image', ImageUploadType::class, [
             'required' => false,
             'image_entity_class' => Store::class,
@@ -318,7 +318,7 @@ final class StoreFormType extends AbstractType
                         . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
                 ]),
             ],
-            'label' => t('Upload image'),
+            'label' => 'Upload image',
             'entity' => $options['store'],
             'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
         ]);

--- a/packages/framework/src/Form/Admin/Superadmin/InputPriceTypeFormType.php
+++ b/packages/framework/src/Form/Admin/Superadmin/InputPriceTypeFormType.php
@@ -24,7 +24,7 @@ final class InputPriceTypeFormType extends AbstractType
     {
         $builder
             ->add('inputPriceType', ChoiceType::class, [
-                'label' => t('Entry price type'),
+                'label' => 'Entry price type',
                 'choices' => [
                     t('Excluding VAT') => PricingSetting::PRICE_TYPE_WITHOUT_VAT,
                     t('Including VAT') => PricingSetting::PRICE_TYPE_WITH_VAT,
@@ -34,7 +34,7 @@ final class InputPriceTypeFormType extends AbstractType
                 ],
             ])
             ->add('sellingPriceType', ChoiceType::class, [
-                'label' => t('Selling price type'),
+                'label' => 'Selling price type',
                 'choices' => [
                     t('Excluding VAT') => PricingSetting::PRICE_TYPE_WITHOUT_VAT,
                     t('Including VAT') => PricingSetting::PRICE_TYPE_WITH_VAT,

--- a/packages/framework/src/Form/Admin/Superadmin/MailWhitelistFormType.php
+++ b/packages/framework/src/Form/Admin/Superadmin/MailWhitelistFormType.php
@@ -45,14 +45,14 @@ final class MailWhitelistFormType extends AbstractType
 
         $builder
             ->add('mailWhitelistEnabled', YesNoType::class, [
-                'label' => t('Enable whitelist'),
+                'label' => 'Enable whitelist',
             ])
             ->add('messageMailWhitelist', MessageType::class, [
                 'message_level' => MessageType::MESSAGE_LEVEL_INFO,
                 'data' => t('E-mails are sent to addresses which comply with at least one regular expression. You can use <a href="https://regex101.com">https://regex101.com</a> for validating regular expressions.'),
             ])
             ->add('mailWhitelist', MailWhitelistCollectionType::class, [
-                'label' => t('E-mail addresses whitelist'),
+                'label' => 'E-mail addresses whitelist',
                 'entry_type' => TextType::class,
                 'entry_options' => [
                     'label' => false,

--- a/packages/framework/src/Form/Admin/Transfer/TransferIssueSearchFormType.php
+++ b/packages/framework/src/Form/Admin/Transfer/TransferIssueSearchFormType.php
@@ -37,7 +37,7 @@ final class TransferIssueSearchFormType extends AbstractType
                 'choices' => $transfers,
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'placeholder' => t('-- Select name of the transfer --'),
+                'placeholder' => '-- Select name of the transfer --',
             ])
             ->add('submit', SubmitType::class);
     }

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -62,12 +62,12 @@ final class TransportFormType extends AbstractType
         /** @var \Shopsys\FrameworkBundle\Model\Transport\Transport $transport */
         $transport = $options['transport'];
         $builderBasicInformationGroup = $builder->create('basicInformation', GroupType::class, [
-            'label' => t('Basic information'),
+            'label' => 'Basic information',
         ]);
 
         if ($transport instanceof Transport) {
             $builderBasicInformationGroup->add('formId', DisplayOnlyType::class, [
-                'label' => t('ID'),
+                'label' => 'ID',
                 'data' => $transport->getId(),
             ]);
         }
@@ -82,14 +82,14 @@ final class TransportFormType extends AbstractType
                         ),
                     ],
                 ],
-                'label' => t('Name'),
+                'label' => 'Name',
             ])
             ->add('enabled', DomainsType::class, [
                 'required' => false,
-                'label' => t('Display on'),
+                'label' => 'Display on',
             ])
             ->add('hidden', YesNoType::class, [
-                'label' => t('Hidden'),
+                'label' => 'Hidden',
             ])
             ->add('payments', ChoiceType::class, [
                 'required' => false,
@@ -101,7 +101,7 @@ final class TransportFormType extends AbstractType
                 'multiple' => true,
                 'expanded' => true,
                 'empty_message' => t('You have to create some payment first.'),
-                'label' => t('Available payment methods'),
+                'label' => 'Available payment methods',
             ])
             ->add('type', ChoiceType::class, [
                 'required' => true,
@@ -109,7 +109,7 @@ final class TransportFormType extends AbstractType
                 'constraints' => [
                     new NotBlank(),
                 ],
-                'label' => t('Transport type'),
+                'label' => 'Transport type',
             ])
             ->add('daysUntilDelivery', TextType::class, [
                 'required' => true,
@@ -122,11 +122,11 @@ final class TransportFormType extends AbstractType
                         'pattern' => '/^\d+$/',
                     ]),
                 ],
-                'label' => t('Days until delivery'),
+                'label' => 'Days until delivery',
             ]);
 
         $builderPricesGroup = $builder->create('prices', GroupType::class, [
-            'label' => t('Prices'),
+            'label' => 'Prices',
         ]);
 
         $optionsByDomainId = [];
@@ -151,29 +151,29 @@ final class TransportFormType extends AbstractType
         ]);
 
         $builderAdditionalInformationGroup = $builder->create('additionalInformation', GroupType::class, [
-            'label' => t('Additional information'),
+            'label' => 'Additional information',
         ]);
 
         $builderAdditionalInformationGroup
             ->add('description', LocalizedType::class, [
                 'required' => false,
                 'entry_type' => TextareaType::class,
-                'label' => t('Description'),
+                'label' => 'Description',
             ])
             ->add('instructions', LocalizedType::class, [
                 'required' => false,
                 'entry_type' => CKEditorType::class,
-                'label' => t('Instructions'),
+                'label' => 'Instructions',
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'label' => t('Image'),
+            'label' => 'Image',
         ]);
 
         $builderImageGroup
             ->add('image', ImageUploadType::class, [
                 'required' => false,
-                'label' => t('Upload image'),
+                'label' => 'Upload image',
                 'image_entity_class' => Transport::class,
                 'file_constraints' => [
                     new Constraints\Image([
@@ -189,12 +189,12 @@ final class TransportFormType extends AbstractType
             ]);
 
         $builderPackageTrackingGroup = $builder->create('packageTracking', GroupType::class, [
-            'label' => t('Package tracking'),
+            'label' => 'Package tracking',
         ]);
 
         $builderPackageTrackingGroup
             ->add('trackingUrl', TextType::class, [
-                'label' => t('Tracking URL'),
+                'label' => 'Tracking URL',
                 'required' => false,
                 'constraints' => [
                     new Length([
@@ -203,7 +203,7 @@ final class TransportFormType extends AbstractType
                 ],
             ])
             ->add('trackingUrlVariables', DisplayVariablesType::class, [
-                'label' => t('Tracking URL variables'),
+                'label' => 'Tracking URL variables',
                 'required' => false,
                 'variables' => [
                     OrderMail::VARIABLE_TRANSPORT_TRACKING_NUMBER => [
@@ -214,11 +214,11 @@ final class TransportFormType extends AbstractType
             ])
             ->add('trackingInstructions', LocalizedType::class, [
                 'entry_type' => CKEditorType::class,
-                'label' => t('Tracking instructions'),
+                'label' => 'Tracking instructions',
                 'required' => false,
             ])
             ->add('trackingInstructionsVariables', DisplayVariablesType::class, [
-                'label' => t('Tracking instructions variables'),
+                'label' => 'Tracking instructions variables',
                 'required' => false,
                 'variables' => [
                     OrderMail::VARIABLE_TRANSPORT_TRACKING_NUMBER => [

--- a/packages/framework/src/Form/Admin/UploadedFile/UploadedFileFormType.php
+++ b/packages/framework/src/Form/Admin/UploadedFile/UploadedFileFormType.php
@@ -27,7 +27,7 @@ final class UploadedFileFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('name', TextType::class, [
-            'label' => t('Filename'),
+            'label' => 'Filename',
             'constraints' => [
                 new Constraints\NotBlank(['message' => 'Please enter the filename']),
                 new Constraints\Length(
@@ -38,7 +38,7 @@ final class UploadedFileFormType extends AbstractType
 
         $builder->add('names', LocalizedType::class, [
             'required' => false,
-            'label' => t('Names'),
+            'label' => 'Names',
             'help' => t('Name in the corresponding locale must be filled-in in order to display the file on the storefront'),
             'entry_options' => [
                 'required' => false,
@@ -64,13 +64,13 @@ final class UploadedFileFormType extends AbstractType
                         . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
                 ]),
             ],
-            'label' => t('Replace file'),
+            'label' => 'Replace file',
         ]);
 
         $builder->add('products', ProductsType::class, [
             'required' => false,
             'label_button_add' => t('Add to products'),
-            'label' => t('Products'),
+            'label' => 'Products',
         ]);
     }
 

--- a/packages/framework/src/Form/Admin/UserConsentPolicy/UserConsentPolicySettingFormType.php
+++ b/packages/framework/src/Form/Admin/UserConsentPolicy/UserConsentPolicySettingFormType.php
@@ -34,7 +34,7 @@ final class UserConsentPolicySettingFormType extends AbstractType
         $articles = $this->articleFacade->getAllByDomainId($options['domain_id']);
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
-            'label' => t('Settings'),
+            'label' => 'Settings',
         ]);
 
         $builderSettingsGroup
@@ -43,8 +43,8 @@ final class UserConsentPolicySettingFormType extends AbstractType
                 'choices' => $articles,
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'placeholder' => t('-- Choose article --'),
-                'label' => t('User consent policy article'),
+                'placeholder' => '-- Choose article --',
+                'label' => 'User consent policy article',
                 'help' => t(
                     'Choose the article that provides information about how user consent is obtained, managed, and withdrawn on this domain.',
                 ),

--- a/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
@@ -42,10 +42,10 @@ final class VatSettingsFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter default VAT']),
                 ],
-                'label' => t('Default VAT rate'),
+                'label' => 'Default VAT rate',
             ])
             ->add('save', SubmitType::class, [
-                'label' => t('Save default VAT rate'),
+                'label' => 'Save default VAT rate',
             ]);
     }
 

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -32,7 +32,7 @@ final class FriendlyUrlType extends AbstractType
         $builder->add(UrlListData::FIELD_SLUG, TextType::class, [
             'required' => true,
             'attr' => [
-                'placeholder' => t('slug'),
+                'placeholder' => 'slug',
             ],
             'constraints' => [
                 new Constraints\NotBlank(),

--- a/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
+++ b/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
@@ -81,7 +81,7 @@ final class PriceAndVatTableByDomainsType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
                 ],
-                'label' => t('VAT'),
+                'label' => 'VAT',
             ]);
 
             $entityPricesByDomainId->add((string)$domainConfig->getId(), MoneyType::class, [
@@ -92,7 +92,7 @@ final class PriceAndVatTableByDomainsType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter price']),
                     new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
                 ],
-                'label' => t('Price'),
+                'label' => 'Price',
             ]);
         }
 

--- a/packages/framework/src/Form/ProductType.php
+++ b/packages/framework/src/Form/ProductType.php
@@ -72,7 +72,7 @@ final class ProductType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'placeholder' => t('Choose product'),
+            'placeholder' => 'Choose product',
             'enableRemove' => false,
             'required' => true,
             'allow_main_variants' => true,

--- a/packages/framework/src/Form/TransportInputPricesType.php
+++ b/packages/framework/src/Form/TransportInputPricesType.php
@@ -41,7 +41,7 @@ final class TransportInputPricesType extends AbstractType
                 'constraints' => [
                     new NotBlank(['message' => 'Please enter VAT rate']),
                 ],
-                'label' => t('VAT'),
+                'label' => 'VAT',
             ])
             ->add(
                 'pricesWithLimits',

--- a/packages/framework/src/Resources/config/parameters_common.yaml
+++ b/packages/framework/src/Resources/config/parameters_common.yaml
@@ -14,7 +14,7 @@ parameters:
     shopsys.admin_display_timezone: ~
 
     # Locales to select from in the administration. The first locale is the default one.
-    shopsys.allowed_admin_locales: ['en', 'cs']
+    shopsys.allowed_admin_locales: ['en', 'cs', 'sk']
 
     # Hours defined in cron.yaml correspond to this timezone (default is PHP timezone)
     shopsys.cron_timezone: ~

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -859,6 +859,9 @@ msgstr "Nastavení výchozí cenové skupiny bylo upraveno"
 msgid "Default store"
 msgstr "Výchozí prodejna"
 
+msgid "Default unit"
+msgstr "Výchozí jednotka"
+
 msgid "Default unit settings modified"
 msgstr "Nastavení výchozí jednotky bylo upraveno"
 
@@ -2236,6 +2239,9 @@ msgstr "Stav objednávky"
 msgid "Ordering"
 msgstr "Řazení"
 
+msgid "Ordering priority"
+msgstr "Priorita řazení"
+
 msgid "Orders"
 msgstr "Objednávky"
 
@@ -2292,6 +2298,9 @@ msgstr "Skupina parametrů <strong><a href=\"{{ url }}\">{{ name }}</a></strong>
 
 msgid "Parameter groups"
 msgstr "Skupiny parametrů"
+
+msgid "Parameter type"
+msgstr "Typ parametru"
 
 msgid "Parameter value"
 msgstr "Hodnota parameteru"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -859,6 +859,9 @@ msgstr ""
 msgid "Default store"
 msgstr ""
 
+msgid "Default unit"
+msgstr ""
+
 msgid "Default unit settings modified"
 msgstr ""
 
@@ -2236,6 +2239,9 @@ msgstr ""
 msgid "Ordering"
 msgstr ""
 
+msgid "Ordering priority"
+msgstr ""
+
 msgid "Orders"
 msgstr ""
 
@@ -2291,6 +2297,9 @@ msgid "Parameter group <strong><a href=\"{{ url }}\">{{ name }}</a></strong> edi
 msgstr ""
 
 msgid "Parameter groups"
+msgstr ""
+
+msgid "Parameter type"
 msgstr ""
 
 msgid "Parameter value"

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -859,6 +859,9 @@ msgstr "Nastavenia predvolenej cenovej skupiny upravené"
 msgid "Default store"
 msgstr "Predvolená predajňa"
 
+msgid "Default unit"
+msgstr "Predvolená jednotka"
+
 msgid "Default unit settings modified"
 msgstr "Nastavenia predvolenej jednotky upravené"
 
@@ -2236,6 +2239,9 @@ msgstr "Stav objednávky"
 msgid "Ordering"
 msgstr "Objednávanie"
 
+msgid "Ordering priority"
+msgstr "Priorita zoraďovania"
+
 msgid "Orders"
 msgstr "Objednávky"
 
@@ -2292,6 +2298,9 @@ msgstr "Skupina parametrov <strong><a href=\"{{ url }}\">{{ name }}</a></strong>
 
 msgid "Parameter groups"
 msgstr "Skupiny parametrov"
+
+msgid "Parameter type"
+msgstr "Typ parametra"
 
 msgid "Parameter value"
 msgstr "Hodnota parametra"

--- a/packages/product-feed-heureka/src/Form/HeurekaFeedSettingFormType.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaFeedSettingFormType.php
@@ -22,7 +22,7 @@ final class HeurekaFeedSettingFormType extends AbstractType
     {
         $builder
             ->add(HeurekaFeedSettingEnum::HEUREKA_FEED_DELIVERY_DAYS, IntegerType::class, [
-                'label' => t('Number of delivery days for out of stock products for Heureka XML feed'),
+                'label' => 'Number of delivery days for out of stock products for Heureka XML feed',
                 'required' => false,
             ])
             ->add('heurekaFeedDeliveryDaysInfo', MessageType::class, [

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -9,7 +9,7 @@ parameters:
     debug.error_handler.throw_at: -1
     locale: en
     shopsys.admin_display_timezone: Europe/Prague
-    shopsys.allowed_admin_locales: ['en', 'cs']
+    shopsys.allowed_admin_locales: ['en', 'cs', 'sk']
     shopsys.cron_timezone: Europe/Prague
 
     # Set to true to log validation errors with log level ERROR instead of INFO


### PR DESCRIPTION
#### Description, the reason for the PR

When there is no label defined for a field, Symfony creates the name magically from the field name. The problem is, such a label might then be missing a translation for locales other than English. 

In the future, it would be nice to check the explicit label automatically (will create an issue for that).

As a bonus, it is now possible to use "SK" locale in the admin. (3rd domain with "SK" localization was added in https://github.com/shopsys/shopsys/pull/4113)
<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-add-labels.odin.shopsys.cloud
  - https://cz.rv-add-labels.odin.shopsys.cloud
  - https://rv-add-labels.odin.shopsys.cloud/sk
<!-- Replace -->
