### PR TITLE
add referer URL validation for social login to prevent open redirect

### DIFF
--- a/packages/frontend-api/src/Controller/SocialNetworkController.php
+++ b/packages/frontend-api/src/Controller/SocialNetworkController.php
@@ -16,10 +16,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SocialNetworkController extends AbstractController
 {
-    protected const string REFERER_URL = 'refererUrl';
-    public const string CART_UUID = 'cartUuid';
-    public const string PRODUCT_LIST_UUIDS = 'productListUuids';
-    public const string SHOULD_OVERWRITE_CART = 'shouldOverwriteCart';
+    protected const string SESSION_REFERER_URL = 'socialLoginRefererUrl';
+    public const string SESSION_CART_UUID = 'socialLoginCartUuid';
+    public const string SESSION_PRODUCT_LIST_UUIDS = 'socialLoginProductListUuids';
+    public const string SESSION_SHOULD_OVERWRITE_CART = 'socialLoginShouldOverwriteCart';
 
     protected const string PARAMETER_CART_UUID = 'cartUuid';
 
@@ -78,18 +78,29 @@ class SocialNetworkController extends AbstractController
     {
         $session = $request->getSession();
 
-        if ($session->has(self::REFERER_URL) === false) {
-            $session->set(self::REFERER_URL, $request->server->get('HTTP_REFERER'));
+        if (
+            $session->has(self::SESSION_REFERER_URL) === false
+            && $request->server->has('HTTP_REFERER')
+        ) {
+            $refererUrl = $request->server->get('HTTP_REFERER');
+
+            $parsedUrl = parse_url($refererUrl);
+            $isValidRelativePath = str_starts_with($refererUrl, '/') && !isset($parsedUrl['host']);
+            $isCurrentDomainUrl = str_starts_with($refererUrl, $this->domain->getUrl());
+
+            if ($isValidRelativePath || $isCurrentDomainUrl) {
+                $session->set(self::SESSION_REFERER_URL, $refererUrl);
+            }
         }
 
         if ($request->query->has(self::PARAMETER_CART_UUID)) {
             $cartUuid = $request->query->get(self::PARAMETER_CART_UUID);
-            $session->set(self::CART_UUID, $cartUuid);
+            $session->set(self::SESSION_CART_UUID, $cartUuid);
         }
 
         if ($request->query->has(self::PARAMETER_PRODUCT_LIST_UUIDS)) {
             $productListsUuids = $request->query->get(self::PARAMETER_PRODUCT_LIST_UUIDS);
-            $session->set(self::PRODUCT_LIST_UUIDS, $productListsUuids);
+            $session->set(self::SESSION_PRODUCT_LIST_UUIDS, $productListsUuids);
         }
 
         if (!$request->query->has(self::PARAMETER_SHOULD_OVERWRITE_CUSTOMER_USER_CART)) {
@@ -97,7 +108,7 @@ class SocialNetworkController extends AbstractController
         }
 
         $shouldOverwriteCustomerUserCart = $request->query->getBoolean(self::PARAMETER_SHOULD_OVERWRITE_CUSTOMER_USER_CART);
-        $session->set(self::SHOULD_OVERWRITE_CART, $shouldOverwriteCustomerUserCart);
+        $session->set(self::SESSION_SHOULD_OVERWRITE_CART, $shouldOverwriteCustomerUserCart);
     }
 
     /**
@@ -137,13 +148,13 @@ class SocialNetworkController extends AbstractController
      */
     protected function getRedirectPathParameter(Request $request, DomainRouter $domainRouter): string
     {
-        $refererUrl = $request->getSession()->get(self::REFERER_URL);
+        $refererUrl = $request->getSession()->get(self::SESSION_REFERER_URL);
 
         if ($refererUrl === null) {
             return $domainRouter->generate('front_homepage');
         }
 
-        $request->getSession()->remove(self::REFERER_URL);
+        $request->getSession()->remove(self::SESSION_REFERER_URL);
         $redirectPath = str_replace($this->domain->getUrl(), '', $refererUrl);
 
         if ($redirectPath === '') {

--- a/packages/frontend-api/src/Model/SocialNetwork/SocialNetworkFacade.php
+++ b/packages/frontend-api/src/Model/SocialNetwork/SocialNetworkFacade.php
@@ -92,20 +92,20 @@ class SocialNetworkFacade
             }
             $adapter->disconnect();
 
-            $productListUuids = $session->get(SocialNetworkController::PRODUCT_LIST_UUIDS);
+            $productListUuids = $session->get(SocialNetworkController::SESSION_PRODUCT_LIST_UUIDS);
             $loginResultData = $this->loginAsUserFacade->runLoginSteps(
                 $customerUser,
                 $type,
                 $isRegistration,
                 $productListUuids !== null ? explode(',', $productListUuids) : [],
-                $session->get(SocialNetworkController::SHOULD_OVERWRITE_CART, false),
-                $session->get(SocialNetworkController::CART_UUID),
+                $session->get(SocialNetworkController::SESSION_SHOULD_OVERWRITE_CART, false),
+                $session->get(SocialNetworkController::SESSION_CART_UUID),
                 (string)$userProfile->identifier,
             );
 
-            $session->remove(SocialNetworkController::CART_UUID);
-            $session->remove(SocialNetworkController::SHOULD_OVERWRITE_CART);
-            $session->remove(SocialNetworkController::PRODUCT_LIST_UUIDS);
+            $session->remove(SocialNetworkController::SESSION_CART_UUID);
+            $session->remove(SocialNetworkController::SESSION_SHOULD_OVERWRITE_CART);
+            $session->remove(SocialNetworkController::SESSION_PRODUCT_LIST_UUIDS);
 
             return $loginResultData;
         } catch (InvalidArgumentException | UnexpectedValueException $exception) {

--- a/upgrade-notes/backend_20251217_130000.md
+++ b/upgrade-notes/backend_20251217_130000.md
@@ -1,0 +1,7 @@
+#### Add referer URL validation for social login to prevent open redirect ([#4320](https://github.com/shopsys/shopsys/pull/4320))
+
+- `\Shopsys\FrontendApiBundle\Controller\SocialNetworkController` constants renamed:
+    - `REFERER_URL` has been renamed to `SESSION_REFERER_URL`
+    - `CART_UUID` has been renamed to `SESSION_CART_UUID`
+    - `PRODUCT_LIST_UUIDS` has been renamed to `SESSION_PRODUCT_LIST_UUIDS`
+    - `SHOULD_OVERWRITE_CART` has been renamed to `SESSION_SHOULD_OVERWRITE_CART`


### PR DESCRIPTION
#### Description, the reason for the PR

  1. Security improvement: Added referer URL validation to prevent open redirect vulnerabilities
    - Now only accepts referer URLs that are relative paths (starting with /) or match the current domain
    - This prevents attackers from redirecting users to malicious external sites after social login
    
  2. Code clarity: Renamed session constants to be more descriptive
    - Added SESSION_ prefix and socialLogin namespace to all constants
    - Makes it clearer these are session keys specific to social login flow

**The implemented changes require thorough testing.**

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
