### PR TITLE
blog friendly URL generation now skips translations with null names

### DIFF
--- a/packages/framework/src/Model/Blog/Article/BlogArticleDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleDetailFriendlyUrlDataProvider.php
@@ -42,7 +42,8 @@ class BlogArticleDetailFriendlyUrlDataProvider implements FriendlyUrlDataProvide
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'ba.id = f.entityId AND f.routeName = :routeName AND f.domainId = :domainId')
             ->setParameter('routeName', static::ROUTE_NAME)
             ->setParameter('domainId', $domainConfig->getId())
-            ->andWhere('f.entityId IS NULL');
+            ->andWhere('f.entityId IS NULL')
+            ->andWhere('bat.name IS NOT NULL');
 
         $scalarData = $queryBuilder->getQuery()->getScalarResult();
 

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryDetailFriendlyUrlDataProvider.php
@@ -42,7 +42,8 @@ class BlogCategoryDetailFriendlyUrlDataProvider implements FriendlyUrlDataProvid
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'bc.id = f.entityId AND f.routeName = :routeName AND f.domainId = :domainId')
             ->setParameter('routeName', static::ROUTE_NAME)
             ->setParameter('domainId', $domainConfig->getId())
-            ->where('f.entityId IS NULL');
+            ->where('f.entityId IS NULL')
+            ->andWhere('bct.name IS NOT NULL');
 
         $scalarData = $queryBuilder->getQuery()->getScalarResult();
 


### PR DESCRIPTION
#### Description, the reason for the PR

This PR fixes a bug in the friendly URL generation for blog articles and blog categories.

**Problem:** The friendly URL data providers were attempting to generate URLs for blog entities that have translations with null names, which would cause errors or generate invalid URLs.

**Solution:** Added filtering conditions (bat.name IS NOT NULL and bct.name IS NOT NULL) to skip translations with null names during friendly URL generation. This ensures only valid translations with actual names are processed.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
