### PR TITLE
minor fixes in elfinder in grapesjs

### DIFF
--- a/docs/administration/javascript-utilities.md
+++ b/docs/administration/javascript-utilities.md
@@ -33,13 +33,14 @@ new ModalWindow({
 
 #### Configuration Options
 
-| Option    | Type   | Default | Description                                                                    |
-| --------- | ------ | ------- | ------------------------------------------------------------------------------ |
-| `content` | string | `''`    | HTML content for modal body                                                    |
-| `title`   | string | `null`  | Optional modal title                                                           |
-| `size`    | string | `'sm'`  | Modal size: `sm`, `md`, `lg`, or `xl`                                          |
-| `style`   | string | `null`  | Modal style: `primary`, `secondary`, `success`, `danger`, `warning`, or `info` |
-| `buttons` | Array  | `[]`    | Array of button configurations                                                 |
+| Option       | Type   | Default | Description                                                                    |
+| ------------ | ------ | ------- | ------------------------------------------------------------------------------ |
+| `content`    | string | `''`    | HTML content for modal body                                                    |
+| `title`      | string | `null`  | Optional modal title                                                           |
+| `size`       | string | `'sm'`  | Modal size: `sm`, `md`, `lg`, `xl`, or `fullscreen`                            |
+| `style`      | string | `null`  | Modal style: `primary`, `secondary`, `success`, `danger`, `warning`, or `info` |
+| `buttons`    | Array  | `[]`    | Array of button configurations                                                 |
+| `borderless` | bool   | `false` | Reduces padding of content                                                     |
 
 #### Button Configuration
 

--- a/packages/administration/assets/src/js/utils/modalWindow.js
+++ b/packages/administration/assets/src/js/utils/modalWindow.js
@@ -4,7 +4,7 @@ import Check from 'icons/tabler/check.svg';
 import ExclamationCircle from 'icons/tabler/exclamation-circle.svg';
 import InfoCircleFilled from 'icons/tabler/info-circle-filled.svg';
 
-const MODAL_SIZES = ['sm', 'md', 'lg', 'xl'];
+const MODAL_SIZES = ['sm', 'md', 'lg', 'xl', 'fullscreen'];
 const MODAL_STYLES = [null, 'primary', 'secondary', 'success', 'danger', 'warning', 'info'];
 
 export default class ModalWindow {

--- a/packages/administration/assets/src/js/utils/modalWindow.js
+++ b/packages/administration/assets/src/js/utils/modalWindow.js
@@ -33,6 +33,7 @@ export default class ModalWindow {
             size: 'sm',
             buttons: [],
             style: null,
+            borderless: false,
             ...options,
         };
 
@@ -66,8 +67,8 @@ export default class ModalWindow {
                 <div class="modal-dialog ${sizeClass} modal-dialog-centered" role="document">
                     <div class="modal-content">
                         ${this.options.style ? `<div class="modal-status bg-${this.options.style}"></div>` : ''}
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="${Translator.trans('Close')}"></button>
-                        <div class="modal-body text-center py-4">
+                        <button type="button" class="btn-close${this.options.borderless ? ' visually-hidden' : ''}" data-bs-dismiss="modal" aria-label="${Translator.trans('Close')}"></button>
+                        <div class="modal-body text-center${this.options.borderless ? ' p-0' : ''}">
                             ${statusIcon ? `<div class="text-center mb-3" aria-hidden="true">${statusIcon}</div>` : ''}
                             ${this.options.title ? `<h3>${this.options.title}</h3>` : ''}
                             ${this.options.content}

--- a/project-base/app/assets/js/admin/grapesjs/GrapesMailEditor.js
+++ b/project-base/app/assets/js/admin/grapesjs/GrapesMailEditor.js
@@ -109,20 +109,39 @@ export default class GrapesMailEditor {
             },
             assetManager: {
                 custom: {
+                    currentModal: null,
+
                     open(props) {
                         const iframeContent = `<iframe src="${elfinderUrl}" style="width: 100%; height: 800px; border: none;"></iframe>`;
 
-                        // eslint-disable-next-line no-new
-                        const modalInstance = new ModalWindow({
+                        this.currentModal = new ModalWindow({
                             content: iframeContent,
                             size: 'xl',
                         });
 
+                        let isClosed = false;
+
+                        this.currentModal.element.on('hidden.bs.modal', () => {
+                            if (!isClosed) {
+                                isClosed = true;
+                                delete window.document.fileManagerInsertImageCallback;
+                                this.currentModal = null;
+                                props.close();
+                            }
+                        });
+
                         window.document.fileManagerInsertImageCallback = (_selector, url) => {
                             props.options.target.set('src', url);
-                            modalInstance.element.modal('hide');
-                            props.close();
+                            this.currentModal.element.modal('hide');
                         };
+                    },
+
+                    close() {
+                        if (this.currentModal) {
+                            this.currentModal.element.modal('hide');
+                            delete window.document.fileManagerInsertImageCallback;
+                            this.currentModal = null;
+                        }
                     },
                 },
             },

--- a/project-base/app/assets/js/admin/grapesjs/GrapesMailEditor.js
+++ b/project-base/app/assets/js/admin/grapesjs/GrapesMailEditor.js
@@ -117,6 +117,7 @@ export default class GrapesMailEditor {
                         this.currentModal = new ModalWindow({
                             content: iframeContent,
                             size: 'xl',
+                            borderless: true,
                         });
 
                         let isClosed = false;

--- a/project-base/app/assets/js/admin/grapesjs/GrapesWebEditor.js
+++ b/project-base/app/assets/js/admin/grapesjs/GrapesWebEditor.js
@@ -129,6 +129,7 @@ export default class GrapesWebEditor {
                         this.currentModal = new ModalWindow({
                             content: iframeContent,
                             size: 'xl',
+                            borderless: true,
                         });
 
                         let isClosed = false;

--- a/project-base/app/assets/js/admin/grapesjs/GrapesWebEditor.js
+++ b/project-base/app/assets/js/admin/grapesjs/GrapesWebEditor.js
@@ -121,20 +121,39 @@ export default class GrapesWebEditor {
             },
             assetManager: {
                 custom: {
+                    currentModal: null,
+
                     open(props) {
                         const iframeContent = `<iframe src="${elfinderUrl}" style="width: 100%; height: 800px; border: none;"></iframe>`;
 
-                        // eslint-disable-next-line no-new
-                        const modalInstance = new ModalWindow({
+                        this.currentModal = new ModalWindow({
                             content: iframeContent,
                             size: 'xl',
                         });
 
+                        let isClosed = false;
+
+                        this.currentModal.element.on('hidden.bs.modal', () => {
+                            if (!isClosed) {
+                                isClosed = true;
+                                delete window.document.fileManagerInsertImageCallback;
+                                this.currentModal = null;
+                                props.close();
+                            }
+                        });
+
                         window.document.fileManagerInsertImageCallback = (_selector, url) => {
                             props.options.target.set('src', url);
-                            modalInstance.element.modal('hide');
-                            props.close();
+                            this.currentModal.element.modal('hide');
                         };
+                    },
+
+                    close() {
+                        if (this.currentModal) {
+                            this.currentModal.element.modal('hide');
+                            delete window.document.fileManagerInsertImageCallback;
+                            this.currentModal = null;
+                        }
                     },
                 },
             },

--- a/project-base/app/assets/js/admin/grapesjs/plugins/shared/buttons.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/shared/buttons.js
@@ -31,25 +31,41 @@ export default grapesjs.plugins.add('buttons', (editor, options) => {
     panels.removeButton('options', 'gjs-open-import-webpage');
     panels.removeButton('options', 'canvas-clear');
 
-    panels.addButton('options', {
-        id: BUTTON_SAVE,
-        context: BUTTON_SAVE,
-        className: 'fa fa-save',
-        command(editor) {
+    commands.add('save-template', {
+        run(editor) {
             const template = editor.runCommand('export-inlined-html');
             $(`#${textareaId}`).val(template);
 
             FormChangeInfo.showInfo();
             resetBody(editor);
         },
+        stop() {
+            // No-op: button is not toggleable
+        },
+    });
+
+    commands.add('close-editor', {
+        run(editor) {
+            resetBody(editor);
+        },
+        stop() {
+            // No-op: button is not toggleable
+        },
+    });
+
+    panels.addButton('options', {
+        id: BUTTON_SAVE,
+        context: BUTTON_SAVE,
+        className: 'fa fa-save',
+        command: 'save-template',
+        attributes: { title: BUTTON_SAVE },
     });
 
     panels.addButton('options', {
         id: BUTTON_CLOSE,
         context: BUTTON_CLOSE,
         className: 'fa fa-times',
-        command(editor) {
-            resetBody(editor);
-        },
+        command: 'close-editor',
+        attributes: { title: BUTTON_CLOSE },
     });
 });

--- a/project-base/app/assets/js/admin/grapesjs/plugins/web/web-image.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/web/web-image.js
@@ -55,6 +55,7 @@ export default grapesjs.plugins.add('custom-image', editor => {
                     },
                 },
                 attributes: {
+                    'data-gjs-type': 'image',
                     [IMAGE_POSITION_DATA_ATTRIBUTE]: 'left',
                     class: ['image-position-left'],
                 },


### PR DESCRIPTION
#### Description, the reason for the PR

- elfinder now can be opened again after closing without reload (fixed bug)
- border around made smaller

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added borderless modal style option for cleaner, streamlined modal appearance
  * Expanded modal size options to include fullscreen
  * Enhanced GrapesJS editor modal experience with improved modal behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-grapesjs-elfinder.odin.shopsys.cloud
  - https://cz.mg-grapesjs-elfinder.odin.shopsys.cloud
  - https://mg-grapesjs-elfinder.odin.shopsys.cloud/sk
<!-- Replace -->
