### PR TITLE
Update BE Node version from 20 to 24

### DIFF
--- a/packages/php-image/Dockerfile
+++ b/packages/php-image/Dockerfile
@@ -1,6 +1,6 @@
 ARG LINUX_DISTRIBUTION=alpine
 ARG project_root='/'
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=24
 ARG PHP_VERSION=8.3
 
 # Node and Composer are already installed in the node_builder and composer_builder stages


### PR DESCRIPTION
#### Description, the reason for the PR

Current Node LTS is used on backend app.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-be-update-node.odin.shopsys.cloud
  - https://cz.mg-be-update-node.odin.shopsys.cloud
  - https://mg-be-update-node.odin.shopsys.cloud/sk
<!-- Replace -->
