### PR TITLE
DX tweaks in administration

### DIFF
--- a/packages/framework/src/Component/AddSentryContextSubscriber.php
+++ b/packages/framework/src/Component/AddSentryContextSubscriber.php
@@ -8,11 +8,15 @@ use App\Environment;
 use Override;
 use RedisException;
 use Sentry\State\Scope;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider;
 use Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface;
 use Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\AdministratorIsNotLoggedException;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\ShopsysFrameworkBundle;
 use Symfony\Component\Console\ConsoleEvents;
@@ -29,6 +33,8 @@ class AddSentryContextSubscriber implements EventSubscriberInterface
      * @param \Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface $displayTimeZoneProvider
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
+     * @param \Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface $contextResolver
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade
      */
     public function __construct(
         protected readonly MaintenanceModeFacade $maintenanceModeFacade,
@@ -36,6 +42,8 @@ class AddSentryContextSubscriber implements EventSubscriberInterface
         protected readonly DisplayTimeZoneProviderInterface $displayTimeZoneProvider,
         protected readonly CurrentCustomerUser $currentCustomerUser,
         protected readonly ErrorIdProvider $errorIdProvider,
+        protected readonly ContextResolverInterface $contextResolver,
+        protected readonly AdministratorFacade $administratorFacade,
     ) {
     }
 
@@ -59,6 +67,19 @@ class AddSentryContextSubscriber implements EventSubscriberInterface
             $context['currentDomainLocale'] = $this->domain->getLocale();
             $context['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName();
         } catch (NoDomainSelectedException | FileNotFoundException) {
+        }
+
+        if ($this->contextResolver->isCurrentContext(AdminContext::class)) {
+            $context['inAdmin'] = true;
+            $context['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneForAdmin()->getName();
+
+            try {
+                $administrator = $this->administratorFacade->getCurrentlyLoggedAdministrator();
+                $context['adminSelectedLocale'] = $administrator->getSelectedLocale();
+                $context['adminId'] = $administrator->getId();
+            } catch (AdministratorIsNotLoggedException) {
+                $context['adminId'] = null;
+            }
         }
 
         configureScope(function (Scope $scope) use ($context): void {

--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -6,9 +6,11 @@ namespace Shopsys\FrameworkBundle\Component\Collector;
 
 use Override;
 use PharIo\Version\Version;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
 use Shopsys\FrameworkBundle\ShopsysFrameworkBundle;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,10 +22,14 @@ class ShopsysFrameworkDataCollector extends DataCollector
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface $displayTimeZoneProvider
+     * @param \Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface $contextResolver
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly DisplayTimeZoneProviderInterface $displayTimeZoneProvider,
+        protected readonly ContextResolverInterface $contextResolver,
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
     ) {
     }
 
@@ -40,16 +46,17 @@ class ShopsysFrameworkDataCollector extends DataCollector
             'systemTimeZone' => date_default_timezone_get(),
         ];
 
-        try {
+        if ($this->contextResolver->isCurrentContext(AdminContext::class)) {
+            $this->data['inAdmin'] = true;
+            $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneForAdmin()->getName();
+            $this->data['adminLocale'] = $this->administratorLocalizationFacade->getCurrentAdminLocaleOrDefault();
+            $this->data['currentDomainId'] = 0;
+        } else {
+            $this->data['inAdmin'] = false;
             $this->data['currentDomainId'] = $this->domain->getId();
             $this->data['currentDomainName'] = $this->domain->getName();
             $this->data['currentDomainLocale'] = $this->domain->getLocale();
             $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName();
-        } catch (NoDomainSelectedException) {
-            $this->data['currentDomainId'] = 0;
-            $this->data['currentDomainName'] = '-';
-            $this->data['currentDomainLocale'] = '-';
-            $this->data['displayTimeZone'] = '-';
         }
     }
 
@@ -100,6 +107,22 @@ class ShopsysFrameworkDataCollector extends DataCollector
     public function getCurrentDomainLocale(): string
     {
         return $this->data['currentDomainLocale'];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInAdmin(): bool
+    {
+        return $this->data['inAdmin'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getAdminLocale(): string
+    {
+        return $this->data['adminLocale'];
     }
 
     /**

--- a/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
+++ b/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
@@ -13,11 +13,21 @@
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Current domain</b>
-                <span>{{ collector.currentDomainName }}</span>
+                {% if collector.inAdmin %}
+                    <span>Administration</span>
+                {% else %}
+                    <span>{{ collector.currentDomainName }}</span>
+                {% endif %}
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Locale</b>
-                <span class="sf-toolbar-status">{{ collector.currentDomainLocale }}</span>
+                <span class="sf-toolbar-status">
+                    {% if collector.inAdmin %}
+                        {{ collector.adminLocale }}
+                    {% else %}
+                        {{ collector.currentDomainLocale }}
+                    {% endif %}
+                </span>
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>System TimeZone</b>


### PR DESCRIPTION
#### Description, the reason for the PR
Since https://github.com/shopsys/shopsys/pull/4113, there is no "current domain config" in the administration. The data collector for the Symfony profiler now takes this into account and provides additional information (such as the administration display time zone, and the current administrator-selected locale) when in administration.

Moreover, the sentry context is now also enriched with the administration data when in the admin context.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-profiler.odin.shopsys.cloud
  - https://cz.rv-fix-profiler.odin.shopsys.cloud
  - https://rv-fix-profiler.odin.shopsys.cloud/sk
<!-- Replace -->
