### PR TITLE
conflicted doctrine/orm 2.20.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,7 +230,8 @@
     "conflict": {
         "symfony/symfony": "*",
         "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0",
-        "doctrine/doctrine-migrations-bundle": "3.4.0"
+        "doctrine/doctrine-migrations-bundle": "3.4.0",
+        "doctrine/orm": ">=2.20.7"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -129,10 +129,13 @@
         "shopsys/biome-config": "18.0.x-dev",
         "shopsys/coding-standards": "18.0.x-dev",
         "sspooky13/yaml-standards": "^9.0",
-        "symfony/maker-bundle": "^1.62" ,
+        "symfony/maker-bundle": "^1.62",
         "symfony/process": "^6.4",
         "symfony/var-dumper": "^6.4",
         "symfony/yaml": "^6.4"
+    },
+    "conflict": {
+        "doctrine/orm": ">=2.20.7"
     },
     "extra": {
         "symfony": {


### PR DESCRIPTION
#### Description, the reason for the PR

- calling `$repository->findBy(['id' => []])` cause SQL error in doctrine/orm 2.20.7
- this version is conflicted as it's not easy to safely identify problematic pieces of code

the conversation pn the fix continues in the original repository - https://github.com/doctrine/orm/pull/12190

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-pin-orm.odin.shopsys.cloud
  - https://cz.mg-pin-orm.odin.shopsys.cloud
  - https://mg-pin-orm.odin.shopsys.cloud/sk
<!-- Replace -->
