### PR TITLE
conflicted webonyx/graphql-php >= 15.29.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -227,7 +227,8 @@
         "symfony/symfony": "*",
         "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0",
         "doctrine/doctrine-migrations-bundle": "3.4.0",
-        "doctrine/orm": ">=2.20.7"
+        "doctrine/orm": ">=2.20.7",
+        "webonyx/graphql-php": ">=15.29.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -48,6 +48,9 @@
         "phpunit/phpunit": "^11.2.1",
         "shopsys/coding-standards": "18.0.x-dev"
     },
+    "conflict": {
+        "webonyx/graphql-php": ">=15.29.0"
+    },
     "config": {
         "allow-plugins": {
             "symfony/flex": true,


### PR DESCRIPTION
#### Description, the reason for the PR

webonyx/graphql-php introduced a BC Break in webonyx/graphql-php#1805 
The released version was conflicted
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-conflict-webonyx.odin.shopsys.cloud
  - https://cz.mg-conflict-webonyx.odin.shopsys.cloud
  - https://mg-conflict-webonyx.odin.shopsys.cloud/sk
<!-- Replace -->
