### PR TITLE
added onclick on tag for gtm events

### DIFF
--- a/project-base/storefront/components/Basic/Tag/Tag.tsx
+++ b/project-base/storefront/components/Basic/Tag/Tag.tsx
@@ -49,7 +49,7 @@ export const Tag: FC<TagProps> = ({
 
     if (href) {
         return (
-            <ExtendedNextLink className={TagTwClassName} href={href} type={type}>
+            <ExtendedNextLink className={TagTwClassName} href={href} type={type} onClick={onClick}>
                 {children}
             </ExtendedNextLink>
         );

--- a/upgrade-notes/storefront_20251210_123055.md
+++ b/upgrade-notes/storefront_20251210_123055.md
@@ -1,0 +1,4 @@
+#### Tag onClick ([#4322](https://github.com/shopsys/shopsys/pull/4322))
+
+- added missing `onClick` on `Tag` components for GTM events
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Added missing `onClick` on `Tag` components for GTM events.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3743-tag-onclick.odin.shopsys.cloud
  - https://cz.tc-ssp-3743-tag-onclick.odin.shopsys.cloud
  - https://tc-ssp-3743-tag-onclick.odin.shopsys.cloud/sk
<!-- Replace -->
