### PR TITLE
Replaced mutagen-compose with direct mutagen usage

### DIFF
--- a/.cursor/rules/backend.mdc
+++ b/.cursor/rules/backend.mdc
@@ -17,20 +17,20 @@ description: Essential backend patterns and commands for PHP/Symfony
 
 ```bash
 # Code quality
-mutagen-compose exec php-fpm php phing standards-fix
-mutagen-compose exec php-fpm php phing phpstan
+docker compose exec php-fpm php phing standards-fix
+docker compose exec php-fpm php phing phpstan
 
 # Database operations
-mutagen-compose exec php-fpm php bin/console doctrine:migrations:migrate
-mutagen-compose exec php-fpm php phing demo-data
+docker compose exec php-fpm php bin/console doctrine:migrations:migrate
+docker compose exec php-fpm php phing demo-data
 
 # GraphQL schema generation
-mutagen-compose exec php-fpm php phing frontend-api-generate-graphql-schema
-mutagen-compose exec php-fpm php bin/console graphql:validate
+docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
+docker compose exec php-fpm php bin/console graphql:validate
 
 # Translations and assets
-mutagen-compose exec php-fpm php phing translations-dump
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php phing translations-dump
+docker compose exec php-fpm php phing assets
 ```
 
 ## Core Architecture Patterns

--- a/.cursor/rules/environment.mdc
+++ b/.cursor/rules/environment.mdc
@@ -10,8 +10,13 @@ description: Complete development environment guide - commands, workflows, and t
 ### Essential Commands
 
 ```bash
-# Start services
-mutagen-compose up -d
+# Start services (macOS) - Use helper script
+./scripts/mutagen-up.sh
+
+# Or manually:
+docker compose --profile mutagen up -d  # Start sidecar containers first
+mutagen project start                    # Start file sync
+docker compose up -d                     # Start remaining containers
 
 # Full code check and fix
 make check-fix
@@ -24,47 +29,47 @@ make generate-schema
 
 ```bash
 # Install dependencies
-mutagen-compose exec storefront pnpm install
+docker compose exec storefront pnpm install
 
 # Development server
-mutagen-compose exec storefront pnpm dev
+docker compose exec storefront pnpm dev
 
 # Code quality (all-in-one)
-mutagen-compose exec storefront pnpm check--fix
+docker compose exec storefront pnpm check--fix
 
 # Testing
-mutagen-compose exec storefront pnpm test
+docker compose exec storefront pnpm test
 
 # Bundle analysis
-mutagen-compose exec storefront pnpm bundle-analyzer
+docker compose exec storefront pnpm bundle-analyzer
 
 # Generate translations
-mutagen-compose exec storefront pnpm translate
+docker compose exec storefront pnpm translate
 ```
 
 ### Backend Development
 
 ```bash
 # Install dependencies
-mutagen-compose exec php-fpm composer install
+docker compose exec php-fpm composer install
 
 # Fix code standards
-mutagen-compose exec php-fpm php phing standards-fix
+docker compose exec php-fpm php phing standards-fix
 
 # Run PHPStan
-mutagen-compose exec php-fpm php phing phpstan
+docker compose exec php-fpm php phing phpstan
 
 # Database migration
-mutagen-compose exec php-fpm php bin/console doctrine:migrations:migrate
+docker compose exec php-fpm php bin/console doctrine:migrations:migrate
 
 # Create demo data (wipes existing database)
-mutagen-compose exec php-fpm php phing demo-data
+docker compose exec php-fpm php phing demo-data
 
 # Build assets
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php phing assets
 
 # Generate backend translations
-mutagen-compose exec php-fpm php phing translations-dump
+docker compose exec php-fpm php phing translations-dump
 ```
 
 ## Key File Locations
@@ -77,7 +82,7 @@ mutagen-compose exec php-fpm php phing translations-dump
 
 ## Essential Principles
 
-1. **Always use `mutagen-compose`** instead of `docker-compose`
+1. **On macOS, use `./scripts/mutagen-up.sh`** or manually run `docker compose --profile mutagen up -d` then `mutagen project start`
 2. **Prefer Tailwind utility classes** over custom CSS
 3. **Use TypeScript strict mode** with explicit types
 4. **Run `make generate-schema`** after GraphQL changes
@@ -87,7 +92,7 @@ mutagen-compose exec php-fpm php phing translations-dump
 
 ## Docker Setup
 
-**ALWAYS use `mutagen-compose` instead of `docker-compose` in this project.**
+**On macOS, use helper scripts or `docker compose --profile mutagen` for sidecar containers + `mutagen project` commands for file synchronization.**
 
 ### Container Services
 
@@ -97,20 +102,38 @@ mutagen-compose exec php-fpm php phing translations-dump
 - **postgres**: PostgreSQL database
 - **redis**: Redis cache
 - **elasticsearch**: Search engine
+- **mutagen-source-code**: Sidecar for source-code volume sync (macOS)
+- **mutagen-storefront**: Sidecar for storefront volume sync (macOS)
 
 ### Essential Commands
 
 ```bash
-# Start development environment
-mutagen-compose up -d
+# Start development environment (macOS) - recommended
+./scripts/mutagen-up.sh
+
+# Stop development environment (macOS)
+./scripts/mutagen-down.sh
+
+# Manual start (macOS)
+docker compose --profile mutagen up -d  # Start sidecar containers
+mutagen project start                    # Start file sync
+mutagen sync list                        # Wait for "Watching for changes"
+docker compose up -d                     # Start remaining containers
+
+# Manual stop (macOS)
+mutagen project terminate
+docker compose --profile mutagen down
 
 # Restart specific services
-mutagen-compose up -d --force-recreate storefront webserver
+docker compose up -d --force-recreate storefront webserver
 
 # Container status and logs
-mutagen-compose ps
-mutagen-compose logs storefront
-mutagen-compose logs php-fpm
+docker compose ps
+docker compose logs storefront
+docker compose logs php-fpm
+
+# Check mutagen sync status
+mutagen sync list
 
 # Full quality check and fix
 make check-fix
@@ -124,89 +147,94 @@ make generate-schema
 ### Starting Development Session
 
 ```bash
-# 1. Start containers
-mutagen-compose up -d
+# 1. Start environment (macOS) - recommended
+./scripts/mutagen-up.sh
+
+# Or manually:
+# docker compose --profile mutagen up -d
+# mutagen project start
+# docker compose up -d
 
 # 2. Install/update dependencies if needed
-mutagen-compose exec storefront pnpm install
-mutagen-compose exec php-fpm composer install
+docker compose exec storefront pnpm install
+docker compose exec php-fpm composer install
 
 # 3. Generate latest schema (if GraphQL changes)
 make generate-schema
 
 # 4. Build assets if needed
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php phing assets
 ```
 
 ### After Pulling Changes
 
 ```bash
 # 1. Update dependencies
-mutagen-compose exec storefront pnpm install
+docker compose exec storefront pnpm install
 
 # 2. Run database migrations
-mutagen-compose exec php-fpm php bin/console doctrine:migrations:migrate
+docker compose exec php-fpm php bin/console doctrine:migrations:migrate
 
 # 3. Generate schema and translations
 make generate-schema
-mutagen-compose exec storefront pnpm translate
-mutagen-compose exec php-fpm php phing translations-dump
+docker compose exec storefront pnpm translate
+docker compose exec php-fpm php phing translations-dump
 
 # 4. Clear cache and rebuild assets
-mutagen-compose exec php-fpm php bin/console cache:clear
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php bin/console cache:clear
+docker compose exec php-fpm php phing assets
 ```
 
 ### Before Committing
 
 ```bash
 # Fix code standards and run tests
-mutagen-compose exec php-fpm php phing standards-fix
-mutagen-compose exec storefront pnpm check--fix
-mutagen-compose exec storefront pnpm test
+docker compose exec php-fpm php phing standards-fix
+docker compose exec storefront pnpm check--fix
+docker compose exec storefront pnpm test
 ```
 
 ## Database & Data Management
 
 ```bash
 # Create demo data (wipes existing data)
-mutagen-compose exec php-fpm php phing demo-data
+docker compose exec php-fpm php phing demo-data
 
 # Create test database with demo data
-mutagen-compose exec php-fpm php phing test-db-demo
+docker compose exec php-fpm php phing test-db-demo
 
 # Run migrations
-mutagen-compose exec php-fpm php bin/console doctrine:migrations:migrate
+docker compose exec php-fpm php bin/console doctrine:migrations:migrate
 
 # Generate new migration
-mutagen-compose exec php-fpm php phing db-migrations-generate
+docker compose exec php-fpm php phing db-migrations-generate
 
 # Reindex Elasticsearch
-mutagen-compose exec php-fpm php phing elasticsearch-reindex
+docker compose exec php-fpm php phing elasticsearch-reindex
 ```
 
 ## Asset & Build Management
 
 ```bash
 # Development assets with source maps
-mutagen-compose exec php-fpm php phing npm-dev
+docker compose exec php-fpm php phing npm-dev
 
 # Watch for changes and rebuild
-mutagen-compose exec php-fpm php phing npm-watch
+docker compose exec php-fpm php phing npm-watch
 
 # Production assets
-mutagen-compose exec php-fpm php phing npm
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php phing npm
+docker compose exec php-fpm php phing assets
 ```
 
 ## Translation Management
 
 ```bash
 # Generate backend translations
-mutagen-compose exec php-fpm php phing translations-dump
+docker compose exec php-fpm php phing translations-dump
 
 # Generate frontend translations
-mutagen-compose exec storefront pnpm translate
+docker compose exec storefront pnpm translate
 ```
 
 ## Troubleshooting Workflows
@@ -215,30 +243,39 @@ mutagen-compose exec storefront pnpm translate
 
 ```bash
 # 1. Restart problematic containers
-mutagen-compose up -d --force-recreate storefront webserver
+docker compose up -d --force-recreate storefront webserver
 
 # 2. Clear caches
-mutagen-compose exec php-fpm php bin/console cache:clear
+docker compose exec php-fpm php bin/console cache:clear
 
 # 3. Rebuild assets
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php phing assets
 
 # 4. Check container logs
-mutagen-compose logs storefront
-mutagen-compose logs php-fpm
+docker compose logs storefront
+docker compose logs php-fpm
 ```
 
 ### Complete Reset
 
 ```bash
-# 1. Stop all containers
-mutagen-compose down
+# 1. Stop everything (macOS) - recommended
+./scripts/mutagen-down.sh
 
-# 2. Start fresh
-mutagen-compose up -d
+# Or manually:
+# mutagen project terminate
+# docker compose --profile mutagen down
+
+# 2. Start fresh (macOS)
+./scripts/mutagen-up.sh
+
+# Or manually:
+# docker compose --profile mutagen up -d
+# mutagen project start
+# docker compose up -d
 
 # 3. Recreate demo environment
-mutagen-compose exec php-fpm php phing demo-data
+docker compose exec php-fpm php phing demo-data
 ```
 
 ## Upgrade & Maintenance
@@ -247,18 +284,18 @@ mutagen-compose exec php-fpm php phing demo-data
 
 ```bash
 # Run upgrade generation (used during platform upgrades)
-mutagen-compose exec php-fpm php phing upgrade-generate
+docker compose exec php-fpm php phing upgrade-generate
 
 # Update schema after upgrade
 make generate-schema
 
 # Update translations
-mutagen-compose exec storefront pnpm translate
-mutagen-compose exec php-fpm php phing translations-dump
+docker compose exec storefront pnpm translate
+docker compose exec php-fpm php phing translations-dump
 
 # Run migrations and rebuild
-mutagen-compose exec php-fpm php bin/console doctrine:migrations:migrate
-mutagen-compose exec php-fpm php phing assets
+docker compose exec php-fpm php bin/console doctrine:migrations:migrate
+docker compose exec php-fpm php phing assets
 ```
 
 ## Makefile Commands
@@ -275,32 +312,35 @@ Use the [Makefile](mdc:Makefile) for common tasks:
 ### Full Environment Refresh
 
 ```bash
-mutagen-compose exec php-fpm php phing demo-data && \
-mutagen-compose exec php-fpm php phing elasticsearch-reindex && \
+docker compose exec php-fpm php phing demo-data && \
+docker compose exec php-fpm php phing elasticsearch-reindex && \
 make generate-schema
 ```
 
 ### Complete Code Check
 
 ```bash
-mutagen-compose exec php-fpm php phing standards-fix && \
-mutagen-compose exec storefront pnpm check--fix && \
-mutagen-compose exec storefront pnpm test
+docker compose exec php-fpm php phing standards-fix && \
+docker compose exec storefront pnpm check--fix && \
+docker compose exec storefront pnpm test
 ```
 
 ## Container Status & Logs
 
 ```bash
 # Check container status
-mutagen-compose ps
+docker compose ps
 
 # View specific container logs
-mutagen-compose logs storefront
-mutagen-compose logs php-fpm
-mutagen-compose logs webserver
+docker compose logs storefront
+docker compose logs php-fpm
+docker compose logs webserver
 
 # Follow logs in real-time
-mutagen-compose logs -f storefront
+docker compose logs -f storefront
+
+# Check mutagen sync status (macOS)
+mutagen sync list
 ```
 
 ## Help Commands
@@ -310,8 +350,8 @@ mutagen-compose logs -f storefront
 make help
 
 # Phing targets (backend)
-mutagen-compose exec php-fpm php phing -l
+docker compose exec php-fpm php phing -l
 
 # Available npm scripts (frontend)
-mutagen-compose exec storefront pnpm run
+docker compose exec storefront pnpm run
 ```

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -19,22 +19,22 @@ description: Comprehensive frontend development guide for React/Next.js/TypeScri
 
 ```bash
 # Development server
-mutagen-compose exec storefront pnpm dev
+docker compose exec storefront pnpm dev
 
 # Code quality (all-in-one)
-mutagen-compose exec storefront pnpm check--fix
+docker compose exec storefront pnpm check--fix
 
 # Individual quality checks
-mutagen-compose exec storefront pnpm typecheck
-mutagen-compose exec storefront pnpm lint--fix
-mutagen-compose exec storefront pnpm format
+docker compose exec storefront pnpm typecheck
+docker compose exec storefront pnpm lint--fix
+docker compose exec storefront pnpm format
 
 # Testing & Analysis
-mutagen-compose exec storefront pnpm test
-mutagen-compose exec storefront pnpm bundle-analyzer
+docker compose exec storefront pnpm test
+docker compose exec storefront pnpm bundle-analyzer
 
 # Translations & GraphQL
-mutagen-compose exec storefront pnpm translate
+docker compose exec storefront pnpm translate
 make generate-schema
 ```
 

--- a/.cursor/rules/graphql.mdc
+++ b/.cursor/rules/graphql.mdc
@@ -28,10 +28,10 @@ This command:
 
 ```bash
 # Backend: Generate schema
-mutagen-compose exec php-fpm php phing frontend-api-generate-graphql-schema
+docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
 
 # Frontend: Generate types
-mutagen-compose exec storefront pnpm run gql
+docker compose exec storefront pnpm run gql
 ```
 
 ### Alternative Backend Schema Generation
@@ -39,8 +39,8 @@ mutagen-compose exec storefront pnpm run gql
 You can also generate the GraphQL schema directly using:
 
 ```bash
-mutagen-compose exec php-fpm php bin/console graphql:validate
-mutagen-compose exec php-fpm php phing frontend-api-generate-graphql-schema
+docker compose exec php-fpm php bin/console graphql:validate
+docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
 ```
 
 ## File Structure

--- a/.cursor/rules/styling.mdc
+++ b/.cursor/rules/styling.mdc
@@ -385,8 +385,8 @@ const SkipLink: FC = () => (
 # Automatic with Next.js production builds
 
 # Analyze CSS bundle size
-mutagen-compose exec storefront pnpm run build
-mutagen-compose exec storefront pnpm run bundle-analyzer
+docker compose exec storefront pnpm run build
+docker compose exec storefront pnpm run bundle-analyzer
 ```
 
 ### Efficient Class Usage

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -40,13 +40,13 @@ description: Testing frameworks and essential testing patterns
 
 ```bash
 # Run tests
-mutagen-compose exec storefront pnpm test
+docker compose exec storefront pnpm test
 
 # Update test snapshots
-mutagen-compose exec storefront pnpm test--update
+docker compose exec storefront pnpm test--update
 
 # Run tests in watch mode
-mutagen-compose exec storefront pnpm test--watch
+docker compose exec storefront pnpm test--watch
 ```
 
 ### Component Testing Pattern
@@ -108,14 +108,14 @@ vi.mock('graphql/requests/products.generated', () => ({
 
 ```bash
 # All backend tests
-mutagen-compose exec php-fpm php phing tests
+docker compose exec php-fpm php phing tests
 
 # Specific test types
-mutagen-compose exec php-fpm php phing tests-unit
-mutagen-compose exec php-fpm php phing tests-functional
+docker compose exec php-fpm php phing tests-unit
+docker compose exec php-fpm php phing tests-functional
 
 # Run specific test
-mutagen-compose exec php-fpm php vendor/bin/phpunit tests/App/Unit/Model/Product/ProductTest.php
+docker compose exec php-fpm php vendor/bin/phpunit tests/App/Unit/Model/Product/ProductTest.php
 ```
 
 ### Unit Test Pattern

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 
 /.claude/**/*.local.*
 /*.local.md
+mutagen.yml
+mutagen.yml.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Shopsys Platform is a **monorepo-based e-commerce platform** with a three-tier a
 
 **Platform-specific Docker Compose:**
 
-- **macOS**: Use `mutagen-compose` instead of `docker compose`
+- **macOS**: Use helper scripts `./scripts/mutagen-up.sh`, `./scripts/mutagen-stop.sh` and `./scripts/mutagen-down.sh`
 - **Linux/Windows**: Use `docker compose`
 
 **Commands that MUST run in Docker containers:**
@@ -52,22 +52,34 @@ Shopsys Platform is a **monorepo-based e-commerce platform** with a three-tier a
 **Correct Docker Command Patterns:**
 
 ```bash
-# Backend/PHP commands (use appropriate compose command)
+# Backend/PHP commands
 docker compose exec php-fpm php phing build-demo-dev-quick
 docker compose exec php-fpm php phing phpstan
 docker compose exec php-fpm composer install
-mutagen-compose exec php-fpm php vendor/bin/phpunit  # macOS
+docker compose exec php-fpm php vendor/bin/phpunit
 
-# Storefront commands (use appropriate compose command)
+# Storefront commands
 docker compose exec storefront pnpm run dev
 docker compose exec storefront pnpm run check--fix
-mutagen-compose exec storefront pnpm install  # macOS
+docker compose exec storefront pnpm install
 
 # System commands (run directly on host)
 git status
 git commit -m "message"
 make check-fix
 ls -la packages/
+
+# macOS only - Start/Stop with helper scripts (recommended)
+./scripts/mutagen-up.sh   # Start everything (sidecar + mutagen + containers)
+./scripts/mutagen-down.sh    # Stop everything
+
+# macOS only - Manual Mutagen workflow
+docker compose --profile mutagen up -d  # Start sidecar containers first
+mutagen project start                    # Start file sync
+mutagen sync list                        # Check sync status (wait for "Watching")
+docker compose up -d                     # Start remaining containers
+mutagen project terminate                # Stop file sync (before stopping containers)
+docker compose --profile mutagen down    # Stop all containers
 ```
 
 ```bash
@@ -79,8 +91,6 @@ ls -la packages/
 ```
 
 ### Backend Development (Phing)
-
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
 
 ```bash
 # Quick development builds
@@ -105,8 +115,6 @@ docker compose exec php-fpm php phing phpstan              # Static analysis
 
 ### Storefront Development
 
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
-
 ```bash
 # Development
 docker compose exec storefront pnpm run dev                   # Start dev server (port 3000)
@@ -122,8 +130,6 @@ docker compose exec storefront pnpm run gql                  # Generate GraphQL 
 ```
 
 ### Testing Commands
-
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
 
 ```bash
 # Backend testing (run in Docker)
@@ -205,7 +211,7 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 4. **GraphQL Changes**: After backend schema changes → `make generate-schema`
 5. **Full Validation**: `make check-fix` before committing
 
-**Remember**: Use `mutagen-compose` instead of `docker compose` on macOS
+**macOS Users**: Ensure `mutagen project start` is running for file synchronization
 
 ## Testing Strategy
 
@@ -226,7 +232,7 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 
 - Always use `make generate-schema` after GraphQL schema changes to sync backend and storefront
 - The platform supports multi-domain/multi-language setups by default
-- Use `docker compose exec php-fpm php phing build-demo-dev-quick` for fastest development setup with demo data (use `mutagen-compose` on macOS)
+- Use `docker compose exec php-fpm php phing build-demo-dev-quick` for fastest development setup with demo data
 - Run `make check-fix` before committing to ensure code quality standards
 - Storefront development requires pnpm, backend requires PHP/Composer - both run in Docker containers
 - Framework packages should only be modified via the monorepo, not directly in `/packages/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Think: "Can other Shopsys projects reuse this?" → Yes = `/packages/`, No = `/p
 
 **Platform-specific Docker Compose:**
 
-- **macOS**: Use `mutagen-compose` instead of `docker compose`
+- **macOS**: Use helper scripts `./scripts/mutagen-up.sh` and `./scripts/mutagen-down.sh`, or manually use `docker compose --profile mutagen` + `mutagen project start/terminate`
 - **Linux/Windows**: Use `docker compose`
 
 **Commands that MUST run in Docker containers:**
@@ -70,22 +70,34 @@ Think: "Can other Shopsys projects reuse this?" → Yes = `/packages/`, No = `/p
 **Correct Docker Command Patterns:**
 
 ```bash
-# Backend/PHP commands (use appropriate compose command)
+# Backend/PHP commands
 docker compose exec php-fpm php phing build-demo-dev-quick
 docker compose exec php-fpm php phing phpstan
 docker compose exec php-fpm composer install
-mutagen-compose exec php-fpm php vendor/bin/phpunit  # macOS
+docker compose exec php-fpm php vendor/bin/phpunit
 
-# Storefront commands (use appropriate compose command)
+# Storefront commands
 docker compose exec storefront pnpm run dev
 docker compose exec storefront pnpm run check--fix
-mutagen-compose exec storefront pnpm install  # macOS
+docker compose exec storefront pnpm install
 
 # System commands (run directly on host)
 git status
 git commit -m "message"
 make check-fix
 ls -la packages/
+
+# macOS only - Start/Stop with helper scripts (recommended)
+./scripts/mutagen-up.sh   # Start everything (sidecar + mutagen + containers)
+./scripts/mutagen-down.sh    # Stop everything
+
+# macOS only - Manual Mutagen workflow
+docker compose --profile mutagen up -d  # Start sidecar containers first
+mutagen project start                    # Start file sync
+mutagen sync list                        # Check sync status (wait for "Watching")
+docker compose up -d                     # Start remaining containers
+mutagen project terminate                # Stop file sync (before stopping containers)
+docker compose --profile mutagen down    # Stop all containers
 ```
 
 ```bash
@@ -97,8 +109,6 @@ ls -la packages/
 ```
 
 ### Backend Development (Phing)
-
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
 
 ```bash
 # Quick development builds
@@ -123,8 +133,6 @@ docker compose exec php-fpm php phing phpstan              # Static analysis
 
 ### Storefront Development
 
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
-
 ```bash
 # Development
 docker compose exec storefront pnpm run dev                   # Start dev server (port 3000)
@@ -140,8 +148,6 @@ docker compose exec storefront pnpm run gql                  # Generate GraphQL 
 ```
 
 ### Testing Commands
-
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
 
 ```bash
 # Backend testing (run in Docker)
@@ -223,7 +229,7 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 4. **GraphQL Changes**: After backend schema changes → `make generate-schema`
 5. **Full Validation**: `make check-fix` before committing
 
-**Remember**: Use `mutagen-compose` instead of `docker compose` on macOS
+**macOS Users**: Ensure `mutagen project start` is running for file synchronization
 
 ## Testing Strategy
 
@@ -244,7 +250,7 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 
 - Always use `make generate-schema` after GraphQL schema changes to sync backend and storefront
 - The platform supports multi-domain/multi-language setups by default
-- Use `docker compose exec php-fpm php phing build-demo-dev-quick` for fastest development setup with demo data (use `mutagen-compose` on macOS)
+- Use `docker compose exec php-fpm php phing build-demo-dev-quick` for fastest development setup with demo data
 - Run `make check-fix` before committing to ensure code quality standards
 - Storefront development requires pnpm, backend requires PHP/Composer - both run in Docker containers
 - Framework packages should only be modified via the monorepo, not directly in `/packages/`

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,32 @@ help: ## Displays list of available commands
 # Phony targets - declaration of targets that are not files
 # ------------------------------------------------------------------------------
 
-.PHONY: help generate-schema generate-schema-native check-fix php-checks php-lock-icons php-translations \
+.PHONY: help mutagen-up mutagen-up-build mutagen-up-build-no-cache mutagen-stop mutagen-down generate-schema generate-schema-native check-fix php-checks php-lock-icons php-translations \
 	storefront-checks storefront-translations check-schema run-acceptance-tests-base \
 	run-acceptance-tests-regression selected-acceptance-tests-base selected-acceptance-tests-regression \
 	run-specific-test-regression run-specific-test-base \
 	open-acceptance-tests-base open-acceptance-tests-regression run-smoke-tests \
 	generate-snapshots-info-table prepare-data-for-acceptance-tests cypress-prepare cypress-cleanup \
 	check-licenses
+
+# ------------------------------------------------------------------------------
+# 🐳 Docker Compose (macOS with Mutagen)
+# ------------------------------------------------------------------------------
+
+mutagen-up: ## Starts Docker environment with Mutagen sync (macOS)
+	./project-base/scripts/mutagen-up.sh
+
+mutagen-up-build: ## Starts Docker environment with Mutagen sync and rebuilds images (macOS)
+	./project-base/scripts/mutagen-up.sh --build
+
+mutagen-up-build-no-cache: ## Starts Docker environment with Mutagen sync and rebuilds images without cache (macOS)
+	./project-base/scripts/mutagen-up.sh --build --no-cache
+
+mutagen-stop: ## Stops Docker environment and Mutagen sync, keeps containers (macOS)
+	./project-base/scripts/mutagen-stop.sh
+
+mutagen-down: ## Removes Docker containers and stops Mutagen sync (macOS)
+	./project-base/scripts/mutagen-down.sh
 
 # ------------------------------------------------------------------------------
 # 🔧 Generating GraphQL schema and types

--- a/WARP.md
+++ b/WARP.md
@@ -52,7 +52,7 @@ Think: "Can other Shopsys projects reuse this?" → Yes = `/packages/`, No = `/p
 
 **Platform-specific Docker Compose:**
 
-- **macOS**: Use `mutagen-compose` instead of `docker compose`
+- **macOS**: Use helper scripts `./scripts/mutagen-up.sh` and `./scripts/mutagen-down.sh`, or manually use `docker compose --profile mutagen` + `mutagen project start/terminate`
 - **Linux/Windows**: Use `docker compose`
 
 **Commands that MUST run in Docker containers:**
@@ -70,22 +70,34 @@ Think: "Can other Shopsys projects reuse this?" → Yes = `/packages/`, No = `/p
 **Correct Docker Command Patterns:**
 
 ```bash
-# Backend/PHP commands (use appropriate compose command)
+# Backend/PHP commands
 docker compose exec php-fpm php phing build-demo-dev-quick
 docker compose exec php-fpm php phing phpstan
 docker compose exec php-fpm composer install
-mutagen-compose exec php-fpm php vendor/bin/phpunit  # macOS
+docker compose exec php-fpm php vendor/bin/phpunit
 
-# Storefront commands (use appropriate compose command)
+# Storefront commands
 docker compose exec storefront pnpm run dev
 docker compose exec storefront pnpm run check--fix
-mutagen-compose exec storefront pnpm install  # macOS
+docker compose exec storefront pnpm install
 
 # System commands (run directly on host)
 git status
 git commit -m "message"
 make check-fix
 ls -la packages/
+
+# macOS only - Start/Stop with helper scripts (recommended)
+./scripts/mutagen-up.sh   # Start everything (sidecar + mutagen + containers)
+./scripts/mutagen-down.sh    # Stop everything
+
+# macOS only - Manual Mutagen workflow
+docker compose --profile mutagen up -d  # Start sidecar containers first
+mutagen project start                    # Start file sync
+mutagen sync list                        # Check sync status (wait for "Watching")
+docker compose up -d                     # Start remaining containers
+mutagen project terminate                # Stop file sync (before stopping containers)
+docker compose --profile mutagen down    # Stop all containers
 ```
 
 ```bash
@@ -97,8 +109,6 @@ ls -la packages/
 ```
 
 ### Backend Development (Phing)
-
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
 
 ```bash
 # Quick development builds
@@ -123,8 +133,6 @@ docker compose exec php-fpm php phing phpstan              # Static analysis
 
 ### Storefront Development
 
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
-
 ```bash
 # Development
 docker compose exec storefront pnpm run dev                   # Start dev server (port 3000)
@@ -140,8 +148,6 @@ docker compose exec storefront pnpm run gql                  # Generate GraphQL 
 ```
 
 ### Testing Commands
-
-**Note**: Replace `docker compose` with `mutagen-compose` on macOS
 
 ```bash
 # Backend testing (run in Docker)
@@ -223,7 +229,7 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 4. **GraphQL Changes**: After backend schema changes → `make generate-schema`
 5. **Full Validation**: `make check-fix` before committing
 
-**Remember**: Use `mutagen-compose` instead of `docker compose` on macOS
+**macOS Users**: Ensure `mutagen project start` is running for file synchronization
 
 ## Testing Strategy
 
@@ -244,7 +250,7 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 
 - Always use `make generate-schema` after GraphQL schema changes to sync backend and storefront
 - The platform supports multi-domain/multi-language setups by default
-- Use `docker compose exec php-fpm php phing build-demo-dev-quick` for fastest development setup with demo data (use `mutagen-compose` on macOS)
+- Use `docker compose exec php-fpm php phing build-demo-dev-quick` for fastest development setup with demo data
 - Run `make check-fix` before committing to ensure code quality standards
 - Storefront development requires pnpm, backend requires PHP/Composer - both run in Docker containers
 - Framework packages should only be modified via the monorepo, not directly in `/packages/`

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -53,6 +53,7 @@ services:
             - dev # change to `- build` if you want to test application build
         volumes:
             - storefront:/home/node/app
+            - storefront-node-modules:/home/node/app/node_modules
         ports:
             - "3000:3000"
             - "9229:9229"
@@ -90,7 +91,7 @@ services:
             - ./project-base/storefront/pages:/app/pages
             - ./project-base/storefront/public/locales:/app/public/locales:delegated
             - ./project-base/app/translations:/app/app-translations:delegated
-            - node_modules:/app/node_modules
+            - storefront-node-modules:/app/node_modules
         profiles:
             - storefront-acceptance-tests
         network_mode: "host"
@@ -106,7 +107,9 @@ services:
                 project_root: project-base/app
         container_name: shopsys-framework-php-fpm
         volumes:
-            - source-code:/var/www/html
+            - php-fpm:/var/www/html
+            - php-fpm-vendor:/var/www/html/vendor
+            - php-fpm-node-modules:/var/www/html/node_modules
             - ./.git/:/var/www/html/.git:delegated
             - ~/.gitconfig:/home/www-data/.gitconfig
         environment:
@@ -130,7 +133,9 @@ services:
             - rabbitmq
         container_name: shopsys-framework-php-consumer
         volumes:
-            - source-code:/var/www/html
+            - php-fpm:/var/www/html
+            - php-fpm-vendor:/var/www/html/vendor
+            - php-fpm-node-modules:/var/www/html/node_modules
         entrypoint:
             - /bin/sh
             - project-base/app/docker/php-fpm/consumer-entrypoint.sh
@@ -215,7 +220,7 @@ services:
         ports:
             - "1300:8000"
         volumes:
-            - source-code:/var/www/html
+            - php-fpm:/var/www/html
 
     img-proxy:
         image: ghcr.io/imgproxy/imgproxy:latest
@@ -226,45 +231,29 @@ services:
         ports:
             - "8060:8080"
 
+    mutagen-php-fpm:
+        image: mutagenio/sidecar:0.18.1
+        container_name: shopsys-framework-mutagen-php-fpm
+        volumes:
+            - php-fpm:/volumes/php-fpm
+        profiles:
+            - mutagen
+
+    mutagen-storefront:
+        image: mutagenio/sidecar:0.18.1
+        container_name: shopsys-framework-mutagen-storefront
+        volumes:
+            - storefront:/volumes/storefront
+        profiles:
+            - mutagen
+
 volumes:
-    source-code:
+    php-fpm:
+    php-fpm-vendor:
+    php-fpm-node-modules:
     storefront:
+    storefront-node-modules:
     elasticsearch-data:
         driver: local
     postgres-data:
         driver: local
-    node_modules:
-
-x-mutagen:
-    sync:
-        defaults:
-            ignore:
-                vcs: true
-            permissions:
-                defaultOwner: "id:501"
-        source-code:
-            alpha: "."
-            beta: "volume://source-code"
-            mode: "two-way-resolved"
-            configurationBeta:
-                permissions:
-                    defaultOwner: "id:501"
-                    defaultDirectoryMode: 0777
-            ignore:
-                paths:
-                    - ./.DS_Store
-                    - ./.idea
-                    - ./.npm-global
-                    - ./nbproject
-                    - ./project-base/app/var/elasticsearch-data
-                    - ./project-base/app/var/postgres-data
-                    - ./project-base/storefront
-        storefront:
-            alpha: "./project-base/storefront"
-            beta: "volume://storefront"
-            mode: "two-way-resolved"
-            configurationBeta:
-                permissions:
-                    defaultOwner: "id:1000"
-                    defaultGroup: "id:1000"
-                    defaultDirectoryMode: 0777

--- a/docker/conf/mutagen.yml.dist
+++ b/docker/conf/mutagen.yml.dist
@@ -1,0 +1,40 @@
+sync:
+    defaults:
+        ignore:
+            vcs: true
+        permissions:
+            defaultOwner: "id:501"
+
+    php-fpm:
+        alpha: "."
+        beta: "docker://shopsys-framework-mutagen-php-fpm/volumes/php-fpm"
+        configurationBeta:
+            permissions:
+                defaultOwner: "id:501"
+                defaultGroup: "id:20"
+                defaultDirectoryMode: 0777
+        ignore:
+            paths:
+                - ".DS_Store"
+                - ".idea"
+                - ".npm-global"
+                - "elasticsearch-data"
+                - "nbproject"
+                - "node_modules"
+                - "postgres-data"
+                - "storefront"
+                - "vendor"
+        mode: "two-way-resolved"
+
+    storefront:
+        alpha: "./project-base/storefront"
+        beta: "docker://shopsys-framework-mutagen-storefront/volumes/storefront"
+        configurationBeta:
+            permissions:
+                defaultOwner: "id:1000"
+                defaultGroup: "id:1000"
+                defaultDirectoryMode: 0777
+        ignore:
+            paths:
+                - "node_modules"
+        mode: "two-way-resolved"

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -17,7 +17,6 @@ This solution uses [_Mutagen_](https://mutagen.io) (for relatively fast two-way 
     - Enable Docker Compose V2 in General settings
     - We recommend to set at least 8 GB RAM, 4 CPUs and 512 MB Swap in `Docker -> Preferences… -> Resources -> ADVANCED`
 - [Mutagen](https://mutagen.io/) (install using [Mutagen installation guide](https://mutagen.io/documentation/introduction/installation))
-- [Mutagen Compose](https://mutagen.io/documentation/orchestration/compose/) (install using [Mutagen Compose installation guide](https://github.com/mutagen-io/mutagen-compose#installation))
 
 ## Steps
 
@@ -65,12 +64,13 @@ There are two domains each for different language in default installation. First
 sudo ifconfig lo0 alias 127.0.0.2 up
 ```
 
-#### 2.2. Create docker-compose.yml
+#### 2.2. Create docker-compose.yml and mutagen.yml
 
-Create `docker-compose.yml` from template [`docker-compose-mac.yml.dist`]({{github.link}}/project-base/docker/conf/docker-compose-mac.yml.dist).
+Create `docker-compose.yml` from template [`docker-compose-mac.yml.dist`]({{github.link}}/project-base/docker/conf/docker-compose-mac.yml.dist) and `mutagen.yml` from template [`mutagen.yml.dist`]({{github.link}}/project-base/docker/conf/mutagen.yml.dist).
 
 ```sh
 cp docker/conf/docker-compose-mac.yml.dist docker-compose.yml
+cp docker/conf/mutagen.yml.dist mutagen.yml
 ```
 
 #### 2.3 Set the UID and GID to allow file access in mounted volumes
@@ -79,20 +79,53 @@ Because we want both the user in host machine (you) and the user running php-fpm
 This can be achieved by build arguments `www_data_uid` and `www_data_gid` that should be set to the same UID and GID as your own user in your `docker-compose.yml`.
 You can find out your UID by running `id -u` and your GID by running `id -g`.
 Once you get these values, set these values into your `docker-compose.yml` into `php-fpm` container definition by replacing values in `args` section.
-Update also `defaultOwner` to your UID in `x-mutagen` section in `docker-compose.yml`.
+Update also `defaultOwner` and `defaultGroup` in `mutagen.yml` to match your UID and GID.
 
 #### 2.4 Build and start containers using Mutagen
 
-On macOS, you want to synchronize folders using Mutagen as it enables faster performance then current implementation in Docker Desktop.
+On macOS, you want to synchronize folders using Mutagen as it enables faster performance than current implementation in Docker Desktop.
+
+**Option A: Use the helper script (recommended)**
 
 ```sh
-mutagen-compose up -d --build
+./scripts/mutagen-up.sh
 ```
+
+**Option B: Manual steps**
+
+```sh
+# 1. Start sidecar containers for Mutagen (with the 'mutagen' profile)
+docker compose --profile mutagen up -d --build
+
+# 2. Start Mutagen file synchronization
+mutagen project start
+
+# 3. Wait for initial sync to complete (check status with: mutagen sync list)
+#    Look for "Watching for changes" status
+
+# 4. Start all remaining containers
+docker compose up -d
+```
+
+!!! tip
+
+    Once Mutagen is running and containers are up, you use standard `docker` and `docker compose` commands like you are used to.
+    ```
 
 !!! note
 
-    With Mutagen Compose you will use `mutagen-compose` instead of `docker compose` for all your Docker Compose commands.<br>
-    `mutagen-compose` is a wrapper around `docker compose` that adds Mutagen synchronization to the `docker compose up` command.
+    The `mutagen project start` command reads the `mutagen.yml` configuration file and creates synchronization sessions between your local filesystem and the Docker volumes via sidecar containers.
+
+!!! note
+
+    To stop the environment (keeps containers):
+    ```sh
+    ./scripts/mutagen-stop.sh
+    ```
+    To remove containers completely:
+    ```sh
+    ./scripts/mutagen-down.sh
+    ```
 
 !!! note
 

--- a/docs/integration/payment-gateways.md
+++ b/docs/integration/payment-gateways.md
@@ -105,7 +105,7 @@ DOMAIN_HOSTNAME_1=http://app.test:8000/
 PUBLIC_GRAPHQL_ENDPOINT_HOSTNAME_1=http://app.test:8000/graphql/
 ```
 
-- recreate the storefront container with `mutagen-compose up -d --force-recreate storefront` or `docker compose up -d --force-recreate storefront` if you are not using Mutagen
+- recreate the storefront container with `docker compose up -d --force-recreate storefront`
 - enjoy the GoPay integration in your local environment on `http://app.test:8000/`
 
 For automated tests, there is a test GoPay client that simulates the GoPay API responses. This allows you to run tests without needing access to the actual GoPay service.

--- a/docs/project/how-to-switch-between-projects-on-macos-with-mutagen.md
+++ b/docs/project/how-to-switch-between-projects-on-macos-with-mutagen.md
@@ -4,14 +4,27 @@ Switching between projects can sometimes be problematic with Mutagen.
 For instance, untracked or changed files, problems with packages in the vendor, and other problems may appear after the switch.
 This article contains some tried and tested recommendations on how to minimize these issues.
 
-## Avoid using `mutagen-compose down` when switching
+## Avoid using `docker compose down` or `mutagen-down` when switching
 
-If you are switching between two or more projects on a regular basis, it's best to avoid using `mutagen-compose down` to stop the current project and then switch to the new one.
-Instead, use `mutagen-compose stop`.
-The difference is that those containers will remain suspended and not be deleted (thus taking up disk space).
+If you are switching between two or more projects on a regular basis, it's best to avoid using `docker compose down` or `./scripts/mutagen-down.sh` (or `make mutagen-down`) to stop the current project and then switch to the new one.
+Instead, use `./scripts/mutagen-stop.sh` (or `make mutagen-stop`).
+The difference is that containers will remain suspended and not be deleted (thus taking up disk space).
 Moreover, this approach will diminish or completely solve the problems described in this article's introduction.
 Switching is also significantly faster.
-After stopping all containers, switch to the folder containing the second project and run `mutagen-compose up -d`.
+
+**Stopping the current project:**
+
+```bash
+./scripts/mutagen-stop.sh
+```
+
+**Starting the next project:**
+
+Switch to the folder containing the second project and run:
+
+```bash
+./scripts/mutagen-up.sh
+```
 
 !!! note
 
@@ -30,6 +43,6 @@ If you encounter this issue after the switch, delete the affected files or perfo
 If you encounter this issue, try the following command:
 
 ```bash
-mutagen-compose exec php-fpm rm -rf vendor
-mutagen-compose exec php-fpm composer install
+docker compose exec php-fpm rm -rf vendor
+docker compose exec php-fpm composer install
 ```

--- a/docs/storefront/coding-standards.md
+++ b/docs/storefront/coding-standards.md
@@ -14,13 +14,13 @@ ESLint is configured with custom rules to catch HTML validation issues and ensur
 
 ```bash
 # Check for validation issues
-mutagen-compose exec storefront pnpm lint
+docker compose exec storefront pnpm lint
 
 # Fix issues automatically (where possible)
-mutagen-compose exec storefront pnpm check--fix
+docker compose exec storefront pnpm check--fix
 
 # Check specific file
-mutagen-compose exec storefront npx eslint path/to/component.tsx
+docker compose exec storefront npx eslint path/to/component.tsx
 ```
 
 #### Button Content Validation

--- a/packages/php-image/Dockerfile
+++ b/packages/php-image/Dockerfile
@@ -118,4 +118,5 @@ RUN echo "source /etc/profile.d/bash_completion.sh" >> ~/.bash_profile
 USER www-data
 
 RUN mkdir -p /var/www/html/.npm-global
+
 ENV NPM_CONFIG_PREFIX=/var/www/html/.npm-global

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -15,13 +15,32 @@ help: ## Displays list of available commands
 # Phony targets - declaration of targets that are not files
 # ------------------------------------------------------------------------------
 
-.PHONY: help generate-schema generate-schema-native check-fix php-checks php-lock-icons php-translations \
+.PHONY: help mutagen-up mutagen-up-build mutagen-up-build-no-cache mutagen-stop mutagen-down generate-schema generate-schema-native check-fix php-checks php-lock-icons php-translations \
 	storefront-checks storefront-translations check-schema run-acceptance-tests-base \
 	run-acceptance-tests-regression selected-acceptance-tests-base selected-acceptance-tests-regression \
 	run-specific-test-regression run-specific-test-base \
 	open-acceptance-tests-base open-acceptance-tests-regression run-smoke-tests \
 	generate-snapshots-info-table prepare-data-for-acceptance-tests cypress-prepare cypress-cleanup \
 	check-licenses
+
+# ------------------------------------------------------------------------------
+# 🐳 Docker Compose (macOS with Mutagen)
+# ------------------------------------------------------------------------------
+
+mutagen-up: ## Starts Docker environment with Mutagen sync (macOS)
+	./scripts/mutagen-up.sh
+
+mutagen-up-build: ## Starts Docker environment with Mutagen sync and rebuilds images (macOS)
+	./scripts/mutagen-up.sh --build
+
+mutagen-up-build-no-cache: ## Starts Docker environment with Mutagen sync and rebuilds images without cache (macOS)
+	./scripts/mutagen-up.sh --build --no-cache
+
+mutagen-stop: ## Stops Docker environment and Mutagen sync, keeps containers (macOS)
+	./scripts/mutagen-stop.sh
+
+mutagen-down: ## Removes Docker containers and stops Mutagen sync (macOS)
+	./scripts/mutagen-down.sh
 
 # ------------------------------------------------------------------------------
 # 🔧 Generating GraphQL schema and types

--- a/project-base/app/docker/php-fpm/Dockerfile
+++ b/project-base/app/docker/php-fpm/Dockerfile
@@ -57,6 +57,10 @@ RUN if [ -n "${www_data_gid}" ] && ! getent group ${www_data_gid} >/dev/null; th
         if id -u www-data >/dev/null; then usermod -u ${www_data_uid} www-data; fi; \
     fi
 
+RUN mkdir -p ./vendor \
+    && mkdir -p ./node_modules \
+    && chown -R www-data:www-data /var/www/html
+
 USER www-data
 
 ########################################################################################################################

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -56,6 +56,7 @@ services:
             - dev # change to `- build` if you want to test application build
         volumes:
             - storefront:/home/node/app
+            - storefront-node-modules:/home/node/app/node_modules
         ports:
             - "3000:3000"
             - "9229:9229"
@@ -93,7 +94,7 @@ services:
             - ./storefront/pages:/app/pages
             - ./storefront/public/locales:/app/public/locales:delegated
             - ./app/translations:/app/app-translations:delegated
-            - node_modules:/app/node_modules
+            - storefront-node-modules:/app/node_modules
         profiles:
             - storefront-acceptance-tests
         network_mode: "host"
@@ -107,7 +108,9 @@ services:
                 <<: *common_build_args
         container_name: shopsys-framework-php-fpm
         volumes:
-            - source-code:/var/www/html
+            - php-fpm:/var/www/html
+            - php-fpm-vendor:/var/www/html/vendor
+            - php-fpm-node-modules:/var/www/html/node_modules
             - ./.npm-global:/var/www/html/.npm-global
         environment:
             <<: *blackfire_environments
@@ -128,7 +131,9 @@ services:
             - rabbitmq
         container_name: shopsys-framework-php-consumer
         volumes:
-            - source-code:/var/www/html
+            - php-fpm:/var/www/html
+            - php-fpm-vendor:/var/www/html/vendor
+            - php-fpm-node-modules:/var/www/html/node_modules
         entrypoint:
             - /bin/sh
             - docker/php-fpm/consumer-entrypoint.sh
@@ -215,45 +220,29 @@ services:
         ports:
             - "8060:8080"
 
+    mutagen-php-fpm:
+        image: mutagenio/sidecar:0.18.1
+        container_name: shopsys-framework-mutagen-php-fpm
+        volumes:
+            - php-fpm:/volumes/php-fpm
+        profiles:
+            - mutagen
+
+    mutagen-storefront:
+        image: mutagenio/sidecar:0.18.1
+        container_name: shopsys-framework-mutagen-storefront
+        volumes:
+            - storefront:/volumes/storefront
+        profiles:
+            - mutagen
+
 volumes:
-    source-code:
+    php-fpm:
+    php-fpm-vendor:
+    php-fpm-node-modules:
     storefront:
+    storefront-node-modules:
     elasticsearch-data:
         driver: local
     postgres-data:
         driver: local
-    node_modules:
-
-x-mutagen:
-    sync:
-        defaults:
-            ignore:
-                vcs: true
-            permissions:
-                defaultOwner: "id:501"
-        source-code:
-            alpha: "./app"
-            beta: "volume://source-code"
-            mode: "two-way-resolved"
-            configurationBeta:
-                permissions:
-                    defaultOwner: "id:501"
-                    defaultDirectoryMode: 0777
-            ignore:
-                paths:
-                    - ./.DS_Store
-                    - ./.idea
-                    - ./.npm-global
-                    - ./nbproject
-                    - ./storefront
-                    - ./app/var/elasticsearch-data
-                    - ./app/var/postgres-data
-        storefront:
-            alpha: "./storefront"
-            beta: "volume://storefront"
-            mode: "two-way-resolved"
-            configurationBeta:
-                permissions:
-                    defaultOwner: "id:1000"
-                    defaultGroup: "id:1000"
-                    defaultDirectoryMode: 0777

--- a/project-base/docker/conf/mutagen.yml.dist
+++ b/project-base/docker/conf/mutagen.yml.dist
@@ -1,0 +1,40 @@
+sync:
+    defaults:
+        ignore:
+            vcs: true
+        permissions:
+            defaultOwner: "id:501"
+
+    php-fpm:
+        alpha: "./app"
+        beta: "docker://shopsys-framework-mutagen-php-fpm/volumes/php-fpm"
+        configurationBeta:
+            permissions:
+                defaultOwner: "id:501"
+                defaultGroup: "id:20"
+                defaultDirectoryMode: 0777
+        ignore:
+            paths:
+                - ".DS_Store"
+                - ".idea"
+                - ".npm-global"
+                - "elasticsearch-data"
+                - "nbproject"
+                - "node_modules"
+                - "postgres-data"
+                - "storefront"
+                - "vendor"
+        mode: "two-way-resolved"
+
+    storefront:
+        alpha: "./storefront"
+        beta: "docker://shopsys-framework-mutagen-storefront/volumes/storefront"
+        configurationBeta:
+            permissions:
+                defaultOwner: "id:1000"
+                defaultGroup: "id:1000"
+                defaultDirectoryMode: 0777
+        ignore:
+            paths:
+                - "node_modules"
+        mode: "two-way-resolved"

--- a/project-base/scripts/configure.sh
+++ b/project-base/scripts/configure.sh
@@ -3,6 +3,7 @@ numberRegex="^[0-9]+([.][0-9]+)?$"
 operatingSystem=""
 allowedValues=(1 2)
 projectPathPrefix="app/"
+scriptsPathPrefix=""
 echo This is installation script that will install demo Shopsys Platform application on docker with all required containers and with demo database created.
 
 docker ps -q &> /dev/null
@@ -34,6 +35,7 @@ done
 
 if [[ -d "project-base" ]]; then
     projectPathPrefix="project-base/app/"
+    scriptsPathPrefix="project-base/"
     echo "You are in monorepo, prefixing paths app paths with ${projectPathPrefix}"
 fi
 
@@ -55,18 +57,20 @@ case "$operatingSystem" in
         ;;
     "2")
         cp -f docker/conf/docker-compose-mac.yml.dist docker-compose.yml
+        cp -f docker/conf/mutagen.yml.dist mutagen.yml
 
         sed -i '' -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
         sed -i '' -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
-        sed -i '' -E "s#defaultOwner: \"id:501\"+#defaultOwner: \"id:$(id -u)\"#" ./docker-compose.yml
         sed -i '' -E "s#LOCAL_PATH_TO_PROJECT_ROOT: .*#LOCAL_PATH_TO_PROJECT_ROOT: $(pwd)#" ./docker-compose.yml
+        sed -i '' -E "s#defaultOwner: \"id:501\"#defaultOwner: \"id:$(id -u)\"#g" ./mutagen.yml
+        sed -i '' -E "s#defaultGroup: \"id:20\"#defaultGroup: \"id:$(id -g)\"#g" ./mutagen.yml
 
         if [[ $1 != --skip-aliasing ]]; then
             echo "You will be asked to enter sudo password in case to allow second domain alias in your system config"
             sudo ifconfig lo0 alias 127.0.0.2 up
         fi
 
-        echo "Starting mutagen-compose"
-        mutagen-compose up -d --build --force-recreate
+        echo "Starting docker compose with Mutagen"
+        ./${scriptsPathPrefix}scripts/mutagen-up.sh --build
         ;;
 esac

--- a/project-base/scripts/mutagen-down.sh
+++ b/project-base/scripts/mutagen-down.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Removing containers...${NC}"
+docker compose down
+
+echo -e "${YELLOW}Stopping mutagen sync...${NC}"
+mutagen project terminate 2>/dev/null || true
+
+echo -e "${YELLOW}Removing Mutagen sidecar containers...${NC}"
+docker compose down mutagen-php-fpm mutagen-storefront
+
+echo -e "${GREEN}Done${NC}"

--- a/project-base/scripts/mutagen-stop.sh
+++ b/project-base/scripts/mutagen-stop.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}Stopping containers...${NC}"
+docker compose stop
+
+echo -e "${YELLOW}Stopping mutagen sync...${NC}"
+mutagen project terminate 2>/dev/null || true
+
+echo -e "${YELLOW}Stopping Mutagen sidecar containers...${NC}"
+docker compose stop mutagen-php-fpm mutagen-storefront
+
+echo -e "${GREEN}Done${NC}"

--- a/project-base/scripts/mutagen-up.sh
+++ b/project-base/scripts/mutagen-up.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+BUILD=false
+NO_CACHE=""
+for arg in "$@"; do
+    case $arg in
+        --build) BUILD=true ;;
+        --no-cache) NO_CACHE="--no-cache" ;;
+    esac
+done
+
+if [[ "$BUILD" == true ]]; then
+    echo -e "${YELLOW}Building images${NO_CACHE:+ without cache}...${NC}"
+    docker compose build $NO_CACHE
+fi
+
+echo -e "${YELLOW}Starting Mutagen sidecar containers...${NC}"
+docker compose up -d mutagen-php-fpm mutagen-storefront
+
+echo -e "${YELLOW}Cleaning up any existing mutagen sessions...${NC}"
+mutagen project terminate 2>/dev/null || true
+
+echo -e "${YELLOW}Starting mutagen sync...${NC}"
+mutagen project start
+
+echo -e "${YELLOW}Waiting for initial sync...${NC}"
+until mutagen sync list 2>/dev/null | grep -q "Watching"; do
+    sleep 2
+done
+
+echo -e "${YELLOW}Starting all containers...${NC}"
+docker compose up -d --force-recreate
+
+echo -e "${GREEN}Done${NC}"

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --no-cache shadow
 
 RUN if [[ -n "$node_uid" && "$node_uid" -ne 1000 ]]; then usermod -u $node_uid node && chown -R node $HOME_DIR; fi;
 
+RUN mkdir -p $APP_DIR/node_modules && chown node:node $APP_DIR/node_modules
+
 USER node
 WORKDIR $APP_DIR
 

--- a/upgrade-notes/_layout.md
+++ b/upgrade-notes/_layout.md
@@ -22,7 +22,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 - check the instructions in all sections; any of them could be relevant to you
 - the typical upgrade sequence should be:
     - run `docker compose down --volumes` to turn off your containers
-    - _(macOS only)_ run `mutagen-compose down --volumes` instead
+    - _(macOS only)_ run `mutagen project terminate` first, then `docker compose down --volumes`
     - follow upgrade notes in the _Infrastructure_ section (related to `docker-compose.yml`, `Dockerfile`, docker containers, `nginx.conf`, `php.ini`, etc.)
     - _(MacOS, Windows only)_ run `docker-sync start` to create volumes
     - run `docker compose build --no-cache --pull` to build your images without cache and with the latest version

--- a/upgrade-notes/backend_20251211_185823.md
+++ b/upgrade-notes/backend_20251211_185823.md
@@ -1,0 +1,31 @@
+#### Replace `mutagen-compose` with plain `mutagen` because `mutagen-compose` is no longer compatible with the latest Docker API ([#4331](https://github.com/shopsys/shopsys/pull/4331))
+
+##### If you were using mutagen-compose, follow these steps to migrate:
+
+1. Stop and clean up your current environment:
+
+    ```bash
+    mutagen-compose down
+    docker system prune -a
+    ```
+
+2. Run the installation script to set up the new environment:
+    ```bash
+    ./project-base/scripts/install.sh
+    ```
+
+##### New Make targets for macOS with Mutagen:
+
+| Target                           | Description                                                            |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `make mutagen-up`                | Starts Docker environment with Mutagen sync                            |
+| `make mutagen-up-build`          | Starts environment and rebuilds images                                 |
+| `make mutagen-up-build-no-cache` | Starts environment and rebuilds images without cache                   |
+| `make mutagen-stop`              | Stops containers while preserving them (useful for switching projects) |
+| `make mutagen-down`              | Removes containers and stops Mutagen sync                              |
+
+##### Using Docker Compose directly:
+
+For commands not covered by Make targets (e.g., `exec`, `logs`, `restart`), use plain `docker compose` like `docker compose exec php-fpm bash`
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
We were using https://github.com/mutagen-io/mutagen-compose, but it is no longer supported and does not work with latest Docker API. 

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-replace-mutagen-compose.odin.shopsys.cloud
  - https://cz.tl-replace-mutagen-compose.odin.shopsys.cloud
  - https://tl-replace-mutagen-compose.odin.shopsys.cloud/sk
<!-- Replace -->
