### PR TITLE
SF: getBasePathWithLocale now requires context instead of locale

### DIFF
--- a/project-base/storefront/pages/articles/[articleSlug].tsx
+++ b/project-base/storefront/pages/articles/[articleSlug].tsx
@@ -80,9 +80,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     articleResponse.error,
                     articleResponse.data?.article,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                 );
 
                 if (serverSideErrorResponse) {

--- a/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
+++ b/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
@@ -83,9 +83,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     blogArticleResponse.error,
                     blogArticleResponse.data?.blogArticle,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                 );
 
                 if (serverSideErrorResponse) {

--- a/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
+++ b/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
@@ -88,9 +88,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     blogCategoryResponse.error,
                     blogCategoryResponse.data?.blogCategory,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                 );
 
                 if (serverSideErrorResponse) {

--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -140,9 +140,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideBrandDetailErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     brandDetailResponse.error,
                     brandDetailResponse.data?.brand,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                     urlSlug,
                 );
 
@@ -153,9 +152,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideBrandProductsErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     brandProductsResponse.error,
                     brandProductsResponse.data?.products,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                     urlSlug,
                 );
 

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -127,9 +127,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideCategoryDetailErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     categoryDetailResponse.error,
                     categoryDetailResponse.data?.category,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                     urlSlug,
                 );
 
@@ -140,9 +139,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideCategoryProductsErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     categoryProductsResponse.error,
                     categoryProductsResponse.data?.products,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                     urlSlug,
                 );
 

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -128,9 +128,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideFlagDetailErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     flagDetailResponse.error,
                     flagDetailResponse.data?.flag,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                     urlSlug,
                 );
 
@@ -141,9 +140,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideFlagProductsErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     flagProductsResponse.error,
                     flagProductsResponse.data?.products,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                     urlSlug,
                 );
 

--- a/project-base/storefront/pages/login.tsx
+++ b/project-base/storefront/pages/login.tsx
@@ -66,7 +66,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 return {
                     redirect: {
                         statusCode: 302,
-                        destination: getBasePathWithLocale(redirectUrl, context.locale),
+                        destination: getBasePathWithLocale(redirectUrl, context),
                     },
                 };
             }

--- a/project-base/storefront/pages/order-confirmation.tsx
+++ b/project-base/storefront/pages/order-confirmation.tsx
@@ -144,7 +144,7 @@ export const getServerSideProps = getServerSidePropsWrapper(({ redisClient, doma
             redirect: {
                 destination: getBasePathWithLocale(
                     getInternationalizedStaticUrls(['/cart'], domainConfig.url)[0],
-                    domainConfig.defaultLocale,
+                    context,
                 ),
                 statusCode: 301,
             },

--- a/project-base/storefront/pages/order-detail/[urlHash].tsx
+++ b/project-base/storefront/pages/order-detail/[urlHash].tsx
@@ -70,7 +70,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
             if (typeof context.params?.urlHash !== 'string') {
                 return {
                     redirect: {
-                        destination: getBasePathWithLocale('/', domainConfig.defaultLocale),
+                        destination: getBasePathWithLocale('/', context),
                         statusCode: 301,
                     },
                 };

--- a/project-base/storefront/pages/order-payment-confirmation.tsx
+++ b/project-base/storefront/pages/order-payment-confirmation.tsx
@@ -169,7 +169,7 @@ export const getServerSideProps = getServerSidePropsWrapper(({ redisClient, doma
     if (orderUuid === '') {
         return {
             redirect: {
-                destination: getBasePathWithLocale('/', domainConfig.defaultLocale),
+                destination: getBasePathWithLocale('/', context),
                 statusCode: 301,
             },
         };

--- a/project-base/storefront/pages/products/[productSlug].tsx
+++ b/project-base/storefront/pages/products/[productSlug].tsx
@@ -105,9 +105,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
             const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                 productResponse.error,
                 productResponse.data?.product,
-                context.res,
+                context,
                 domainConfig.url,
-                context.locale,
             );
 
             if (serverSideErrorResponse) {
@@ -120,10 +119,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
             ) {
                 return {
                     redirect: {
-                        destination: getBasePathWithLocale(
-                            productResponse.data.product.mainVariant.slug,
-                            domainConfig.defaultLocale,
-                        ),
+                        destination: getBasePathWithLocale(productResponse.data.product.mainVariant.slug, context),
                         permanent: false,
                     },
                 };

--- a/project-base/storefront/pages/stores/[storeSlug].tsx
+++ b/project-base/storefront/pages/stores/[storeSlug].tsx
@@ -69,9 +69,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     storeResponse.error,
                     storeResponse.data?.store,
-                    context.res,
+                    context,
                     domainConfig.url,
-                    context.locale,
                 );
 
                 if (serverSideErrorResponse) {

--- a/project-base/storefront/utils/auth/getLoginUrlWithRedirect.ts
+++ b/project-base/storefront/utils/auth/getLoginUrlWithRedirect.ts
@@ -1,3 +1,4 @@
+import { GetServerSidePropsContext } from 'next';
 import { getBasePathWithLocale } from 'utils/domain/domainUtils';
 import { getStringWithoutLeadingSlash } from 'utils/parsing/stringWIthoutSlash';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
@@ -5,11 +6,11 @@ import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationa
 export const getLoginUrlWithRedirect = (
     redirectTargetUrl: string,
     domainUrl: string,
-    contextLocale: string,
+    context: GetServerSidePropsContext,
 ): string => {
     const [loginUrl] = getInternationalizedStaticUrls(['/login'], domainUrl);
 
     const redirectQuery = redirectTargetUrl.length > 0 ? `?r=${getStringWithoutLeadingSlash(redirectTargetUrl)}` : '';
 
-    return getBasePathWithLocale(`${loginUrl}${redirectQuery}`, contextLocale);
+    return getBasePathWithLocale(`${loginUrl}${redirectQuery}`, context);
 };

--- a/project-base/storefront/utils/auth/getUnauthenticatedRedirectSSR.ts
+++ b/project-base/storefront/utils/auth/getUnauthenticatedRedirectSSR.ts
@@ -1,13 +1,12 @@
 import { getLoginUrlWithRedirect } from './getLoginUrlWithRedirect';
 import { STATIC_REWRITE_PATHS, StaticRewritePathKeyType } from 'config/staticRewritePaths';
-import { Redirect } from 'next';
-import { DEFAULT_LOCALE } from 'utils/domain/domainUtils';
+import { GetServerSidePropsContext, Redirect } from 'next';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
 
 export const getUnauthenticatedRedirectSSR = (
     resolvedUrl: string,
     domainUrl: string,
-    contextLocale: string = DEFAULT_LOCALE,
+    context: GetServerSidePropsContext,
 ): { redirect: Redirect } => {
     let redirectTargetUrlWithLeadingSlash = getInternationalizedStaticUrls(['/login'], domainUrl)[0];
 
@@ -21,7 +20,7 @@ export const getUnauthenticatedRedirectSSR = (
     return {
         redirect: {
             statusCode: 302,
-            destination: getLoginUrlWithRedirect(redirectTargetUrlWithLeadingSlash, domainUrl, contextLocale),
+            destination: getLoginUrlWithRedirect(redirectTargetUrlWithLeadingSlash, domainUrl, context),
         },
     };
 };

--- a/project-base/storefront/utils/domain/domainUtils.ts
+++ b/project-base/storefront/utils/domain/domainUtils.ts
@@ -1,4 +1,5 @@
 import { DomainConfigType } from './domainConfig';
+import { GetServerSidePropsContext } from 'next';
 
 export const DEFAULT_LOCALE = 'default';
 
@@ -6,10 +7,10 @@ export const getBaseUrlWithLocale = (baseUrl: string, locale = DEFAULT_LOCALE) =
     return `${baseUrl}${locale !== DEFAULT_LOCALE ? `/${locale}` : ''}`;
 };
 
-export const getBasePathWithLocale = (basePath: string, locale = DEFAULT_LOCALE) => {
+export const getBasePathWithLocale = (basePath: string, context: GetServerSidePropsContext) => {
     const normalizedBasePath = basePath.startsWith('/') ? basePath : `/${basePath}`;
 
-    return `${locale !== DEFAULT_LOCALE ? `/${locale}` : ''}${normalizedBasePath}`;
+    return `${context.locale !== DEFAULT_LOCALE ? `/${context.locale}` : ''}${normalizedBasePath}`;
 };
 
 export const getInternalGraphqlEndpoint = (internalEndpoint: string | undefined, locale = DEFAULT_LOCALE) => {

--- a/project-base/storefront/utils/errors/handleServerSideErrorResponseForFriendlyUrls.ts
+++ b/project-base/storefront/utils/errors/handleServerSideErrorResponseForFriendlyUrls.ts
@@ -1,18 +1,16 @@
 import { isExpectedPriceFilterError } from './expectedErrors';
 import { isWithErrorDebugging } from './isWithErrorDebugging';
 import { mapGraphqlErrorForDevelopment } from './mapGraphqlErrorForDevelopment';
-import { IncomingMessage, ServerResponse } from 'http';
+import { GetServerSidePropsContext } from 'next';
 import { CombinedError } from 'urql';
 import { getLoginUrlWithRedirect } from 'utils/auth/getLoginUrlWithRedirect';
-import { DEFAULT_LOCALE } from 'utils/domain/domainUtils';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
 
 export const handleServerSideErrorResponseForFriendlyUrls = (
     error: CombinedError | undefined,
     serverSideRequestData: unknown,
-    res: ServerResponse<IncomingMessage>,
+    context: GetServerSidePropsContext,
     domainUrl: string,
-    contextLocale: string = DEFAULT_LOCALE,
     urlSlug: string | undefined = undefined,
 ) => {
     if (error?.response.status === 401) {
@@ -20,7 +18,7 @@ export const handleServerSideErrorResponseForFriendlyUrls = (
 
         return {
             redirect: {
-                destination: getLoginUrlWithRedirect(redirectTargetUrlWithLeadingSlash, domainUrl, contextLocale),
+                destination: getLoginUrlWithRedirect(redirectTargetUrlWithLeadingSlash, domainUrl, context),
                 permanent: false,
             },
         };
@@ -43,7 +41,7 @@ export const handleServerSideErrorResponseForFriendlyUrls = (
         };
     }
 
-    if (!serverSideRequestData && !(res.statusCode === 503)) {
+    if (!serverSideRequestData && !(context.res.statusCode === 503)) {
         return {
             notFound: true as const,
         };

--- a/project-base/storefront/utils/serverSide/initServerSideProps.ts
+++ b/project-base/storefront/utils/serverSide/initServerSideProps.ts
@@ -171,7 +171,7 @@ export const initServerSideProps = async <VariablesType extends Variables>({
             return getUnauthenticatedRedirectSSR(
                 getUrlWithoutGetParameters(context.resolvedUrl),
                 domainConfig.url,
-                context.locale,
+                context,
             );
         }
     }

--- a/upgrade-notes/storefront_20251027_101838.md
+++ b/upgrade-notes/storefront_20251027_101838.md
@@ -1,0 +1,11 @@
+#### SF: getBasePathWithLocale now requires context instead of locale ([#4249](https://github.com/shopsys/shopsys/pull/4249))
+
+- **`getBasePathWithLocale()` function signature changed**
+    - update all calls to pass the full `context` object instead of just the locale string
+- **`handleServerSideErrorResponseForFriendlyUrls()` function signature changed**
+    - pass the full `context` object instead of separate `res` and `contextLocale` parameters (the `contextLocale` parameter was removed entirely)
+- **`getLoginUrlWithRedirect()` function signature changed**
+    - pass the `context` object as the third parameter instead of `contextLocale` string
+- **`getUnauthenticatedRedirectSSR()` function signature changed**
+    - pass the `context` object as the third parameter instead of `contextLocale` string
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- to avoid confusion between context.locale and domainConfig.defaultLocale
- the method actually needs the context locale (which might be "default") but at a few places, domain locale was passed, and that caused bugs
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-base-path-locale.odin.shopsys.cloud
  - https://cz.rv-fix-base-path-locale.odin.shopsys.cloud
  - https://rv-fix-base-path-locale.odin.shopsys.cloud/sk
<!-- Replace -->
