### PR TITLE
changed heureka key in data fixtures

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
@@ -147,7 +147,7 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
             if ($this->heurekaShopCertificationLocaleHelper->isDomainLocaleSupported($locale)) {
                 $this->setting->setForDomain(
                     HeurekaSetting::HEUREKA_API_KEY,
-                    '96411416349324269511946875061235',
+                    'JustMadeUpDemoKeyToEnableHeureka',
                     $domainId,
                 );
             }


### PR DESCRIPTION
#### Description, the reason for the PR

The originally set key gave the impression that it was real, and that could have been confusing.
Now it's clear that the key is made up. 

_We want a key set, so the checkbox for heureka agreement shows._ 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-remove-key.odin.shopsys.cloud
  - https://cz.mg-remove-key.odin.shopsys.cloud
  - https://mg-remove-key.odin.shopsys.cloud/sk
<!-- Replace -->
