### PR TITLE
calculated selling denied no longer uses product_visibility for its calculation and includes stocks

### DIFF
--- a/packages/framework/src/Model/Product/ProductSellingDeniedRecalculator.php
+++ b/packages/framework/src/Model/Product/ProductSellingDeniedRecalculator.php
@@ -54,17 +54,22 @@ class ProductSellingDeniedRecalculator
                 WHEN (
                     p.selling_denied = TRUE
                     OR
-                    pv.visible = FALSE
-                    OR
                     pd.domain_hidden = TRUE
                     OR
                     pd.selling_denied = TRUE
+                    OR (
+                        p.is_allowed_negative_stock = FALSE AND NOT EXISTS (
+                            SELECT 1 FROM product_stocks as ps
+                            JOIN stock_domains as sd ON ps.stock_id = sd.stock_id AND sd.domain_id = :domainId AND sd.is_enabled = TRUE
+                            WHERE ps.product_id = p.id 
+                            AND ps.product_quantity > 0
+                        )
+                    )
                 )
                 THEN TRUE
                 ELSE FALSE
             END
             FROM products AS p
-            JOIN product_visibilities AS pv ON pv.product_id = p.id AND pv.domain_id = :domainId
             WHERE p.id = pd.product_id
                 AND pd.domain_id = :domainId
             ' . (count($productIds) > 0 ? ' AND p.id IN (:productIds)' : '');

--- a/project-base/app/tests/App/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\App\Functional\Model\Product;
 
+use App\DataFixtures\Demo\ProductDataFixture;
 use App\Model\Product\ProductDataFactory;
 use App\Model\Product\ProductFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -145,6 +146,68 @@ class ProductSellingDeniedRecalculatorTest extends TransactionFunctionalTestCase
 
         foreach ($this->domain->getAll() as $domainConfig) {
             $this->assertTrue($variant1->isCalculatedSellingDenied($domainConfig->getId()));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{isAllowedNegativeStock: bool, setZeroStock: bool, expectedSellingDenied: bool}>
+     */
+    public static function calculatedSellingDeniedDataProvider(): iterable
+    {
+        yield 'not allowed negative stock with zero stock' => [
+            'isAllowedNegativeStock' => false,
+            'setZeroStock' => true,
+            'expectedSellingDenied' => true,
+        ];
+
+        yield 'allowed negative stock with zero stock' => [
+            'isAllowedNegativeStock' => true,
+            'setZeroStock' => true,
+            'expectedSellingDenied' => false,
+        ];
+
+        yield 'not allowed negative stock with positive stock' => [
+            'isAllowedNegativeStock' => false,
+            'setZeroStock' => false,
+            'expectedSellingDenied' => false,
+        ];
+    }
+
+    /**
+     * @dataProvider calculatedSellingDeniedDataProvider
+     * @param bool $isAllowedNegativeStock
+     * @param bool $setZeroStock
+     * @param bool $expectedSellingDenied
+     */
+    public function testCalculatedSellingDeniedDependOnNegativeStockSettings(
+        bool $isAllowedNegativeStock,
+        bool $setZeroStock,
+        bool $expectedSellingDenied,
+    ): void {
+        /** @var \App\Model\Product\Product $product */
+        $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . 1);
+
+        /** @var \App\Model\Product\ProductData $productData */
+        $productData = $this->productDataFactory->createFromProduct($product);
+        $productData->isAllowedNegativeStock = $isAllowedNegativeStock;
+
+        foreach ($productData->productStockData as $productStockData) {
+            $productStockData->productQuantity = $setZeroStock === true ? 0 : 1;
+        }
+
+        $this->productFacade->edit($product->getId(), $productData);
+
+        $this->handleDispatchedRecalculationMessages();
+
+        $this->em->clear();
+
+        $editedProduct = $this->productFacade->getById(1);
+
+        foreach ($this->domain->getAll() as $domainConfig) {
+            $this->assertSame(
+                $expectedSellingDenied,
+                $editedProduct->isCalculatedSellingDenied($domainConfig->getId()),
+            );
         }
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
- product_visibility is dependent on pricing groups and would need special table and recalculations that would increase complexity of recalculations mainly for B2B
- product_visibility is not necessary here as it is included in all query builders used for requesting sellability
- stocks are now included to correctly calculate sellability based on its current available stock

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-calculated-selling-denied.odin.shopsys.cloud
  - https://cz.tl-fix-calculated-selling-denied.odin.shopsys.cloud
  - https://tl-fix-calculated-selling-denied.odin.shopsys.cloud/sk
<!-- Replace -->
