### PR TITLE
fix operationNameExchange to properly preserve existingFetchOptions

### DIFF
--- a/project-base/storefront/urql/operationNameExchange.ts
+++ b/project-base/storefront/urql/operationNameExchange.ts
@@ -19,24 +19,24 @@ export const operationNameExchange: Exchange =
                 const urlWithoutTrailingSlash = getStringWithoutTrailingSlash(operation.context.url);
                 const urlWithOperationName = urlWithoutTrailingSlash + `/${operationName}`;
 
-                const existingHeaders = (() => {
+                const existingFetchOptions = (() => {
                     if (!operation.context.fetchOptions) {
                         return {};
                     }
 
                     if (typeof operation.context.fetchOptions === 'function') {
-                        return operation.context.fetchOptions().headers ?? {};
+                        return operation.context.fetchOptions();
                     }
 
-                    return operation.context.fetchOptions.headers ?? {};
+                    return operation.context.fetchOptions;
                 })();
 
                 operation.context = {
                     ...operation.context,
                     fetchOptions: {
-                        ...operation.context.fetch,
+                        ...existingFetchOptions,
                         headers: {
-                            ...existingHeaders,
+                            ...(existingFetchOptions.headers ?? {}),
                             'X-operation-name': operationName,
                         },
                     },

--- a/upgrade-notes/storefront_20251209_082822.md
+++ b/upgrade-notes/storefront_20251209_082822.md
@@ -1,0 +1,3 @@
+#### fix operationNameExchange to properly preserve existingFetchOptions ([#4306](https://github.com/shopsys/shopsys/pull/4306))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
`operation.context.fetch` was spread into `fetchOptions` instead of the original `operation.context.fetchOptions`, so if any other fetch options were set besides the headers, they would be lost in `operationNameExchange`.

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-exchange.odin.shopsys.cloud
  - https://cz.rv-exchange.odin.shopsys.cloud
  - https://rv-exchange.odin.shopsys.cloud/sk
<!-- Replace -->
