### PR TITLE
improved install script to set correct version for mutagenio/sidecar image

### DIFF
--- a/project-base/scripts/configure.sh
+++ b/project-base/scripts/configure.sh
@@ -56,6 +56,12 @@ case "$operatingSystem" in
         docker compose up -d --build --force-recreate
         ;;
     "2")
+        if ! command -v mutagen &> /dev/null; then
+            1>&2 printf "\e[31mERROR:\e[0m Mutagen is not installed. Please install it first by running:\n"
+            1>&2 printf "    brew install mutagen-io/mutagen/mutagen\n"
+            exit 1
+        fi
+
         cp -f docker/conf/docker-compose-mac.yml.dist docker-compose.yml
         cp -f docker/conf/mutagen.yml.dist mutagen.yml
 
@@ -64,6 +70,7 @@ case "$operatingSystem" in
         sed -i '' -E "s#LOCAL_PATH_TO_PROJECT_ROOT: .*#LOCAL_PATH_TO_PROJECT_ROOT: $(pwd)#" ./docker-compose.yml
         sed -i '' -E "s#defaultOwner: \"id:501\"#defaultOwner: \"id:$(id -u)\"#g" ./mutagen.yml
         sed -i '' -E "s#defaultGroup: \"id:20\"#defaultGroup: \"id:$(id -g)\"#g" ./mutagen.yml
+        sed -i '' -E "s#mutagenio/sidecar:[0-9.]+#mutagenio/sidecar:$(mutagen version)#g" ./docker-compose.yml
 
         if [[ $1 != --skip-aliasing ]]; then
             echo "You will be asked to enter sudo password in case to allow second domain alias in your system config"

--- a/upgrade-notes/backend_20251211_185823.md
+++ b/upgrade-notes/backend_20251211_185823.md
@@ -1,4 +1,4 @@
-#### Replace `mutagen-compose` with plain `mutagen` because `mutagen-compose` is no longer compatible with the latest Docker API ([#4331](https://github.com/shopsys/shopsys/pull/4331))
+#### Replace `mutagen-compose` with plain `mutagen` because `mutagen-compose` is no longer compatible with the latest Docker API ([#4331](https://github.com/shopsys/shopsys/pull/4331)) and ([#4336](https://github.com/shopsys/shopsys/pull/4336))
 
 ##### If you were using mutagen-compose, follow these steps to migrate:
 
@@ -9,7 +9,13 @@
     docker system prune -a
     ```
 
-2. Run the installation script to set up the new environment:
+2. Ensure you are running the latest version of Mutagen
+
+    ```bash
+    brew upgrade mutagen
+    ```
+
+3. Run the installation script to set up the new environment:
     ```bash
     ./project-base/scripts/install.sh
     ```
@@ -28,4 +34,4 @@
 
 For commands not covered by Make targets (e.g., `exec`, `logs`, `restart`), use plain `docker compose` like `docker compose exec php-fpm bash`
 
-- see #project-base-diff to update your project
+- see #project-base-diff1 and #project-base-diff2 to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
In #4331 we have replaced `mutagen-compose` with pure `mutagen` but there could be problem when upgrading for people with older `mutagen` version as sidecar images were using current latest version. Now install script will fix this and use same version as is currently installed mutagen.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-mutagen-improve-upgrade.odin.shopsys.cloud
  - https://cz.tl-mutagen-improve-upgrade.odin.shopsys.cloud
  - https://tl-mutagen-improve-upgrade.odin.shopsys.cloud/sk
<!-- Replace -->
