### PR TITLE
complaint and payment form is not marked as modified after load

### DIFF
--- a/packages/framework/assets/js/admin/components/Complaint.js
+++ b/packages/framework/assets/js/admin/components/Complaint.js
@@ -6,7 +6,7 @@ export default class Complaint {
         this.$bankAccountNumberRow = $container.find('[data-js-complaint-bank-account-number]');
 
         this.$complaintResolutionInput.on('change', () => this.handleResolutionChange());
-        this.$complaintResolutionInput.trigger('change');
+        this.handleResolutionChange();
     }
 
     handleResolutionChange() {

--- a/packages/framework/assets/js/admin/components/Payment.js
+++ b/packages/framework/assets/js/admin/components/Payment.js
@@ -21,7 +21,7 @@ export default class Payment {
         };
 
         $paymentTypeSelect.on('change', onPaymentChange);
-        $paymentTypeSelect.change();
+        onPaymentChange();
     }
 
     static init($container) {

--- a/packages/framework/assets/js/admin/components/SelectToggle.js
+++ b/packages/framework/assets/js/admin/components/SelectToggle.js
@@ -30,7 +30,7 @@ export default class SelectToggle {
 
         const $firstEnabled = $select.find(`option[data-js-toggle-option=${domainId}]:not(:disabled)`).first();
 
-        if ($firstEnabled.length > 0 && $firstEnabled.val() !== '') {
+        if ($firstEnabled.val() !== $select.val() && $firstEnabled.length > 0 && $firstEnabled.val() !== '') {
             $select.val($firstEnabled.val()).trigger('change');
         }
 


### PR DESCRIPTION
#### Description, the reason for the PR

Previously, immediately after page load, the form with payment/complaint edit/create was marked as changed. 
This is fixed now.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-form-change-fix.odin.shopsys.cloud
  - https://cz.mg-form-change-fix.odin.shopsys.cloud
  - https://mg-form-change-fix.odin.shopsys.cloud/sk
<!-- Replace -->
