### PR TITLE
fixes of domain URL with path

### DIFF
--- a/project-base/app/config/shopsys-routing/routing_front_sk.yaml
+++ b/project-base/app/config/shopsys-routing/routing_front_sk.yaml
@@ -5,7 +5,7 @@ front_customer_order_detail_unregistered:
     path: /detail-objednavky/{urlHash}
 
 front_login:
-    path: /prihlaseni
+    path: /prihlasenie
 
 front_logout:
     # controller's action is unnecessary, because firewall processes whole request
@@ -25,7 +25,7 @@ front_customer_activation:
     path: /potvrdenie-registracie
 
 front_brand_list:
-    path: /prehled-znacek
+    path: /prehlad-znaciek
 
 front_personal_data:
     path: /prehlad-osobnych-udajov
@@ -40,4 +40,4 @@ front_stores:
     path: /obchodne-domy
 
 front_complaint_detail:
-    path: /zakaznik/detail-reklamace
+    path: /zakaznik/detail-reklamacie

--- a/project-base/storefront/components/Blocks/Product/Watchdog/watchdogFormMeta.tsx
+++ b/project-base/storefront/components/Blocks/Product/Watchdog/watchdogFormMeta.tsx
@@ -73,7 +73,6 @@ export const useWatchdogFormMeta = (formProviderMethods: UseFormReturn<WatchdogF
                             components={{
                                 lnk1: privacyPolicyArticleUrl ? (
                                     <Link
-                                        isExternal
                                         aria-label={t('Go to privacy policy article', { ns: 'accessibility' })}
                                         className="inline text-sm"
                                         href={privacyPolicyArticleUrl}

--- a/project-base/storefront/components/Blocks/UserConsent/UserConsentForm.tsx
+++ b/project-base/storefront/components/Blocks/UserConsent/UserConsentForm.tsx
@@ -1,4 +1,5 @@
 import { useUserConsentForm, useUserConsentFormMeta } from './userConsentFormMeta';
+import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Button } from 'components/Forms/Button/Button';
 import { ToggleSwitchControlled } from 'components/Forms/ToggleSwitch/ToggleSwitchControlled';
 import { useSettingsQuery } from 'graphql/requests/settings/queries/SettingsQuery.generated';
@@ -62,7 +63,7 @@ export const UserConsentForm: FC<UserConsentFormProps> = ({ onSetCallback }) => 
                     i18nKey="userConsentPolicyLink"
                     components={{
                         link: userConsentPolicyArticleUrl ? (
-                            <a
+                            <ExtendedNextLink
                                 aria-labelledby="user-consent-policy-link"
                                 href={userConsentPolicyArticleUrl}
                                 rel="noreferrer"

--- a/project-base/storefront/components/Layout/Footer/NewsletterForm/newsletterFormMeta.tsx
+++ b/project-base/storefront/components/Layout/Footer/NewsletterForm/newsletterFormMeta.tsx
@@ -68,7 +68,6 @@ export const useNewsletterFormMeta = (
                             components={{
                                 lnk1: privacyPolicyArticleUrl ? (
                                     <Link
-                                        isExternal
                                         aria-label={t('Go to privacy policy article', { ns: 'accessibility' })}
                                         className="inline text-sm"
                                         href={privacyPolicyArticleUrl}

--- a/project-base/storefront/components/Pages/Contact/contactFormMeta.tsx
+++ b/project-base/storefront/components/Pages/Contact/contactFormMeta.tsx
@@ -89,12 +89,7 @@ export const useContactFormMeta = (formProviderMethods: UseFormReturn<ContactFor
                             i18nKey="GdprAgreementCheckbox"
                             components={{
                                 lnk1: privacyPolicyUrl ? (
-                                    <Link
-                                        isExternal
-                                        className="inline text-sm"
-                                        href={privacyPolicyUrl}
-                                        target="_blank"
-                                    />
+                                    <Link className="inline text-sm" href={privacyPolicyUrl} target="_blank" />
                                 ) : (
                                     <span className={linkPlaceholderTwClass} />
                                 ),

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationSendOrderButton.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationSendOrderButton.tsx
@@ -64,7 +64,6 @@ export const ContactInformationSendOrderButton: FC = () => {
                         components={{
                             lnk1: termsAndConditionsArticleUrl ? (
                                 <Link
-                                    isExternal
                                     aria-label={t('Go to terms and conditions article', { ns: 'accessibility' })}
                                     className="font-secondary inline text-sm font-semibold"
                                     href={termsAndConditionsArticleUrl}
@@ -75,7 +74,6 @@ export const ContactInformationSendOrderButton: FC = () => {
                             ),
                             lnk2: privacyPolicyArticleUrl ? (
                                 <Link
-                                    isExternal
                                     aria-label={t('Go to privacy policy article', { ns: 'accessibility' })}
                                     className="font-secondary inline text-sm font-semibold"
                                     href={privacyPolicyArticleUrl}

--- a/project-base/storefront/components/Pages/OrderConfirmation/registrationAfterOrderFormMeta.tsx
+++ b/project-base/storefront/components/Pages/OrderConfirmation/registrationAfterOrderFormMeta.tsx
@@ -68,12 +68,7 @@ export const useRegistrationAfterOrderFormMeta = (
                             i18nKey="I agree with terms and conditions and privacy policy"
                             components={{
                                 lnk1: termsAndConditionUrl ? (
-                                    <Link
-                                        isExternal
-                                        className="inline text-sm"
-                                        href={termsAndConditionUrl}
-                                        target="_blank"
-                                    />
+                                    <Link className="inline text-sm" href={termsAndConditionUrl} target="_blank" />
                                 ) : (
                                     <span className={linkPlaceholderTwClass} />
                                 ),

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadSticky.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadSticky.tsx
@@ -1,3 +1,4 @@
+import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Image } from 'components/Basic/Image/Image';
 import { TypeProductInProductListFragment } from 'graphql/requests/productLists/fragments/ProductInProductListFragment.generated';
 import { useState } from 'react';
@@ -51,18 +52,22 @@ const ProductComparisonHeadStickyContent = ({ comparedProducts, tableMarginLeft 
                 className="flex max-w-[calc(182px+12px*2)] min-w-[calc(182px+12px*2)] shrink-0 basis-64 items-center border-r-1 px-1 py-3 sm:max-w-[calc(205px+20px*2)] sm:min-w-[calc(205px+20px*2)]"
                 style={index === 0 ? { marginLeft: -tableMarginLeft } : undefined}
             >
-                <a className="relative size-16" href={product.slug} tabIndex={0}>
+                <ExtendedNextLink className="relative size-16" href={product.slug} tabIndex={0}>
                     <Image
                         fill
                         alt={generateProductImageAlt(product.fullName, product.categories[0]?.name)}
                         className="object-contain"
                         src={product.mainImage?.url}
                     />
-                </a>
+                </ExtendedNextLink>
                 <div className="ml-2 flex flex-1 flex-col">
-                    <a className="text-xs no-underline hover:no-underline" href={product.slug} tabIndex={0}>
+                    <ExtendedNextLink
+                        className="text-xs no-underline hover:no-underline"
+                        href={product.slug}
+                        tabIndex={0}
+                    >
                         {product.fullName}
-                    </a>
+                    </ExtendedNextLink>
                 </div>
             </div>
         ))}

--- a/project-base/storefront/components/Pages/Registration/registrationFormMeta.tsx
+++ b/project-base/storefront/components/Pages/Registration/registrationFormMeta.tsx
@@ -207,7 +207,6 @@ export const useRegistrationFormMeta = (
                             components={{
                                 lnk1: privacyPolicyArticleUrl ? (
                                     <Link
-                                        isExternal
                                         aria-label={t('Go to privacy policy article', { ns: 'accessibility' })}
                                         className="inline text-sm"
                                         href={privacyPolicyArticleUrl}

--- a/project-base/storefront/urql/createClient.ts
+++ b/project-base/storefront/urql/createClient.ts
@@ -10,6 +10,8 @@ import { getServerConfigProperty } from 'utils/config/getNextConfig';
 import { DomainConfigType } from 'utils/domain/domainConfig';
 import { getExplicitPathDomainLocaleOrDefault, getInternalGraphqlEndpoint } from 'utils/domain/domainUtils';
 
+export const DOMAIN_ID_HEADER = 'X-Domain-Id' as const;
+
 export const createClient = ({
     t,
     ssrExchange,
@@ -39,6 +41,7 @@ export const createClient = ({
             fetchOptions: {
                 headers: {
                     OriginalHost: publicGraphqlEndpointObject.host,
+                    [DOMAIN_ID_HEADER]: domainConfig.domainId.toString(),
                     'X-Forwarded-Proto': publicGraphqlEndpointObject.protocol === 'https:' ? 'on' : 'off',
                 },
             },

--- a/project-base/storefront/urql/fetcher.ts
+++ b/project-base/storefront/urql/fetcher.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/nextjs';
 import md5 from 'crypto-js/md5';
 import { RedisClientType, RedisFunctions, RedisModules, RedisScripts } from 'redis';
+import { DOMAIN_ID_HEADER } from 'urql/createClient';
 import { isClient } from 'utils/isClient';
 
 const FRIENDLY_URL_REGEXP = `@friendlyUrl` as const;
@@ -95,9 +96,9 @@ export const fetcher =
             const body = removeDirectiveFromQuery(init.body, [CACHE_REGEXP, FRIENDLY_URL_REGEXP]);
             const headers = init.headers ? new Headers(init.headers) : new Headers();
             const host = headers.get('OriginalHost');
-            const locale = headers.get('Locale');
+            const domainId = headers.get(DOMAIN_ID_HEADER);
             const [, queryName] = init.body.match(QUERY_NAME_REGEXP) ?? [];
-            const key = `${getRedisPrefixPattern()}${queryName}:${host}:${locale && locale !== 'default' ? locale + ':' : ''}`;
+            const key = `${getRedisPrefixPattern()}${queryName}:${host}:${domainId ? domainId + ':' : ''}`;
             const hash = `${key}${md5(body).toString().substring(0, 7)}`;
             const fromCache = await redisClient.get(hash);
 

--- a/upgrade-notes/backend_20250915_140343.md
+++ b/upgrade-notes/backend_20250915_140343.md
@@ -21,3 +21,4 @@
     - the section name is now resolved using `SitemapFacade::getSectionNameForDomainConfig()` method
 - in your `composer.json`, update the dependency on `shopsys/deployment` package to `^4.1.0` version and check [the upgrade notes](https://github.com/shopsys/deployment/blob/v4.1.0/UPGRADE.md) for this package
 - see #project-base-diff to update your project
+- see also #project-base-diff of [#4265](https://github.com/shopsys/shopsys/pull/4265) with additional fix

--- a/upgrade-notes/storefront_20250923_141026.md
+++ b/upgrade-notes/storefront_20250923_141026.md
@@ -19,3 +19,4 @@ This feature allows configuring domains with locale paths (e.g., `/sk/`, `/cs/`)
     - see `utils/cookies/cookieNaming.ts` and `components/providers/PersistStoreProvider.tsx` for references
 - see [the docs](https://docs.shopsys.com/en/18.0/storefront/domain-configuration) for the comprehensive information
 - see #project-base-diff to update your project
+- see also #project-base-diff of [#4265](https://github.com/shopsys/shopsys/pull/4265) with additional fix


### PR DESCRIPTION
#### Description, the reason for the PR
Urql fetcher now relies on the domain id to properly resolve redis cache key.
Originally, it expected locale, and moreover, it was missing from the headers (see original implementation in https://github.com/shopsys/shopsys/pull/4113)

Also, links created from slugs fixed to work properly even on a domain with a locale in the path. Originally, on the 3rd domain in demo data (`http://127.0.0.1:8000/sk`), the slug `/privacy-policy` was rendered as a link to `http://127.0.0.1:8000/privacy-policy`  (1st domain). Now it properly renders as `http://127.0.0.1:8000/sk/privacy-policy`.

And finally, some BE route translations were fixed for the SK domain. For example, the bad translation of the SF login page caused a 404 error after navigating from the registration email.

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-path-domain-redis.odin.shopsys.cloud
  - https://cz.rv-fix-path-domain-redis.odin.shopsys.cloud
  - https://rv-fix-path-domain-redis.odin.shopsys.cloud/sk
<!-- Replace -->
