### PR TITLE
graphql queries are sent exclusively by POST

### DIFF
--- a/packages/frontend-api/src/Resources/config/routing.yaml
+++ b/packages/frontend-api/src/Resources/config/routing.yaml
@@ -1,5 +1,6 @@
 overblog_graphql_endpoint:
     path: /{query}
+    methods: [POST]
     requirements:
         query: "^(?!batch|graphiql).*"
     defaults:
@@ -10,6 +11,7 @@ overblog_graphql_endpoint:
 
 overblog_graphql_batch_endpoint:
     path: /batch/
+    methods: [POST]
     defaults:
         _controller: Shopsys\FrontendApiBundle\Controller\FrontendApiController::batchEndpointAction
         _format: 'json'

--- a/project-base/app/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/app/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -171,12 +171,12 @@ abstract class GraphQlTestCase extends ApplicationTestCase
             );
         } else {
             self::$client->request(
-                'GET',
+                'POST',
                 $path,
-                [
+                content: json_encode([
                     'query' => file_get_contents($pathToFile),
-                    'variables' => json_encode($variables, JSON_THROW_ON_ERROR),
-                ],
+                    'variables' => $variables, JSON_THROW_ON_ERROR,
+                ], JSON_THROW_ON_ERROR),
             );
         }
 

--- a/project-base/storefront/urql/createClient.ts
+++ b/project-base/storefront/urql/createClient.ts
@@ -35,6 +35,7 @@ export const createClient = ({
         {
             url: internalGraphqlEndpoint ?? publicGraphqlEndpoint,
             exchanges: getUrqlExchanges(ssrExchange, t, domainConfig, context),
+            preferGetMethod: false,
             fetchOptions: {
                 headers: {
                     OriginalHost: publicGraphqlEndpointObject.host,

--- a/project-base/storefront/vitest/utils/urql/createClient.test.tsx
+++ b/project-base/storefront/vitest/utils/urql/createClient.test.tsx
@@ -84,7 +84,7 @@ describe('createClient test', () => {
             expect(mockRequestWithFetcher).toBeCalledWith(
                 expect.stringContaining(mockDomainConfig.publicGraphqlEndpoint + OPERATION_NAME),
                 expect.objectContaining({
-                    method: 'GET',
+                    method: 'POST',
                     headers: expect.objectContaining({
                         originalhost: 'test.ts',
                         'x-forwarded-proto': 'on',
@@ -119,7 +119,7 @@ describe('createClient test', () => {
         expect(mockRequestWithFetcher).toBeCalledWith(
             expect.stringContaining(mockDomainConfig.publicGraphqlEndpoint + OPERATION_NAME),
             expect.objectContaining({
-                method: 'GET',
+                method: 'POST',
                 headers: expect.objectContaining({
                     originalhost: 'test.ts',
                     'x-forwarded-proto': 'on',

--- a/upgrade-notes/backend_20251017_114521.md
+++ b/upgrade-notes/backend_20251017_114521.md
@@ -1,0 +1,5 @@
+#### GraphQL queries are sent exclusively by POST ([#4236](https://github.com/shopsys/shopsys/pull/4236))
+
+- GraphQL endpoints now accept only POST requests – GET requests will return 405 (method not allowed) error
+    - if you have custom GraphQL clients or external integrations using GET method, update them to use POST
+    - see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20251017_114521.md
+++ b/upgrade-notes/storefront_20251017_114521.md
@@ -1,0 +1,5 @@
+#### graphql queries are sent exclusively by POST ([#4236](https://github.com/shopsys/shopsys/pull/4236))
+
+- the storefront urql client now explicitly uses POST method via `preferGetMethod: false` configuration
+    - this disables the automatic GET optimization introduced in urql v5.1.0
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Since https://github.com/urql-graphql/urql/pull/3789, urql has started to send some queries by the GET method. 
This is unwanted for us as the potential performance benefits do not outweigh the worsened DX (profiler, storefront query log) and the security considerations.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GraphQL endpoint routing configuration to enforce HTTP method constraints on API endpoints.
  * Modified API client request method handling to adjust default request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-graphql-only-post.odin.shopsys.cloud
  - https://cz.mg-graphql-only-post.odin.shopsys.cloud
  - https://mg-graphql-only-post.odin.shopsys.cloud/sk
<!-- Replace -->
