### PR TITLE
Statuses of orders and complaints are now color coded

### DIFF
--- a/packages/administration/templates/content/complaint/listGrid.html.twig
+++ b/packages/administration/templates/content/complaint/listGrid.html.twig
@@ -21,6 +21,21 @@
     {{ value|formatDateTime }}
 {% endblock %}
 
+{% block grid_value_cell_id_status_name %}
+    {% if row.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Complaint\\Status\\ComplaintStatusTypeEnum::STATUS_TYPE_NEW')) %}
+        {% set status_class = 'yellow' %}
+    {% elseif row.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Complaint\\Status\\ComplaintStatusTypeEnum::STATUS_TYPE_RESOLVED')) %}
+        {% set status_class = 'green' %}
+    {% else %}
+        {% set status_class = 'blue' %}
+    {% endif %}
+
+    <span class="status status-{{ status_class }}">
+        <span class="status-dot"></span>
+        {{ value }}
+    </span>
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No complaints found.'|trans }}
 {% endblock %}

--- a/packages/administration/templates/content/complaintStatus/listGrid.html.twig
+++ b/packages/administration/templates/content/complaintStatus/listGrid.html.twig
@@ -20,6 +20,21 @@
     {% endif %}
 {% endblock %}
 
+{% block grid_value_cell_id_name %}
+    {% if row.cs.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Complaint\\Status\\ComplaintStatusTypeEnum::STATUS_TYPE_NEW')) %}
+        {% set status_class = 'yellow' %}
+    {% elseif row.cs.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Complaint\\Status\\ComplaintStatusTypeEnum::STATUS_TYPE_RESOLVED')) %}
+        {% set status_class = 'green' %}
+    {% else %}
+        {% set status_class = 'blue' %}
+    {% endif %}
+
+    <span class="status status-{{ status_class }}">
+        <span class="status-dot"></span>
+        {{ value }}
+    </span>
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No complaint statuses found.'|trans }}
 {% endblock %}

--- a/packages/administration/templates/content/order/listGrid.html.twig
+++ b/packages/administration/templates/content/order/listGrid.html.twig
@@ -17,6 +17,23 @@
     <a href="{{ url('admin_order_edit', { id: row.id }) }}">{{ value }}</a>
 {% endblock %}
 
+{% block grid_value_cell_id_status_name %}
+    {% if row.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Order\\Status\\OrderStatusTypeEnum::TYPE_NEW')) %}
+        {% set status_class = 'yellow' %}
+    {% elseif row.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Order\\Status\\OrderStatusTypeEnum::TYPE_DONE')) %}
+        {% set status_class = 'green' %}
+    {% elseif row.statusType is same as(constant('Shopsys\\FrameworkBundle\\Model\\Order\\Status\\OrderStatusTypeEnum::TYPE_CANCELED')) %}
+        {% set status_class = 'red' %}
+    {% else %}
+        {% set status_class = 'blue' %}
+    {% endif %}
+
+    <span class="status status-{{ status_class }}">
+        <span class="status-dot"></span>
+        {{ value }}
+    </span>
+{% endblock %}
+
 {% block grid_value_cell_id_total_price %}
     {{ value|priceWithCurrency(row.order.currency) }}
 {% endblock %}

--- a/packages/administration/templates/content/orderStatus/listGrid.html.twig
+++ b/packages/administration/templates/content/orderStatus/listGrid.html.twig
@@ -27,6 +27,23 @@
     {% endif %}
 {% endblock %}
 
+{% block grid_value_cell_id_name %}
+    {% if row.os.type is same as(constant('Shopsys\\FrameworkBundle\\Model\\Order\\Status\\OrderStatusTypeEnum::TYPE_NEW')) %}
+        {% set status_class = 'yellow' %}
+    {% elseif row.os.type is same as(constant('Shopsys\\FrameworkBundle\\Model\\Order\\Status\\OrderStatusTypeEnum::TYPE_DONE')) %}
+        {% set status_class = 'green' %}
+    {% elseif row.os.type is same as(constant('Shopsys\\FrameworkBundle\\Model\\Order\\Status\\OrderStatusTypeEnum::TYPE_CANCELED')) %}
+        {% set status_class = 'red' %}
+    {% else %}
+        {% set status_class = 'blue' %}
+    {% endif %}
+
+    <span class="status status-{{ status_class }}">
+        <span class="status-dot"></span>
+        {{ value }}
+    </span>
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No orders status found.'|trans }}
 {% endblock %}

--- a/packages/framework/src/Model/Complaint/ComplaintRepository.php
+++ b/packages/framework/src/Model/Complaint/ComplaintRepository.php
@@ -57,6 +57,7 @@ class ComplaintRepository
                 END AS customerName',
             )
             ->addSelect('MAX(cst.name) AS statusName')
+            ->addSelect('cs.statusType AS statusType')
             ->join('cmp.status', 'cs')
             ->join('cs.translations', 'cst', Join::WITH, 'cst.locale = :locale')
             ->join('cmp.customerUser', 'cu')
@@ -66,6 +67,7 @@ class ComplaintRepository
             ->addGroupBy('o.number')
             ->addGroupBy('o.id')
             ->addGroupBy('cu.id')
+            ->addGroupBy('cs.statusType')
             ->addGroupBy('ba.id')
             ->setParameter('locale', $locale);
     }

--- a/packages/framework/src/Model/Order/Listing/OrderListAdminRepository.php
+++ b/packages/framework/src/Model/Order/Listing/OrderListAdminRepository.php
@@ -30,6 +30,7 @@ class OrderListAdminRepository
                 o.domainId,
                 o.createdAt,
                 MAX(ost.name) AS statusName,
+                os.type AS statusType,
                 o.totalPriceWithVat,
                 CASE WHEN o.companyName IS NOT NULL
                     THEN o.companyName
@@ -40,6 +41,7 @@ class OrderListAdminRepository
             ->join('o.status', 'os')
             ->join('os.translations', 'ost', Join::WITH, 'ost.locale = :locale')
             ->groupBy('o.id')
+            ->addGroupBy('os.id')
             ->setParameter('deleted', false)
             ->setParameter('locale', $locale);
     }


### PR DESCRIPTION
#### Description, the reason for the PR

Better visual distinction.

<img width="1625" height="505" alt="Snímek obrazovky 2025-10-16 v 22 44 35" src="https://github.com/user-attachments/assets/9e71f0bd-78b3-4082-b792-81fb05ac645c" />


<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced color-coded status badges in the admin dashboard for complaints and orders, providing instant visual distinction between new, resolved, completed, and canceled statuses across all related views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-statuses-colors.odin.shopsys.cloud
  - https://cz.mg-statuses-colors.odin.shopsys.cloud
  - https://mg-statuses-colors.odin.shopsys.cloud/sk
<!-- Replace -->
