### PR TITLE
removed shopsys naming

### DIFF
--- a/project-base/storefront/components/Blocks/Login/loginFormMeta.ts
+++ b/project-base/storefront/components/Blocks/Login/loginFormMeta.ts
@@ -3,8 +3,8 @@ import { validateEmail, validatePassword } from 'components/Forms/validationRule
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { LoginFormType } from 'types/form';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import { useOnFinishHydrationDefaultValuesPrefill } from 'utils/forms/useOnFinishHydrationDefaultValuesPrefill';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -23,7 +23,7 @@ export const useLoginForm = (defaultEmail?: string): [UseFormReturn<LoginFormTyp
         password: '',
     };
 
-    const formProviderMethods = useShopsysForm(resolver, defaultValues);
+    const formProviderMethods = useFormWrapper(resolver, defaultValues);
     useOnFinishHydrationDefaultValuesPrefill(defaultValues, formProviderMethods);
 
     return [formProviderMethods, defaultValues];

--- a/project-base/storefront/components/Blocks/Product/Inquiry/inquiryFormMeta.ts
+++ b/project-base/storefront/components/Blocks/Product/Inquiry/inquiryFormMeta.ts
@@ -10,7 +10,7 @@ import {
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { InquiryFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -37,7 +37,7 @@ export const useInquiryForm = (
         }),
     );
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type InquiryFormMetaType = {

--- a/project-base/storefront/components/Blocks/Product/Watchdog/watchdogFormMeta.tsx
+++ b/project-base/storefront/components/Blocks/Product/Watchdog/watchdogFormMeta.tsx
@@ -6,7 +6,7 @@ import Trans from 'next-translate/Trans';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { WatchdogFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -23,7 +23,7 @@ export const useWatchdogForm = (
         }),
     );
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type WatchdogFormMetaType = {

--- a/project-base/storefront/components/Blocks/PromoCode/promoCodeFormMeta.tsx
+++ b/project-base/storefront/components/Blocks/PromoCode/promoCodeFormMeta.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { PromoCodeFormType } from 'types/form';
 import { useCurrentCart } from 'utils/cart/useCurrentCart';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -18,7 +18,7 @@ export const usePromoCodeForm = (): [UseFormReturn<PromoCodeFormType>, PromoCode
     );
     const defaultValues = { promoCode: promoCodes[0]?.code ?? '' };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type PromoCodeFormMetaType = {

--- a/project-base/storefront/components/Blocks/UserConsent/userConsentFormMeta.ts
+++ b/project-base/storefront/components/Blocks/UserConsent/userConsentFormMeta.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { usePersistStore } from 'store/usePersistStore';
 import { UserConsentFormType } from 'types/form';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import { useOnFinishHydrationDefaultValuesPrefill } from 'utils/forms/useOnFinishHydrationDefaultValuesPrefill';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
 
 export const useUserConsentForm = (): [UseFormReturn<UserConsentFormType>, UserConsentFormType] => {
     const userConsent = usePersistStore((store) => store.userConsent);
@@ -13,7 +13,7 @@ export const useUserConsentForm = (): [UseFormReturn<UserConsentFormType>, UserC
         marketing: false,
         preferences: false,
     };
-    const formProviderMethods = useShopsysForm(undefined, defaultValues);
+    const formProviderMethods = useFormWrapper(undefined, defaultValues);
 
     useOnFinishHydrationDefaultValuesPrefill(defaultValues, formProviderMethods);
 

--- a/project-base/storefront/components/Layout/Footer/NewsletterForm/newsletterFormMeta.tsx
+++ b/project-base/storefront/components/Layout/Footer/NewsletterForm/newsletterFormMeta.tsx
@@ -6,7 +6,7 @@ import Trans from 'next-translate/Trans';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { NewsletterFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -20,7 +20,7 @@ export const useNewsletterForm = (): [UseFormReturn<NewsletterFormType>, Newslet
     );
     const defaultValues = { email: '', privacyPolicy: false };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type NewsletterFormMetaType = {

--- a/project-base/storefront/components/Pages/Contact/contactFormMeta.tsx
+++ b/project-base/storefront/components/Pages/Contact/contactFormMeta.tsx
@@ -7,8 +7,8 @@ import Trans from 'next-translate/Trans';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { ContactFormType } from 'types/form';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import { useOnFinishHydrationDefaultValuesPrefill } from 'utils/forms/useOnFinishHydrationDefaultValuesPrefill';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -30,7 +30,7 @@ export const useContactForm = (): [UseFormReturn<ContactFormType>, ContactFormTy
         message: '',
         privacyPolicy: false,
     };
-    const formProviderMethods = useShopsysForm(resolver, defaultValues);
+    const formProviderMethods = useFormWrapper(resolver, defaultValues);
 
     useOnFinishHydrationDefaultValuesPrefill(defaultValues, formProviderMethods);
 

--- a/project-base/storefront/components/Pages/Customer/ChangePassword/changePasswordFormMeta.ts
+++ b/project-base/storefront/components/Pages/Customer/ChangePassword/changePasswordFormMeta.ts
@@ -3,7 +3,7 @@ import { validateNewPassword, validateNewPasswordConfirm, validateOldPassword } 
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { ChangePasswordFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -20,7 +20,7 @@ export const useChangePasswordForm = (
         }),
     );
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type ChangePasswordFormMetaType = {

--- a/project-base/storefront/components/Pages/Customer/Complaints/complaintFormMeta.ts
+++ b/project-base/storefront/components/Pages/Customer/Complaints/complaintFormMeta.ts
@@ -21,7 +21,7 @@ import { FieldError, UseFormReturn } from 'react-hook-form';
 import { ComplaintFormType } from 'types/form';
 import { SelectOptionType } from 'types/selectOptions';
 import { isResolutionMoneyReturn } from 'utils/complaints/isResolutionMoneyReturn';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -121,7 +121,7 @@ export const useComplaintForm = (
         bankAccountNumber: '',
     };
 
-    return [useShopsysForm<ComplaintFormType>(resolver, defaultValues), defaultValues];
+    return [useFormWrapper<ComplaintFormType>(resolver, defaultValues), defaultValues];
 };
 
 export type ComplaintFormMetaType = {

--- a/project-base/storefront/components/Pages/Customer/EditProfile/customerChangeProfileFormMeta.ts
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/customerChangeProfileFormMeta.ts
@@ -15,7 +15,7 @@ import {
 import { useMemo } from 'react';
 import { FieldError, UseFormReturn } from 'react-hook-form';
 import { CustomerChangeProfileFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -54,7 +54,7 @@ export const useCustomerChangeProfileForm = (
         }),
     );
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type CustomerChangeProfileFormMetaType = {

--- a/project-base/storefront/components/Pages/Customer/EditProfile/deliveryAddressFormMeta.ts
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/deliveryAddressFormMeta.ts
@@ -11,7 +11,7 @@ import {
 import { useMemo } from 'react';
 import { FieldError, UseFormReturn } from 'react-hook-form';
 import { DeliveryAddressFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -33,7 +33,7 @@ export const useDeliveryAddressForm = (
         }),
     );
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type DeliveryAddressFormMetaType = {

--- a/project-base/storefront/components/Pages/Customer/customerUserManageProfileFormMeta.ts
+++ b/project-base/storefront/components/Pages/Customer/customerUserManageProfileFormMeta.ts
@@ -9,7 +9,7 @@ import {
 import { useMemo } from 'react';
 import { FieldError, UseFormReturn } from 'react-hook-form';
 import { CustomerUserManageProfileFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -28,7 +28,7 @@ export const useCustomerUserManageProfileForm = (
         }),
     );
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type CustomerUserManageProfileFormMetaType = {

--- a/project-base/storefront/components/Pages/NewPassword/recoveryPasswordFormMeta.ts
+++ b/project-base/storefront/components/Pages/NewPassword/recoveryPasswordFormMeta.ts
@@ -3,7 +3,7 @@ import { validateNewPassword, validateNewPasswordConfirm } from 'components/Form
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { NewPasswordFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -24,7 +24,7 @@ export const useRecoveryPasswordForm = (): [UseFormReturn<NewPasswordFormType>, 
         newPasswordConfirm: '',
     };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type NewPasswordFormMetaType = {

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
@@ -21,7 +21,7 @@ import { ContactInformation } from 'store/slices/createContactInformationSlice';
 import { CustomerTypeEnum } from 'types/customer';
 import { useIsUserLoggedIn } from 'utils/auth/useIsUserLoggedIn';
 import { useCurrentCart } from 'utils/cart/useCurrentCart';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import { useCurrentUserContactInformation } from 'utils/user/useCurrentUserContactInformation';
 import * as Yup from 'yup';
@@ -152,7 +152,7 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
         ...contactInformationValues,
         deliveryAddressUuid: pickupPlace ? '' : contactInformationValues.deliveryAddressUuid,
     };
-    const formProviderMethods = useShopsysForm(resolver, defaultValues);
+    const formProviderMethods = useFormWrapper(resolver, defaultValues);
 
     useEffect(() => {
         if (defaultValues.email && defaultValues.email.length > 0) {

--- a/project-base/storefront/components/Pages/OrderConfirmation/registrationAfterOrderFormMeta.tsx
+++ b/project-base/storefront/components/Pages/OrderConfirmation/registrationAfterOrderFormMeta.tsx
@@ -6,7 +6,7 @@ import Trans from 'next-translate/Trans';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { RegistrationAfterOrderFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -24,7 +24,7 @@ export const useRegistrationAfterOrderForm = (): [
     );
     const defaultValues = { password: '', passwordConfirm: '', privacyPolicy: false };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type RegistrationAfterOrderFormMetaType = {

--- a/project-base/storefront/components/Pages/OrderWithdrawal/orderWithdrawalFormMeta.tsx
+++ b/project-base/storefront/components/Pages/OrderWithdrawal/orderWithdrawalFormMeta.tsx
@@ -10,8 +10,8 @@ import { TypeOrderWithdrawalDataFragment } from 'graphql/requests/orders/fragmen
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { OrderWithdrawalFormType } from 'types/form';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import { useOnFinishHydrationDefaultValuesPrefill } from 'utils/forms/useOnFinishHydrationDefaultValuesPrefill';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -39,7 +39,7 @@ export const useOrderWithdrawalForm = (
         note: '',
     };
 
-    const formProviderMethods = useShopsysForm(resolver, defaultValues);
+    const formProviderMethods = useFormWrapper(resolver, defaultValues);
     useOnFinishHydrationDefaultValuesPrefill(defaultValues, formProviderMethods);
 
     return [formProviderMethods, defaultValues];

--- a/project-base/storefront/components/Pages/PersonalData/Export/personalDataExportFormMeta.ts
+++ b/project-base/storefront/components/Pages/PersonalData/Export/personalDataExportFormMeta.ts
@@ -3,7 +3,7 @@ import { validateEmail } from 'components/Forms/validationRules';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { PersonalDataExportFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -19,7 +19,7 @@ export const usePersonalDataExportForm = (): [
     );
     const defaultValues = { email: '' };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type PersonalDataExportFormMetaType = {

--- a/project-base/storefront/components/Pages/PersonalData/Overview/personalDataOverviewFormMeta.ts
+++ b/project-base/storefront/components/Pages/PersonalData/Overview/personalDataOverviewFormMeta.ts
@@ -3,7 +3,7 @@ import { validateEmail } from 'components/Forms/validationRules';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { PersonalDataOverviewFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -19,7 +19,7 @@ export const usePersonalDataOverviewForm = (): [
     );
     const defaultValues = { email: '' };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type PersonalDataOverviewFormMetaType = {

--- a/project-base/storefront/components/Pages/Registration/registrationFormMeta.tsx
+++ b/project-base/storefront/components/Pages/Registration/registrationFormMeta.tsx
@@ -23,7 +23,7 @@ import { useMemo } from 'react';
 import { FieldError, UseFormReturn, useWatch } from 'react-hook-form';
 import { CustomerTypeEnum } from 'types/customer';
 import { RegistrationFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -80,7 +80,7 @@ export const useRegistrationForm = (): [UseFormReturn<RegistrationFormType>, Reg
         newsletterSubscription: false,
     };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type RegistrationFormMetaType = {

--- a/project-base/storefront/components/Pages/ResetPassword/passwordResetFormMeta.ts
+++ b/project-base/storefront/components/Pages/ResetPassword/passwordResetFormMeta.ts
@@ -3,7 +3,7 @@ import { validateEmail } from 'components/Forms/validationRules';
 import { useMemo } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { PasswordResetFormType } from 'types/form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -16,7 +16,7 @@ export const usePasswordResetForm = (): [UseFormReturn<PasswordResetFormType>, P
     );
     const defaultValues = { email: '' };
 
-    return [useShopsysForm(resolver, defaultValues), defaultValues];
+    return [useFormWrapper(resolver, defaultValues), defaultValues];
 };
 
 type PasswordResetFormMetaType = {

--- a/project-base/storefront/components/Pages/Styleguide/StyleguideForms.tsx
+++ b/project-base/storefront/components/Pages/Styleguide/StyleguideForms.tsx
@@ -6,7 +6,7 @@ import { FormLine } from 'components/Forms/Lib/FormLine';
 import { TextInputControlled } from 'components/Forms/TextInput/TextInputControlled';
 import { Translate } from 'next-translate';
 import { FormProvider } from 'react-hook-form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import * as Yup from 'yup';
 
@@ -20,7 +20,7 @@ export const StyleguideForms: FC = () => {
 
 export const StyleguideFormExample: FC = () => {
     const { t } = useTranslation();
-    const formProviderMethods = useShopsysForm(getStyleguideExampleFormResolver(t), {
+    const formProviderMethods = useFormWrapper(getStyleguideExampleFormResolver(t), {
         optionalValue: '',
         requiredValue: '',
     });

--- a/project-base/storefront/components/Pages/Styleguide/StyleguideRadiogroup.tsx
+++ b/project-base/storefront/components/Pages/Styleguide/StyleguideRadiogroup.tsx
@@ -3,7 +3,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { FormLine } from 'components/Forms/Lib/FormLine';
 import { RadiobuttonGroup } from 'components/Forms/Radiobutton/RadiobuttonGroup';
 import { FormProvider } from 'react-hook-form';
-import { useShopsysForm } from 'utils/forms/useShopsysForm';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
 import * as Yup from 'yup';
 
 const getStyleguideExampleFormResolver = () =>
@@ -14,7 +14,7 @@ const getStyleguideExampleFormResolver = () =>
     );
 
 export const StyleguideRadiogroup: FC = () => {
-    const formProviderMethods = useShopsysForm(getStyleguideExampleFormResolver(), {
+    const formProviderMethods = useFormWrapper(getStyleguideExampleFormResolver(), {
         country: 'cz',
     });
 

--- a/project-base/storefront/utils/forms/useFormWrapper.ts
+++ b/project-base/storefront/utils/forms/useFormWrapper.ts
@@ -1,6 +1,6 @@
 import { DeepPartial, FieldValues, Resolver, useForm, UseFormReturn } from 'react-hook-form';
 
-export const useShopsysForm = <T extends FieldValues>(
+export const useFormWrapper = <T extends FieldValues>(
     resolver: Resolver<T> | undefined,
     defaultValues: DeepPartial<T>,
 ): UseFormReturn<T> =>

--- a/upgrade-notes/storefront_20251223_122434.md
+++ b/upgrade-notes/storefront_20251223_122434.md
@@ -1,0 +1,4 @@
+#### Remove Shopsys naming ([#4354](https://github.com/shopsys/shopsys/pull/4354))
+
+- the codebase is now free of Shopsys-specific naming
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The codebase is now free of Shopsys-specific naming.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-1586-remove-shopsys-naming.odin.shopsys.cloud
  - https://cz.tc-ssp-1586-remove-shopsys-naming.odin.shopsys.cloud
  - https://tc-ssp-1586-remove-shopsys-naming.odin.shopsys.cloud/sk
<!-- Replace -->
