### PR TITLE
refactored auto-group orphaned fields to cards

### DIFF
--- a/packages/administration/templates/form/theme.html.twig
+++ b/packages/administration/templates/form/theme.html.twig
@@ -78,22 +78,44 @@
             {{ form_errors(form) }}
         {%- endif -%}
 
-        {% set auto_card_blocks = auto_card_blocks|default([]) %}
+        {% if form is rootform and has_auto_cardable_fields|default(false) %}
+            {# Iterate through children and group consecutive auto-card fields #}
+            {% set current_auto_card_field_names = [] %}
+            {% for child_name, child in form.children %}
+                {# Skip invisible fields (hidden, action bars, etc.) - they'll be rendered by form_rest #}
+                {% if not child.vars.is_invisible_field|default(false) %}
+                    {% if child.vars.renders_in_own_card|default(false) %}
+                        {# Render any accumulated auto-card fields first #}
+                        {% if current_auto_card_field_names|length > 0 %}
+                            <div class="card mb-3">
+                                <div class="card-body">
+                                    {% for field_name in current_auto_card_field_names %}
+                                        {{ form_row(form[field_name]) }}
+                                    {% endfor %}
+                                </div>
+                            </div>
+                            {% set current_auto_card_field_names = [] %}
+                        {% endif %}
 
-        {% if form is rootform and auto_card_blocks|length > 0 %}
-            {% for block in auto_card_blocks %}
-                {% if block.type == 'auto_card' %}
-                    <div class="card mb-3">
-                        <div class="card-body">
-                            {% for child_name in block.children %}
-                                {{ form_row(form[child_name]) }}
-                            {% endfor %}
-                        </div>
-                    </div>
-                {% else %}
-                    {{ form_row(form[block.child]) }}
+                        {# Render field that has its own card #}
+                        {{ form_row(form[child_name]) }}
+                    {% else %}
+                        {# Collect consecutive auto-card field names #}
+                        {% set current_auto_card_field_names = current_auto_card_field_names|merge([child_name]) %}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
+
+            {# Render any remaining auto-card fields #}
+            {% if current_auto_card_field_names|length > 0 %}
+                <div class="card mb-3">
+                    <div class="card-body">
+                        {% for field_name in current_auto_card_field_names %}
+                            {{ form_row(form[field_name]) }}
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
 
             {{ form_rest(form) }}
         {% else %}

--- a/packages/framework/src/Form/AutoCardGroupableExtension.php
+++ b/packages/framework/src/Form/AutoCardGroupableExtension.php
@@ -36,20 +36,21 @@ final class AutoCardGroupableExtension extends AbstractTypeExtension
             return;
         }
 
-        $this->addGroupingMetadataToView($view, $form);
+        $this->markChildrenWithCardMetadata($view, $form);
     }
 
     /**
      * @param \Symfony\Component\Form\FormView $view
      * @param \Symfony\Component\Form\FormInterface $form
      */
-    private function addGroupingMetadataToView(FormView $view, FormInterface $form): void
+    private function markChildrenWithCardMetadata(FormView $view, FormInterface $form): void
     {
-        $cardBlocks = [];
-        $currentUngroupedSequence = [];
+        $hasAutoCardableFields = false;
 
         foreach ($view->children as $name => $childView) {
             if (!isset($form[$name])) {
+                $childView->vars['is_invisible_field'] = true;
+
                 continue;
             }
 
@@ -57,37 +58,20 @@ final class AutoCardGroupableExtension extends AbstractTypeExtension
             $childFormType = $child->getConfig()->getType()->getInnerType();
 
             if ($this->isInvisibleType($childFormType::class)) {
+                $childView->vars['is_invisible_field'] = true;
+
                 continue;
             }
 
             $isRenderedInOwnCard = $child->getConfig()->getOption('renders_in_own_card', false);
+            $childView->vars['renders_in_own_card'] = $isRenderedInOwnCard;
 
-            if ($isRenderedInOwnCard) {
-                if (count($currentUngroupedSequence) > 0) {
-                    $cardBlocks[] = [
-                        'type' => 'auto_card',
-                        'children' => $currentUngroupedSequence,
-                    ];
-                    $currentUngroupedSequence = [];
-                }
-
-                $cardBlocks[] = [
-                    'type' => 'card',
-                    'child' => $name,
-                ];
-            } else {
-                $currentUngroupedSequence[] = $name;
+            if (!$isRenderedInOwnCard) {
+                $hasAutoCardableFields = true;
             }
         }
 
-        if (count($currentUngroupedSequence) > 0) {
-            $cardBlocks[] = [
-                'type' => 'auto_card',
-                'children' => $currentUngroupedSequence,
-            ];
-        }
-
-        $view->vars['auto_card_blocks'] = $cardBlocks;
+        $view->vars['has_auto_cardable_fields'] = $hasAutoCardableFields;
     }
 
     /**

--- a/project-base/app/tests/App/Functional/Form/AutoCardGroupingRenderingTest.php
+++ b/project-base/app/tests/App/Functional/Form/AutoCardGroupingRenderingTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Form;
+
+use DOMDocument;
+use DOMNodeList;
+use DOMXPath;
+use Override;
+use Shopsys\FrameworkBundle\Form\GroupType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Tests\App\Test\FunctionalTestCase;
+use Twig\Environment;
+
+class AutoCardGroupingRenderingTest extends FunctionalTestCase
+{
+    private const string XPATH_CARD = '//div[contains(concat(" ", normalize-space(@class), " "), " card ")]';
+    private const string XPATH_CARD_BODY = '//div[contains(@class, "card-body")]';
+    private const string XPATH_CARD_BODY_ROWS = self::XPATH_CARD_BODY . '//div[contains(@class, "row")]';
+    private const string XPATH_HIDDEN_FIELDS_NO_TOKEN = '//input[@type="hidden"][@id and not(contains(@id, "_token"))]';
+
+    /**
+     * @inject
+     */
+    private Environment $twig;
+
+    /**
+     * @inject
+     */
+    private FormFactoryInterface $formFactory;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createRequest();
+    }
+
+    public function testConsecutiveFieldsAreGroupedIntoSingleCard(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('name', TextType::class)
+            ->add('email', TextType::class)
+            ->add('phone', TextType::class)
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(1, $cards, 'Expected exactly 1 auto-card wrapper for 3 consecutive fields');
+
+        $cardBody = $xpath->query(self::XPATH_CARD . self::XPATH_CARD_BODY);
+        $this->assertCount(1, $cardBody, 'Expected card to have card-body');
+
+        $rowsInCard = $xpath->query(self::XPATH_CARD_BODY_ROWS);
+        $this->assertCount(3, $rowsInCard, 'Expected exactly 3 form rows in card body');
+    }
+
+    public function testRendersInOwnCardBreaksAutoGrouping(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('field1', TextType::class)
+            ->add('field2', TextType::class)
+            ->add('group', GroupType::class, ['label' => 'Group Label'])
+            ->add('field3', TextType::class)
+            ->add('field4', TextType::class)
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(3, $cards, 'Expected 3 cards: 2 auto-cards (field1+field2, field3+field4) and 1 GroupType card');
+
+        $firstCardRows = $xpath->query('(' . self::XPATH_CARD . ')[1]//div[contains(@class, "row")]');
+        $this->assertCount(2, $firstCardRows, 'Expected first card to contain exactly 2 fields');
+    }
+
+    public function testInvisibleFieldsDontBreakAutoGrouping(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('name', TextType::class)
+            ->add('hidden1', HiddenType::class)
+            ->add('email', TextType::class)
+            ->add('hidden2', HiddenType::class)
+            ->add('phone', TextType::class)
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(1, $cards, 'Hidden fields should not break auto-grouping');
+
+        $hiddenInputs = $this->queryHiddenFieldsExcludingToken($xpath);
+        $this->assertCount(2, $hiddenInputs, 'Expected exactly 2 hidden fields to be rendered');
+    }
+
+    public function testPositionOptionMaintainsCorrectOrderWithAutoGrouping(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('last', TextType::class, ['position' => 'last'])
+            ->add('first', TextType::class, ['position' => 'first'])
+            ->add('middle', TextType::class)
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(1, $cards, 'Expected single auto-card for all positioned fields');
+
+        $formRows = $xpath->query(self::XPATH_CARD_BODY_ROWS);
+        $this->assertCount(3, $formRows, 'Expected exactly 3 form rows');
+
+        $firstInFirstPosition = $xpath->query('(' . self::XPATH_CARD_BODY_ROWS . ')[1]//label[contains(@for, "first")]');
+        $this->assertCount(1, $firstInFirstPosition, 'Field "first" should be in first position');
+
+        $middleInSecondPosition = $xpath->query('(' . self::XPATH_CARD_BODY_ROWS . ')[2]//label[contains(@for, "middle")]');
+        $this->assertCount(1, $middleInSecondPosition, 'Field "middle" should be in second position');
+
+        $lastInThirdPosition = $xpath->query('(' . self::XPATH_CARD_BODY_ROWS . ')[3]//label[contains(@for, "last")]');
+        $this->assertCount(1, $lastInThirdPosition, 'Field "last" should be in third position');
+    }
+
+    public function testFormWithOnlyOwnCardFieldsHasNoAutoCards(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('group1', GroupType::class, ['label' => 'Group 1'])
+            ->add('group2', GroupType::class, ['label' => 'Group 2'])
+            ->add('group3', GroupType::class, ['label' => 'Group 3'])
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $allCards = $this->queryCards($xpath);
+        $this->assertCount(3, $allCards, 'Expected exactly 3 GroupType cards');
+
+        $group1Card = $xpath->query('//div[contains(@class, "card")]//h3[contains(text(), "Group 1")]');
+        $this->assertCount(1, $group1Card, 'Group 1 should be rendered in a card');
+
+        $group2Card = $xpath->query('//div[contains(@class, "card")]//h3[contains(text(), "Group 2")]');
+        $this->assertCount(1, $group2Card, 'Group 2 should be rendered in a card');
+
+        $group3Card = $xpath->query('//div[contains(@class, "card")]//h3[contains(text(), "Group 3")]');
+        $this->assertCount(1, $group3Card, 'Group 3 should be rendered in a card');
+    }
+
+    public function testExplicitRendersInOwnCardFalseIsAutoGrouped(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('field1', TextType::class, ['renders_in_own_card' => false])
+            ->add('field2', TextType::class, ['renders_in_own_card' => false])
+            ->add('field3', TextType::class, ['renders_in_own_card' => false])
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(1, $cards, 'Explicit renders_in_own_card: false should create auto-card');
+    }
+
+    public function testSingleFieldCreatesAutoCard(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('alone', TextType::class)
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(1, $cards, 'Single field should be wrapped in auto-card');
+    }
+
+    public function testAlternatingAutoCardAndOwnCardFields(): void
+    {
+        $form = $this->createFormBuilder()
+            ->add('field1', TextType::class)
+            ->add('group1', GroupType::class, ['label' => 'Group 1'])
+            ->add('field2', TextType::class)
+            ->add('group2', GroupType::class, ['label' => 'Group 2'])
+            ->add('field3', TextType::class)
+            ->getForm();
+
+        $html = $this->renderForm($form);
+        $xpath = $this->createXpath($html);
+
+        $cards = $this->queryCards($xpath);
+        $this->assertCount(5, $cards, 'Expected 5 cards: 3 auto-cards (field1, field2, field3) and 2 GroupType cards');
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormBuilderInterface<mixed>
+     */
+    private function createFormBuilder(): FormBuilderInterface
+    {
+        return $this->formFactory->createBuilder();
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormInterface $form
+     * @return string
+     */
+    private function renderForm(FormInterface $form): string
+    {
+        $view = $form->createView();
+
+        $template = $this->twig->createTemplate(
+            "{% form_theme form '@ShopsysAdministration/form/theme.html.twig' %}\n{{ form_widget(form) }}",
+        );
+
+        return $template->render(['form' => $view]);
+    }
+
+    /**
+     * @param string $html
+     * @return \DOMXPath
+     */
+    private function createXpath(string $html): DOMXPath
+    {
+        $dom = new DOMDocument();
+        $dom->loadHTML($html, LIBXML_NOERROR | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+        return new DOMXPath($dom);
+    }
+
+    /**
+     * @param \DOMXPath $xpath
+     * @return \DOMNodeList
+     */
+    private function queryCards(DOMXPath $xpath): DOMNodeList
+    {
+        return $xpath->query(self::XPATH_CARD);
+    }
+
+    /**
+     * @param \DOMXPath $xpath
+     * @return \DOMNodeList
+     */
+    private function queryHiddenFieldsExcludingToken(DOMXPath $xpath): DOMNodeList
+    {
+        return $xpath->query(self::XPATH_HIDDEN_FIELDS_NO_TOKEN);
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

Fixes the issue where it was not possible to reorder fields from the form type extension.
Added test.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-autocard.odin.shopsys.cloud
  - https://cz.mg-fix-autocard.odin.shopsys.cloud
  - https://mg-fix-autocard.odin.shopsys.cloud/sk
<!-- Replace -->
