### PR TITLE
fixed improper frontend api role section class placement

### DIFF
--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -136,9 +136,6 @@ msgstr "Všechny domény"
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr "Pokud je zaškrtnuto, všechny ceny je třeba nastavovat ručně, jinak se jednotková cena bez DPH a celkové ceny pro tuto položku přepočítají automaticky."
 
-msgid "All roles"
-msgstr "Všechny role"
-
 msgid "Alternate language"
 msgstr "Alternativní jazyky"
 
@@ -987,9 +984,6 @@ msgstr "Na záložce konkrétní domény není možné upravovat pořadí a zano
 
 msgid "Incl. VAT"
 msgstr "Včetně DPH"
-
-msgid "Individual roles"
-msgstr "Jednotlivé role"
 
 msgid "Inquired product"
 msgstr "Poptávaný produkt"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -136,9 +136,6 @@ msgstr ""
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr ""
 
-msgid "All roles"
-msgstr ""
-
 msgid "Alternate language"
 msgstr ""
 
@@ -986,9 +983,6 @@ msgid "In a particular domain tab it is not possible to adjust the order and plu
 msgstr ""
 
 msgid "Incl. VAT"
-msgstr ""
-
-msgid "Individual roles"
 msgstr ""
 
 msgid "Inquired product"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -136,9 +136,6 @@ msgstr "Všetky domény"
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr "Všetky ceny musia byť spracované manuálne ak je zaškrtnuté, inak bude jednotková cena bez DPH a celkové ceny pre túto položku prepočítané automaticky."
 
-msgid "All roles"
-msgstr "Všetky role"
-
 msgid "Alternate language"
 msgstr "Alternatívny jazyk"
 
@@ -987,9 +984,6 @@ msgstr "V konkrétnej záložke domény nie je možné upraviť poradie a zarade
 
 msgid "Incl. VAT"
 msgstr "Vrát. DPH"
-
-msgid "Individual roles"
-msgstr "Individuálne role"
 
 msgid "Inquired product"
 msgstr "Dopytovaný produkt"

--- a/packages/frontend-api/src/Component/Security/FrontendApiRoleProvider.php
+++ b/packages/frontend-api/src/Component/Security/FrontendApiRoleProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Security;
 
 use Override;
-use Shopsys\AdministrationBundle\Component\Security\Role\CustomerRoleSectionsProvider;
 use Shopsys\FrameworkBundle\Component\Context\FrontendApiContext;
 use Shopsys\FrameworkBundle\Component\Security\Role\CoreRoleProviderInterface;
 use Shopsys\FrameworkBundle\Component\Security\Role\Role;
@@ -42,13 +41,13 @@ class FrontendApiRoleProvider implements CoreRoleProviderInterface
     public function configureRoles(RoleCollection $roleCollection): void
     {
         $roleAll = new Role(CustomerUserRole::ROLE_API_ALL, t('All roles'));
-        $roleAll->setRoleSection(CustomerRoleSectionsProvider::ALL);
+        $roleAll->setRoleSection(FrontendApiRoleSectionProvider::ALL);
         $roleAll->setOverwritable(false);
 
         $roleCollection->add($roleAll);
 
         foreach ($this->getCustomerUserRoles() as $role) {
-            $role->setRoleSection(CustomerRoleSectionsProvider::INDIVIDUAL);
+            $role->setRoleSection(FrontendApiRoleSectionProvider::INDIVIDUAL);
             $role->setOverwritable(false);
             $roleCollection->add($role);
         }

--- a/packages/frontend-api/src/Component/Security/FrontendApiRoleSectionProvider.php
+++ b/packages/frontend-api/src/Component/Security/FrontendApiRoleSectionProvider.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\AdministrationBundle\Component\Security\Role;
+namespace Shopsys\FrontendApiBundle\Component\Security;
 
 use Override;
 use Shopsys\FrameworkBundle\Component\Context\FrontendApiContext;
 use Shopsys\FrameworkBundle\Component\Security\Role\Section\AbstractRoleSectionProvider;
 use Shopsys\FrameworkBundle\Component\Security\Role\Section\RoleSection;
 
-class CustomerRoleSectionsProvider extends AbstractRoleSectionProvider
+class FrontendApiRoleSectionProvider extends AbstractRoleSectionProvider
 {
     public const string ALL = 'all';
     public const string INDIVIDUAL = 'individual';

--- a/packages/frontend-api/src/Resources/translations/messages.cs.po
+++ b/packages/frontend-api/src/Resources/translations/messages.cs.po
@@ -28,6 +28,9 @@ msgstr "Zákazník vidí ceny"
 msgid "Customer self manage"
 msgstr "Spravovat své údaje"
 
+msgid "Individual roles"
+msgstr "Jednotlivé role"
+
 msgid "Manage all customers under the user's company"
 msgstr "Spravovat všechny zákazníky pod firmou uživatele"
 

--- a/packages/frontend-api/src/Resources/translations/messages.en.po
+++ b/packages/frontend-api/src/Resources/translations/messages.en.po
@@ -28,6 +28,9 @@ msgstr ""
 msgid "Customer self manage"
 msgstr ""
 
+msgid "Individual roles"
+msgstr ""
+
 msgid "Manage all customers under the user's company"
 msgstr ""
 

--- a/packages/frontend-api/src/Resources/translations/messages.sk.po
+++ b/packages/frontend-api/src/Resources/translations/messages.sk.po
@@ -28,6 +28,9 @@ msgstr "Zákazník vidí ceny"
 msgid "Customer self manage"
 msgstr "Samospráva zákazníka"
 
+msgid "Individual roles"
+msgstr "Individuálne role"
+
 msgid "Manage all customers under the user's company"
 msgstr "Spravovať všetkých zákazníkov v rámci spoločnosti používateľa"
 


### PR DESCRIPTION
#### Description, the reason for the PR

In #4262 the class `CustomerRoleSectionsProvider` was created, but improperly placed into administration bundle. 
Now it's renamed according to te appropriate role provider and moved to the Frontend API bundle. 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fixup-4262.odin.shopsys.cloud
  - https://cz.mg-fixup-4262.odin.shopsys.cloud
  - https://mg-fixup-4262.odin.shopsys.cloud/sk
<!-- Replace -->
