### PR TITLE
product elastic index: fix default value for X+Y promotion data

### DIFF
--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php
@@ -76,7 +76,9 @@ class ProductElasticsearchConverter
 
         $result[ProductExportFieldProvider::VAT_PERCENT] = $product[ProductExportFieldProvider::VAT_PERCENT] ?? '0';
 
-        $result[ProductExportFieldProvider::PROMOTION] = $product[ProductExportFieldProvider::PROMOTION] ?? null;
+        $result[ProductExportFieldProvider::PROMOTION] = $this->fillEmptyPromotion(
+            $product[ProductExportFieldProvider::PROMOTION] ?? null,
+        );
 
         return $result;
     }
@@ -118,5 +120,24 @@ class ProductElasticsearchConverter
         }
 
         return $results;
+    }
+
+    /**
+     * @param array|null $promotion
+     * @return array{buy_quantity: int|null, free_quantity: int|null}
+     */
+    protected function fillEmptyPromotion(?array $promotion): array
+    {
+        if (!is_array($promotion)) {
+            return [
+                'buy_quantity' => null,
+                'free_quantity' => null,
+            ];
+        }
+
+        return [
+            'buy_quantity' => $promotion['buy_quantity'] ?? null,
+            'free_quantity' => $promotion['free_quantity'] ?? null,
+        ];
     }
 }

--- a/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
@@ -67,7 +67,10 @@ class ProductElasticsearchConverterTest extends TestCase
             'selling_from' => null,
             'product_videos' => [],
             'vat_percent' => '0',
-            'promotion' => null,
+            'promotion' => [
+                'buy_quantity' => null,
+                'free_quantity' => null,
+            ],
         ];
 
         $converter = new ProductElasticsearchConverter();
@@ -147,7 +150,10 @@ class ProductElasticsearchConverterTest extends TestCase
             'selling_from' => null,
             'product_videos' => [],
             'vat_percent' => '0',
-            'promotion' => null,
+            'promotion' => [
+                'buy_quantity' => null,
+                'free_quantity' => null,
+            ],
         ];
 
         $converter = new ProductElasticsearchConverter();


### PR DESCRIPTION
#### Description, the reason for the PR
When adding a new field to Elasticsearch index, we need to define the default values for not-yet exported products using `ProductElasticsearchConverter`. However, we have to take the field type into account so that the nested type fields have the default values for the nested fields as well. In https://github.com/shopsys/shopsys/pull/4194, we have set `null` as a default value for a field that is then accessed as `$data['promotion']['buy_quantity']`, leading to `Trying to access array offset on null` error for products that are not yet exported.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-products-xy.odin.shopsys.cloud
  - https://cz.rv-fix-products-xy.odin.shopsys.cloud
  - https://rv-fix-products-xy.odin.shopsys.cloud/sk
<!-- Replace -->
