### PR TITLE
product selling from is prefilled in admin in new product page

### DIFF
--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Admin\Product;
 
+use DateTimeImmutable;
 use FOS\CKEditorBundle\Form\Type\CKEditorType;
 use Override;
 use Shopsys\FormTypesBundle\ActionBarType;
@@ -389,6 +390,7 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'invalid_message' => 'Enter date in DD.MM.YYYY format',
                 'label' => 'Selling start date',
+                ...($product === null ? ['data' => new DateTimeImmutable()] : []),
             ])
             ->add('sellingTo', DatePickerType::class, [
                 'required' => false,


### PR DESCRIPTION
#### Description, the reason for the PR

If the product is created in the admin, it has prefilled the `Selling from` field with the current date. 
This doesn't apply to any products created differently (import, ...)

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The product creation form now automatically pre-fills the selling date field with today's date, streamlining the product setup process for new items while preserving previously configured dates for existing products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-selling-start-auto.odin.shopsys.cloud
  - https://cz.mg-selling-start-auto.odin.shopsys.cloud
  - https://mg-selling-start-auto.odin.shopsys.cloud/sk
<!-- Replace -->
