### PR TITLE
updated robots.txt to support locale-only domain configs

### DIFF
--- a/project-base/storefront/pages/robots.txt.tsx
+++ b/project-base/storefront/pages/robots.txt.tsx
@@ -6,7 +6,7 @@ import {
 import { createClient } from 'urql/createClient';
 import { getPublicConfigProperty } from 'utils/config/getNextConfig';
 import { DomainConfigType, getDomainConfig } from 'utils/domain/domainConfig';
-import { getHostFromDomain, getLocalePrefix } from 'utils/domain/domainUtils';
+import { DEFAULT_LOCALE, getHostFromDomain, getLocalePrefix } from 'utils/domain/domainUtils';
 import {
     FILTER_QUERY_PARAMETER_NAME,
     LOAD_MORE_QUERY_PARAMETER_NAME,
@@ -25,8 +25,8 @@ const domains = getPublicConfigProperty('domains', []) as DomainConfigType[];
 export const getServerSideProps = getServerSidePropsWrapper(({ redisClient, t, ssrExchange }) => async (context) => {
     const domainConfig = getDomainConfig(context);
 
-    // Return 404 if robots.txt is accessed from a domain with locale suffix
-    if (getLocalePrefix(domainConfig) !== '') {
+    // Allow only root /robots.txt, return 404 for locale-prefixed URLs
+    if (context.locale !== DEFAULT_LOCALE) {
         return {
             notFound: true,
         };

--- a/project-base/storefront/utils/domain/domainConfig.ts
+++ b/project-base/storefront/utils/domain/domainConfig.ts
@@ -71,6 +71,19 @@ export function getDomainConfig(context: GetServerSidePropsContext | NextPageCon
         }
     }
 
+    // Fallback for default locale when only locale-suffixed domains exist
+    if (isDefaultLocale) {
+        const requestUrl = new URL(`http://${normalizedDomain}`);
+        const fallbackDomain = domainsConfig.find((domainConfig) => {
+            const configDomainHost = new URL(domainConfig.url || '').host;
+            return configDomainHost === requestUrl.host;
+        });
+
+        if (fallbackDomain) {
+            return fallbackDomain;
+        }
+    }
+
     if (cdnDomain.length > 0) {
         const cdnDomainHost = getBaseUrlWithLocale(new URL(cdnDomain).host, locale);
         if (hostWithLocale === cdnDomainHost) {

--- a/upgrade-notes/storefront_20251203_094353.md
+++ b/upgrade-notes/storefront_20251203_094353.md
@@ -1,0 +1,10 @@
+#### Fixed robots.txt for domains with locale-only configuration ([#4302](https://github.com/shopsys/shopsys/pull/4302))
+
+- fixed `robots.txt` returning an error when all domains on a host have locale suffixes (e.g., `example.com/cs`, `example.com/sk`) with no pure host domain configured
+- example on domains `example.com/cs` and `example.com/sk`:
+    - `example.com/robots.txt` - before: "Domain not configured" error, now: returns robots.txt
+    - `example.com/cs/robots.txt` - returns 404 (by design, robots.txt must be in root)
+- added fallback domain resolution in `getDomainConfig` for requests to root host when only locale-suffixed domains exist
+- the original 404 condition checked domain configuration (`getLocalePrefix(domainConfig)`), which always returned locale suffix for fallback domains - this worked only when a pure host domain existed
+- changed the condition to check the actual request URL (`context.locale`) - now it correctly distinguishes between `example.com/robots.txt` (allowed) and `example.com/cs/robots.txt` (404)
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixes robots.txt returning an error when all domains on a host have locale suffixes (e.g., example.com/cs, example.com/sk) with no pure host domain. Added fallback domain resolution and changed the 404 condition to check the actual request URL instead of domain config.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3619-robots-txt.odin.shopsys.cloud
  - https://cz.tc-ssp-3619-robots-txt.odin.shopsys.cloud
  - https://tc-ssp-3619-robots-txt.odin.shopsys.cloud/sk
<!-- Replace -->
