### PR TITLE
upgrade symfony/doctrine-messenger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,7 +160,7 @@
         "symfony/clock": "^6.4",
         "symfony/console": "^6.4",
         "symfony/css-selector": "^6.4",
-        "symfony/doctrine-messenger": "^6.4",
+        "symfony/doctrine-messenger": "^6.4.31",
         "symfony/dom-crawler": "^6.4",
         "symfony/dotenv": "^6.4",
         "symfony/error-handler": "^6.4",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -97,7 +97,7 @@
         "symfony/amqp-messenger": "^6.4",
         "symfony/clock": "^6.4",
         "symfony/css-selector": "^6.4",
-        "symfony/doctrine-messenger": "^6.4",
+        "symfony/doctrine-messenger": "^6.4.31",
         "symfony/dom-crawler": "^6.4",
         "symfony/error-handler": "^6.4",
         "symfony/event-dispatcher": "^6.4",

--- a/packages/framework/src/Migrations/Version20241223020557.php
+++ b/packages/framework/src/Migrations/Version20241223020557.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace App\Migrations;
+namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Override;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
-class Version20231227143511 extends AbstractMigration
+class Version20241223020557 extends AbstractMigration
 {
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
@@ -16,7 +16,8 @@ class Version20231227143511 extends AbstractMigration
     #[Override]
     public function up(Schema $schema): void
     {
-        $this->sql('
+        if ($this->isAppMigrationNotInstalledRemoveIfExists('Version20231227143511')) {
+            $this->sql('
             CREATE TABLE messenger_messages (
                 id BIGSERIAL NOT NULL,
                 body TEXT NOT NULL,
@@ -27,21 +28,22 @@ class Version20231227143511 extends AbstractMigration
                 delivered_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
                 PRIMARY KEY(id)
             )');
-        $this->sql('CREATE INDEX IDX_75EA56E0FB7336F0 ON messenger_messages (queue_name)');
-        $this->sql('CREATE INDEX IDX_75EA56E0E3BD61CE ON messenger_messages (available_at)');
-        $this->sql('CREATE INDEX IDX_75EA56E016BA31DB ON messenger_messages (delivered_at)');
-        $this->sql('
+            $this->sql('CREATE INDEX IDX_75EA56E0FB7336F0 ON messenger_messages (queue_name)');
+            $this->sql('CREATE INDEX IDX_75EA56E0E3BD61CE ON messenger_messages (available_at)');
+            $this->sql('CREATE INDEX IDX_75EA56E016BA31DB ON messenger_messages (delivered_at)');
+            $this->sql('
             CREATE
             OR REPLACE FUNCTION notify_messenger_messages() RETURNS TRIGGER AS $$ BEGIN PERFORM pg_notify(
                 \'messenger_messages\', NEW.queue_name :: text
             ); RETURN NEW; END; $$ LANGUAGE plpgsql;');
-        $this->sql('DROP TRIGGER IF EXISTS notify_trigger ON messenger_messages;');
-        $this->sql('
+            $this->sql('DROP TRIGGER IF EXISTS notify_trigger ON messenger_messages;');
+            $this->sql('
             CREATE TRIGGER notify_trigger
             AFTER
                 INSERT
                 OR
             UPDATE
                 ON messenger_messages FOR EACH ROW EXECUTE PROCEDURE notify_messenger_messages();');
+        }
     }
 }

--- a/packages/framework/src/Migrations/Version20251231124034.php
+++ b/packages/framework/src/Migrations/Version20251231124034.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20251231124034 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('
+            CREATE INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750 ON messenger_messages (
+                queue_name, available_at, delivered_at,
+                id
+            )');
+        $this->sql('DROP INDEX IF EXISTS IDX_75EA56E016BA31DB');
+        $this->sql('DROP INDEX IF EXISTS IDX_75EA56E0E3BD61CE');
+        $this->sql('DROP INDEX IF EXISTS IDX_75EA56E0FB7336F0');
+    }
+}

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -88,7 +88,7 @@
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony-cmf/routing": "^3.0.3",
         "symfony-cmf/routing-bundle": "^3.0.3",
-        "symfony/doctrine-messenger": "^6.4",
+        "symfony/doctrine-messenger": "^6.4.31",
         "symfony/dotenv": "^6.4",
         "symfony/error-handler": "^6.4",
         "symfony/flex": "^1.17",

--- a/upgrade-notes/backend_20251231_135802.md
+++ b/upgrade-notes/backend_20251231_135802.md
@@ -1,0 +1,5 @@
+#### upgrade symfony/doctrine-messenger ([#4365](https://github.com/shopsys/shopsys/pull/4365))
+
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the framework package:
+    - migration for creating `messenger_messages` table (see `Shopsys\FrameworkBundle\Migrations\Version20241223020557`)
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
After `symfony/doctrine-messenger@v6.4.31` was [released](https://github.com/symfony/symfony/pull/62894), our builds started to fail as the database schema needed to be updated (because of https://github.com/symfony/symfony/pull/61963). This PR ensures we require the latest version and updates the schema properly.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-messages-table.odin.shopsys.cloud
  - https://cz.rv-messages-table.odin.shopsys.cloud
  - https://rv-messages-table.odin.shopsys.cloud/sk
<!-- Replace -->
