### PR TITLE
fixed advanced search multiple ajax call

### DIFF
--- a/packages/framework/assets/js/admin/components/AdvancedSearch.js
+++ b/packages/framework/assets/js/admin/components/AdvancedSearch.js
@@ -20,7 +20,7 @@ export default class AdvancedSearch {
             return false;
         });
 
-        $rulesContainer.on('change', '.js-advanced-search-rule-subject', function () {
+        $rulesContainer.on('change', 'select.js-advanced-search-rule-subject', function () {
             const $rule = $(this).closest('.js-advanced-search-rule');
             AdvancedSearch.updateRule($rulesContainer, $rule, $(this).val(), `new_${newRuleIndexCounter}`);
             newRuleIndexCounter++;


### PR DESCRIPTION
#### Description, the reason for the PR

Fixes an issue where searching in a select box within an advanced search filter triggered multiple Ajax calls, which resulted in an error.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-advanced-filter-fix.odin.shopsys.cloud
  - https://cz.mg-advanced-filter-fix.odin.shopsys.cloud
  - https://mg-advanced-filter-fix.odin.shopsys.cloud/sk
<!-- Replace -->
