### PR TITLE
Add copy code functionality to code blocks in documentation

### DIFF
--- a/docs/_theme/copy-code.js
+++ b/docs/_theme/copy-code.js
@@ -1,0 +1,65 @@
+/**
+ * Sanitizes diff code by removing lines starting with "-" and stripping leading "+" from added lines.
+ *
+ * @param {string} text - Raw diff text content
+ * @returns {string} - Clean code without diff markers
+ */
+function sanitizeDiffCode(text) {
+    const lines = text.split('\n');
+
+    return lines
+        .filter(function(line) {
+            return !line.startsWith('-') && !line.startsWith('---');
+        })
+        .map(function(line) {
+            if (line.startsWith('+') && !line.startsWith('+++')) {
+                return line.substring(1);
+            }
+
+            if (line.startsWith(' ')) {
+                return line.substring(1);
+            }
+            return line;
+        })
+        .join('\n')
+        .trim();
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const codeBlocks = document.querySelectorAll('pre');
+
+    codeBlocks.forEach(function(pre) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'code-block-wrapper';
+
+        const button = document.createElement('button');
+        button.className = 'copy-code-button';
+        button.textContent = 'Copy';
+        button.type = 'button';
+
+        button.addEventListener('click', function() {
+            const codeElement = pre.querySelector('code');
+            let text = codeElement ? codeElement.textContent : pre.textContent;
+
+            const isDiff = pre.classList.contains('language-diff') ||
+                (codeElement && codeElement.classList.contains('language-diff'));
+
+            if (isDiff) {
+                text = sanitizeDiffCode(text);
+            }
+
+            navigator.clipboard.writeText(text).then(function() {
+                button.textContent = 'Copied!';
+                button.classList.add('copied');
+                setTimeout(function() {
+                    button.textContent = 'Copy';
+                    button.classList.remove('copied');
+                }, 2000);
+            });
+        });
+
+        pre.parentNode.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
+        wrapper.appendChild(button);
+    });
+});

--- a/docs/_theme/main.css
+++ b/docs/_theme/main.css
@@ -479,3 +479,38 @@ div.toc {
     color: var(--color-text);
     padding: 2px 10px 0 0;
 }
+
+/** COPY CODE BUTTON **/
+.code-block-wrapper {
+    position: relative;
+}
+
+.copy-code-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-code-text);
+    background-color: #3a3a3a;
+    border: 1px solid #555;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s, background-color 0.2s;
+    z-index: 10;
+}
+
+.code-block-wrapper:hover .copy-code-button {
+    opacity: 1;
+}
+
+.copy-code-button:hover {
+    background-color: #4a4a4a;
+}
+
+.copy-code-button.copied {
+    background-color: #2e7d32;
+    border-color: #4caf50;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ current_version: 18.0
 extra_css:
     - _theme/main.css
 
+extra_javascript:
+    - _theme/copy-code.js
+
 hooks:
     - docs/_hooks/replace_links.py
 


### PR DESCRIPTION
- introduced a new JavaScript file to sanitize diff code and enable a copy button for code blocks
- updated CSS to style the copy button and ensure it appears on hover
- modified mkdocs.yml to include the new JavaScript file

#### Description, the reason for the PR
... 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-3614-docs-copy-code-snippet.odin.shopsys.cloud
  - https://cz.jm-ssp-3614-docs-copy-code-snippet.odin.shopsys.cloud
  - https://jm-ssp-3614-docs-copy-code-snippet.odin.shopsys.cloud/sk
<!-- Replace -->
