### PR TITLE
fixed rendering DatePoint object in grid as date

### DIFF
--- a/packages/administration/templates/datagrid/grid.html.twig
+++ b/packages/administration/templates/datagrid/grid.html.twig
@@ -378,6 +378,10 @@
     {{ value|formatDateTime }}
 {% endblock %}
 
+{% block grid_value_cell_type_Symfony_Component_Clock_DatePoint %}
+    {{ value|formatDateTime }}
+{% endblock %}
+
 {% block grid_value_cell_type_DateTimeImmutable %}
     {{ value|formatDateTime }}
 {% endblock %}


### PR DESCRIPTION
#### Description, the reason for the PR

When a value rendered in the Grid was of type DatePoint, it ended up with an error due to the inability to render DatePoint as a string. 

Now DatePoint object is rendered the same as DateTime (and DateTimeImmutable)

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-grid-datepoint-fix.odin.shopsys.cloud
  - https://cz.mg-grid-datepoint-fix.odin.shopsys.cloud
  - https://mg-grid-datepoint-fix.odin.shopsys.cloud/sk
<!-- Replace -->
