### PR TITLE
translations: do not extract empty strings anymore

### DIFF
--- a/packages/framework/src/Component/Translation/MessageIdNormalizer.php
+++ b/packages/framework/src/Component/Translation/MessageIdNormalizer.php
@@ -30,6 +30,11 @@ class MessageIdNormalizer
         foreach ($catalogue->getDomains() as $domain => $messageCollection) {
             foreach ($messageCollection->all() as $message) {
                 $normalizedMessage = $this->getNormalizedMessage($message, $domain);
+
+                if ($normalizedMessage->getId() === '') {
+                    continue;
+                }
+
                 $normalizedCatalogue->add($normalizedMessage);
             }
         }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -4,9 +4,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 
-msgid ""
-msgstr ""
-
 msgid "\"Valid to\" must be greater than \"Valid from\""
 msgstr "\"Platnost do\" musí být větší než \"Platnost od\""
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -4,9 +4,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 
-msgid ""
-msgstr ""
-
 msgid "\"Valid to\" must be greater than \"Valid from\""
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -4,9 +4,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sk\n"
 
-msgid ""
-msgstr ""
-
 msgid "\"Valid to\" must be greater than \"Valid from\""
 msgstr "\"Platí do\" musí byť väčšie ako \"Platí od\""
 

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -4,9 +4,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 
-msgid ""
-msgstr ""
-
 msgid "\"Valid to\" must be greater than \"Valid from\""
 msgstr "\"Platnost do\" musí být větší než \"Platnost od\""
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -4,9 +4,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 
-msgid ""
-msgstr ""
-
 msgid "\"Valid to\" must be greater than \"Valid from\""
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/validators.sk.po
+++ b/packages/framework/src/Resources/translations/validators.sk.po
@@ -4,9 +4,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: sk\n"
 
-msgid ""
-msgstr ""
-
 msgid "\"Valid to\" must be greater than \"Valid from\""
 msgstr "\"Platné do\" musí byť väčšie ako \"Platné od\""
 

--- a/packages/framework/tests/Unit/Component/Translation/MessageIdNormalizerTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/MessageIdNormalizerTest.php
@@ -90,4 +90,33 @@ class MessageIdNormalizerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $normalizedCatalogue->get($message->getId(), $message->getDomain());
     }
+
+    /**
+     * @param string $messageId
+     */
+    #[DataProvider('emptyMessageIdProvider')]
+    public function testEmptyMessageIsNotAddedToCatalogue(string $messageId): void
+    {
+        $messageIdNormalizer = new MessageIdNormalizer();
+        $messageWithOnlyWhitespace = new Message($messageId);
+        $catalogue = new MessageCatalogue();
+
+        $catalogue->add($messageWithOnlyWhitespace);
+
+        $normalizedCatalogue = $messageIdNormalizer->getNormalizedCatalogue($catalogue);
+
+        $this->assertFalse($normalizedCatalogue->has($messageWithOnlyWhitespace));
+    }
+
+    /**
+     * @return iterable
+     */
+    public static function emptyMessageIdProvider(): iterable
+    {
+        yield 'empty string' => [''];
+
+        yield 'empty string with spaces' => ['     '];
+
+        yield 'string with tabs and new lines' => ["\t\t\n\t"];
+    }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
For example, when an empty string was set as a message for a constraint, it was automatically extracted into the PO files, resulting in useless entries:
```
msgid ""
msgstr ""
```
 These are not added anymore.
#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-constraint-message.odin.shopsys.cloud
  - https://cz.rv-constraint-message.odin.shopsys.cloud
  - https://rv-constraint-message.odin.shopsys.cloud/sk
<!-- Replace -->
