### PR TITLE
added New Year's Day as closed day to data fixture

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/ClosedDayDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ClosedDayDataFixture.php
@@ -80,6 +80,12 @@ class ClosedDayDataFixture extends AbstractReferenceFixture implements Dependent
             t('Second Christmas Day', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
             true,
         ];
+
+        yield [
+            new DatePoint('1 January next year'),
+            t('New Year\'s Day', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+            true,
+        ];
     }
 
     /**

--- a/project-base/app/translations/dataFixtures.cs.po
+++ b/project-base/app/translations/dataFixtures.cs.po
@@ -1153,6 +1153,9 @@ msgstr "NS-9710 Prominent náhradní sáčky papírové pro VP-9711/12/13"
 msgid "New"
 msgstr "Novinka"
 
+msgid "New Year's Day"
+msgstr "Nový rok"
+
 msgid "New [adjective]"
 msgstr "Nová"
 

--- a/project-base/app/translations/dataFixtures.en.po
+++ b/project-base/app/translations/dataFixtures.en.po
@@ -1153,6 +1153,9 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+msgid "New Year's Day"
+msgstr ""
+
 msgid "New [adjective]"
 msgstr "New"
 

--- a/project-base/app/translations/dataFixtures.sk.po
+++ b/project-base/app/translations/dataFixtures.sk.po
@@ -1153,6 +1153,9 @@ msgstr "NS-9710 Prominent náhradné sáčky papierové pre VP-9711/12/13"
 msgid "New"
 msgstr "Nový"
 
+msgid "New Year's Day"
+msgstr "Nový rok"
+
 msgid "New [adjective]"
 msgstr "Nový [prídavné meno]"
 

--- a/upgrade-notes/backend_20251218_095404.md
+++ b/upgrade-notes/backend_20251218_095404.md
@@ -1,0 +1,3 @@
+#### add New Year's Day to data fixtures ([#4342](https://github.com/shopsys/shopsys/pull/4342))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Prevent the info message after loading demo data each year in December.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-new-year-datafixture.odin.shopsys.cloud
  - https://cz.mg-new-year-datafixture.odin.shopsys.cloud
  - https://mg-new-year-datafixture.odin.shopsys.cloud/sk
<!-- Replace -->
