### PR TITLE
fixed superadmin behavior

### DIFF
--- a/docs/introduction/role-based-access-control.md
+++ b/docs/introduction/role-based-access-control.md
@@ -91,13 +91,13 @@ The system automatically manages role inheritance:
 
 ```
 ROLE_SUPER_ADMIN (highest)
-    └── ROLE_ADMIN
-        └── ROLE_ALL (all FULL permissions)
-            ├── ROLE_PRODUCT_FULL
-            │   ├── ROLE_PRODUCT_EDIT (includes VIEW)
-            │   ├── ROLE_PRODUCT_CREATE (includes VIEW)
-            │   └── ROLE_PRODUCT_DELETE (includes VIEW)
-            └── [other role hierarchies...]
+    └── ROLE_ALL (all FULL permissions)
+        ├── ROLE_PRODUCT_FULL
+        │   ├── ROLE_PRODUCT_EDIT (includes VIEW)
+        │   ├── ROLE_PRODUCT_CREATE (includes VIEW)
+        │   └── ROLE_PRODUCT_DELETE (includes VIEW)
+        └── [other role hierarchies...]
+ROLE_ADMIN (lowest) - allows login and access to basic admin functions
 ```
 
 !!! note

--- a/packages/administration/templates/content/administrator/edit.html.twig
+++ b/packages/administration/templates/content/administrator/edit.html.twig
@@ -3,7 +3,18 @@
 {% block title %}- {{ 'Editing administrator'|trans }} - {{ administrator.realName }}{% endblock %}
 
 {% block pre_title %}{{ 'Edit administrator'|trans }}{% endblock %}
-{% block h1 %}{{ administrator.realName }}{% endblock %}
+{% block h1 %}
+    {{ administrator.realName }}
+    {% if administrator.isSuperadmin() %}
+        <span class="badge fs-5 ms-2 bg-yellow text-yellow-fg"
+              data-bs-toggle="tooltip"
+              title="{{ 'Superadmins have all permissions including changing system configuration and access to hidden administration sections.'|trans }}"
+        >
+            {{ ux_icon('crown') }}
+            {{ 'Super Administrator'|trans }}
+        </span>
+    {% endif %}
+{% endblock %}
 
 {% block admin_log %}
     {% if lastAdminActivities|length > 0 %}

--- a/packages/administration/templates/content/administrator/listGrid.html.twig
+++ b/packages/administration/templates/content/administrator/listGrid.html.twig
@@ -4,6 +4,12 @@
     <a href="{{ url('admin_administrator_edit', { id: row.a.id }) }}">{{ value }}</a>
 {% endblock %}
 
+{% block grid_value_cell_id_superadmin %}
+    {% if value %}
+        <span class="badge bg-red-lt text-red-lt-fg">{{ 'Yes'|trans }}</span>
+    {% endif %}
+{% endblock %}
+
 {% block grid_pager_totalcount %}
     {% set entityName = 'administrators'|trans %}
     {{ parent() }}

--- a/packages/administration/templates/form/type/DisplayOnlyUrlType.html.twig
+++ b/packages/administration/templates/form/type/DisplayOnlyUrlType.html.twig
@@ -6,8 +6,10 @@
             {% set url = url(route, route_params) %}
         {% endif %}
 
-        <a href="{{ url }}" target="{{ link_target }}">
-            {{ ux_icon('forward-page') }}
+        <a href="{{ url }}" target="{{ link_target }}" {% with {attr: route_attr} %}{{ block('attributes') }}{% endwith %}>
+            {% if link_target is same as('_blank') %}
+                {{ ux_icon('forward-page') }}
+            {% endif %}
             {% if route_label is not empty %}
                 {{ route_label }}
             {% else %}
@@ -15,4 +17,4 @@
             {% endif %}
         </a>
     </div>
-{% endblock display_only_url_widget %}
+{% endblock %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -1852,6 +1852,9 @@ msgstr "Super administrátor"
 msgid "Superadmin - URL addresses"
 msgstr "Superadmin - URL adresy"
 
+msgid "Superadmins have all permissions including changing system configuration and access to hidden administration sections."
+msgstr "Superadministrátoři mají všechna oprávnění včetně změny systémové konfigurace a přístupu k skrytým sekcím administrace."
+
 msgid "Switch domain"
 msgstr "Přepnout doménu"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -1852,6 +1852,9 @@ msgstr ""
 msgid "Superadmin - URL addresses"
 msgstr ""
 
+msgid "Superadmins have all permissions including changing system configuration and access to hidden administration sections."
+msgstr ""
+
 msgid "Switch domain"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -1852,6 +1852,9 @@ msgstr "Super Administrator"
 msgid "Superadmin - URL addresses"
 msgstr "Superadmin - URL adresy"
 
+msgid "Superadmins have all permissions including changing system configuration and access to hidden administration sections."
+msgstr "Superadmini majú všetky povolenia vrátane zmeny systémovej konfigurácie a prístupu k skrytým sekciám administrácie."
+
 msgid "Switch domain"
 msgstr "Prepnúť doménu"
 

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -79,7 +79,11 @@ class AdministratorController extends AdminBaseController
     #[CanView]
     public function listAction(): Response
     {
-        $queryBuilder = $this->administratorFacade->getAllListableQueryBuilder();
+        if ($this->getCurrentAdministrator()->isSuperadmin()) {
+            $queryBuilder = $this->administratorFacade->getAllQueryBuilder();
+        } else {
+            $queryBuilder = $this->administratorFacade->getAllListableExcludingSuperadminQueryBuilder();
+        }
         $dataSource = $this->queryBuilderDataSourceFactory->create($queryBuilder, 'a.id');
 
         $grid = $this->gridFactory->create('administratorList', $dataSource, AdminRoleConstant::ROLE_ADMINISTRATOR);
@@ -88,6 +92,11 @@ class AdministratorController extends AdminBaseController
         $grid->addColumn('realName', 'a.realName', t('Full name'), true);
         $grid->addColumn('userName', 'a.username', t('Username'), true);
         $grid->addColumn('email', 'a.email', t('Email'));
+
+        if ($this->getCurrentAdministrator()->isSuperadmin()) {
+            $grid->addColumn('superadmin', 'is_superadmin', t('Superadmin'))
+                ->setClassAttribute('text-center w-1');
+        }
 
         $grid->addEditActionColumn('admin_administrator_edit', ['id' => 'a.id']);
         $grid->addDeleteActionColumn('admin_administrator_delete', ['id' => 'a.id'])

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Security\Attribute\CanCreate;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanView;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\PublicAccess;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\RequireRole;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\SuperAdminOnly;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
@@ -598,7 +599,7 @@ class AdministratorController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/administrator/set-new-password/', name: 'admin_administrator_set-new-password')]
-    #[CanView]
+    #[PublicAccess]
     public function setNewPasswordAction(Request $request): Response
     {
         $email = $request->query->get('email', '');

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanView;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\RequireRole;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\SuperAdminOnly;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
 use Shopsys\FrameworkBundle\Component\Security\Role\SystemRole;
 use Shopsys\FrameworkBundle\Form\Admin\Administrator\AdministratorFormType;
@@ -560,6 +561,33 @@ class AdministratorController extends AdminBaseController
             [
                 'email' => $administrator->getEmail(),
             ],
+        );
+
+        return $this->redirectToRoute('admin_administrator_edit', ['id' => $id]);
+    }
+
+    /**
+     * @CsrfProtection
+     * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    #[Route(path: '/administrator/promote-to-superadmin/{id}', name: 'admin_administrator_promote-to-superadmin', requirements: ['id' => '\d+'])]
+    #[SuperAdminOnly]
+    public function promoteToSuperadminAction(int $id): Response
+    {
+        $administrator = $this->administratorFacade->getById($id);
+        $administratorData = $this->administratorDataFactory->createFromAdministrator($administrator);
+
+        $administratorData->roleGroup = null;
+        $administratorData->roles = [SystemRole::SUPER_ADMIN];
+
+        $this->administratorFacade->edit($id, $administratorData);
+
+        $this->addSuccessFlash(
+            t(
+                'Administrator "%administrator_name%" now has superadmin permissions.',
+                ['%administrator_name%' => $administrator->getRealName()],
+            ),
         );
 
         return $this->redirectToRoute('admin_administrator_edit', ['id' => $id]);

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -160,6 +160,35 @@ final class AdministratorFormType extends AbstractType
                 'back_route' => 'admin_administrator_list',
                 'entity' => $adminToEdit,
             ]);
+
+        if ($options['scenario'] !== self::SCENARIO_EDIT || !$this->canWorkWithRoles($adminToEdit) || !$this->getCurrentAdministrator()->isSuperadmin()) {
+            return;
+        }
+
+        $builderPromoteGroup = $builder->create('promote', GroupType::class, [
+            'label' => 'Super Administrator',
+        ]);
+
+        $builderPromoteGroup->add('promoteToSuperadmin', DisplayOnlyUrlType::class, [
+            'route' => 'admin_administrator_promote-to-superadmin',
+            'route_params' => [
+                'id' => $adminToEdit->getId(),
+                RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER => $this->routeCsrfProtector->getCsrfTokenByRoute(
+                    'admin_administrator_promote-to-superadmin',
+                ),
+            ],
+            'route_attr' => [
+                'data-confirm-window' => null,
+                'data-confirm-style' => 'warning',
+                'data-confirm-message' => t('Are you sure you want to promote this user to Superadmin?'),
+            ],
+            'label' => 'Superadmin permissions',
+            'help' => 'Superadmins have all permissions including changing system configuration and access to hidden administration sections.',
+            'route_label' => t('Promote user to Superadmin'),
+            'link_target' => '_self',
+        ]);
+
+        $builder->add($builderPromoteGroup);
     }
 
     /**
@@ -176,14 +205,22 @@ final class AdministratorFormType extends AbstractType
             return false;
         }
 
-        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $currentAdministrator */
-        $currentAdministrator = $this->security->getUser();
-
-        if ($currentAdministrator->getId() === $adminToEdit->getId()) {
+        if ($this->getCurrentAdministrator()->getId() === $adminToEdit->getId()) {
             return false;
         }
 
         return $this->accessChecker->canEdit(AdminRoleConstant::ROLE_ADMINISTRATOR);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator
+     */
+    private function getCurrentAdministrator(): Administrator
+    {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $currentAdministrator */
+        $currentAdministrator = $this->security->getUser();
+
+        return $currentAdministrator;
     }
 
     /**

--- a/packages/framework/src/Form/DisplayOnlyUrlType.php
+++ b/packages/framework/src/Form/DisplayOnlyUrlType.php
@@ -19,10 +19,11 @@ final class DisplayOnlyUrlType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setRequired(['route', 'route_params', 'route_label', 'domain_id', 'link_target'])
+            ->setRequired(['route', 'route_params', 'route_label', 'route_attr', 'domain_id', 'link_target'])
             ->setAllowedTypes('route', ['string'])
             ->setAllowedTypes('route_params', ['array', 'null'])
             ->setAllowedTypes('route_label', ['string', 'null'])
+            ->setAllowedTypes('route_attr', ['array', 'null'])
             ->setAllowedTypes('domain_id', ['int', 'null'])
             ->setAllowedTypes('link_target', ['string', 'null'])
             ->setDefaults([
@@ -33,6 +34,7 @@ final class DisplayOnlyUrlType extends AbstractType
                 ],
                 'route_params' => [],
                 'route_label' => null,
+                'route_attr' => [],
                 'domain_id' => null,
                 'link_target' => '_blank',
             ]);
@@ -49,6 +51,7 @@ final class DisplayOnlyUrlType extends AbstractType
         $view->vars['route'] = $options['route'];
         $view->vars['route_params'] = $options['route_params'];
         $view->vars['route_label'] = $options['route_label'];
+        $view->vars['route_attr'] = $options['route_attr'];
         $view->vars['domain_id'] = $options['domain_id'];
         $view->vars['link_target'] = $options['link_target'];
     }

--- a/packages/framework/src/Migrations/Version20250711031748.php
+++ b/packages/framework/src/Migrations/Version20250711031748.php
@@ -51,6 +51,8 @@ class Version20250711031748 extends AbstractMigration
             ['name' => SystemRole::ALL_VIEW],
         );
 
+        $this->migrateSuperAdministrators();
+
         $administratorsWithSystemRoles = $this->connection->fetchAllAssociative(
             'SELECT DISTINCT administrator_id, 
                     MAX(CASE WHEN role = :role_all THEN 1 ELSE 0 END) as has_role_all
@@ -81,6 +83,29 @@ class Version20250711031748 extends AbstractMigration
             $this->sql(
                 'DELETE FROM administrator_roles WHERE administrator_id = :administrator_id',
                 ['administrator_id' => $administratorId],
+            );
+        }
+    }
+
+    public function migrateSuperAdministrators(): void
+    {
+        $superAdministratorIds = $this->connection->fetchAllAssociative(
+            'SELECT administrator_id FROM administrator_roles WHERE role = :superadmin_role',
+            ['superadmin_role' => SystemRole::SUPER_ADMIN],
+        );
+
+        foreach ($superAdministratorIds as $superAdministratorId) {
+            $this->sql(
+                'UPDATE administrators SET role_group_id = NULL WHERE id = :administrator_id AND role_group_id IS NOT NULL',
+                ['administrator_id' => $superAdministratorId['administrator_id']],
+            );
+
+            $this->sql(
+                'DELETE FROM administrator_roles WHERE administrator_id = :administrator_id AND role != :superadmin_role',
+                [
+                    'administrator_id' => $superAdministratorId['administrator_id'],
+                    'superadmin_role' => SystemRole::SUPER_ADMIN,
+                ],
             );
         }
     }

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -16,6 +16,7 @@ use Scheb\TwoFactorBundle\Model\Google\TwoFactorInterface as GoogleTwoFactorInte
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Security\ResetPasswordInterface;
 use Shopsys\FrameworkBundle\Component\Security\Role\SystemRole;
+use Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole;
 use Shopsys\FrameworkBundle\Model\Security\TimelimitLoginInterface;
 use Shopsys\FrameworkBundle\Model\Security\UniqueLoginInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -426,6 +427,10 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     #[Override]
     public function getRoles(): array
     {
+        if ($this->roles->exists(fn ($key, AdministratorRole $role) => $role->getRole() === SystemRole::SUPER_ADMIN)) {
+            return [SystemRole::SUPER_ADMIN];
+        }
+
         if ($this->roleGroup !== null) {
             return $this->roleGroup->getRoles();
         }

--- a/packages/framework/src/Model/Administrator/AdministratorFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFacade.php
@@ -129,9 +129,17 @@ class AdministratorFacade
     /**
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getAllListableQueryBuilder(): QueryBuilder
+    public function getAllListableExcludingSuperadminQueryBuilder(): QueryBuilder
     {
-        return $this->administratorRepository->getAllListableQueryBuilder();
+        return $this->administratorRepository->getAllListableExcludingSuperadminQueryBuilder();
+    }
+
+    /**
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getAllQueryBuilder(): QueryBuilder
+    {
+        return $this->administratorRepository->getAllQueryBuilder();
     }
 
     /**

--- a/packages/framework/src/Model/Administrator/AdministratorRepository.php
+++ b/packages/framework/src/Model/Administrator/AdministratorRepository.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
 use Shopsys\FrameworkBundle\Component\Security\Role\SystemRole;
 use Shopsys\FrameworkBundle\Model\Administrator\Exception\AdministratorNotFoundException;
+use Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole;
 
 class AdministratorRepository
 {
@@ -111,21 +113,39 @@ class AdministratorRepository
     /**
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getAllListableQueryBuilder()
+    public function getAllListableExcludingSuperadminQueryBuilder(): QueryBuilder
     {
         return $this->getAdministratorRepository()->createQueryBuilder('a')
             ->leftJoin('a.roles', 'ar')
-            ->where('ar.role = :role')
-            ->orWhere('a.roleGroup is not NULL')
-            ->setParameter('role', SystemRole::ADMIN);
+            ->where('ar.role = :role OR a.roleGroup is not NULL')
+            ->andWhere('ar.role != :superadminRole OR ar.role IS NULL')
+            ->setParameter('role', SystemRole::ADMIN)
+            ->setParameter('superadminRole', SystemRole::SUPER_ADMIN);
+    }
+
+    /**
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getAllQueryBuilder(): QueryBuilder
+    {
+        $subquery = $this->em->createQueryBuilder()
+            ->select('1')
+            ->from(AdministratorRole::class, 'ar')
+            ->where('ar.administrator = a')
+            ->andWhere('ar.role = :superadminRole')
+            ->getDQL();
+
+        return $this->getAdministratorRepository()->createQueryBuilder('a')
+            ->addSelect(sprintf('CASE WHEN EXISTS(%s) THEN true ELSE false END AS is_superadmin', $subquery))
+            ->setParameter('superadminRole', SystemRole::SUPER_ADMIN);
     }
 
     /**
      * @return int
      */
-    public function getCountExcludingSuperadmin()
+    public function getCountExcludingSuperadmin(): int
     {
-        return (int)($this->getAllListableQueryBuilder()
+        return (int)($this->getAllListableExcludingSuperadminQueryBuilder()
             ->select('COUNT(a)')
             ->getQuery()->getSingleScalarResult());
     }

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleFacade.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleFacade.php
@@ -58,7 +58,7 @@ class AdministratorRoleFacade
     {
         $adminRole = SystemRole::ADMIN;
 
-        if ($administrator->isSuperadmin()) {
+        if ($administrator->isSuperadmin() || in_array(SystemRole::SUPER_ADMIN, $roles, true)) {
             $adminRole = SystemRole::SUPER_ADMIN;
         }
 

--- a/packages/framework/src/Model/Product/ProductGridFactory.php
+++ b/packages/framework/src/Model/Product/ProductGridFactory.php
@@ -48,7 +48,7 @@ class ProductGridFactory
         $grid->addColumn('catnum', 'p.catnum', t('Catalog number'), true);
         $grid->addColumn('price', 'priceForProductList', t('Price'), true)->setClassAttribute('text-right');
         $grid->addColumn('visibility', 'visibility', t('Visibility'))
-            ->setClassAttribute('text-center table-col table-col-10');
+            ->setClassAttribute('text-center');
 
         $grid->addEditActionColumn('admin_product_edit', ['id' => 'p.id']);
         $grid->addDeleteActionColumn('admin_product_delete', ['id' => 'p.id'])

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -139,6 +139,9 @@ msgstr "URL detailu poptávky v administraci"
 msgid "Administration localization was changed to \"%locale%\""
 msgstr "Administrace byla přepnuta do jazyka \"%locale%\""
 
+msgid "Administrator \"%administrator_name%\" now has superadmin permissions."
+msgstr "Administrátor \"%administrator_name%\" nyní má oprávnění superadministrátora."
+
 msgid "Administrator <strong><a href=\"{{ url }}\">{{ name }}</a></strong> created. A link to set a password has been sent to his email."
 msgstr "Byl vytvořen administrátor <strong><a href=\"{{ url }}\">{{ name }}</a></strong>. Odkaz pro nastavení hesla byl odeslán na jeho e-mail."
 
@@ -228,6 +231,9 @@ msgstr "Aplikovat na vybrané produkty"
 
 msgid "Approved with zero amount"
 msgstr "Schváleno s nulovou částkou"
+
+msgid "Are you sure you want to promote this user to Superadmin?"
+msgstr "Opravdu chcete tomuto uživateli přidělit práva super administrátora?"
 
 msgid "Area"
 msgstr "Plocha"
@@ -2647,6 +2653,9 @@ msgstr "Prefix slevového kupónu"
 msgid "Promo codes"
 msgstr "Slevové kupóny"
 
+msgid "Promote user to Superadmin"
+msgstr "Povýšit uživatele na Super administrátora"
+
 msgid "Promoted categories"
 msgstr "Promované kategorie"
 
@@ -3127,8 +3136,14 @@ msgstr "Odběratel newsletteru <strong>{{ email }}</strong> byl smazán"
 msgid "Successfully uploaded"
 msgstr "Úspěšně nahráno"
 
+msgid "Super Administrator"
+msgstr "Super administrátor"
+
 msgid "Superadmin"
 msgstr "Superadmin"
+
+msgid "Superadmin permissions"
+msgstr "Oprávnění super administrátora"
 
 msgid "System data"
 msgstr "Systémové údaje"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -139,6 +139,9 @@ msgstr ""
 msgid "Administration localization was changed to \"%locale%\""
 msgstr ""
 
+msgid "Administrator \"%administrator_name%\" now has superadmin permissions."
+msgstr ""
+
 msgid "Administrator <strong><a href=\"{{ url }}\">{{ name }}</a></strong> created. A link to set a password has been sent to his email."
 msgstr ""
 
@@ -227,6 +230,9 @@ msgid "Apply to selected products"
 msgstr ""
 
 msgid "Approved with zero amount"
+msgstr ""
+
+msgid "Are you sure you want to promote this user to Superadmin?"
 msgstr ""
 
 msgid "Area"
@@ -2647,6 +2653,9 @@ msgstr ""
 msgid "Promo codes"
 msgstr ""
 
+msgid "Promote user to Superadmin"
+msgstr ""
+
 msgid "Promoted categories"
 msgstr ""
 
@@ -3127,7 +3136,13 @@ msgstr ""
 msgid "Successfully uploaded"
 msgstr ""
 
+msgid "Super Administrator"
+msgstr ""
+
 msgid "Superadmin"
+msgstr ""
+
+msgid "Superadmin permissions"
 msgstr ""
 
 msgid "System data"

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -139,6 +139,9 @@ msgstr "URL detailu adminského dopytu"
 msgid "Administration localization was changed to \"%locale%\""
 msgstr "Lokalizácia administrácie bola zmenená na \"%locale%\""
 
+msgid "Administrator \"%administrator_name%\" now has superadmin permissions."
+msgstr "Administrátor \"%administrator_name%\" teraz má oprávnenia super administrátora."
+
 msgid "Administrator <strong><a href=\"{{ url }}\">{{ name }}</a></strong> created. A link to set a password has been sent to his email."
 msgstr "Administrátor <strong><a href=\"{{ url }}\">{{ name }}</a></strong> bol vytvorený. Odkaz na nastavenie hesla bol poslaný na jeho email."
 
@@ -228,6 +231,9 @@ msgstr "Použiť na vybrané produkty"
 
 msgid "Approved with zero amount"
 msgstr "Schválené s nulovou sumou"
+
+msgid "Are you sure you want to promote this user to Superadmin?"
+msgstr "Naozaj chcete povýšiť tohto používateľa na super administrátora?"
 
 msgid "Area"
 msgstr "Oblasť"
@@ -2647,6 +2653,9 @@ msgstr "Predpona promo kódu"
 msgid "Promo codes"
 msgstr "Zľavové kupóny"
 
+msgid "Promote user to Superadmin"
+msgstr "Povýšiť používateľa na super administrátora"
+
 msgid "Promoted categories"
 msgstr "Propagované kategórie"
 
@@ -3127,8 +3136,14 @@ msgstr "Odberateľ newslettera <strong>{{ email }}</strong> bol zmazaný"
 msgid "Successfully uploaded"
 msgstr "Úspešne nahrané"
 
+msgid "Super Administrator"
+msgstr "Super administrátor"
+
 msgid "Superadmin"
 msgstr "Superadmin"
+
+msgid "Superadmin permissions"
+msgstr "Oprávnenia superadmina"
 
 msgid "System data"
 msgstr "Systémové údaje"

--- a/project-base/app/assets/icons/tabler/crown.svg
+++ b/project-base/app/assets/icons/tabler/crown.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m12 6l4 6l5-4l-2 10H5L3 8l5 4z"/></svg>

--- a/project-base/app/config/packages/ux_icons.yaml
+++ b/project-base/app/config/packages/ux_icons.yaml
@@ -23,6 +23,7 @@ ux_icons:
         circle-plus: 'tabler:circle-plus'
         circle-remove: 'tabler:circle-minus'
         company: 'tabler:building'
+        crown: 'tabler:crown'
         delete: 'tabler:x'
         delete-thin: 'tabler:x'
         document-copy: 'tabler:clipboard-text-filled'

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -195,6 +195,28 @@ class RouteConfigCustomization
                     ->setAuth(new NoAuth())
                     ->setExpectedStatusCode(200);
             })
+            ->customizeByRouteName('admin_administrator_promote-to-superadmin', function (RouteConfig $config) {
+                $config->changeDefaultRequestDataSet('Standard admin is not allowed to promote to superadmin')
+                    ->addCallDuringTestExecution(
+                        function (RequestDataSet $requestDataSet, ContainerInterface $container) {
+                            $container = $container->get('test.service_container');
+                            /** @var \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector $routeCsrfProtector */
+                            $routeCsrfProtector = $container->get(RouteCsrfProtector::class);
+                            /** @var \Symfony\Component\Security\Csrf\CsrfTokenManager $csrfTokenManager */
+                            $csrfTokenManager = $container->get('security.csrf.token_manager');
+
+                            $tokenId = $routeCsrfProtector->getCsrfTokenId($requestDataSet->getRouteName());
+                            $token = $csrfTokenManager->getToken($tokenId);
+
+                            $parameterName = RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER;
+                            $requestDataSet->setParameter($parameterName, $token->getValue());
+                        },
+                    )
+                    ->setExpectedStatusCode(308);
+                $config->addExtraRequestDataSet('Superadmin can promote to superadmin')
+                    ->setAuth(new BasicHttpAuth('superadmin', 'admin123'))
+                    ->setExpectedStatusCode(302);
+            })
             ->customizeByRouteName('admin_default_schedulecron', function (RouteConfig $config) {
                 $config->changeDefaultRequestDataSet('Standard admin is not allowed to schedule cron')
                     ->setExpectedStatusCode(308);
@@ -421,8 +443,7 @@ class RouteConfigCustomization
                 $config->changeDefaultRequestDataSet('First two role groups are system managed, so they can not be copied.')
                     ->setParameter('id', 3)
                     ->setExpectedStatusCode(200);
-            })
-        ;
+            });
     }
 
     /**

--- a/upgrade-notes/backend_20251028_213307.md
+++ b/upgrade-notes/backend_20251028_213307.md
@@ -1,0 +1,7 @@
+#### fixed superadmin behavior ([#4238](https://github.com/shopsys/shopsys/pull/4238))
+
+- method `getAllListableQueryBuilder()` in `Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository` was renamed to `getAllListableExcludingSuperadminQueryBuilder()`
+    - use new method `getAllQueryBuilder()` if you need to fetch all administrators including superadmins
+- method `getAllListableQueryBuilder()` in `Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade` was renamed to `getAllListableExcludingSuperadminQueryBuilder()`
+    - use new method `getAllQueryBuilder()` if you need to fetch all administrators including superadmins
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

- superadmin users are now displayed in the administrator list grid if the currently logged admin is a superadmin
- superadmin can promote regular admin to superadmin
- edit superadmin now show that the currently edited admin is superadmin
- back-fixed RBAC migration - will be backported to 17.0.1
- fixed access to reset password page - it's now public as it's used as unlogged admin

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-superadmin-role.odin.shopsys.cloud
  - https://cz.mg-fix-superadmin-role.odin.shopsys.cloud
  - https://mg-fix-superadmin-role.odin.shopsys.cloud/sk
<!-- Replace -->
