### PR TITLE
updated setting for delivery addresses in edit profile and contact informations

### DIFF
--- a/project-base/storefront/components/Blocks/AddressList/AddressList.tsx
+++ b/project-base/storefront/components/Blocks/AddressList/AddressList.tsx
@@ -22,7 +22,7 @@ export const AddressList: FC<AddressListProps> = ({
     const [, setDefaultDeliveryAddress] = useSetDefaultDeliveryAddressMutation();
 
     useEffect(() => {
-        if (defaultDeliveryAddress === undefined && deliveryAddresses.length > 0) {
+        if (defaultDeliveryAddress === undefined && deliveryAddresses.length === 1) {
             setDefaultDeliveryAddress({ deliveryAddressUuid: deliveryAddresses[0].uuid });
         }
     }, [defaultDeliveryAddress, deliveryAddresses, setDefaultDeliveryAddress]);

--- a/project-base/storefront/components/Blocks/Skeleton/SkeletonModuleCustomerUsers.tsx
+++ b/project-base/storefront/components/Blocks/Skeleton/SkeletonModuleCustomerUsers.tsx
@@ -14,7 +14,7 @@ export const SkeletonModuleCustomerUsers: FC = () => (
     <SkeletonModuleCustomer>
         <SkeletonModulePageHero />
 
-        <Skeleton className="h-9 w-36" />
+        <Skeleton className="h-9 w-36 self-center" />
 
         <SkeletonCustomerUsersTable />
     </SkeletonModuleCustomer>

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
@@ -38,10 +38,16 @@ export const ContactInformationDeliveryAddress: FC = () => {
     };
 
     useEffect(() => {
-        if (user?.defaultDeliveryAddress === undefined && user?.deliveryAddresses.length === 1) {
+        if (deliveryAddressUuid) {
+            return;
+        }
+
+        if (user?.defaultDeliveryAddress !== undefined) {
+            formProviderMethods.setValue(formMeta.fields.deliveryAddressUuid.name, user.defaultDeliveryAddress.uuid);
+        } else if (user?.deliveryAddresses && user.deliveryAddresses.length > 0) {
             formProviderMethods.setValue(formMeta.fields.deliveryAddressUuid.name, user.deliveryAddresses[0].uuid);
         }
-    }, [user?.defaultDeliveryAddress, user?.deliveryAddresses.length]);
+    }, [user?.defaultDeliveryAddress?.uuid, user?.deliveryAddresses.length, deliveryAddressUuid]);
 
     return (
         <FormBlockWrapper>

--- a/project-base/storefront/pages/customer/users.tsx
+++ b/project-base/storefront/pages/customer/users.tsx
@@ -71,7 +71,7 @@ const UsersPage: FC = () => {
                     )}
                 />
 
-                <div className="flex w-full flex-col gap-4">
+                <div className="flex w-full flex-col items-center gap-4">
                     <Button
                         aria-haspopup="dialog"
                         className="w-fit"

--- a/upgrade-notes/storefront_20251208_150346.md
+++ b/upgrade-notes/storefront_20251208_150346.md
@@ -1,0 +1,6 @@
+#### Delivery address pre-selection fix ([#4316](https://github.com/shopsys/shopsys/pull/4316))
+
+- fixed delivery address pre-selection in order contact information to correctly select user's default address (or first address as fallback)
+- user can now change selected delivery address without it resetting back to default
+- first created delivery address is now automatically set as default only when user has exactly one address
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed delivery address pre-selection in order contact information – now correctly selects user's default address (or first address as fallback), allows user to change selection, and automatically sets the first created address as default.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3668-delivery-address.odin.shopsys.cloud
  - https://cz.tc-ssp-3668-delivery-address.odin.shopsys.cloud
  - https://tc-ssp-3668-delivery-address.odin.shopsys.cloud/sk
<!-- Replace -->
