### PR TITLE
createInstance() now serve only intended purpose

### DIFF
--- a/packages/framework/src/Model/Advert/AdvertDataFactory.php
+++ b/packages/framework/src/Model/Advert/AdvertDataFactory.php
@@ -21,11 +21,7 @@ class AdvertDataFactory
      */
     protected function createInstance(): AdvertData
     {
-        $advertData = new AdvertData();
-        $advertData->image = $this->imageUploadDataFactory->create();
-        $advertData->mobileImage = $this->imageUploadDataFactory->create();
-
-        return $advertData;
+        return new AdvertData();
     }
 
     /**
@@ -33,7 +29,12 @@ class AdvertDataFactory
      */
     public function create(): AdvertData
     {
-        return $this->createInstance();
+        $advertData = $this->createInstance();
+
+        $advertData->image = $this->imageUploadDataFactory->create();
+        $advertData->mobileImage = $this->imageUploadDataFactory->create();
+
+        return $advertData;
     }
 
     /**
@@ -61,7 +62,6 @@ class AdvertDataFactory
         $advertData->positionName = $advert->getPositionName();
         $advertData->hidden = $advert->isHidden();
         $advertData->domainId = $advert->getDomainId();
-        $advertData->image = $this->imageUploadDataFactory->createFromEntityAndType($advert);
         $advertData->categories = $advert->getCategories();
 
         $advertData->image = $this->imageUploadDataFactory->createFromEntityAndType($advert, AdvertFacade::IMAGE_TYPE_WEB);

--- a/packages/framework/src/Model/Category/CategoryDataFactory.php
+++ b/packages/framework/src/Model/Category/CategoryDataFactory.php
@@ -32,10 +32,7 @@ class CategoryDataFactory
      */
     protected function createInstance(): CategoryData
     {
-        $categoryData = new CategoryData();
-        $categoryData->image = $this->imageUploadDataFactory->create();
-
-        return $categoryData;
+        return new CategoryData();
     }
 
     /**
@@ -66,6 +63,8 @@ class CategoryDataFactory
      */
     protected function fillNew(CategoryData $categoryData): void
     {
+        $categoryData->image = $this->imageUploadDataFactory->create();
+
         foreach ($this->domain->getAllIds() as $domainId) {
             $categoryData->seoMetaDescriptions[$domainId] = null;
             $categoryData->seoTitles[$domainId] = null;

--- a/packages/framework/src/Model/NotificationBar/NotificationBarDataFactory.php
+++ b/packages/framework/src/Model/NotificationBar/NotificationBarDataFactory.php
@@ -21,10 +21,7 @@ class NotificationBarDataFactory
      */
     protected function createInstance(): NotificationBarData
     {
-        $notificationBarData = new NotificationBarData();
-        $notificationBarData->image = $this->imageUploadDataFactory->create();
-
-        return $notificationBarData;
+        return new NotificationBarData();
     }
 
     /**
@@ -64,5 +61,6 @@ class NotificationBarDataFactory
     protected function fillNew(NotificationBarData $notificationBarData): void
     {
         $notificationBarData->hidden = false;
+        $notificationBarData->image = $this->imageUploadDataFactory->create();
     }
 }

--- a/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
@@ -27,10 +27,7 @@ class BrandDataFactory
      */
     protected function createInstance(): BrandData
     {
-        $brandData = new BrandData();
-        $brandData->image = $this->imageUploadDataFactory->create();
-
-        return $brandData;
+        return new BrandData();
     }
 
     /**
@@ -49,6 +46,8 @@ class BrandDataFactory
      */
     protected function fillNew(BrandData $brandData): void
     {
+        $brandData->image = $this->imageUploadDataFactory->create();
+
         foreach ($this->domain->getAllIds() as $domainId) {
             $brandData->seoMetaDescriptions[$domainId] = null;
             $brandData->seoTitles[$domainId] = null;

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -64,11 +64,7 @@ class ProductDataFactory
      */
     protected function createInstance(): ProductData
     {
-        $productData = new ProductData();
-        $productData->images = $this->imageUploadDataFactory->create();
-        $productData->files = $this->uploadedFileDataFactory->create();
-
-        return $productData;
+        return new ProductData();
     }
 
     /**
@@ -102,6 +98,9 @@ class ProductDataFactory
 
         $productData->productInputPricesByDomain = $this->productInputPriceDataFactory->createEmptyForAllDomains();
         $productData->unit = $this->unitFacade->getDefaultUnit();
+
+        $productData->images = $this->imageUploadDataFactory->create();
+        $productData->files = $this->uploadedFileDataFactory->create();
 
         $productParameterValuesData = [];
         $productData->parameters = $productParameterValuesData;

--- a/packages/framework/src/Model/Slider/SliderItemDataFactory.php
+++ b/packages/framework/src/Model/Slider/SliderItemDataFactory.php
@@ -21,10 +21,7 @@ class SliderItemDataFactory
      */
     protected function createInstance(): SliderItemData
     {
-        $sliderItemData = new SliderItemData();
-        $sliderItemData->image = $this->imageUploadDataFactory->create();
-
-        return $sliderItemData;
+        return new SliderItemData();
     }
 
     /**
@@ -32,7 +29,11 @@ class SliderItemDataFactory
      */
     public function create(): SliderItemData
     {
-        return $this->createInstance();
+        $sliderItemData = $this->createInstance();
+
+        $sliderItemData->image = $this->imageUploadDataFactory->create();
+
+        return $sliderItemData;
     }
 
     /**

--- a/packages/framework/src/Model/Transport/TransportDataFactory.php
+++ b/packages/framework/src/Model/Transport/TransportDataFactory.php
@@ -29,10 +29,7 @@ class TransportDataFactory
      */
     protected function createInstance(): TransportData
     {
-        $transportData = new TransportData();
-        $transportData->image = $this->imageUploadDataFactory->create();
-
-        return $transportData;
+        return new TransportData();
     }
 
     /**
@@ -52,6 +49,7 @@ class TransportDataFactory
     protected function fillNew(TransportData $transportData): void
     {
         $transportData->daysUntilDelivery = 0;
+        $transportData->image = $this->imageUploadDataFactory->create();
 
         foreach ($this->domain->getAllIds() as $domainId) {
             $transportData->enabled[$domainId] = false;

--- a/project-base/app/src/Model/Category/CategoryDataFactory.php
+++ b/project-base/app/src/Model/Category/CategoryDataFactory.php
@@ -35,10 +35,7 @@ class CategoryDataFactory extends BaseCategoryDataFactory
     #[Override]
     protected function createInstance(): BaseCategoryData
     {
-        $categoryData = new CategoryData();
-        $categoryData->image = $this->imageUploadDataFactory->create();
-
-        return $categoryData;
+        return new CategoryData();
     }
 
     /**

--- a/project-base/app/src/Model/Product/Brand/BrandDataFactory.php
+++ b/project-base/app/src/Model/Product/Brand/BrandDataFactory.php
@@ -22,9 +22,6 @@ class BrandDataFactory extends BaseBrandDataFactory
     #[Override]
     protected function createInstance(): BaseBrandData
     {
-        $brandData = new BrandData();
-        $brandData->image = $this->imageUploadDataFactory->create();
-
-        return $brandData;
+        return new BrandData();
     }
 }

--- a/project-base/app/src/Model/Product/ProductDataFactory.php
+++ b/project-base/app/src/Model/Product/ProductDataFactory.php
@@ -29,11 +29,7 @@ class ProductDataFactory extends BaseProductDataFactory
     #[Override]
     protected function createInstance(): BaseProductData
     {
-        $productData = new ProductData();
-        $productData->images = $this->imageUploadDataFactory->create();
-        $productData->files = $this->uploadedFileDataFactory->create();
-
-        return $productData;
+        return new ProductData();
     }
 
     /**

--- a/project-base/app/src/Model/Slider/SliderItemDataFactory.php
+++ b/project-base/app/src/Model/Slider/SliderItemDataFactory.php
@@ -14,7 +14,6 @@ use Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactory as BaseSliderItem
  * @method setImageFacade(\App\Component\Image\ImageFacade $imageFacade)
  * @property \App\Component\Image\ImageFacade $imageFacade
  * @method __construct(\App\Component\Image\ImageFacade $imageFacade)
- * @method \App\Model\Slider\SliderItemData create()
  */
 class SliderItemDataFactory extends BaseSliderItemDataFactory
 {
@@ -24,8 +23,18 @@ class SliderItemDataFactory extends BaseSliderItemDataFactory
     #[Override]
     protected function createInstance(): BaseSliderItemData
     {
-        $sliderItemData = new SliderItemData();
-        $sliderItemData->image = $this->imageUploadDataFactory->create();
+        return new SliderItemData();
+    }
+
+    /**
+     * @return \App\Model\Slider\SliderItemData
+     */
+    #[Override]
+    public function create(): BaseSliderItemData
+    {
+        /** @var \App\Model\Slider\SliderItemData $sliderItemData */
+        $sliderItemData = parent::create();
+
         $sliderItemData->mobileImage = $this->imageUploadDataFactory->create();
 
         return $sliderItemData;

--- a/upgrade-notes/backend_20251218_072959.md
+++ b/upgrade-notes/backend_20251218_072959.md
@@ -1,0 +1,4 @@
+#### make createInstance() method responsible only for its intended purpose ([#4338](https://github.com/shopsys/shopsys/pull/4338))
+
+- the `createInstance()` method in factories is now responsible only for creating an instance of the given class, any default value setting or other logic has been moved to appropriate methods
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The createInstance() method is responsible only for creating an instance of the object. Any default value settings were moved to the appropriate methods.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-create-instance.odin.shopsys.cloud
  - https://cz.mg-create-instance.odin.shopsys.cloud
  - https://mg-create-instance.odin.shopsys.cloud/sk
<!-- Replace -->
