### PR TITLE
disabled adding products to the cart when isAllowedNegativeStock is set to false

### DIFF
--- a/project-base/storefront/components/Blocks/Product/ProductAction.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductAction.tsx
@@ -68,6 +68,10 @@ export const ProductAction: FC<ProductActionProps> = ({
         );
     }
 
+    if (!product.isAllowedNegativeStock) {
+        return null;
+    }
+
     return (
         <AddToCart
             ariaPrice={product.price.priceWithVat}
@@ -79,7 +83,7 @@ export const ProductAction: FC<ProductActionProps> = ({
             gtmProductListName={gtmProductListName}
             isWithSpinbox={isWithSpinbox}
             listIndex={listIndex}
-            maxQuantity={product.isAllowedNegativeStock ? null : product.stockQuantity}
+            maxQuantity={product.stockQuantity}
             minQuantity={1}
             productUuid={product.uuid}
             showResponsiveCartIcon={showResponsiveCartIcon}

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationPersonalInformation.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationPersonalInformation.tsx
@@ -78,6 +78,7 @@ export const ContactInformationPersonalInformation: FC = () => {
                             aria-haspopup="dialog"
                             className="cursor-pointer text-sm underline hover:no-underline"
                             data-tid={TIDs.login_in_order_button}
+                            tabIndex={0}
                             type="button"
                             onClick={openLoginPopup}
                         >

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart/ProductDetailAddToCart.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart/ProductDetailAddToCart.tsx
@@ -51,7 +51,7 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
         );
     }
 
-    if (!canCreateOrder) {
+    if (!canCreateOrder || !product.isAllowedNegativeStock) {
         return null;
     }
 
@@ -64,7 +64,7 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
             <Spinbox
                 defaultValue={1}
                 id={product.uuid}
-                max={product.isAllowedNegativeStock ? null : product.stockQuantity}
+                max={product.stockQuantity}
                 min={1}
                 ref={spinboxRef}
                 size="xlarge"

--- a/upgrade-notes/storefront_20251203_120435.md
+++ b/upgrade-notes/storefront_20251203_120435.md
@@ -1,0 +1,4 @@
+#### Disabled negative stock ([#4305](https://github.com/shopsys/shopsys/pull/4305))
+
+- disabled adding products to the cart when isAllowedNegativeStock is set to false
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Disabled adding products to the cart when isAllowedNegativeStock is set to false.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3682-allow-negative-stock.odin.shopsys.cloud
  - https://cz.tc-ssp-3682-allow-negative-stock.odin.shopsys.cloud
  - https://tc-ssp-3682-allow-negative-stock.odin.shopsys.cloud/sk
<!-- Replace -->
