### PR TITLE
fixed group admin form fields in cards

### DIFF
--- a/docs/introduction/using-form-types.md
+++ b/docs/introduction/using-form-types.md
@@ -11,6 +11,40 @@ We use two types of naming for form types:
 
 Every form type has some default options that can be used for various things.
 
+### renders_in_own_card
+
+Controls how form fields are grouped into visual cards in the administration interface.
+
+#### Default value
+
+- `false` for most form types
+- `true` for `GroupType` and other specialized container types
+
+#### Behavior
+
+**When set to `false` (default)**:
+
+Fields are automatically grouped with adjacent fields into shared "auto cards".
+Consecutive fields without this option will be rendered together in a single card container.
+
+**When set to `true`**:
+
+The field breaks the auto-grouping sequence and is rendered separately.
+For types like `GroupType`, this means they render in their own styled card section.
+
+#### Visual impact
+
+In the administration interface, auto cards are rendered as Bootstrap card components (`<div class="card mb-3">`).
+This automatic grouping helps organize forms visually without requiring manual card creation.
+
+#### When to use
+
+You typically don't need to set this option explicitly, as the defaults work well:
+
+- Use `GroupType` when you want a labeled section in its own card
+- Regular fields will automatically group together visually
+- Only override this option if you need custom grouping behavior
+
 ## Form types
 
 We created some form types which can help you with creating your own form types.

--- a/packages/administration/templates/content/administrator/edit.html.twig
+++ b/packages/administration/templates/content/administrator/edit.html.twig
@@ -32,13 +32,13 @@
                             <div class="card timeline-event-card">
                                 <div class="card-body">
                                     <div class="text-secondary float-end">
-                                        {{ 'Last action' }}:
+                                        {{ 'Last action'|trans }}:
                                         {{ adminActivity.lastActionTime|formatDateTime }}
                                     </div>
-                                    <h4 class="mb-2">{{ 'Administrator logged in' }}</h4>
+                                    <h4 class="mb-2">{{ 'Administrator logged in'|trans }}</h4>
                                     <div class="text-secondary">
                                         {{ adminActivity.loginTime|formatDateTime }}
-                                        {{ 'from IP' }}
+                                        {{ 'from IP'|trans }}
                                         {{ adminActivity.ipAddress }}
                                     </div>
                                 </div>

--- a/packages/administration/templates/content/administrator/edit.html.twig
+++ b/packages/administration/templates/content/administrator/edit.html.twig
@@ -18,29 +18,35 @@
 
 {% block admin_log %}
     {% if lastAdminActivities|length > 0 %}
-        <h2>{{ 'Administrator activities history'|trans }}</h2>
-        <ul class="timeline">
-            {% for adminActivity in lastAdminActivities %}
-                <li class="timeline-event">
-                    <div class="timeline-event-icon">
-                        {{ ux_icon('lock') }}
-                    </div>
-                    <div class="card timeline-event-card">
-                        <div class="card-body">
-                            <div class="text-secondary float-end">
-                                {{ 'Last action' }}:
-                                {{ adminActivity.lastActionTime|formatDateTime }}
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">{{ 'Administrator activities history'|trans }}</h3>
+            </div>
+            <div class="card-body">
+                <ul class="timeline">
+                    {% for adminActivity in lastAdminActivities %}
+                        <li class="timeline-event">
+                            <div class="timeline-event-icon">
+                                {{ ux_icon('lock') }}
                             </div>
-                            <h4 class="mb-2">{{ 'Administrator logged in' }}</h4>
-                            <div class="text-secondary">
-                                {{ adminActivity.loginTime|formatDateTime }}
-                                {{ 'from IP' }}
-                                {{ adminActivity.ipAddress }}
+                            <div class="card timeline-event-card">
+                                <div class="card-body">
+                                    <div class="text-secondary float-end">
+                                        {{ 'Last action' }}:
+                                        {{ adminActivity.lastActionTime|formatDateTime }}
+                                    </div>
+                                    <h4 class="mb-2">{{ 'Administrator logged in' }}</h4>
+                                    <div class="text-secondary">
+                                        {{ adminActivity.loginTime|formatDateTime }}
+                                        {{ 'from IP' }}
+                                        {{ adminActivity.ipAddress }}
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                    </div>
-                </li>
-            {% endfor %}
-        </ul>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
     {% endif %}
 {% endblock %}

--- a/packages/administration/templates/content/categorySeo/newCombinations.html.twig
+++ b/packages/administration/templates/content/categorySeo/newCombinations.html.twig
@@ -6,47 +6,53 @@
 {% block h1 %}{{ '%categoryName% - Combinations'|trans({'%categoryName%': category.name(locale)}) }}{% endblock %}
 
 {% block main_content %}
-    <table class="table">
-        <tr>
-            {% for parameter in categorySeoFiltersData.parameters %}
-                <th>{{ parameter.name }}</th>
-            {% endfor %}
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table">
+                    <tr>
+                        {% for parameter in categorySeoFiltersData.parameters %}
+                            <th>{{ parameter.name }}</th>
+                        {% endfor %}
 
-            {% if categorySeoFiltersData.useFlags %}
-                <th>{{ 'Flag'|trans }}</th>
-            {% endif %}
+                        {% if categorySeoFiltersData.useFlags %}
+                            <th>{{ 'Flag'|trans }}</th>
+                        {% endif %}
 
-            {% if categorySeoFiltersData.useOrdering %}
-                <th>{{ 'Ordering'|trans }}</th>
-            {% endif %}
+                        {% if categorySeoFiltersData.useOrdering %}
+                            <th>{{ 'Ordering'|trans }}</th>
+                        {% endif %}
 
-            <th class="w-1 text-end">{{ 'Action'|trans }}</th>
-        </tr>
+                        <th class="w-1 text-end">{{ 'Action'|trans }}</th>
+                    </tr>
 
-        {% for key, categorySeoMix in categorySeoMixes %}
-            <tr>
-                {% for parameterValue in categorySeoMix.parameterValues %}
-                    <td>{{ parameterValue.text }}</td>
-                {% endfor %}
+                    {% for key, categorySeoMix in categorySeoMixes %}
+                        <tr>
+                            {% for parameterValue in categorySeoMix.parameterValues %}
+                                <td>{{ parameterValue.text }}</td>
+                            {% endfor %}
 
-                {% if categorySeoMix.flag %}
-                    <td>{{ categorySeoMix.flag.name }}</td>
-                {% endif %}
+                            {% if categorySeoMix.flag %}
+                                <td>{{ categorySeoMix.flag.name }}</td>
+                            {% endif %}
 
-                {% if categorySeoMix.ordering %}
-                    <td>{{ getOrderingNameByOrderingId(categorySeoMix.ordering) }}</td>
-                {% endif %}
+                            {% if categorySeoMix.ordering %}
+                                <td>{{ getOrderingNameByOrderingId(categorySeoMix.ordering) }}</td>
+                            {% endif %}
 
-                <td>
-                    {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\CategorySeoController::readyCombinationButtonAction', {
-                        categoryId: categoryId,
-                        categorySeoFilterFormTypeAllQueries: categorySeoFilterFormTypeAllQueries,
-                        selectedCategorySeoMixCombination: selectedCategorySeoMixCombinations[key],
-                    })) }}
-                </td>
-            </tr>
-        {% endfor %}
-    </table>
+                            <td>
+                                {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\CategorySeoController::readyCombinationButtonAction', {
+                                    categoryId: categoryId,
+                                    categorySeoFilterFormTypeAllQueries: categorySeoFilterFormTypeAllQueries,
+                                    selectedCategorySeoMixCombination: selectedCategorySeoMixCombinations[key],
+                                })) }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
+        </div>
+    </div>
 
     {% embed '@ShopsysAdministration/partial/_fixed_bar.html.twig' %}
         {% block fixed_bar_content %}

--- a/packages/administration/templates/content/categorySeo/readyCombination.html.twig
+++ b/packages/administration/templates/content/categorySeo/readyCombination.html.twig
@@ -8,7 +8,7 @@
 {% block h1 %}{{ 'Edit the combination with SEO values'|trans }}{% endblock %}
 
 {% block main_content %}
-    <div class="card mb-3">
+    <div class="card">
         <div class="card-body">
             <h3 class="card-title">{{ 'Filter summary' }}</h3>
             <div class="datagrid">
@@ -24,7 +24,7 @@
     </div>
 
     {% if parameterValueNamesIndexedByParameterNames|length %}
-        <div class="card mb-3">
+        <div class="card">
             <div class="card-body">
                 <h3 class="card-title">{{ 'Filtered parameters' }}</h3>
                 <div class="datagrid">

--- a/packages/administration/templates/content/default/cronDetail.html.twig
+++ b/packages/administration/templates/content/default/cronDetail.html.twig
@@ -6,7 +6,7 @@
 {% block h1 %}{{ cronName }}{% endblock %}
 
 {% block main_content %}
-    <div class="card mb-3">
+    <div class="card">
         <div class="card-body">
             <canvas
                     class="js-cron-line-chart"

--- a/packages/administration/templates/content/transportAndPayment/freeTransportAndPaymentLimitSetting.html.twig
+++ b/packages/administration/templates/content/transportAndPayment/freeTransportAndPaymentLimitSetting.html.twig
@@ -28,7 +28,6 @@
                             <tr id="{{ priceLimitForm.vars.id }}" class="js-free-transport-and-payment-price-limit" data-domain-id="{{ domainId }}">
                                 {% if isMultidomain() %}
                                     <td>
-                                        {{ form_errors(priceLimitForm.priceLimit) }}
                                         {{ domainName }}
                                     </td>
                                 {% endif %}
@@ -37,6 +36,7 @@
                                 </td>
                                 <td>
                                     {{ form_widget(priceLimitForm.priceLimit, { symbolAfterInput: currencySymbolByDomainId(domainId), attr: { class: 'js-free-transport-and-payment-price-limit-input' } }) }}
+                                    {{ form_errors(priceLimitForm.priceLimit) }}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/packages/administration/templates/content/transportAndPayment/freeTransportAndPaymentLimitSetting.html.twig
+++ b/packages/administration/templates/content/transportAndPayment/freeTransportAndPaymentLimitSetting.html.twig
@@ -6,40 +6,44 @@
 {% block h1 %}{{ 'Free shipping and payment'|trans }}{% endblock %}
 
 {% block main_content %}
-    {{ form_start(form) }}
-    {{ form_errors(form) }}
-    <div class="table-responsive">
-        <table class="table table-vcenter">
-            <thead>
-                {% if isMultidomain() %}
-                    <th>{{ 'Domain'|trans }}</th>
-                {% endif %}
-                <th>{{ 'Use'|trans }}</th>
-                <th>
-                    {{ 'Free from order value'|trans }} {{ priceVatLabel({ isSimple: true }) }}
-                    {{ info_icon('Value of bought products after application of all discounts and promo codes without price of shipping and payment'|trans) }}
-                </th>
-            </thead>
-            <tbody>
-                {% for domainId, priceLimitForm in form.priceLimits %}
-                    {% set domainName = domain.getDomainConfigById(domainId).getName() %}
-                    <tr id="{{ priceLimitForm.vars.id }}" class="js-free-transport-and-payment-price-limit" data-domain-id="{{ domainId }}">
+    <div class="card">
+        <div class="card-body p-0">
+            {{ form_start(form) }}
+            {{ form_errors(form) }}
+            <div class="table-responsive">
+                <table class="table table-vcenter">
+                    <thead>
                         {% if isMultidomain() %}
-                            <td>
-                                {{ form_errors(priceLimitForm.priceLimit) }}
-                                {{ domainName }}
-                            </td>
+                            <th>{{ 'Domain'|trans }}</th>
                         {% endif %}
-                        <td>
-                            {{ form_widget(priceLimitForm.enabled, { attr: { class: 'js-free-transport-and-payment-price-limit-enabled' } } ) }}
-                        </td>
-                        <td>
-                            {{ form_widget(priceLimitForm.priceLimit, { symbolAfterInput: currencySymbolByDomainId(domainId), attr: { class: 'js-free-transport-and-payment-price-limit-input' } }) }}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                        <th>{{ 'Use'|trans }}</th>
+                        <th>
+                            {{ 'Free from order value'|trans }} {{ priceVatLabel({ isSimple: true }) }}
+                            {{ info_icon('Value of bought products after application of all discounts and promo codes without price of shipping and payment'|trans) }}
+                        </th>
+                    </thead>
+                    <tbody>
+                        {% for domainId, priceLimitForm in form.priceLimits %}
+                            {% set domainName = domain.getDomainConfigById(domainId).getName() %}
+                            <tr id="{{ priceLimitForm.vars.id }}" class="js-free-transport-and-payment-price-limit" data-domain-id="{{ domainId }}">
+                                {% if isMultidomain() %}
+                                    <td>
+                                        {{ form_errors(priceLimitForm.priceLimit) }}
+                                        {{ domainName }}
+                                    </td>
+                                {% endif %}
+                                <td>
+                                    {{ form_widget(priceLimitForm.enabled, { attr: { class: 'js-free-transport-and-payment-price-limit-enabled' } } ) }}
+                                </td>
+                                <td>
+                                    {{ form_widget(priceLimitForm.priceLimit, { symbolAfterInput: currencySymbolByDomainId(domainId), attr: { class: 'js-free-transport-and-payment-price-limit-input' } }) }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {{ form_end(form) }}
+        </div>
     </div>
-    {{ form_end(form) }}
 {% endblock %}

--- a/packages/administration/templates/content/uploadedFile/edit.html.twig
+++ b/packages/administration/templates/content/uploadedFile/edit.html.twig
@@ -29,7 +29,7 @@
 
             <div class="row mb-3">
                 <div class="col-3">
-                    <label class="form-label">File</label>
+                    <label class="form-label">{{ 'File'|trans }}</label>
 
                     <div class="card card-sm" style="max-width: 17.5rem;">
                         <div class="position-relative ratio ratio-16x9 overflow-hidden">
@@ -42,7 +42,7 @@
                     </div>
                 </div>
                 <div class="col">
-                    <label class="form-label">Replace file</label>
+                    <label class="form-label">{{ 'Replace file'|trans }}</label>
                     {{ form_widget(form.files) }}
                     {{ form_errors(form.files) }}
                 </div>

--- a/packages/administration/templates/content/uploadedFile/edit.html.twig
+++ b/packages/administration/templates/content/uploadedFile/edit.html.twig
@@ -24,29 +24,33 @@
 {% block main_content_inner %}
     {{ form_row(form.products) }}
 
-    <div class="row mb-3">
-        <div class="col-3">
-            <label class="form-label">File</label>
+    <div class="card">
+        <div class="card-body">
 
-            <div class="card card-sm" style="max-width: 17.5rem;">
-                <div class="position-relative ratio ratio-16x9 overflow-hidden">
-                    {{ uploadedFilePreviewWithLink(entity) }}
+            <div class="row mb-3">
+                <div class="col-3">
+                    <label class="form-label">File</label>
+
+                    <div class="card card-sm" style="max-width: 17.5rem;">
+                        <div class="position-relative ratio ratio-16x9 overflow-hidden">
+                            {{ uploadedFilePreviewWithLink(entity) }}
+                        </div>
+
+                        <div class="card-footer">
+                            {{ entity.nameWithExtension }}
+                        </div>
+                    </div>
                 </div>
-
-                <div class="card-footer">
-                    {{ entity.nameWithExtension }}
+                <div class="col">
+                    <label class="form-label">Replace file</label>
+                    {{ form_widget(form.files) }}
+                    {{ form_errors(form.files) }}
                 </div>
             </div>
-        </div>
-        <div class="col">
-            <label class="form-label">Replace file</label>
-            {{ form_widget(form.files) }}
-            {{ form_errors(form.files) }}
+
+            <div>
+                {{ form_rest(form) }}
+            </div>
         </div>
     </div>
-
-    <div>
-        {{ form_rest(form) }}
-    </div>
-
 {% endblock %}

--- a/packages/administration/templates/form/content/PriceListProductsPickerType.html.twig
+++ b/packages/administration/templates/form/content/PriceListProductsPickerType.html.twig
@@ -3,7 +3,7 @@
         <div class="card-header">
             <h3 class="card-title">{{ 'Products'|trans }}</h3>
         </div>
-        <div class="card-body">
+        <div class="card-body p-0">
             {{- form_widget(form) -}}
         </div>
     </div>

--- a/packages/administration/templates/form/content/RoleSectionType.html.twig
+++ b/packages/administration/templates/form/content/RoleSectionType.html.twig
@@ -3,7 +3,7 @@
 
     {% set section = form.vars.section %}
 
-    <div class="card mb-3" data-scope="{{ section.identifier }}">
+    <div class="card" data-scope="{{ section.identifier }}">
         {% if form.vars.show_header %}
             <div class="card-header">
                 {% if section.icon %}

--- a/packages/administration/templates/form/content/RolesType.html.twig
+++ b/packages/administration/templates/form/content/RolesType.html.twig
@@ -10,8 +10,10 @@
             </div>
         {% endif %}
 
-        {% for child in form %}
-            {{ form_widget(child) }}
-        {% endfor %}
+        <div class="space-y">
+            {% for child in form %}
+                {{ form_widget(child) }}
+            {% endfor %}
+        </div>
     </div>
 {% endblock %}

--- a/packages/administration/templates/form/theme.html.twig
+++ b/packages/administration/templates/form/theme.html.twig
@@ -71,3 +71,35 @@
 
     {{ parent('number_widget') }}
 {% endblock number_widget %}
+
+{# Ensures that form fields without explicit group is wrapped in a card. See AutoCardGroupableExtension #}
+{%- block form_auto_group_widget -%}
+    <div {{ block('widget_container_attributes') }}>
+        {%- if form is rootform -%}
+            {{ form_errors(form) }}
+        {%- endif -%}
+
+        {% set auto_card_blocks = auto_card_blocks|default([]) %}
+
+        {% if form is rootform and auto_card_blocks|length > 0 %}
+            {% for block in auto_card_blocks %}
+                {% if block.type == 'auto_card' %}
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            {% for child_name in block.children %}
+                                {{ form_row(form[child_name]) }}
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% else %}
+                    {{ form_row(form[block.child]) }}
+                {% endif %}
+            {% endfor %}
+
+            {{ form_rest(form) }}
+        {% else %}
+            {{- block('form_rows') -}}
+            {{- form_rest(form) -}}
+        {% endif %}
+    </div>
+{%- endblock -%}

--- a/packages/administration/templates/form/theme.html.twig
+++ b/packages/administration/templates/form/theme.html.twig
@@ -72,8 +72,7 @@
     {{ parent('number_widget') }}
 {% endblock number_widget %}
 
-{# Ensures that form fields without explicit group is wrapped in a card. See AutoCardGroupableExtension #}
-{%- block form_auto_group_widget -%}
+{%- block form_widget_compound -%}
     <div {{ block('widget_container_attributes') }}>
         {%- if form is rootform -%}
             {{ form_errors(form) }}

--- a/packages/administration/templates/form/type/ProductsType.html.twig
+++ b/packages/administration/templates/form/type/ProductsType.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block products_label -%}
-    {{ label }}
+    {{ label|trans }}
 {% endblock -%}
 
 {% block products_widget %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -100,6 +100,9 @@ msgstr "Administrátor"
 msgid "Administrator activities history"
 msgstr "Historie aktivit administrátora"
 
+msgid "Administrator logged in"
+msgstr "Administrátor přihlášen"
+
 msgid "Administrator role group"
 msgstr "Skupiny práv pro administrátora"
 
@@ -1024,6 +1027,9 @@ msgstr "Posledních %limit% objednávek zákazníka"
 msgid "Last 7 days"
 msgstr "Posledních 7 dní"
 
+msgid "Last action"
+msgstr "Poslední akce"
+
 msgid "Last name"
 msgstr "Příjmení"
 
@@ -1593,6 +1599,9 @@ msgstr "Odebrat"
 
 msgid "Remove rule"
 msgstr "Odebrat pravidlo"
+
+msgid "Replace file"
+msgstr "Nahradit soubor"
 
 msgid "Request a one-time passcode by email"
 msgstr "Požádejte o jednorázový přístupový kód e-mailem"
@@ -2214,6 +2223,9 @@ msgstr "příznaků"
 
 msgid "from"
 msgstr "z"
+
+msgid "from IP"
+msgstr "z IP"
 
 msgid "g"
 msgstr "g"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -100,6 +100,9 @@ msgstr ""
 msgid "Administrator activities history"
 msgstr ""
 
+msgid "Administrator logged in"
+msgstr ""
+
 msgid "Administrator role group"
 msgstr ""
 
@@ -1024,6 +1027,9 @@ msgstr ""
 msgid "Last 7 days"
 msgstr ""
 
+msgid "Last action"
+msgstr ""
+
 msgid "Last name"
 msgstr ""
 
@@ -1592,6 +1598,9 @@ msgid "Remove"
 msgstr ""
 
 msgid "Remove rule"
+msgstr ""
+
+msgid "Replace file"
 msgstr ""
 
 msgid "Request a one-time passcode by email"
@@ -2213,6 +2222,9 @@ msgid "flags"
 msgstr ""
 
 msgid "from"
+msgstr ""
+
+msgid "from IP"
 msgstr ""
 
 msgid "g"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -100,6 +100,9 @@ msgstr "Administrátor"
 msgid "Administrator activities history"
 msgstr "História aktivit administrátora"
 
+msgid "Administrator logged in"
+msgstr "Administrátor prihlásený"
+
 msgid "Administrator role group"
 msgstr "Skupina rolí administrátora"
 
@@ -1024,6 +1027,9 @@ msgstr "Posledných %limit% objednávok zákazníka"
 msgid "Last 7 days"
 msgstr "Posledných 7 dní"
 
+msgid "Last action"
+msgstr "Posledná akcia"
+
 msgid "Last name"
 msgstr "Priezvisko"
 
@@ -1593,6 +1599,9 @@ msgstr "Odstrániť"
 
 msgid "Remove rule"
 msgstr "Odstrániť pravidlo"
+
+msgid "Replace file"
+msgstr "Nahradiť súbor"
 
 msgid "Request a one-time passcode by email"
 msgstr "Požiadať o jednorazový prístupový kód e-mailom"
@@ -2214,6 +2223,9 @@ msgstr "príznakov"
 
 msgid "from"
 msgstr "z"
+
+msgid "from IP"
+msgstr "z IP"
 
 msgid "g"
 msgstr "g"

--- a/packages/framework/src/Form/Admin/Autocomplete/AutocompleteFavoriteFormType.php
+++ b/packages/framework/src/Form/Admin/Autocomplete/AutocompleteFavoriteFormType.php
@@ -55,12 +55,10 @@ final class AutocompleteFavoriteFormType extends AbstractType
             $brandNames[$brand->getId()] = $brand->getName();
         }
 
-        $productsGroup = $builder->create('productsGroup', GroupType::class, [
-            'label' => 'Favorite Products',
-        ]);
-        $productsGroup->add(
+        $builder->add(
             $builder->create('products', ProductsType::class, [
                 'required' => false,
+                'label' => 'Favorite Products',
                 'sortable' => true,
                 'allow_variants' => false,
                 'attr' => [
@@ -100,7 +98,6 @@ final class AutocompleteFavoriteFormType extends AbstractType
         );
 
         $builder
-            ->add($productsGroup)
             ->add($categoriesGroup)
             ->add($brandsGroup)
             ->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -182,6 +182,7 @@ final class BillingAddressFormType extends AbstractType
                 'data_class' => BillingAddressData::class,
                 'disableCompanyCustomerCheckbox' => false,
                 'attr' => ['novalidate' => 'novalidate'],
+                'renders_in_own_card' => true,
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -284,6 +284,7 @@ final class CustomerUserFormType extends AbstractType
             ->setDefaults([
                 'data_class' => CustomerUserData::class,
                 'attr' => ['novalidate' => 'novalidate'],
+                'renders_in_own_card' => true,
                 'constraints' => [
                     new FieldsAreNotIdentical([
                         'field1' => 'email',

--- a/packages/framework/src/Form/Admin/GiftPlan/GiftPlanFormType.php
+++ b/packages/framework/src/Form/Admin/GiftPlan/GiftPlanFormType.php
@@ -91,16 +91,15 @@ final class GiftPlanFormType extends AbstractType
             ->add('validTo', DatePickerType::class, [
                 'required' => false,
                 'label' => 'Valid to',
-            ])
-            ->add('mainProducts', ProductsType::class, [
-                'required' => false,
-                'label' => 'Main products',
             ]);
         $builderSettingsGroup->get('validTo')->addModelTransformer($this->endOfDayTransformer);
 
-
         $builder
             ->add($builderSettingsGroup)
+            ->add('mainProducts', ProductsType::class, [
+                'required' => false,
+                'label' => 'Main products',
+            ])
             ->add('actionBar', ActionBarType::class, [
                 'back_route' => 'admin_giftplan_list',
                 'entity' => $options['giftPlan'],

--- a/packages/framework/src/Form/Admin/PriceList/PriceListProductsPickerType.php
+++ b/packages/framework/src/Form/Admin/PriceList/PriceListProductsPickerType.php
@@ -35,6 +35,7 @@ final class PriceListProductsPickerType extends AbstractType
             'allow_delete' => true,
             'delete_empty' => true,
             'error_bubbling' => false,
+            'renders_in_own_card' => true,
         ]);
     }
 

--- a/packages/framework/src/Form/AutoCardGroupableExtension.php
+++ b/packages/framework/src/Form/AutoCardGroupableExtension.php
@@ -36,8 +36,6 @@ final class AutoCardGroupableExtension extends AbstractTypeExtension
             return;
         }
 
-        $view->vars['block_prefixes'][] = 'form_auto_group';
-
         $this->addGroupingMetadataToView($view, $form);
     }
 

--- a/packages/framework/src/Form/AutoCardGroupableExtension.php
+++ b/packages/framework/src/Form/AutoCardGroupableExtension.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form;
+
+use Override;
+use Shopsys\FormTypesBundle\ActionBarType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class AutoCardGroupableExtension extends AbstractTypeExtension
+{
+    /**
+     * Invisible/utility types that don't break auto-card sequences
+     * These fields are skipped during grouping and rendered by form_rest()
+     *
+     * @var array<class-string>
+     */
+    private array $invisibleTypes = [
+        ActionBarType::class,
+        HiddenType::class,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function finishView(FormView $view, FormInterface $form, array $options): void
+    {
+        if ($form->getParent() !== null) {
+            return;
+        }
+
+        $view->vars['block_prefixes'][] = 'form_auto_group';
+
+        $this->addGroupingMetadataToView($view, $form);
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormView $view
+     * @param \Symfony\Component\Form\FormInterface $form
+     */
+    private function addGroupingMetadataToView(FormView $view, FormInterface $form): void
+    {
+        $cardBlocks = [];
+        $currentUngroupedSequence = [];
+
+        foreach ($view->children as $name => $childView) {
+            if (!isset($form[$name])) {
+                continue;
+            }
+
+            $child = $form[$name];
+            $childFormType = $child->getConfig()->getType()->getInnerType();
+
+            if ($this->isInvisibleType($childFormType::class)) {
+                continue;
+            }
+
+            $isRenderedInOwnCard = $child->getConfig()->getOption('renders_in_own_card', false);
+
+            if ($isRenderedInOwnCard) {
+                if (count($currentUngroupedSequence) > 0) {
+                    $cardBlocks[] = [
+                        'type' => 'auto_card',
+                        'children' => $currentUngroupedSequence,
+                    ];
+                    $currentUngroupedSequence = [];
+                }
+
+                $cardBlocks[] = [
+                    'type' => 'card',
+                    'child' => $name,
+                ];
+            } else {
+                $currentUngroupedSequence[] = $name;
+            }
+        }
+
+        if (count($currentUngroupedSequence) > 0) {
+            $cardBlocks[] = [
+                'type' => 'auto_card',
+                'children' => $currentUngroupedSequence,
+            ];
+        }
+
+        $view->vars['auto_card_blocks'] = $cardBlocks;
+    }
+
+    /**
+     * @param class-string $typeClass
+     * @return bool
+     */
+    private function isInvisibleType(string $typeClass): bool
+    {
+        return in_array($typeClass, $this->invisibleTypes, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'renders_in_own_card' => false,
+        ]);
+
+        $resolver->setAllowedTypes('renders_in_own_card', 'bool');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getExtendedTypes(): iterable
+    {
+        yield FormType::class;
+    }
+}

--- a/packages/framework/src/Form/CustomerUserListType.php
+++ b/packages/framework/src/Form/CustomerUserListType.php
@@ -40,6 +40,7 @@ final class CustomerUserListType extends AbstractType
                 'allowEdit' => false,
                 'allowAdd' => false,
                 'deleteConfirmMessage' => null,
+                'renders_in_own_card' => true,
             ]);
     }
 

--- a/packages/framework/src/Form/DeliveryAddressListType.php
+++ b/packages/framework/src/Form/DeliveryAddressListType.php
@@ -36,6 +36,7 @@ final class DeliveryAddressListType extends AbstractType
                 'allowEdit' => false,
                 'allowAdd' => false,
                 'mapped' => false,
+                'renders_in_own_card' => true,
             ]);
     }
 

--- a/packages/framework/src/Form/GroupType.php
+++ b/packages/framework/src/Form/GroupType.php
@@ -20,6 +20,7 @@ final class GroupType extends AbstractType
             ->setAllowedTypes('label', 'string')
             ->setDefaults([
                 'inherit_data' => true,
+                'renders_in_own_card' => true,
             ]);
     }
 }

--- a/packages/framework/src/Form/OrderItemsType.php
+++ b/packages/framework/src/Form/OrderItemsType.php
@@ -108,6 +108,7 @@ final class OrderItemsType extends AbstractType
             ->addAllowedTypes('order', [Order::class])
             ->setDefaults([
                 'inherit_data' => true,
+                'renders_in_own_card' => true,
             ]);
     }
 }

--- a/packages/framework/src/Form/OrderListType.php
+++ b/packages/framework/src/Form/OrderListType.php
@@ -37,6 +37,7 @@ final class OrderListType extends AbstractType
             ->setDefaults([
                 'mapped' => false,
                 'limit' => 10,
+                'renders_in_own_card' => true,
             ]);
     }
 

--- a/packages/framework/src/Form/ProductsType.php
+++ b/packages/framework/src/Form/ProductsType.php
@@ -65,6 +65,7 @@ final class ProductsType extends AbstractType
             'allow_variants' => true,
             'label_button_add' => t('Add product'),
             'top_info_title' => '',
+            'renders_in_own_card' => true,
         ]);
     }
 

--- a/upgrade-notes/backend_20251111_133848.md
+++ b/upgrade-notes/backend_20251111_133848.md
@@ -1,0 +1,7 @@
+#### Improved automatic card grouping in admin forms ([#4261](https://github.com/shopsys/shopsys/pull/4261))
+
+- form fields without an explicit group are now automatically placed inside Bootstrap cards in the administration
+- a new form option `renders_in_own_card` has been added (default: `false`):
+    - when set to `true`, the form field renders in its own Bootstrap card and is excluded from automatic grouping
+- built-in container form types like GroupType, ProductsType, OrderItemsType, and OrderListType now use this option by default
+- if you have custom form types that render their own Bootstrap card, set `'renders_in_own_card' => true` in their configureOptions() method


### PR DESCRIPTION
#### Description, the reason for the PR

If form contain fields that are not inside a group, they are now still rendered inside a card.
Form types that renders card by their nature (ProductsType, ...) now use interface to mark this behavior (and disable auto-placing inside a card)
+ Fixed few visual incosistencies across the administration 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic card-based grouping system for form fields with improved layout organization.

* **Style**
  * Restructured admin interface templates with Bootstrap card layouts for better visual organization across multiple admin pages.
  * Refined spacing and margins on various admin interface cards for improved visual hierarchy.

* **Refactor**
  * Reorganized form field structure and grouping to support improved card-based rendering throughout the admin panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-admin-auto-card.odin.shopsys.cloud
  - https://cz.mg-admin-auto-card.odin.shopsys.cloud
  - https://mg-admin-auto-card.odin.shopsys.cloud/sk
<!-- Replace -->
