### PR TITLE
ensure AccessChecker::hasPermission works properly with single roles

### DIFF
--- a/packages/administration/src/Component/Security/Role/CoreAdminRoleProvider.php
+++ b/packages/administration/src/Component/Security/Role/CoreAdminRoleProvider.php
@@ -45,8 +45,6 @@ class CoreAdminRoleProvider implements CoreRoleProviderInterface
         // Those are special roles that are always present in the system.
         $roleCollection->add(new Role(SystemRole::ADMIN, t('Administrator'), allowOverwrite: false));
         $roleCollection->add(new Role(SystemRole::SUPER_ADMIN, t('Super Administrator'), allowOverwrite: false));
-        $roleCollection->add(new Role(SystemRole::ALL, t('Full access'), allowOverwrite: false));
-        $roleCollection->add(new Role(SystemRole::ALL_VIEW, t('Full access (view only)'), allowOverwrite: false));
         $roleCollection->add(new Role(SystemRole::PUBLIC_ACCESS, t('Public access'), allowOverwrite: false));
 
         $coreRoles = [

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -907,12 +907,6 @@ msgstr "Pátek"
 msgid "From"
 msgstr "Od"
 
-msgid "Full access"
-msgstr "Plný přístup"
-
-msgid "Full access (view only)"
-msgstr "Plný přístup (pouze prohlížení)"
-
 msgid "Future"
 msgstr "Budoucí"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -907,12 +907,6 @@ msgstr ""
 msgid "From"
 msgstr ""
 
-msgid "Full access"
-msgstr ""
-
-msgid "Full access (view only)"
-msgstr ""
-
 msgid "Future"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -907,12 +907,6 @@ msgstr "Piatok"
 msgid "From"
 msgstr "Od"
 
-msgid "Full access"
-msgstr "Úplný prístup"
-
-msgid "Full access (view only)"
-msgstr "Úplný prístup (iba zobrazenie)"
-
 msgid "Future"
 msgstr "Budúcnosť"
 

--- a/packages/framework/src/Component/Security/AccessControl/AccessChecker.php
+++ b/packages/framework/src/Component/Security/AccessControl/AccessChecker.php
@@ -69,7 +69,11 @@ final readonly class AccessChecker implements AccessCheckerInterface
     #[Override]
     public function hasPermission(string $roleConstant, Permission $permission): bool
     {
-        $this->roleRegistry->getRole($roleConstant, AdminContext::class);
+        $role = $this->roleRegistry->getRole($roleConstant, AdminContext::class);
+
+        if ($role->isSingleRole()) {
+            return $this->authorizationChecker->isGranted($roleConstant);
+        }
 
         $roleWithPermission = RoleIdentifierHelper::getIdentifierWithPermission($roleConstant, $permission);
 

--- a/packages/framework/tests/Unit/Component/Security/AccessControl/AccessCheckerTest.php
+++ b/packages/framework/tests/Unit/Component/Security/AccessControl/AccessCheckerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Security\AccessControl;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Security\AccessControl\AccessChecker;
+use Shopsys\FrameworkBundle\Component\Security\AccessControl\RouteAccessCheckerInterface;
+use Shopsys\FrameworkBundle\Component\Security\Role\Permission;
+use Shopsys\FrameworkBundle\Component\Security\Role\Role;
+use Shopsys\FrameworkBundle\Component\Security\Role\RoleIdentifierHelper;
+use Shopsys\FrameworkBundle\Component\Security\Role\RoleRegistryInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class AccessCheckerTest extends TestCase
+{
+    private const string ROLE_CONSTANT = 'ROLE';
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Security\Role\Permission[] $availablePermissions
+     * @param \Shopsys\FrameworkBundle\Component\Security\Role\Permission $permission
+     * @param string $expectedRoleIdentifier
+     */
+    #[DataProvider('hasPermissionDataProvider')]
+    public function testHasPermissionPassesCorrectRoleIdentifierToAuthorizationChecker(
+        array $availablePermissions,
+        Permission $permission,
+        string $expectedRoleIdentifier,
+    ): void {
+        $role = $this->createRole($availablePermissions);
+        $roleConstant = $role->getConstant();
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with($expectedRoleIdentifier);
+
+        $roleRegistry = $this->createMock(RoleRegistryInterface::class);
+        $roleRegistry->method('getRole')
+            ->with($roleConstant, AdminContext::class)
+            ->willReturn($role);
+
+        $routeAccessChecker = $this->createMock(RouteAccessCheckerInterface::class);
+
+        $accessChecker = new AccessChecker($authorizationChecker, $roleRegistry, $routeAccessChecker);
+
+        $accessChecker->hasPermission($roleConstant, $permission);
+    }
+
+    /**
+     * @return iterable<string, array{availablePermissions: array<\Shopsys\FrameworkBundle\Component\Security\Role\Permission>, permission: \Shopsys\FrameworkBundle\Component\Security\Role\Permission, expectedRoleIdentifier: string}>
+     */
+    public static function hasPermissionDataProvider(): iterable
+    {
+        yield 'single role passes role constant directly' => [
+            'availablePermissions' => [],
+            'permission' => Permission::VIEW,
+            'expectedRoleIdentifier' => self::ROLE_CONSTANT,
+        ];
+
+        yield 'permission role passes role constant with permission' => [
+            'availablePermissions' => [Permission::EDIT],
+            'permission' => Permission::EDIT,
+            'expectedRoleIdentifier' => RoleIdentifierHelper::getIdentifierWithPermission(self::ROLE_CONSTANT, Permission::EDIT),
+        ];
+    }
+
+    /**
+     * @param array<\Shopsys\FrameworkBundle\Component\Security\Role\Permission> $availablePermissions
+     * @return \Shopsys\FrameworkBundle\Component\Security\Role\Role
+     */
+    private function createRole(array $availablePermissions = []): Role
+    {
+        return new Role(self::ROLE_CONSTANT, 'Role name', $availablePermissions);
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR
When a single role is passed to `AccessChecker::hasPermission`, we must not append the permission value to the role constant. 

It should not happen very often, however, we had one bug caused by this. `CurrencyInlineEdit` defines its role constant as `SystemRole::SUPER_ADMIN` (ensuring only superadmins can work with the currencies in the inline grid), however, since the permission value was appended internally to the constant name, superadministrators were not able to create/edit/delete currencies at all.

Moreover, `SystemRole::ALL` and `SystemRole::ALL_VIEW` were removed from the role collection to avoid their misuse. Such roles serve only to mimic role groups covering all child roles and should not be used within security attributes like `CanCreate`, `CanEdit`, `ForRole`, etc.
<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved permission checking performance for single-role access scenarios.

* **Chores**
  * Removed "Full access" and "Full access (view-only)" system roles from default admin role configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-currency.odin.shopsys.cloud
  - https://cz.rv-currency.odin.shopsys.cloud
  - https://rv-currency.odin.shopsys.cloud/sk
<!-- Replace -->
