### PR TITLE
removed workaround for empty base_url

### DIFF
--- a/docs/installation/application-configuration.md
+++ b/docs/installation/application-configuration.md
@@ -72,7 +72,7 @@ You may want to set some settings in a different way (such as production, test, 
 `TRUSTED_PROXIES` (default: `'127.0.0.1'`)
 : proxies that are trusted to pass traffic, used mainly for production (set as text separated by comma for multiple values)
 
-`CDN_DOMAIN` (default: `'//'`)
+`CDN_DOMAIN` (default: `''`)
 : specifies URL of a Content Delivery Network (CDN) that is used to serve static assets such as images, CSS, and JavaScript files
 
 ### Storefront

--- a/project-base/app/.env
+++ b/project-base/app/.env
@@ -35,8 +35,7 @@ MESSENGER_TRANSPORT_VHOST='/'
 APP_SECRET=ThisTokenIsNotSoSecretChangeIt
 TRUSTED_PROXIES=127.0.0.1
 
-# When you do not want to use CDN, it is used value '//' as workaround by https://github.com/symfony/symfony/issues/28391
-CDN_DOMAIN=//
+CDN_DOMAIN=
 # CDN_DOMAIN=http://127.0.0.1:8001 # uncomment this line if you want to test CDN locally
 CDN_API_KEY=''
 CDN_API_SALT=''

--- a/project-base/app/web/imageResizer.php
+++ b/project-base/app/web/imageResizer.php
@@ -16,7 +16,7 @@ require $projectRootDirectory . '/vendor/symfony/dotenv/Dotenv.php';
 
 $CDN_API_KEY = $_ENV['CDN_API_KEY'] ?? null;
 $CDN_API_SALT = $_ENV['CDN_API_SALT'] ?? null;
-$CDN_DOMAIN = $_ENV['CDN_DOMAIN'] ?? '//';
+$CDN_DOMAIN = $_ENV['CDN_DOMAIN'] ?? '';
 $CDN_RESIZE_DISABLE = $_ENV['CDN_RESIZE_DISABLE'] ?? false;
 
 $imagePath = $_SERVER['DOCUMENT_URI'] ?? '';
@@ -41,7 +41,7 @@ if ($width === 0 && $height === 0) {
     exit();
 }
 
-if ($CDN_DOMAIN === '//' || $CDN_API_KEY === null || $CDN_API_SALT === null) {
+if ($CDN_DOMAIN === '' || $CDN_API_KEY === null || $CDN_API_SALT === null) {
     # see https://docs.imgproxy.net/usage/processing
     $imgProxyInternalUrl = $_ENV['IMG_PROXY_INTERNAL_URL'] ?? 'http://img-proxy:8080';
     $webserverInternalUrl = $_ENV['WEBSERVER_INTERNAL_URL'] ?? 'http://webserver:8080';

--- a/upgrade-notes/backend_20251204_085601.md
+++ b/upgrade-notes/backend_20251204_085601.md
@@ -1,0 +1,4 @@
+#### removed workaround for empty base_url ([#4308](https://github.com/shopsys/shopsys/pull/4308))
+
+- check your custom code for usage of `CDN_DOMAIN` environment variable and verify you don't rely on the `//` as a value
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

previously we used '//' as workaround by https://github.com/symfony/symfony/issues/28391

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-wrong-slash.odin.shopsys.cloud
  - https://cz.mg-fix-wrong-slash.odin.shopsys.cloud
  - https://mg-fix-wrong-slash.odin.shopsys.cloud/sk
<!-- Replace -->
