### PR TITLE
updated access token refresh when expired

### DIFF
--- a/project-base/storefront/urql/authExchange.ts
+++ b/project-base/storefront/urql/authExchange.ts
@@ -115,10 +115,22 @@ const refreshAuth = async (
     }
 };
 
+const willAuthError = (
+    domainConfig: DomainConfigType,
+    context?: GetServerSidePropsContext | NextPageContext,
+): boolean => {
+    const { accessToken, refreshToken } = getTokensFromCookies(domainConfig, context);
+
+    // If we have a refresh token but no access token, we should refresh
+    // This handles the case where access token expired but backend returns 200 with null instead of 401
+    return !!refreshToken && !accessToken;
+};
+
 export const getAuthExchangeOptions =
     (domainConfig: DomainConfigType, context?: GetServerSidePropsContext | NextPageContext) =>
     async (authUtilities: AuthUtilities): Promise<AuthConfig> => ({
         addAuthToOperation: (operation) => addAuthToOperation(operation, domainConfig, context),
         didAuthError,
+        willAuthError: () => willAuthError(domainConfig, context),
         refreshAuth: () => refreshAuth(authUtilities, domainConfig, context),
     });

--- a/upgrade-notes/storefront_20251104_120207.md
+++ b/upgrade-notes/storefront_20251104_120207.md
@@ -1,0 +1,4 @@
+#### Fixed automatic token refresh after token expiration ([#4258](https://github.com/shopsys/shopsys/pull/4258))
+
+- when the access token expires, it will automatically be refreshed using the refresh token stored in cookies
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Refresh access token when expired.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic access token refresh: expired access tokens are now automatically refreshed using stored refresh tokens, keeping users signed in without interruption.
  * Improved auth detection: the system can now determine when an auth refresh would occur, enabling smarter handling of authentication events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3672-access-token-expiration.odin.shopsys.cloud
  - https://cz.tc-ssp-3672-access-token-expiration.odin.shopsys.cloud
  - https://tc-ssp-3672-access-token-expiration.odin.shopsys.cloud/sk
<!-- Replace -->
