### PR TITLE
Fix locale parameter in BlogArticleDetailFriendlyUrlDataProvider

### DIFF
--- a/packages/framework/src/Model/Blog/Article/BlogArticleDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleDetailFriendlyUrlDataProvider.php
@@ -38,7 +38,7 @@ class BlogArticleDetailFriendlyUrlDataProvider implements FriendlyUrlDataProvide
             ->distinct()
             ->from(BlogArticle::class, 'ba')
             ->join('ba.translations', 'bat', Join::WITH, 'bat.locale = :locale')
-            ->setParameter('locale', $domainConfig->getId())
+            ->setParameter('locale', $domainConfig->getLocale())
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'ba.id = f.entityId AND f.routeName = :routeName AND f.domainId = :domainId')
             ->setParameter('routeName', static::ROUTE_NAME)
             ->setParameter('domainId', $domainConfig->getId())


### PR DESCRIPTION
#### Description, the reason for the PR

There was a wrong parameter passed to a DB query

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-blog-article-friendly-url.odin.shopsys.cloud
  - https://cz.mg-fix-blog-article-friendly-url.odin.shopsys.cloud
  - https://mg-fix-blog-article-friendly-url.odin.shopsys.cloud/sk
<!-- Replace -->
