### PR TITLE
Shopsys CLI: A new project bootstrapper

### DIFF
--- a/.github/monorepo/monorepo_functions.sh
+++ b/.github/monorepo/monorepo_functions.sh
@@ -21,6 +21,7 @@ get_all_packages() {
         biome-config \
         framework \
         frontend-api \
+        cli \
         google-cloud-bundle \
         s3-bridge \
         category-feed-luigis-box \

--- a/CHANGELOG-19.0.md
+++ b/CHANGELOG-19.0.md
@@ -30,6 +30,7 @@ There is a list of all the repositories maintained by the monorepo:
 - [shopsys/luigis-box](https://github.com/shopsys/luigis-box)
 - [shopsys/administration](https://github.com/shopsys/administration)
 - [shopsys/maker](https://github.com/shopsys/maker)
+- [shopsys/cli](https://github.com/shopsys/cli)
 
 Packages are formatted by release version.
 You can see all the changes done to the package that you carry about with this tree.

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
             "Shopsys\\AdministrationBundle\\": "packages/administration/src/",
             "Shopsys\\CodingStandards\\": "packages/coding-standards/src/",
             "Shopsys\\FormTypesBundle\\": "packages/form-types-bundle/src/",
+            "Shopsys\\Cli\\": "packages/cli/src/",
             "Shopsys\\FrontendApiBundle\\": "packages/frontend-api/src/",
             "Shopsys\\GoogleCloudBundle\\": "packages/google-cloud-bundle/src/",
             "Shopsys\\HttpSmokeTesting\\": "packages/http-smoke-testing/src/",

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,5 +1,6 @@
 # Installation
 
+- [Project Initialization with Shopsys CLI](./project-initialization-with-shopsys-cli.md)
 - [Application Configuration](./application-configuration.md)
 - [Application Requirements](./application-requirements.md)
 - [Installation Guide](./installation-guide.md)

--- a/docs/installation/installation-guide.md
+++ b/docs/installation/installation-guide.md
@@ -1,8 +1,24 @@
 # Installation Guide
 
-This document will provide you with information about 2 ways of developing and running Shopsys Platform project and the services that it depends on.  
-The first option [using docker](#installation-using-docker) is **highly recommended** since it is the easiest and fastest way to start Shopsys Platform.
-In the case the operating system does not support docker, or you are not able to use Docker (e.g., due to the performance problems with Docker-sync), we prepared also second section with document about project [installation without docker](#installation-without-docker), however this way is slower and harder to configure and maintain because of different operating systems and their versions.
+This document will provide you with information about ways of developing and running Shopsys Platform project and the services that it depends on.
+
+## Quick Start with Shopsys CLI
+
+For new projects, we recommend using **Shopsys CLI** - a command-line tool that automates project initialization and configuration:
+
+> **Windows Users:** Run these commands inside WSL2 (Windows Subsystem for Linux).
+
+```bash
+# Download Shopsys CLI
+curl -L https://github.com/shopsys/cli/releases/latest/download/shopsys.phar -o shopsys
+chmod +x shopsys
+
+# Initialize a new project
+./shopsys init my-project
+```
+
+The CLI will guide you through domain configuration, locale settings, and more.
+See [Project Initialization with Shopsys CLI](./project-initialization-with-shopsys-cli.md) for detailed documentation.
 
 ## Installation using Docker
 

--- a/docs/installation/installation-guide.md
+++ b/docs/installation/installation-guide.md
@@ -4,12 +4,20 @@ This document will provide you with information about ways of developing and run
 
 ## Quick Start with Shopsys CLI
 
-For new projects, we recommend using **Shopsys CLI** - a command-line tool that automates project initialization and configuration:
+For new projects, the **Shopsys CLI** is automatically downloaded when you create a project using Composer:
 
 > **Windows Users:** Run these commands inside WSL2 (Windows Subsystem for Linux).
 
 ```bash
-# Download Shopsys CLI
+composer create-project shopsys/project-base --no-install --keep-vcs --ignore-platform-reqs
+```
+
+The CLI (`shopsys.phar`) is automatically downloaded and the configuration wizard launches, guiding you through domain configuration, locale settings, and more.
+
+Alternatively, you can download the CLI manually and initialize a project:
+
+```bash
+# Download Shopsys CLI manually
 curl -L https://github.com/shopsys/cli/releases/latest/download/shopsys.phar -o shopsys
 chmod +x shopsys
 
@@ -17,7 +25,6 @@ chmod +x shopsys
 ./shopsys init my-project
 ```
 
-The CLI will guide you through domain configuration, locale settings, and more.
 See [Project Initialization with Shopsys CLI](./project-initialization-with-shopsys-cli.md) for detailed documentation.
 
 ## Installation using Docker

--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -4,6 +4,10 @@ This guide covers building new projects based on Shopsys Platform.
 If you want to contribute to Shopsys Platform itself, you need to install the whole [shopsys/shopsys](https://github.com/shopsys/shopsys) monorepo.
 Take a look at the article about [Monorepo](../introduction/monorepo.md) for more information.
 
+!!! tip "Automate with Shopsys CLI"
+
+    Instead of manual project setup, you can use [Shopsys CLI](./project-initialization-with-shopsys-cli.md) to automate project initialization, domain configuration, and locale settings with a single command.
+
 ## Requirements
 
 - [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)

--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -33,6 +33,11 @@ cd project-base
     - The `--keep-vcs` option initializes GIT repository in your project folder that is needed for diff commands of the application build and keeps the GIT history of `shopsys/project-base`
     - The `--ignore-platform-reqs` option ensures your local PHP setup is not verified (it is not needed, everything is installed in Docker later)
 
+!!! info "Automatic CLI Download"
+
+    During project creation, the [Shopsys CLI](./project-initialization-with-shopsys-cli.md) (`shopsys.phar`) is automatically downloaded and the configuration wizard is launched.
+    This allows you to configure your domains, locales, and other project settings interactively before proceeding with the installation.
+
 ### 2. Installation
 
 Now, you have two options:

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -7,6 +7,10 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 
 This solution uses [_Mutagen_](https://mutagen.io) (for relatively fast two-way synchronization of the application files between the host machine and Docker volume).
 
+!!! tip "Automate with Shopsys CLI"
+
+    Instead of manual project setup, you can use [Shopsys CLI](./project-initialization-with-shopsys-cli.md) to automate project initialization, domain configuration, and locale settings with a single command.
+
 ## Requirements
 
 - [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -37,6 +37,11 @@ cd project-base
     - The `--keep-vcs` option initializes GIT repository in your project folder that is needed for diff commands of the application build and keeps the GIT history of `shopsys/project-base`
     - The `--ignore-platform-reqs` option ensures your local PHP setup is not verified (it is not needed, everything is installed in Docker later)
 
+!!! info "Automatic CLI Download"
+
+    During project creation, the [Shopsys CLI](./project-initialization-with-shopsys-cli.md) (`shopsys.phar`) is automatically downloaded and the configuration wizard is launched.
+    This allows you to configure your domains, locales, and other project settings interactively before proceeding with the installation.
+
 ### 2. Installation
 
 Now, you have two options:

--- a/docs/installation/installation-using-docker-windows-10.md
+++ b/docs/installation/installation-using-docker-windows-10.md
@@ -6,6 +6,10 @@ This guide covers building new projects based on Shopsys Platform.
 In case you want to contribute to Shopsys Platform itself, you need to install the whole [shopsys/shopsys](https://github.com/shopsys/shopsys) monorepo.
 Take a look at the article about [Monorepo](../introduction/monorepo.md) for more information.
 
+!!! tip "Automate with Shopsys CLI"
+
+    Instead of manual project setup, you can use [Shopsys CLI](./project-initialization-with-shopsys-cli.md) to automate project initialization, domain configuration, and locale settings with a single command.
+
 ## Supported systems
 
 - Windows 10 version 2004 and higher

--- a/docs/installation/installation-using-docker-windows-10.md
+++ b/docs/installation/installation-using-docker-windows-10.md
@@ -99,6 +99,11 @@ cd project-base
     - The `--keep-vcs` option initializes GIT repository in your project folder that is needed for diff commands of the application build and keeps the GIT history of `shopsys/project-base`
     - The `--ignore-platform-reqs` option ensures your local PHP setup is not verified (it is not needed, everything is installed in Docker later)
 
+!!! info "Automatic CLI Download"
+
+    During project creation, the [Shopsys CLI](./project-initialization-with-shopsys-cli.md) (`shopsys.phar`) is automatically downloaded and the configuration wizard is launched.
+    This allows you to configure your domains, locales, and other project settings interactively before proceeding with the installation.
+
 ### 2. Installation
 
 Now, you have two options:

--- a/docs/installation/native-installation.md
+++ b/docs/installation/native-installation.md
@@ -2,6 +2,10 @@
 
 This document will provide you with the general information that is needed for running Shopsys Platform on different operation systems like (Windows, Mac, Linux, ... ), however it is not a step-by-step guide, since it would be very difficult to maintain all operation systems and their versions.
 
+!!! tip "Automate with Shopsys CLI"
+
+    Instead of manual project setup, you can use [Shopsys CLI](./project-initialization-with-shopsys-cli.md) to automate project initialization, domain configuration, and locale settings with a single command.
+
 First it is truly essential to read and understand the articles about requirements and configurations for Shopsys Platform application.
 
 1. [Application Requirements](application-requirements.md)

--- a/docs/installation/project-initialization-with-shopsys-cli.md
+++ b/docs/installation/project-initialization-with-shopsys-cli.md
@@ -9,18 +9,24 @@ It simplifies multi-domain setup by providing interactive configuration prompts 
 
 > **Windows Users:** The Shopsys CLI must be run inside WSL2 (Windows Subsystem for Linux). Open your WSL2 terminal before running these commands.
 
-Download the PHAR file from the [shopsys/cli releases](https://github.com/shopsys/cli/releases):
+### Automatic Installation (Recommended)
+
+When you create a new Shopsys Platform project using `composer create-project`, the CLI is **automatically downloaded** and the configuration wizard is launched:
+
+```bash
+composer create-project shopsys/project-base --no-install --keep-vcs --ignore-platform-reqs
+```
+
+The `post-create-project-cmd` hook downloads `shopsys.phar` and runs `php shopsys.phar configure .` automatically.
+
+### Manual Installation
+
+If you need to download the CLI manually (e.g., to use with an existing project), download the PHAR file from the [shopsys/cli releases](https://github.com/shopsys/cli/releases):
 
 ```bash
 # Download the latest release
 curl -L https://github.com/shopsys/cli/releases/latest/download/shopsys.phar -o shopsys
 chmod +x shopsys
-```
-
-You can also install it globally:
-
-```bash
-sudo mv shopsys /usr/local/bin/shopsys
 ```
 
 ## Commands

--- a/docs/installation/project-initialization-with-shopsys-cli.md
+++ b/docs/installation/project-initialization-with-shopsys-cli.md
@@ -1,0 +1,92 @@
+# Project Initialization with Shopsys CLI
+
+Shopsys CLI (package name: `shopsys/cli`) is a command-line tool that automates the initialization and configuration of new Shopsys Platform projects.
+It simplifies multi-domain setup by providing interactive configuration prompts or YAML-based configuration files.
+
+> **Important:** The Shopsys CLI version is coupled with the Shopsys Platform version. Always use the CLI version that matches your target Platform version (e.g., use CLI 18.0 for Platform 18.0).
+
+## Installation
+
+> **Windows Users:** The Shopsys CLI must be run inside WSL2 (Windows Subsystem for Linux). Open your WSL2 terminal before running these commands.
+
+Download the PHAR file from the [shopsys/cli releases](https://github.com/shopsys/cli/releases):
+
+```bash
+# Download the latest release
+curl -L https://github.com/shopsys/cli/releases/latest/download/shopsys.phar -o shopsys
+chmod +x shopsys
+```
+
+You can also install it globally:
+
+```bash
+sudo mv shopsys /usr/local/bin/shopsys
+```
+
+## Commands
+
+### Initialize a New Project
+
+The `init` command clones the project-base repository and runs the configuration wizard:
+
+```bash
+# Interactive mode (recommended)
+./shopsys init my-project
+
+# With a specific version (use matching CLI version!)
+./shopsys init my-project --branch=18.0.0
+
+# Non-interactive mode with YAML configuration
+./shopsys init my-project --config=project-config.yaml
+
+# Use the latest stable release (default)
+./shopsys init my-project --branch=stable
+```
+
+**Options:**
+
+- `--branch` (`-b`): Git branch or tag to clone (default: `stable`)
+- `--config` (`-c`): Path to YAML configuration file for non-interactive mode
+
+### Configure an Existing Project
+
+The `configure` command applies configuration to an existing project-base:
+
+```bash
+# Interactive mode
+./shopsys configure /path/to/project
+
+# Non-interactive mode
+./shopsys configure /path/to/project --config=project-config.yaml
+```
+
+### List Available Workers
+
+View all configuration workers and their descriptions:
+
+```bash
+./shopsys workers
+```
+
+## Interactive Configuration
+
+When running in interactive mode, the CLI will guide you through configuring your domains and project settings step by step.
+After collecting all information, it displays a YAML summary and asks for confirmation before applying changes.
+
+## YAML Configuration
+
+For automated or repeatable setups, you can provide a YAML configuration file instead of using interactive mode.
+Run the interactive mode once to see the expected YAML structure, then save it for future use:
+
+```bash
+./shopsys init my-project --config=project-config.yaml
+```
+
+## Next Steps
+
+After running the CLI:
+
+1. **Review changes**: Check the generated configuration files
+2. **Commit to git**: Save your configuration
+3. **Install the project**: Run `./scripts/install.sh`
+4. **Start development**

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -3,6 +3,10 @@
 This article describes how to work with domains and languages during the development of your project.
 For an explanation of the basic terms, please read [domain, multidomain and multilanguage](domain-multidomain-multilanguage.md) article first.
 
+!!! tip "Automate with Shopsys CLI"
+
+    Setting up domains and locales manually can be complex. [Shopsys CLI](../installation/project-initialization-with-cli.md) automates this entire process - it guides you through domain configuration, locale settings, and URL setup interactively or via YAML configuration files.
+
 !!! note
 
     Demo data on Shopsys Platform are only translated to `en` and `cs` locales.<br>

--- a/docs/introduction/monorepo.md
+++ b/docs/introduction/monorepo.md
@@ -54,6 +54,7 @@ If you are interested, you can read more about the monorepo approach here - http
 - [shopsys/luigis-box](https://github.com/shopsys/luigis-box)
 - [shopsys/administration](https://github.com/shopsys/administration)
 - [shopsys/maker](https://github.com/shopsys/maker)
+- [shopsys/cli](https://github.com/shopsys/cli)
 
 !!! note
 

--- a/packages/cli/.github/workflows/build-phar.yaml
+++ b/packages/cli/.github/workflows/build-phar.yaml
@@ -1,0 +1,94 @@
+name: Build Shopsys CLI PHAR
+
+on:
+    push:
+        branches:
+            - '[0-9]+.[0-9]+'
+        tags:
+            - 'v*'
+    workflow_dispatch:
+        inputs:
+            release_tag:
+                description: 'Release tag name (e.g., v1.0.0)'
+                required: true
+                type: string
+
+jobs:
+    build:
+        name: Build PHAR
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.3'
+                    tools: composer
+                    extensions: json, yaml
+
+            -   name: Install dependencies
+                run: composer install --no-dev --optimize-autoloader --prefer-dist
+
+            -   name: Install Box
+                run: composer global require humbug/box
+
+            -   name: Determine release tag
+                id: release_tag
+                run: |
+                    if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+                        # Version tag (v*) - proper release
+                        echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+                        echo "is_prerelease=false" >> $GITHUB_OUTPUT
+                        echo "replace_existing=false" >> $GITHUB_OUTPUT
+                    elif [[ -n "$INPUT_TAG" ]]; then
+                        # Manual dispatch with specific tag - always replaceable
+                        echo "tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+                        echo "is_prerelease=false" >> $GITHUB_OUTPUT
+                        echo "replace_existing=true" >> $GITHUB_OUTPUT
+                    else
+                        # Version branch (e.g., 19.0, 17.1) - replaceable release
+                        echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+                        echo "is_prerelease=true" >> $GITHUB_OUTPUT
+                        echo "replace_existing=true" >> $GITHUB_OUTPUT
+                    fi
+                env:
+                    INPUT_TAG: ${{ inputs.release_tag }}
+
+            -   name: Add build metadata
+                run: |
+                    echo "BUILD_SHA=${{ github.sha }}" >> .build-metadata
+                    echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> .build-metadata
+                    echo "BUILD_REF=${{ steps.release_tag.outputs.tag }}" >> .build-metadata
+
+            -   name: Set CLI version in box.json
+                run: sed -i 's/\$CLI_VERSION/${{ steps.release_tag.outputs.tag }}/' box.json
+
+            -   name: Build PHAR
+                run: box compile
+
+            -   name: Test PHAR
+                run: |
+                    php shopsys.phar --version
+                    php shopsys.phar workers
+
+            -   name: Delete existing release
+                if: steps.release_tag.outputs.replace_existing == 'true'
+                run: gh release delete "$RELEASE_TAG" --cleanup-tag --yes || true
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+
+            -   name: Create Release
+                uses: softprops/action-gh-release@v2
+                with:
+                    files: shopsys.phar
+                    tag_name: ${{ steps.release_tag.outputs.tag }}
+                    name: ${{ steps.release_tag.outputs.tag }}
+                    prerelease: ${{ steps.release_tag.outputs.is_prerelease == 'true' }}
+                    generate_release_notes: ${{ steps.release_tag.outputs.replace_existing != 'true' }}
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for your contributions to Shopsys CLI package.
+Together we are making Shopsys Platform better.
+
+This repository is READ-ONLY.
+If you want to [report issues](https://github.com/shopsys/shopsys/issues/new) and/or send [pull requests](https://github.com/shopsys/shopsys/compare),
+please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
+
+Please check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/HEAD/CONTRIBUTING.md) before contributing.

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,14 @@
+MIT License
+
+Copyright (c) 2016-2026 Shopsys s.r.o., http://www.shopsys.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,54 @@
+# Shopsys CLI
+
+Command-line tool for configuring new Shopsys Platform projects.
+
+This repository is maintained by [shopsys/shopsys] monorepo, information about changes is in [CHANGELOG.md](https://github.com/shopsys/shopsys/blob/HEAD/CHANGELOG.md).
+
+## Installation
+
+Download the latest PHAR from [GitHub Releases](https://github.com/shopsys/cli/releases)
+
+```bash
+curl -L https://github.com/shopsys/cli/releases/latest/download/shopsys.phar -o shopsys
+chmod +x shopsys
+```
+
+## Usage
+
+### Initialize a new project
+
+```bash
+./shopsys init my-project
+```
+
+### Configure an existing project
+
+```bash
+./shopsys configure
+```
+
+### List available workers
+
+```bash
+./shopsys workers
+```
+
+## Contributing
+
+Thank you for your contributions to Shopsys CLI package.
+Together we are making Shopsys Platform better.
+
+This repository is READ-ONLY.
+If you want to [report issues](https://github.com/shopsys/shopsys/issues/new) and/or send [pull requests](https://github.com/shopsys/shopsys/compare),
+please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
+
+Please check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/HEAD/CONTRIBUTING.md) before contributing.
+
+## Support
+
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
+
+If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
+
+[shopsys/shopsys]: (https://github.com/shopsys/shopsys)

--- a/packages/cli/bin/shopsys
+++ b/packages/cli/bin/shopsys
@@ -1,0 +1,11 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Shopsys\Cli\Application;
+
+$application = new Application();
+$application->run();

--- a/packages/cli/box.json
+++ b/packages/cli/box.json
@@ -1,0 +1,29 @@
+{
+    "output": "shopsys.phar",
+    "main": "bin/shopsys",
+    "replacements": {
+        "cli_version": "$CLI_VERSION"
+    },
+    "directories": [
+        "src",
+        "config"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": ["tests", "Tests"],
+            "in": "vendor"
+        },
+        {
+            "name": "*.yaml",
+            "in": "vendor/symfony"
+        },
+        {
+            "name": "*.json",
+            "in": "vendor/commerceguys/intl/resources"
+        }
+    ],
+    "compactors": [
+        "KevinGH\\Box\\Compactor\\Php"
+    ]
+}

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -16,13 +16,15 @@
     },
     "require": {
         "php": "^8.3",
+        "commerceguys/intl": "^2.0",
         "symfony/config": "^6.4",
         "symfony/console": "^6.4",
         "symfony/dependency-injection": "^6.4",
         "symfony/filesystem": "^6.4",
         "symfony/finder": "^6.4",
         "symfony/process": "^6.4",
-        "symfony/yaml": "^6.4"
+        "symfony/yaml": "^6.4",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.2",

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "shopsys/cli",
+    "type": "project",
+    "description": "Shopsys CLI - Command-line tool for configuring new Shopsys Platform projects",
+    "license": "MIT",
+    "bin": ["bin/shopsys"],
+    "autoload": {
+        "psr-4": {
+            "Shopsys\\Cli\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\Cli\\": "tests/"
+        }
+    },
+    "require": {
+        "php": "^8.3",
+        "symfony/config": "^6.4",
+        "symfony/console": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/filesystem": "^6.4",
+        "symfony/finder": "^6.4",
+        "symfony/process": "^6.4",
+        "symfony/yaml": "^6.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.2",
+        "phpstan/phpstan": "^2.1"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
+    }
+}

--- a/packages/cli/config/services.yaml
+++ b/packages/cli/config/services.yaml
@@ -3,17 +3,30 @@ services:
         autowire: true
         autoconfigure: true
 
+    _instanceof:
+        Shopsys\Cli\Config\DomainConfigSectionInterface:
+            tags: [ 'cli.domain_config_section' ]
+            shared: false
+        Shopsys\Cli\Config\ProjectConfigSectionInterface:
+            tags: [ 'cli.project_config_section' ]
+            shared: false
+        Shopsys\Cli\Worker\WorkerInterface:
+            tags: [ 'cli.worker' ]
+
     Shopsys\Cli\:
-        resource: '../src/**/*{Handler}.php'
+        resource: '../src/**/*{Collector,Handler,Loader,Registry,Section,Worker}.php'
 
     Shopsys\Cli\Command\:
         resource: '../src/Command/*'
         public: true
 
-    Shopsys\Cli\Worker\:
-        resource: '../src/Worker/**/*Worker.php'
-        tags: [ 'cli.worker' ]
+    Symfony\Component\Filesystem\Filesystem: ~
 
     Shopsys\Cli\Worker\WorkerRunner:
         arguments:
-            $taggedWorkers: !tagged_iterator 'cli.worker'
+            $workers: !tagged_iterator 'cli.worker'
+
+    Shopsys\Cli\Config\ConfigSectionRegistry:
+        arguments:
+            $domainConfigSections: !tagged_locator { tag: 'cli.domain_config_section' }
+            $projectConfigSections: !tagged_locator { tag: 'cli.project_config_section' }

--- a/packages/cli/config/services.yaml
+++ b/packages/cli/config/services.yaml
@@ -9,3 +9,11 @@ services:
     Shopsys\Cli\Command\:
         resource: '../src/Command/*'
         public: true
+
+    Shopsys\Cli\Worker\:
+        resource: '../src/Worker/**/*Worker.php'
+        tags: [ 'cli.worker' ]
+
+    Shopsys\Cli\Worker\WorkerRunner:
+        arguments:
+            $taggedWorkers: !tagged_iterator 'cli.worker'

--- a/packages/cli/config/services.yaml
+++ b/packages/cli/config/services.yaml
@@ -1,7 +1,7 @@
 services:
     _defaults:
-        autowire: true
         autoconfigure: true
+        autowire: true
 
     _instanceof:
         Shopsys\Cli\Config\DomainConfigSectionInterface:
@@ -17,16 +17,16 @@ services:
         resource: '../src/**/*{Collector,Handler,Loader,Registry,Section,Worker}.php'
 
     Shopsys\Cli\Command\:
-        resource: '../src/Command/*'
         public: true
-
-    Symfony\Component\Filesystem\Filesystem: ~
-
-    Shopsys\Cli\Worker\WorkerRunner:
-        arguments:
-            $workers: !tagged_iterator 'cli.worker'
+        resource: '../src/Command/*'
 
     Shopsys\Cli\Config\ConfigSectionRegistry:
         arguments:
             $domainConfigSections: !tagged_locator { tag: 'cli.domain_config_section' }
             $projectConfigSections: !tagged_locator { tag: 'cli.project_config_section' }
+
+    Shopsys\Cli\Worker\WorkerRunner:
+        arguments:
+            $workers: !tagged_iterator 'cli.worker'
+
+    Symfony\Component\Filesystem\Filesystem: ~

--- a/packages/cli/config/services.yaml
+++ b/packages/cli/config/services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Shopsys\Cli\Command\:
+        resource: '../src/Command/*'
+        public: true

--- a/packages/cli/config/services.yaml
+++ b/packages/cli/config/services.yaml
@@ -3,6 +3,9 @@ services:
         autowire: true
         autoconfigure: true
 
+    Shopsys\Cli\:
+        resource: '../src/**/*{Handler}.php'
+
     Shopsys\Cli\Command\:
         resource: '../src/Command/*'
         public: true

--- a/packages/cli/src/Application.php
+++ b/packages/cli/src/Application.php
@@ -16,7 +16,7 @@ final class Application extends BaseApplication
 {
     public const string NAME = 'Shopsys CLI';
 
-    public const string VERSION = '1.0.0';
+    public const string VERSION = '@cli_version@';
 
     public function __construct()
     {

--- a/packages/cli/src/Application.php
+++ b/packages/cli/src/Application.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\Cli;
 
 use Override;
+use Shopsys\Cli\Command\ConfigureCommand;
 use Shopsys\Cli\Command\InitCommand;
 use Shopsys\Cli\Command\ListWorkersCommand;
 use Symfony\Component\Config\FileLocator;
@@ -29,6 +30,8 @@ final class Application extends BaseApplication
         $this->addCommands([
             /** @phpstan-ignore symfonyContainer.serviceNotFound */
             $container->get(InitCommand::class),
+            /** @phpstan-ignore symfonyContainer.serviceNotFound */
+            $container->get(ConfigureCommand::class),
             /** @phpstan-ignore symfonyContainer.serviceNotFound */
             $container->get(ListWorkersCommand::class),
         ]);

--- a/packages/cli/src/Application.php
+++ b/packages/cli/src/Application.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\Cli;
 
 use Override;
+use Shopsys\Cli\Command\InitCommand;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\HelpCommand;
@@ -22,7 +23,12 @@ final class Application extends BaseApplication
     {
         parent::__construct(self::NAME, self::VERSION);
 
-        $this->buildContainer();
+        $container = $this->buildContainer();
+
+        $this->addCommands([
+            /** @phpstan-ignore symfonyContainer.serviceNotFound */
+            $container->get(InitCommand::class),
+        ]);
     }
 
     /**

--- a/packages/cli/src/Application.php
+++ b/packages/cli/src/Application.php
@@ -6,6 +6,7 @@ namespace Shopsys\Cli;
 
 use Override;
 use Shopsys\Cli\Command\InitCommand;
+use Shopsys\Cli\Command\ListWorkersCommand;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\HelpCommand;
@@ -28,6 +29,8 @@ final class Application extends BaseApplication
         $this->addCommands([
             /** @phpstan-ignore symfonyContainer.serviceNotFound */
             $container->get(InitCommand::class),
+            /** @phpstan-ignore symfonyContainer.serviceNotFound */
+            $container->get(ListWorkersCommand::class),
         ]);
     }
 

--- a/packages/cli/src/Application.php
+++ b/packages/cli/src/Application.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli;
+
+use Override;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Command\HelpCommand;
+use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+final class Application extends BaseApplication
+{
+    public const string NAME = 'Shopsys CLI';
+
+    public const string VERSION = '1.0.0';
+
+    public function __construct()
+    {
+        parent::__construct(self::NAME, self::VERSION);
+
+        $this->buildContainer();
+    }
+
+    /**
+     * @return \Symfony\Component\DependencyInjection\ContainerBuilder
+     */
+    private function buildContainer(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', dirname(__DIR__));
+
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../config'),
+        );
+        $loader->load('services.yaml');
+
+        $container->compile();
+
+        return $container;
+    }
+
+    /**
+     * @return \Symfony\Component\Console\Command\Command[]
+     */
+    #[Override]
+    protected function getDefaultCommands(): array
+    {
+        return [
+            new HelpCommand(),
+            new ListCommand(),
+        ];
+    }
+}

--- a/packages/cli/src/Command/ConfigureCommand.php
+++ b/packages/cli/src/Command/ConfigureCommand.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Command;
+
+use Exception;
+use Override;
+use Shopsys\Cli\Exception\CancelledException;
+use Shopsys\Cli\Input\InteractiveInputCollector;
+use Shopsys\Cli\Input\YamlConfigLoader;
+use Shopsys\Cli\Worker\WorkerInterface;
+use Shopsys\Cli\Worker\WorkerResult;
+use Shopsys\Cli\Worker\WorkerRunner;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'configure',
+    description: 'Configure an existing Shopsys Platform project',
+)]
+class ConfigureCommand extends Command
+{
+    private const string OPTION_CONFIG = 'config';
+    private const string OPTION_MODIFICATIONS = 'modifications';
+    private const string ARGUMENT_PATH = 'path';
+
+    /**
+     * @param \Shopsys\Cli\Worker\WorkerRunner $workerRunner
+     * @param \Shopsys\Cli\Input\InteractiveInputCollector $interactiveInputCollector
+     * @param \Shopsys\Cli\Input\YamlConfigLoader $yamlConfigLoader
+     */
+    public function __construct(
+        private readonly WorkerRunner $workerRunner,
+        private readonly InteractiveInputCollector $interactiveInputCollector,
+        private readonly YamlConfigLoader $yamlConfigLoader,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $optionConfig = self::OPTION_CONFIG;
+        $optionModifications = self::OPTION_MODIFICATIONS;
+
+        $this
+            ->addArgument(
+                self::ARGUMENT_PATH,
+                InputArgument::REQUIRED,
+                'Path to the project directory',
+            )
+            ->addOption(
+                $optionConfig,
+                $optionConfig[0],
+                InputOption::VALUE_REQUIRED,
+                'Path to YAML configuration file (for non-interactive mode)',
+            )
+            ->addOption(
+                $optionModifications,
+                $optionModifications[0],
+                InputOption::VALUE_NONE,
+                'Display modified files',
+            )
+            ->setHelp(
+                <<<HELP
+The <info>%command.name%</info> command configures an existing Shopsys Platform project.
+
+<info>Interactive mode:</info>
+    <comment>%command.full_name% /path/to/project</comment>
+
+<info>Non-interactive mode (from YAML file):</info>
+    <comment>%command.full_name% --{$optionConfig}=project-config.yaml</comment>
+
+<info>Show modified files for each step:</info>
+    <comment>%command.full_name% --{$optionModifications}</comment>
+HELP,
+            );
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $projectPath = realpath($input->getArgument(self::ARGUMENT_PATH));
+
+        if ($projectPath === false) {
+            $io->error(sprintf('Project path not found: %s', $input->getArgument(self::ARGUMENT_PATH)));
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $configFile = $input->getOption(self::OPTION_CONFIG);
+
+            if ($configFile !== null) {
+                $config = $this->yamlConfigLoader->load($configFile, $projectPath);
+            } else {
+                $config = $this->interactiveInputCollector->collect($projectPath, $io);
+            }
+        } catch (CancelledException) {
+            $io->warning('Configuration cancelled by user.');
+            $io->block(
+                sprintf('Copy the configuration printed above into a YAML file, fix it, and rerun with the --%s option', self::OPTION_CONFIG),
+                'TIP',
+                'fg=bright-cyan',
+            );
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Applying Configuration');
+
+        $results = $this->workerRunner->run(
+            $config,
+            $projectPath,
+            function (WorkerInterface $worker, WorkerResult $result) use ($io, $input) {
+                if ($result->success) {
+                    $io->section(sprintf('<fg=green>✓</> %s', $result->message));
+
+                    if ($input->getOption(self::OPTION_MODIFICATIONS)) {
+                        if (count($result->filesModified) > 0) {
+                            $io->writeln('✏️ <fg=green>Modified files:</>');
+                            $io->listing($result->filesModified);
+                        }
+
+                        if (count($result->filesCreated) > 0) {
+                            $io->writeln('️➕ <fg=green>Created files:</>');
+                            $io->listing($result->filesCreated);
+                        }
+
+                        if (count($result->filesDeleted) > 0) {
+                            $io->writeln('️🗑️ <fg=green>Deleted files:</>');
+                            $io->listing($result->filesDeleted);
+                        }
+                    }
+                } else {
+                    $io->writeln(sprintf('<fg=red>✗</> %s: %s', $worker->getName(), $result->message));
+                }
+            },
+        );
+
+        $io->newLine();
+
+        if ($this->workerRunner->allSuccessful($results)) {
+            $io->success('Configuration complete!');
+            $this->displayHints($io, $results);
+            $this->displayNextSteps($io);
+
+            return Command::SUCCESS;
+        }
+
+        $io->warning('Configuration completed with some errors. Please review the output above.');
+
+        return Command::FAILURE;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @param array<\Shopsys\Cli\Worker\WorkerResult> $results
+     */
+    private function displayHints(SymfonyStyle $io, array $results): void
+    {
+        $hints = $this->workerRunner->collectHints($results);
+
+        if (count($hints) === 0) {
+            return;
+        }
+
+        $io->writeln('<info>Important notes:</info>');
+        $io->listing($hints);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     */
+    private function displayNextSteps(SymfonyStyle $io): void
+    {
+        $io->writeln('<info>Next steps:</info>');
+        $io->listing([
+            'Install project: <comment>./scripts/install.sh</comment>',
+            'Fix backend standards: <comment>docker compose exec php-fpm php phing standards-fix</comment>',
+            'Dump backend translations: <comment>docker compose exec php-fpm php phing translations-dump</comment>',
+            'Fix storefront standards: <comment>docker compose exec storefront pnpm run check--fix</comment>',
+            'Dump storefront translations: <comment>docker compose exec storefront pnpm run translate</comment>',
+            'Verify and commit changes to git',
+        ]);
+    }
+}

--- a/packages/cli/src/Command/InitCommand.php
+++ b/packages/cli/src/Command/InitCommand.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Command;
+
+use Override;
+use Shopsys\Cli\Exception\GitException;
+use Shopsys\Cli\Model\GitHandler;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'init',
+    description: 'Initialize a new Shopsys Platform project',
+)]
+class InitCommand extends Command
+{
+    private const string REPOSITORY_URL = 'https://github.com/shopsys/project-base.git';
+
+    private const string OPTION_BRANCH = 'branch';
+    private const string OPTION_PROJECT_NAME = 'project-name';
+    private const string OPTION_CONFIG = 'config';
+    private const string BRANCH_STABLE = 'stable';
+
+    /**
+     * @param \Shopsys\Cli\Model\GitHandler $gitHandler
+     */
+    public function __construct(
+        private readonly GitHandler $gitHandler,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $optionBranch = self::OPTION_BRANCH;
+        $optionConfig = self::OPTION_CONFIG;
+
+        $this
+            ->addArgument(
+                self::OPTION_PROJECT_NAME,
+                InputArgument::OPTIONAL,
+                'Name of the project directory to create',
+                'project-base',
+            )
+            ->addOption(
+                $optionBranch,
+                $optionBranch[0],
+                InputOption::VALUE_REQUIRED,
+                'Git branch or tag to clone',
+                self::BRANCH_STABLE,
+            )
+            ->addOption(
+                $optionConfig,
+                $optionConfig[0],
+                InputOption::VALUE_REQUIRED,
+                'Path to YAML configuration file (for non-interactive mode)',
+            )
+            ->setHelp(
+                <<<HELP
+The <info>%command.name%</info> command creates a new Shopsys Platform project.
+
+<info>Interactive mode:</info>
+    <comment>%command.full_name% my-project</comment>
+
+<info>Non-interactive mode (from YAML file):</info>
+    <comment>%command.full_name% my-project --{$optionConfig}=project-config.yaml</comment>
+
+<info>Init a specific version (tag or branch):</info>
+    <comment>%command.full_name% my-project --{$optionBranch}=18.0.0</comment>
+
+<info>Default behavior:</info>
+    If no version is specified, the latest released tag is used.
+HELP,
+            );
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $projectName = (string)$input->getArgument(self::OPTION_PROJECT_NAME);
+        $branch = $this->resolveReference((string)$input->getOption(self::OPTION_BRANCH));
+        $configFile = $input->getOption(self::OPTION_CONFIG);
+
+        if (!preg_match('/^[a-zA-Z0-9_-]+$/', $projectName)) {
+            $io->error('Invalid project name. Use only letters, numbers, underscores, and hyphens.');
+
+            return Command::FAILURE;
+        }
+
+        if (is_dir($projectName)) {
+            $io->error(sprintf('Directory already exists: %s', $projectName));
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Shopsys Cli - Project Initialization');
+        $io->section('Cloning Shopsys Platform repository');
+
+        $refDescription = (preg_match('/^(v\d+\.\d+\.\d+)$/', $branch)) ? 'version' : 'branch';
+        $io->writeln(sprintf('Cloning %s <info>%s</info>...', $refDescription, $branch));
+
+        try {
+            $this->gitHandler->cloneRepository(
+                self::REPOSITORY_URL,
+                $projectName,
+                $branch,
+                function ($type, $buffer) use ($io) {
+                    $io->write($buffer);
+                },
+            );
+        } catch (GitException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Repository cloned successfully');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string $branch
+     * @return string
+     */
+    private function resolveReference(string $branch): string
+    {
+        if ($branch === self::BRANCH_STABLE) {
+            return $this->gitHandler->getLatestTag(self::REPOSITORY_URL);
+        }
+
+        if (preg_match('/^\d+\.\d+\.\d+$/', $branch)) {
+            $branch = 'v' . $branch;
+        }
+
+        return $branch;
+    }
+}

--- a/packages/cli/src/Command/InitCommand.php
+++ b/packages/cli/src/Command/InitCommand.php
@@ -9,6 +9,7 @@ use Shopsys\Cli\Exception\GitException;
 use Shopsys\Cli\Model\GitHandler;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -130,7 +131,17 @@ HELP,
 
         $io->success('Repository cloned successfully');
 
-        return Command::SUCCESS;
+
+        $configureCommandParameters = [
+            'command' => 'configure',
+            'path' => $projectName,
+        ];
+
+        if ($configFile !== null) {
+            $configureCommandParameters['--config'] = $configFile;
+        }
+
+        return $this->getApplication()?->doRun(new ArrayInput($configureCommandParameters), $output);
     }
 
     /**

--- a/packages/cli/src/Command/ListWorkersCommand.php
+++ b/packages/cli/src/Command/ListWorkersCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Command;
+
+use Exception;
+use Override;
+use Shopsys\Cli\Worker\WorkerInterface;
+use Shopsys\Cli\Worker\WorkerRunner;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'workers',
+    description: 'List all available configuration workers',
+)]
+final class ListWorkersCommand extends Command
+{
+    /**
+     * @param \Shopsys\Cli\Worker\WorkerRunner $workerRunner
+     */
+    public function __construct(
+        private readonly WorkerRunner $workerRunner,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Available Configuration Workers');
+
+        try {
+            $workers = $this->workerRunner->getWorkers();
+        } catch (Exception $e) {
+            $io->error('Failed to load workers: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->section('Backend Workers');
+        $io->table(
+            ['Worker', 'Description', 'Priority'],
+            $this->getWorkersInfo($workers, 'Backend'),
+        );
+
+        $io->section('Storefront Workers');
+        $io->table(
+            ['Worker', 'Description', 'Priority'],
+            $this->getWorkersInfo($workers, 'Storefront'),
+        );
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<\Shopsys\Cli\Worker\WorkerInterface> $workers
+     * @param string $type
+     * @return array<int, array<int, string>>
+     */
+    private function getWorkersInfo(array $workers, string $type): array
+    {
+        $filteredWorkers = array_filter(
+            $workers,
+            static fn (WorkerInterface $worker) => str_contains(get_class($worker), '\\' . $type . '\\'),
+        );
+
+        return array_map(
+            static function (WorkerInterface $worker) {
+                return [
+                    $worker->getName(),
+                    $worker->getDescription(),
+                    (string)$worker->getPriority(),
+                ];
+            },
+            $filteredWorkers,
+        );
+    }
+}

--- a/packages/cli/src/Config/ConfigSectionInterface.php
+++ b/packages/cli/src/Config/ConfigSectionInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+interface ConfigSectionInterface
+{
+    /**
+     * Unique key for YAML mapping (e.g., 'map_settings')
+     *
+     * @return string
+     */
+    public static function getKey(): string;
+
+    /**
+     * Order for interactive questions (higher = earlier)
+     *
+     * @return int
+     */
+    public static function getPriority(): int;
+
+    /**
+     * Populate from parsed YAML/array data
+     *
+     * @param array<string, mixed> $data
+     */
+    public function fromArray(array $data): void;
+
+    /**
+     * Validate current values, throw on error
+     */
+    public function validate(): void;
+
+    /**
+     * Serialize to array for YAML output
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/packages/cli/src/Config/ConfigSectionRegistry.php
+++ b/packages/cli/src/Config/ConfigSectionRegistry.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class ConfigSectionRegistry
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ServiceLocator $domainConfigSections
+     * @param \Symfony\Component\DependencyInjection\ServiceLocator $projectConfigSections
+     */
+    public function __construct(
+        private readonly ServiceLocator $domainConfigSections,
+        private readonly ServiceLocator $projectConfigSections,
+    ) {
+    }
+
+    /**
+     * @return \Shopsys\Cli\Config\DomainConfigSectionInterface[]
+     */
+    public function getDomainConfigSections(): array
+    {
+        /** @var \Shopsys\Cli\Config\DomainConfigSectionInterface[] $configSections */
+        $configSections = $this->getConfigSectionsBySectionLocator($this->domainConfigSections);
+
+        return $configSections;
+    }
+
+    /**
+     * @return \Shopsys\Cli\Config\ProjectConfigSectionInterface[]
+     */
+    public function getProjectConfigSections(): array
+    {
+        /** @var \Shopsys\Cli\Config\ProjectConfigSectionInterface[] $configSections */
+        $configSections = $this->getConfigSectionsBySectionLocator($this->projectConfigSections);
+
+        return $configSections;
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ServiceLocator $configSectionLocator
+     * @return \Shopsys\Cli\Config\ConfigSectionInterface[]
+     */
+    private function getConfigSectionsBySectionLocator(ServiceLocator $configSectionLocator): array
+    {
+        $configSections = [];
+
+        foreach ($configSectionLocator->getProvidedServices() as $serviceId => $metadata) {
+            // new instance is returned each time to avoid shared state between domains thanks to the service locator and shared: false in services.yaml
+            $configSections[$serviceId] = $configSectionLocator->get($serviceId);
+        }
+
+        return $configSections;
+    }
+}

--- a/packages/cli/src/Config/CoreDomainConfig.php
+++ b/packages/cli/src/Config/CoreDomainConfig.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+use LogicException;
+
+final class CoreDomainConfig
+{
+    /**
+     * @var array<class-string<\Shopsys\Cli\Config\ConfigSectionInterface>, \Shopsys\Cli\Config\ConfigSectionInterface>
+     */
+    private array $configSections = [];
+
+    /**
+     * @param int $id
+     * @param string $name
+     * @param string $locale
+     * @param string $timezone
+     * @param string $type
+     * @param string $currencyCode
+     * @param bool $loadDemoData
+     */
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly string $locale,
+        public readonly string $timezone,
+        public readonly string $type,
+        public readonly string $currencyCode,
+        public readonly bool $loadDemoData,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param \Shopsys\Cli\Config\ConfigSectionRegistry|null $registry
+     * @return self
+     */
+    public static function fromArray(array $data, ?ConfigSectionRegistry $registry = null): self
+    {
+        $domainConfig = new self(
+            id: (int)$data['id'],
+            name: CoreDomainConfigValidator::validateDomainName($data['name'] ?? ''),
+            locale: CoreDomainConfigValidator::validateLocale($data['locale'] ?? ''),
+            timezone: CoreDomainConfigValidator::validateTimeZone($data['timezone'] ?? ''),
+            type: CoreDomainConfigValidator::validateDomainType($data['type'] ?? ''),
+            currencyCode: CoreDomainConfigValidator::validateCurrencyCode($data['currency_code'] ?? ''),
+            loadDemoData: (bool)($data['load_demo_data'] ?? true),
+        );
+
+        if ($registry !== null) {
+            foreach ($registry->getDomainConfigSections() as $section) {
+                $key = $section::getKey();
+                $section->fromArray($data[$key] ?? []);
+                $section->validate();
+                $domainConfig->addConfigSection($section);
+            }
+        }
+
+        return $domainConfig;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'id' => $this->id,
+            'name' => $this->name,
+            'locale' => $this->locale,
+            'timezone' => $this->timezone,
+            'type' => $this->type,
+            'currency_code' => $this->currencyCode,
+            'load_demo_data' => $this->loadDemoData,
+        ];
+
+        foreach ($this->configSections as $section) {
+            $data[$section::getKey()] = $section->toArray();
+        }
+
+        return $data;
+    }
+
+    /**
+     * @template T of \Shopsys\Cli\Config\ConfigSectionInterface
+     * @param class-string<T> $sectionClass
+     * @return T
+     */
+    public function getConfigSection(string $sectionClass): ConfigSectionInterface
+    {
+        return $this->configSections[$sectionClass] ?? throw new LogicException(sprintf('Unknown section class: %s', $sectionClass));
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\ConfigSectionInterface $section
+     */
+    public function addConfigSection(ConfigSectionInterface $section): void
+    {
+        $this->configSections[$section::class] = $section;
+    }
+}

--- a/packages/cli/src/Config/CoreDomainConfigValidator.php
+++ b/packages/cli/src/Config/CoreDomainConfigValidator.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+use DateTimeZone;
+use Exception;
+use RuntimeException;
+
+final class CoreDomainConfigValidator
+{
+    /**
+     * @var string[]
+     */
+    public const array SUPPORTED_DOMAIN_TYPES = ['b2c', 'b2b'];
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function validateDomainName(string $value): string
+    {
+        if (trim($value) === '') {
+            throw new RuntimeException('Domain name cannot be empty');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function validateLocale(string $value): string
+    {
+        if (mb_strlen(trim($value)) !== 2) {
+            throw new RuntimeException(sprintf('Locale has to be exactly two characters long, "%s" provided', $value));
+        }
+
+        return strtolower($value);
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function validateTimeZone(string $value): string
+    {
+        try {
+            new DateTimeZone($value);
+        } catch (Exception) {
+            throw new RuntimeException(sprintf('Invalid timezone: "%s"', $value));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function validateDomainType(string $value): string
+    {
+        if (!in_array($value, self::SUPPORTED_DOMAIN_TYPES, true)) {
+            throw new RuntimeException(sprintf(
+                'Domain type must be one of: %s. Got: %s',
+                implode(', ', self::SUPPORTED_DOMAIN_TYPES),
+                $value,
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function validateCurrencyCode(string $value): string
+    {
+        if (!preg_match('/^[A-Za-z]{3}$/', $value)) {
+            throw new RuntimeException('Currency code must be a 3-letter ISO code (e.g., EUR, CZK)');
+        }
+
+        return strtoupper($value);
+    }
+}

--- a/packages/cli/src/Config/CoreProjectConfig.php
+++ b/packages/cli/src/Config/CoreProjectConfig.php
@@ -40,6 +40,22 @@ final class CoreProjectConfig
     }
 
     /**
+     * @return array<string>
+     */
+    public function getUniqueCurrencies(): array
+    {
+        $currencies = [];
+
+        foreach ($this->domains as $domain) {
+            if (!in_array($domain->currencyCode, $currencies, true)) {
+                $currencies[] = $domain->currencyCode;
+            }
+        }
+
+        return $currencies;
+    }
+
+    /**
      * @return array<int>
      */
     public function getAllDomainIds(): array

--- a/packages/cli/src/Config/CoreProjectConfig.php
+++ b/packages/cli/src/Config/CoreProjectConfig.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+use LogicException;
+
+final class CoreProjectConfig
+{
+    /**
+     * @var array<class-string<\Shopsys\Cli\Config\ConfigSectionInterface>, \Shopsys\Cli\Config\ConfigSectionInterface>
+     */
+    private array $sections = [];
+
+    /**
+     * @param string $projectPath
+     * @param array<\Shopsys\Cli\Config\CoreDomainConfig> $domains
+     */
+    public function __construct(
+        public readonly string $projectPath,
+        public readonly array $domains = [],
+    ) {
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUniqueLocales(): array
+    {
+        $locales = [];
+
+        foreach ($this->domains as $domain) {
+            if (!in_array($domain->locale, $locales, true)) {
+                $locales[] = $domain->locale;
+            }
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getAllDomainIds(): array
+    {
+        return array_map(static fn (CoreDomainConfig $domain) => $domain->id, $this->domains);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param string $projectPath
+     * @param \Shopsys\Cli\Config\ConfigSectionRegistry|null $registry
+     * @return self
+     */
+    public static function fromArray(array $data, string $projectPath, ?ConfigSectionRegistry $registry = null): self
+    {
+        $domains = [];
+
+        if (isset($data['domains']) && is_array($data['domains'])) {
+            foreach ($data['domains'] as $domainData) {
+                $domains[] = CoreDomainConfig::fromArray($domainData, $registry);
+            }
+        }
+
+        $projectConfig = new self(
+            projectPath: $projectPath,
+            domains: $domains,
+        );
+
+        if ($registry !== null) {
+            foreach ($registry->getProjectConfigSections() as $section) {
+                $key = $section::getKey();
+                $section->fromArray($data[$key] ?? []);
+                $section->validate();
+                $projectConfig->addConfigSection($section);
+            }
+        }
+
+        return $projectConfig;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'domains' => array_map(
+                static fn (CoreDomainConfig $domain) => $domain->toArray(),
+                $this->domains,
+            ),
+        ];
+
+        foreach ($this->sections as $section) {
+            $data[$section::getKey()] = $section->toArray();
+        }
+
+        return $data;
+    }
+
+    /**
+     * @template T of \Shopsys\Cli\Config\ConfigSectionInterface
+     * @param class-string<T> $sectionClass
+     * @return T
+     */
+    public function getConfigSection(string $sectionClass): ConfigSectionInterface
+    {
+        return $this->sections[$sectionClass] ?? throw new LogicException(sprintf('Unknown section class: %s', $sectionClass));
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\ConfigSectionInterface $section
+     */
+    public function addConfigSection(ConfigSectionInterface $section): void
+    {
+        $this->sections[$section::class] = $section;
+    }
+}

--- a/packages/cli/src/Config/DomainConfigSectionInterface.php
+++ b/packages/cli/src/Config/DomainConfigSectionInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+interface DomainConfigSectionInterface extends ConfigSectionInterface
+{
+    /**
+     * Collect values interactively
+     *
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @param int $domainId
+     */
+    public function collectInteractive(SymfonyStyle $io, int $domainId): void;
+}

--- a/packages/cli/src/Config/ProjectConfigSectionInterface.php
+++ b/packages/cli/src/Config/ProjectConfigSectionInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+interface ProjectConfigSectionInterface extends ConfigSectionInterface
+{
+    /**
+     * Collect values interactively
+     *
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     */
+    public function collectInteractive(SymfonyStyle $io): void;
+}

--- a/packages/cli/src/Config/Section/MapSettingsSection.php
+++ b/packages/cli/src/Config/Section/MapSettingsSection.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config\Section;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\DomainConfigSectionInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class MapSettingsSection implements DomainConfigSectionInterface
+{
+    public float $latitude = 49.956;
+
+    public float $longitude = 15.5173;
+
+    public int $zoom = 7;
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getKey(): string
+    {
+        return 'map_settings';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getPriority(): int
+    {
+        return 50;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function collectInteractive(SymfonyStyle $io, int $domainId): void
+    {
+        $io->section(sprintf('Map Settings for Domain %d', $domainId));
+
+        $this->latitude = (float)$io->ask(
+            'Map center latitude (-90 to 90)',
+            (string)$this->latitude,
+            fn ($v) => $this->validateLatitudeInput($v),
+        );
+
+        $this->longitude = (float)$io->ask(
+            'Map center longitude (-180 to 180)',
+            (string)$this->longitude,
+            fn ($v) => $this->validateLongitudeInput($v),
+        );
+
+        $this->zoom = (int)$io->ask(
+            'Map zoom level (1-20)',
+            (string)$this->zoom,
+            fn ($v) => $this->validateZoomInput($v),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function fromArray(array $data): void
+    {
+        $this->latitude = (float)($data['latitude'] ?? $this->latitude);
+        $this->longitude = (float)($data['longitude'] ?? $this->longitude);
+        $this->zoom = (int)($data['zoom'] ?? $this->zoom);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function validate(): void
+    {
+        $this->assertLatitude($this->latitude);
+        $this->assertLongitude($this->longitude);
+        $this->assertZoom($this->zoom);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function toArray(): array
+    {
+        return [
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'zoom' => $this->zoom,
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @return float
+     */
+    protected function validateLatitudeInput($value): float
+    {
+        $float = (float)$value;
+        $this->assertLatitude($float);
+
+        return $float;
+    }
+
+    /**
+     * @param mixed $value
+     * @return float
+     */
+    protected function validateLongitudeInput($value): float
+    {
+        $float = (float)$value;
+        $this->assertLongitude($float);
+
+        return $float;
+    }
+
+    /**
+     * @param mixed $value
+     * @return int
+     */
+    protected function validateZoomInput($value): int
+    {
+        $int = (int)$value;
+        $this->assertZoom($int);
+
+        return $int;
+    }
+
+    /**
+     * @param float $value
+     */
+    protected function assertLatitude(float $value): void
+    {
+        if ($value < -90 || $value > 90) {
+            throw new RuntimeException('Latitude must be between -90 and 90');
+        }
+    }
+
+    /**
+     * @param float $value
+     */
+    protected function assertLongitude(float $value): void
+    {
+        if ($value < -180 || $value > 180) {
+            throw new RuntimeException('Longitude must be between -180 and 180');
+        }
+    }
+
+    /**
+     * @param int $value
+     */
+    protected function assertZoom(int $value): void
+    {
+        if ($value < 1 || $value > 20) {
+            throw new RuntimeException('Zoom must be between 1 and 20');
+        }
+    }
+}

--- a/packages/cli/src/Config/Section/MetatagSiteNameSection.php
+++ b/packages/cli/src/Config/Section/MetatagSiteNameSection.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config\Section;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\ProjectConfigSectionInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class MetatagSiteNameSection implements ProjectConfigSectionInterface
+{
+    public string $siteName = 'Shopsys Platform';
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getKey(): string
+    {
+        return 'metatag_site_name';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getPriority(): int
+    {
+        return 40;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function collectInteractive(SymfonyStyle $io): void
+    {
+        $io->section('Metatag Site Name');
+
+        $this->siteName = $io->ask(
+            'Enter the site name for metatag',
+            $this->siteName,
+            fn ($v) => $this->validateSiteNameInput($v),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function fromArray(array $data): void
+    {
+        $this->siteName = (string)($data['site_name'] ?? $this->siteName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function validate(): void
+    {
+        $this->assertSiteName($this->siteName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function toArray(): array
+    {
+        return [
+            'site_name' => $this->siteName,
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    protected function validateSiteNameInput($value): string
+    {
+        $string = trim((string)$value);
+        $this->assertSiteName($string);
+
+        return $string;
+    }
+
+    /**
+     * @param string $value
+     */
+    protected function assertSiteName(string $value): void
+    {
+        if ($value === '') {
+            throw new RuntimeException('Site name cannot be empty');
+        }
+
+        if (mb_strlen($value) > 100) {
+            throw new RuntimeException('Site name must be at most 100 characters');
+        }
+    }
+}

--- a/packages/cli/src/Config/Section/SocialLoginSection.php
+++ b/packages/cli/src/Config/Section/SocialLoginSection.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Config\Section;
+
+use Override;
+use Shopsys\Cli\Config\DomainConfigSectionInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class SocialLoginSection implements DomainConfigSectionInterface
+{
+    public bool $facebook = false;
+
+    public bool $google = false;
+
+    public bool $seznam = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getKey(): string
+    {
+        return 'social_login';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getPriority(): int
+    {
+        return 30;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function collectInteractive(SymfonyStyle $io, int $domainId): void
+    {
+        $io->section(sprintf('Social Login Settings for Domain %d', $domainId));
+
+        $this->facebook = $io->confirm('Enable Facebook login?', $this->facebook);
+        $this->google = $io->confirm('Enable Google login?', $this->google);
+        $this->seznam = $io->confirm('Enable Seznam login?', $this->seznam);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function fromArray(array $data): void
+    {
+        $this->facebook = (bool)($data['facebook'] ?? $this->facebook);
+        $this->google = (bool)($data['google'] ?? $this->google);
+        $this->seznam = (bool)($data['seznam'] ?? $this->seznam);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function validate(): void
+    {
+        // No specific validation needed for boolean values
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function toArray(): array
+    {
+        return [
+            'facebook' => $this->facebook,
+            'google' => $this->google,
+            'seznam' => $this->seznam,
+        ];
+    }
+}

--- a/packages/cli/src/Exception/CancelledException.php
+++ b/packages/cli/src/Exception/CancelledException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Exception;
+
+use Exception;
+
+class CancelledException extends Exception
+{
+}

--- a/packages/cli/src/Exception/GitException.php
+++ b/packages/cli/src/Exception/GitException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Exception;
+
+use Exception;
+
+class GitException extends Exception
+{
+}

--- a/packages/cli/src/Input/InteractiveInputCollector.php
+++ b/packages/cli/src/Input/InteractiveInputCollector.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Input;
+
+use RuntimeException;
+use Shopsys\Cli\Config\ConfigSectionRegistry;
+use Shopsys\Cli\Config\CoreDomainConfig;
+use Shopsys\Cli\Config\CoreDomainConfigValidator;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Exception\CancelledException;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Yaml\Yaml;
+
+final class InteractiveInputCollector
+{
+    /**
+     * @param \Shopsys\Cli\Config\ConfigSectionRegistry $registry
+     */
+    public function __construct(
+        private readonly ConfigSectionRegistry $registry,
+    ) {
+    }
+
+    /**
+     * @param string $projectPath
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @return \Shopsys\Cli\Config\CoreProjectConfig
+     */
+    public function collect(string $projectPath, SymfonyStyle $io): CoreProjectConfig
+    {
+        $this->displayHeader($io);
+
+        $domains = $this->collectDomains($io);
+
+        $config = new CoreProjectConfig($projectPath, $domains);
+
+        foreach ($this->registry->getProjectConfigSections() as $projectConfigSection) {
+            $projectConfigSection->collectInteractive($io);
+            $projectConfigSection->validate();
+
+            $config->addConfigSection($projectConfigSection);
+        }
+
+        $this->displaySummary($config, $io);
+
+        if (!$io->confirm('Proceed with configuration?')) {
+            throw new CancelledException('Configuration cancelled by user');
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     */
+    private function displayHeader(SymfonyStyle $io): void
+    {
+        $io->writeln('');
+        $io->writeln('<fg=cyan>╔══════════════════════════════════════════════════════════════╗</>');
+        $io->writeln('<fg=cyan>║                 ⚒️ Shopsys Cli ⚒️                            ║</>');
+        $io->writeln('<fg=cyan>║              Project Configuration Tool                      ║</>');
+        $io->writeln('<fg=cyan>╚══════════════════════════════════════════════════════════════╝</>');
+        $io->writeln('');
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @return array<\Shopsys\Cli\Config\CoreDomainConfig>
+     */
+    private function collectDomains(SymfonyStyle $io): array
+    {
+        $domainCount = (int)$io->ask(
+            'How many domains will this project have?',
+            '2',
+            function (string $answer): string {
+                $count = (int)$answer;
+
+                if ($count < 1 || $count > 100) {
+                    throw new RuntimeException('Domain count must be between 1 and 100');
+                }
+
+                return $answer;
+            },
+        );
+
+        $domains = [];
+
+        for ($domainId = 1; $domainId <= $domainCount; $domainId++) {
+            $domain = $this->collectCoreFields($io, $domainId);
+
+            foreach ($this->registry->getDomainConfigSections() as $domainConfigSection) {
+                $domainConfigSection->collectInteractive($io, $domainId);
+                $domainConfigSection->validate();
+
+                $domain->addConfigSection($domainConfigSection);
+            }
+
+            $domains[] = $domain;
+        }
+
+        return $domains;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @param int $domainId
+     * @return \Shopsys\Cli\Config\CoreDomainConfig
+     */
+    private function collectCoreFields(SymfonyStyle $io, int $domainId): CoreDomainConfig
+    {
+        $io->section(sprintf('Domain %d Configuration', $domainId));
+
+        return new CoreDomainConfig(
+            id: $domainId,
+            name: $io->ask(
+                'Domain name',
+                sprintf('Domain %d', $domainId),
+                CoreDomainConfigValidator::validateDomainName(...),
+            ),
+            locale: $io->ask(
+                'Locale (e.g., en, cs, de, fr)',
+                'en',
+                CoreDomainConfigValidator::validateLocale(...),
+            ),
+            timezone: $io->ask(
+                'Timezone',
+                'Europe/Prague',
+                CoreDomainConfigValidator::validateTimeZone(...),
+            ),
+            type: $io->choice(
+                'Domain type',
+                CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES,
+                CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES[array_key_first(CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES)],
+            ),
+            currencyCode: $io->ask(
+                'Currency code (e.g., EUR, CZK)',
+                'EUR',
+                CoreDomainConfigValidator::validateCurrencyCode(...),
+            ),
+            loadDemoData: $io->confirm('Load demo data?', $domainId < 3),
+        );
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     */
+    private function displaySummary(CoreProjectConfig $config, SymfonyStyle $io): void
+    {
+        $io->section('Configuration Summary');
+
+        $yamlConfig = Yaml::dump($config->toArray(), 4);
+
+        $io->newLine();
+        $io->writeln($yamlConfig);
+        $io->newLine();
+    }
+}

--- a/packages/cli/src/Input/YamlConfigLoader.php
+++ b/packages/cli/src/Input/YamlConfigLoader.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Input;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Shopsys\Cli\Config\ConfigSectionRegistry;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Symfony\Component\Yaml\Yaml;
+
+final class YamlConfigLoader
+{
+    /**
+     * @param \Shopsys\Cli\Config\ConfigSectionRegistry $registry
+     */
+    public function __construct(
+        private readonly ConfigSectionRegistry $registry,
+    ) {
+    }
+
+    /**
+     * @param string $configPath
+     * @param string $projectPath
+     * @return \Shopsys\Cli\Config\CoreProjectConfig
+     */
+    public function load(string $configPath, string $projectPath): CoreProjectConfig
+    {
+        if (!file_exists($configPath)) {
+            throw new InvalidArgumentException(sprintf('Configuration file not found: %s', $configPath));
+        }
+
+        $content = file_get_contents($configPath);
+
+        if ($content === false) {
+            throw new RuntimeException(sprintf('Could not read configuration file: %s', $configPath));
+        }
+
+        $data = Yaml::parse($content);
+
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('Invalid YAML configuration: root must be an array');
+        }
+
+        if (count($data['domains']) === 0) {
+            throw new RuntimeException('At least one domain is required');
+        }
+
+        return CoreProjectConfig::fromArray($data, $projectPath, $this->registry);
+    }
+}

--- a/packages/cli/src/Model/FileHandler.php
+++ b/packages/cli/src/Model/FileHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Model;
+
+use RuntimeException;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class FileHandler
+{
+    /**
+     * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+     */
+    public function __construct(
+        private readonly Filesystem $filesystem,
+    ) {
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    public function readFile(string $path): string
+    {
+        if (!file_exists($path)) {
+            throw new RuntimeException(sprintf('File not found: %s', $path));
+        }
+
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            throw new RuntimeException(sprintf('Could not read file: %s', $path));
+        }
+
+        return $content;
+    }
+
+    /**
+     * @param string $path
+     * @param string $content
+     */
+    public function writeFile(string $path, string $content): void
+    {
+        $this->ensureDirectory(dirname($path));
+        $this->filesystem->dumpFile($path, $content);
+    }
+
+    /**
+     * @param string $path
+     */
+    public function ensureDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            $this->filesystem->mkdir($path, 0755);
+        }
+    }
+
+    /**
+     * @param string $source
+     * @param string $destination
+     */
+    public function copyFile(string $source, string $destination): void
+    {
+        $this->ensureDirectory(dirname($destination));
+        $this->filesystem->copy($source, $destination, true);
+    }
+
+    /**
+     * @param string $path
+     */
+    public function deleteFile(string $path): void
+    {
+        if (file_exists($path)) {
+            $this->filesystem->remove($path);
+        }
+    }
+}

--- a/packages/cli/src/Model/GitHandler.php
+++ b/packages/cli/src/Model/GitHandler.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Model;
+
+use Shopsys\Cli\Exception\GitException;
+use Symfony\Component\Process\Process;
+
+final class GitHandler
+{
+    /**
+     * @param string $repositoryUrl
+     * @param string $targetDirectory
+     * @param string $branch
+     * @param callable|null $outputCallback
+     */
+    public function cloneRepository(
+        string $repositoryUrl,
+        string $targetDirectory,
+        string $branch,
+        ?callable $outputCallback = null,
+    ): void {
+        $process = new Process([
+            'git',
+            'clone',
+            '--branch',
+            $branch,
+            $repositoryUrl,
+            $targetDirectory,
+        ]);
+
+        $process->setTimeout(3000);
+
+        $process->run($outputCallback);
+
+        if (!$process->isSuccessful()) {
+            throw new GitException(
+                sprintf(
+                    'Failed to clone repository: %s',
+                    $process->getErrorOutput(),
+                ),
+            );
+        }
+
+        $this->removeRemoteOrigin($targetDirectory, $outputCallback);
+    }
+
+    /**
+     * @param string $repositoryUrl
+     * @return string
+     */
+    public function getLatestTag(string $repositoryUrl): string
+    {
+        $process = new Process([
+            'git',
+            'ls-remote',
+            '--tags',
+            '--refs',
+            '--sort=-v:refname',
+            $repositoryUrl,
+        ]);
+
+        $process->setTimeout(60);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new GitException(
+                sprintf(
+                    'Failed to fetch tags from repository: %s',
+                    $process->getErrorOutput(),
+                ),
+            );
+        }
+
+        $output = trim($process->getOutput());
+
+        if ($output === '') {
+            throw new GitException('No tags found in the repository');
+        }
+
+        $lines = explode("\n", $output);
+        $firstLine = $lines[0];
+        preg_match('/refs\/tags\/(.+)$/', $firstLine, $matches);
+
+        if (!isset($matches[1])) {
+            throw new GitException('Failed to parse tag name from git output');
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * @param string $targetDirectory
+     * @param callable|null $outputCallback
+     */
+    private function removeRemoteOrigin(string $targetDirectory, ?callable $outputCallback): void
+    {
+        $process = new Process(
+            [
+                'git',
+                'remote',
+                'remove',
+                'origin',
+            ],
+            $targetDirectory,
+        );
+
+        $process->setTimeout(60);
+        $process->run($outputCallback);
+
+        if (!$process->isSuccessful()) {
+            throw new GitException(
+                sprintf(
+                    'Failed to remove remote origin: %s',
+                    $process->getErrorOutput(),
+                ),
+            );
+        }
+    }
+}

--- a/packages/cli/src/Model/JsonHandler.php
+++ b/packages/cli/src/Model/JsonHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Model;
+
+use RuntimeException;
+
+class JsonHandler
+{
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * @param string $path
+     * @return array<mixed>
+     */
+    public function readJson(string $path): array
+    {
+        $content = $this->fileHandler->readFile($path);
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($decoded)) {
+            throw new RuntimeException(sprintf('Invalid JSON in file: %s', $path));
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param string $path
+     * @param array<mixed> $data
+     */
+    public function writeJson(string $path, array $data): void
+    {
+        $content = json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if ($content === false) {
+            throw new RuntimeException('Failed to encode JSON');
+        }
+
+        $this->fileHandler->writeFile($path, $content . "\n");
+    }
+}

--- a/packages/cli/src/Model/TwigHandler.php
+++ b/packages/cli/src/Model/TwigHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Model;
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final class TwigHandler
+{
+    private Environment $twig;
+
+    public function __construct()
+    {
+        $loader = new FilesystemLoader();
+        $this->twig = new Environment($loader, [
+            'autoescape' => false,
+            'strict_variables' => true,
+        ]);
+    }
+
+    /**
+     * @param string $templatePath
+     * @param array<string, mixed> $variables
+     * @return string
+     */
+    public function render(string $templatePath, array $variables = []): string
+    {
+        $templateDir = dirname($templatePath);
+        $templateName = basename($templatePath);
+
+        $loader = $this->twig->getLoader();
+
+        if ($loader instanceof FilesystemLoader) {
+            $loader->addPath($templateDir);
+        }
+
+        return $this->twig->render($templateName, $variables);
+    }
+}

--- a/packages/cli/src/Model/YamlHandler.php
+++ b/packages/cli/src/Model/YamlHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Model;
+
+use Symfony\Component\Yaml\Yaml;
+
+final class YamlHandler
+{
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * @param string $path
+     * @return array<mixed>
+     */
+    public function readYaml(string $path): array
+    {
+        $content = $this->fileHandler->readFile($path);
+        $parsed = Yaml::parse($content);
+
+        return is_array($parsed) ? $parsed : [];
+    }
+
+    /**
+     * @param string $path
+     * @param array<mixed> $data
+     */
+    public function writeYaml(string $path, array $data): void
+    {
+        $content = Yaml::dump($data, 4, 4, Yaml::DUMP_NULL_AS_TILDE);
+        $this->fileHandler->writeFile($path, $content);
+    }
+}

--- a/packages/cli/src/Model/YamlHandler.php
+++ b/packages/cli/src/Model/YamlHandler.php
@@ -31,10 +31,11 @@ final class YamlHandler
     /**
      * @param string $path
      * @param array<mixed> $data
+     * @param int $inline
      */
-    public function writeYaml(string $path, array $data): void
+    public function writeYaml(string $path, array $data, int $inline = 4): void
     {
-        $content = Yaml::dump($data, 4, 4, Yaml::DUMP_NULL_AS_TILDE);
+        $content = Yaml::dump($data, $inline, 4, Yaml::DUMP_NULL_AS_TILDE | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         $this->fileHandler->writeFile($path, $content);
     }
 }

--- a/packages/cli/src/Worker/AbstractWorker.php
+++ b/packages/cli/src/Worker/AbstractWorker.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker;
+
+use Override;
+use ReflectionClass;
+
+abstract class AbstractWorker implements WorkerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getName(): string
+    {
+        return (new ReflectionClass(static::class))->getShortName();
+    }
+}

--- a/packages/cli/src/Worker/Backend/AdminLocaleWorker.php
+++ b/packages/cli/src/Worker/Backend/AdminLocaleWorker.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\YamlHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class AdminLocaleWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'app/config/parameters_common.yaml';
+
+    /**
+     * @param \Shopsys\Cli\Model\YamlHandler $yamlHandler
+     */
+    public function __construct(
+        private readonly YamlHandler $yamlHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Set allowed administration locales in parameters_common.yaml';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        try {
+            $data = $this->yamlHandler->readYaml($filePath);
+
+            $data['parameters']['shopsys.allowed_admin_locales'] = $config->getUniqueLocales();
+            $data['parameters']['locale'] = $config->domains[0]->locale;
+
+            $this->yamlHandler->writeYaml($filePath, $data);
+
+            return WorkerResult::success(
+                'Allowed admin locales set',
+                filesModified: [self::FILE_PATH],
+            );
+        } catch (RuntimeException $e) {
+            return WorkerResult::failure($e->getMessage());
+        }
+    }
+}

--- a/packages/cli/src/Worker/Backend/DomainConfigWorker.php
+++ b/packages/cli/src/Worker/Backend/DomainConfigWorker.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\YamlHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class DomainConfigWorker extends AbstractWorker
+{
+    private const string DOMAINS_URLS_FILE_PATH = 'app/config/domains_urls.yaml.dist';
+    private const string DOMAINS_FILE_PATH = 'app/config/domains.yaml';
+
+    /**
+     * @param \Shopsys\Cli\Model\YamlHandler $yamlHandler
+     */
+    public function __construct(
+        private readonly YamlHandler $yamlHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates app/config/domains_urls.yaml.dist and app/config/domains.yaml with requested domain setup';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 1024;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $this->updateDomainsUrlsYamlFile($config, $projectPath);
+
+        $this->updateDomainsYamlFile($config, $projectPath);
+
+        return WorkerResult::success(
+            'Domain files updated',
+            filesModified: [self::DOMAINS_URLS_FILE_PATH, self::DOMAINS_FILE_PATH],
+            hints: [
+                'Domain URLs are set to default values (127.0.0.1:8000, 127.0.0.2:8000, ...).',
+                'To customize URLs or use path fragments, edit domains on backend and storefront after setup.',
+            ],
+        );
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     */
+    private function updateDomainsUrlsYamlFile(CoreProjectConfig $config, string $projectPath): void
+    {
+        $filePath = $projectPath . '/' . self::DOMAINS_URLS_FILE_PATH;
+
+        $domainsUrls = [];
+
+        foreach ($config->domains as $domain) {
+            $domainsUrls[] = [
+                'id' => $domain->id,
+                'url' => sprintf('http://127.0.0.%d:8000', $domain->id),
+            ];
+        }
+
+        $this->yamlHandler->writeYaml(
+            $filePath,
+            ['domains_urls' => $domainsUrls],
+        );
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     */
+    private function updateDomainsYamlFile(CoreProjectConfig $config, string $projectPath): void
+    {
+        $filePath = $projectPath . '/' . self::DOMAINS_FILE_PATH;
+        $domains = [];
+
+        foreach ($config->domains as $domain) {
+            $domains[] = [
+                'id' => $domain->id,
+                'load_demo_data' => $domain->loadDemoData,
+                'locale' => $domain->locale,
+                'name' => $domain->name,
+                'timezone' => $domain->timezone,
+                'type' => $domain->type,
+            ];
+        }
+
+        $this->yamlHandler->writeYaml($filePath, ['domains' => $domains]);
+    }
+}

--- a/packages/cli/src/Worker/Backend/DomainsInDeployWorker.php
+++ b/packages/cli/src/Worker/Backend/DomainsInDeployWorker.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class DomainsInDeployWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'app/deploy/deploy-project.sh';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates DOMAIN_HOSTNAME_* in deploy-project.sh';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 928;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        try {
+            $content = $this->fileHandler->readFile($filePath);
+
+            $domainHostnames = [];
+
+            foreach ($config->domains as $domain) {
+                $domainHostnames[] = sprintf('        DOMAIN_HOSTNAME_%d', $domain->id);
+            }
+
+            $domainsArrayContent = implode("\n", $domainHostnames);
+
+            $pattern = '/(DOMAINS=\(\n)(.*?)(\n\s*\))/s';
+            $replacement = '$1' . $domainsArrayContent . '$3';
+
+            $updatedContent = preg_replace($pattern, $replacement, $content);
+
+            if ($updatedContent === null) {
+                return WorkerResult::failure('Failed to update DOMAINS array in ' . self::FILE_PATH);
+            }
+
+            $this->fileHandler->writeFile($filePath, $updatedContent);
+
+            return WorkerResult::success(
+                'Updated DOMAIN_HOSTNAME_* in ' . self::FILE_PATH,
+                filesModified: [self::FILE_PATH],
+            );
+        } catch (RuntimeException $e) {
+            return WorkerResult::failure($e->getMessage());
+        }
+    }
+}

--- a/packages/cli/src/Worker/Backend/ElasticsearchDefinitionWorker.php
+++ b/packages/cli/src/Worker/Backend/ElasticsearchDefinitionWorker.php
@@ -1,0 +1,527 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreDomainConfig;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Model\JsonHandler;
+use Shopsys\Cli\Model\YamlHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+use Symfony\Component\Finder\Finder;
+
+final class ElasticsearchDefinitionWorker extends AbstractWorker
+{
+    private const string DEFINITION_DIR = 'app/src/Resources/definition';
+    private const string LOCALE_CONFIG_PATH = __DIR__ . '/resources/elastic-locales.yaml';
+    private const string ELASTICSEARCH_DOCKERFILE = 'app/docker/elasticsearch/Dockerfile';
+    private const string DEFAULT_LOCALE = 'en';
+
+    /**
+     * @var array<string, array{stemmer: string|null, stopwords: string|array<string>, plugins?: array<string>}>|null
+     */
+    private ?array $localeConfig = null;
+
+    /**
+     * @param \Shopsys\Cli\Model\JsonHandler $jsonHandler
+     * @param \Shopsys\Cli\Model\YamlHandler $yamlHandler
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly JsonHandler $jsonHandler,
+        private readonly YamlHandler $yamlHandler,
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates Elasticsearch index definitions with locale-specific analysis settings';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 880;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $definitionPath = $projectPath . '/' . self::DEFINITION_DIR;
+
+        if (!is_dir($definitionPath)) {
+            return WorkerResult::failure(sprintf('Definition directory not found: %s', self::DEFINITION_DIR));
+        }
+
+        $indexFolders = $this->getIndexFolders($definitionPath);
+
+        if ($indexFolders === []) {
+            return WorkerResult::failure('No index folders found');
+        }
+
+        $filesCreated = [];
+        $filesModified = [];
+        $filesDeleted = [];
+
+        foreach ($indexFolders as $indexFolder) {
+            $result = $this->processIndexFolder($indexFolder, $config, $projectPath);
+            array_push($filesCreated, ...$result['created']);
+            array_push($filesModified, ...$result['modified']);
+            array_push($filesDeleted, ...$result['deleted']);
+        }
+
+        $dockerfileResult = $this->updateDockerfilePlugins($config, $projectPath);
+
+        if ($dockerfileResult !== null) {
+            $filesModified[] = $dockerfileResult;
+        }
+
+        return WorkerResult::success(
+            'Elasticsearch definitions updated',
+            filesModified: $filesModified,
+            filesCreated: $filesCreated,
+            filesDeleted: $filesDeleted,
+        );
+    }
+
+    /**
+     * @param string $definitionPath
+     * @return array<string>
+     */
+    private function getIndexFolders(string $definitionPath): array
+    {
+        $finder = Finder::create()
+            ->directories()
+            ->in($definitionPath)
+            ->depth(0)
+            ->sortByName();
+
+        $folders = [];
+
+        foreach ($finder as $directory) {
+            $folders[] = $directory->getRealPath();
+        }
+
+        return $folders;
+    }
+
+    /**
+     * @param string $indexFolder
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     * @throws \JsonException
+     * @return array{created: array<string>, modified: array<string>, deleted: array<string>}
+     */
+    private function processIndexFolder(
+        string $indexFolder,
+        CoreProjectConfig $config,
+        string $projectPath,
+    ): array {
+        $result = ['created' => [], 'modified' => [], 'deleted' => []];
+        $templateData = $this->getTemplateData($indexFolder);
+
+        if ($templateData === null) {
+            throw new RuntimeException('No template data found');
+        }
+
+        foreach ($config->domains as $domain) {
+            $filePath = $indexFolder . '/' . $domain->id . '.json';
+            $relativePath = preg_replace(sprintf('#^%s#', preg_quote($projectPath, '#')), '', $filePath);
+
+            $definitionData = $this->generateDefinitionForLocale($templateData, $domain);
+
+            $fileExisted = file_exists($filePath);
+            $this->jsonHandler->writeJson($filePath, $definitionData);
+
+            if ($fileExisted) {
+                $result['modified'][] = $relativePath;
+            } else {
+                $result['created'][] = $relativePath;
+            }
+        }
+
+        $deletedFiles = $this->deleteUnusedDefinitions($indexFolder, $config);
+        $result['deleted'] = array_merge($result['deleted'], $deletedFiles);
+
+        return $result;
+    }
+
+    /**
+     * @param string $indexFolder
+     * @return array<mixed>|null
+     */
+    private function getTemplateData(string $indexFolder): ?array
+    {
+        $firstFile = $indexFolder . '/1.json';
+
+        if (file_exists($firstFile)) {
+            return $this->jsonHandler->readJson($firstFile);
+        }
+
+        $finderIterator = Finder::create()
+            ->files()
+            ->in($indexFolder)
+            ->name('*.json')
+            ->sortByName()
+            ->getIterator();
+
+        $finderIterator->rewind();
+        $finderIterator->current();
+
+        if (!$finderIterator->valid()) {
+            return null;
+        }
+
+        return $this->jsonHandler->readJson($finderIterator->current()->getRealPath());
+    }
+
+    /**
+     * @param array<mixed> $templateData
+     * @param \Shopsys\Cli\Config\CoreDomainConfig $domain
+     * @return array<mixed>
+     */
+    private function generateDefinitionForLocale(array $templateData, CoreDomainConfig $domain): array
+    {
+        $locale = $domain->locale;
+        $localeSettings = $this->getLocaleSettings($locale);
+
+        $data = $templateData;
+        $data = $this->updateAnalysisFilters($data, $localeSettings);
+        $data = $this->updateStemmingAnalyzer($data, $localeSettings);
+        $data = $this->updateIcuCollationLanguage($data, $locale);
+
+        return $data;
+    }
+
+    /**
+     * @param string $locale
+     * @return array{stemmer: string|null, stopwords: string|array<string>, prefix: string, builtin_filters: array<string>}
+     */
+    private function getLocaleSettings(string $locale): array
+    {
+        $config = $this->getLocaleConfig();
+
+        if (isset($config[$locale])) {
+            return [
+                'prefix' => $config[$locale]['prefix'] ?? $locale,
+                'stemmer' => $config[$locale]['stemmer'] ?? null,
+                'stopwords' => $config[$locale]['stopwords'] ?? '_' . self::DEFAULT_LOCALE . '_',
+                'builtin_filters' => $config[$locale]['builtin_filters'] ?? [],
+            ];
+        }
+
+        return [
+            'prefix' => $locale,
+            'stemmer' => self::DEFAULT_LOCALE,
+            'stopwords' => '_' . self::DEFAULT_LOCALE . '_',
+            'builtin_filters' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, array{stemmer: string|null, stopwords: string|array<string>, plugins?: array<string>}>
+     */
+    private function getLocaleConfig(): array
+    {
+        if ($this->localeConfig === null) {
+            $data = $this->yamlHandler->readYaml(self::LOCALE_CONFIG_PATH);
+            $this->localeConfig = $data['locales'] ?? [];
+        }
+
+        return $this->localeConfig;
+    }
+
+    /**
+     * @param array<mixed> $data
+     * @param array{stemmer: string|null, stopwords: string|array<string>, prefix: string, builtin_filters: array<string>} $localeSettings
+     * @return array<mixed>
+     */
+    private function updateAnalysisFilters(array $data, array $localeSettings): array
+    {
+        if (!isset($data['settings']['analysis']['filter'])) {
+            return $data;
+        }
+
+        $filters = $data['settings']['analysis']['filter'];
+        $prefix = $localeSettings['prefix'];
+        $useBuiltinFilters = $localeSettings['builtin_filters'] !== [];
+        $newFilters = [];
+
+        foreach ($filters as $filterName => $filterConfig) {
+            if ($this->isStopFilter($filterName)) {
+                if (!$useBuiltinFilters) {
+                    $newFilters[$prefix . '_stop'] = $this->createStopFilter($localeSettings['stopwords']);
+                }
+            } elseif ($this->isStemmerFilter($filterName)) {
+                if (!$useBuiltinFilters && $localeSettings['stemmer'] !== null) {
+                    $newFilters[$prefix . '_stemmer'] = [
+                        'type' => 'stemmer',
+                        'language' => $localeSettings['stemmer'],
+                    ];
+                }
+            } else {
+                $newFilters[$filterName] = $filterConfig;
+            }
+        }
+
+        $data['settings']['analysis']['filter'] = $newFilters;
+
+        return $data;
+    }
+
+    /**
+     * @param string $filterName
+     * @return bool
+     */
+    private function isStopFilter(string $filterName): bool
+    {
+        return str_ends_with($filterName, '_stop');
+    }
+
+    /**
+     * @param string $filterName
+     * @return bool
+     */
+    private function isStemmerFilter(string $filterName): bool
+    {
+        return str_ends_with($filterName, '_stemmer');
+    }
+
+    /**
+     * @param string|array<string> $stopwords
+     * @return array<string, mixed>
+     */
+    private function createStopFilter(string|array $stopwords): array
+    {
+        return [
+            'type' => 'stop',
+            'stopwords' => $stopwords,
+        ];
+    }
+
+    /**
+     * @param array<mixed> $data
+     * @param array{stemmer: string|null, stopwords: string|array<string>, prefix: string, builtin_filters: array<string>} $localeSettings
+     * @return array<mixed>
+     */
+    private function updateStemmingAnalyzer(array $data, array $localeSettings): array
+    {
+        if (!isset($data['settings']['analysis']['analyzer']['stemming'])) {
+            return $data;
+        }
+
+        $stemmingAnalyzer = $data['settings']['analysis']['analyzer']['stemming'];
+
+        if (!isset($stemmingAnalyzer['filter']) || !is_array($stemmingAnalyzer['filter'])) {
+            return $data;
+        }
+
+        $prefix = $localeSettings['prefix'];
+        $builtinFilters = $localeSettings['builtin_filters'];
+        $useBuiltinFilters = $builtinFilters !== [];
+        $newFilters = [];
+        $builtinFiltersAdded = false;
+
+        foreach ($stemmingAnalyzer['filter'] as $filter) {
+            if ($this->isStopFilter($filter) || $this->isStemmerFilter($filter)) {
+                if ($useBuiltinFilters) {
+                    if (!$builtinFiltersAdded) {
+                        array_push($newFilters, ...$builtinFilters);
+                        $builtinFiltersAdded = true;
+                    }
+                } elseif ($this->isStopFilter($filter)) {
+                    $newFilters[] = $prefix . '_stop';
+                } elseif ($localeSettings['stemmer'] !== null) {
+                    $newFilters[] = $prefix . '_stemmer';
+                }
+            } else {
+                $newFilters[] = $filter;
+            }
+        }
+
+        $data['settings']['analysis']['analyzer']['stemming']['filter'] = $newFilters;
+
+        return $data;
+    }
+
+    /**
+     * @param array<mixed> $data
+     * @param string $locale
+     * @return array<mixed>
+     */
+    private function updateIcuCollationLanguage(array $data, string $locale): array
+    {
+        if (!isset($data['mappings']['properties'])) {
+            return $data;
+        }
+
+        $data['mappings']['properties'] = $this->updatePropertiesLanguage(
+            $data['mappings']['properties'],
+            $locale,
+        );
+
+        return $data;
+    }
+
+    /**
+     * @param array<mixed> $properties
+     * @param string $locale
+     * @return array<mixed>
+     */
+    private function updatePropertiesLanguage(array $properties, string $locale): array
+    {
+        foreach ($properties as $propertyName => $propertyConfig) {
+            if (!is_array($propertyConfig)) {
+                continue;
+            }
+
+            if (isset($propertyConfig['type']) && $propertyConfig['type'] === 'icu_collation_keyword') {
+                $properties[$propertyName]['language'] = $locale;
+            }
+
+            if (isset($propertyConfig['fields'])) {
+                $properties[$propertyName]['fields'] = $this->updatePropertiesLanguage(
+                    $propertyConfig['fields'],
+                    $locale,
+                );
+            }
+
+            if (isset($propertyConfig['properties'])) {
+                $properties[$propertyName]['properties'] = $this->updatePropertiesLanguage(
+                    $propertyConfig['properties'],
+                    $locale,
+                );
+            }
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @param string $indexFolder
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return array<string>
+     */
+    private function deleteUnusedDefinitions(
+        string $indexFolder,
+        CoreProjectConfig $config,
+    ): array {
+        $indexName = basename($indexFolder);
+        $domainIds = $config->getAllDomainIds();
+        $deleted = [];
+
+        $finder = Finder::create()
+            ->files()
+            ->in($indexFolder)
+            ->name('/^\d+\.json$/');
+
+        foreach ($finder as $file) {
+            $fileId = (int)pathinfo($file->getFilename(), PATHINFO_FILENAME);
+
+            if (in_array($fileId, $domainIds, true)) {
+                continue;
+            }
+
+            $this->fileHandler->deleteFile($file->getRealPath());
+            $deleted[] = self::DEFINITION_DIR . '/' . $indexName . '/' . $file->getFilename();
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     * @return string|null Relative path to modified Dockerfile, or null if no changes
+     */
+    private function updateDockerfilePlugins(CoreProjectConfig $config, string $projectPath): ?string
+    {
+        $dockerfilePath = $projectPath . '/' . self::ELASTICSEARCH_DOCKERFILE;
+
+        $requiredPlugins = $this->getRequiredPlugins($config);
+
+        if ($requiredPlugins === []) {
+            return null;
+        }
+
+        $content = $this->fileHandler->readFile($dockerfilePath);
+        $installedPlugins = $this->getInstalledPlugins($content);
+        $missingPlugins = array_diff($requiredPlugins, $installedPlugins);
+
+        if ($missingPlugins === []) {
+            return null;
+        }
+
+        $newContent = $this->addPluginsToDockerfile($content, $missingPlugins);
+        $this->fileHandler->writeFile($dockerfilePath, $newContent);
+
+        return self::ELASTICSEARCH_DOCKERFILE;
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return array<string>
+     */
+    private function getRequiredPlugins(CoreProjectConfig $config): array
+    {
+        $plugins = [];
+        $localeConfig = $this->getLocaleConfig();
+
+        foreach ($config->getUniqueLocales() as $locale) {
+            if (isset($localeConfig[$locale]['plugins'])) {
+                array_push($plugins, ...$localeConfig[$locale]['plugins']);
+            }
+        }
+
+        return array_unique($plugins);
+    }
+
+    /**
+     * @param string $dockerfileContent
+     * @return array<string>
+     */
+    private function getInstalledPlugins(string $dockerfileContent): array
+    {
+        preg_match_all(
+            '/elasticsearch-plugin\s+install\s+(\S+)/',
+            $dockerfileContent,
+            $matches,
+        );
+
+        return $matches[1];
+    }
+
+    /**
+     * @param string $content
+     * @param array<string> $plugins
+     * @return string
+     */
+    private function addPluginsToDockerfile(string $content, array $plugins): string
+    {
+        $pluginLines = [];
+
+        foreach ($plugins as $plugin) {
+            $pluginLines[] = sprintf('RUN bin/elasticsearch-plugin install %s', $plugin);
+        }
+
+        $pluginBlock = implode("\n", $pluginLines);
+
+        return rtrim($content) . "\n\n" . $pluginBlock . "\n";
+    }
+}

--- a/packages/cli/src/Worker/Backend/GitlabCiHostsWorker.php
+++ b/packages/cli/src/Worker/Backend/GitlabCiHostsWorker.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreDomainConfig;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class GitlabCiHostsWorker extends AbstractWorker
+{
+    private const string FILE_PATH = '.gitlab-ci.yml';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates HOSTS variable in .gitlab-ci.yml';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 856;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        try {
+            $content = $this->fileHandler->readFile($filePath);
+
+            $hostsValue = $this->buildHostsValue($config->domains);
+
+            $pattern = '/(HOSTS:\s*).*/';
+            $replacement = '$1' . $hostsValue;
+
+            $updatedContent = preg_replace($pattern, $replacement, $content);
+
+            if ($updatedContent === null) {
+                return WorkerResult::failure('Failed to update HOSTS variable in ' . self::FILE_PATH);
+            }
+
+            $this->fileHandler->writeFile($filePath, $updatedContent);
+
+            return WorkerResult::success(
+                'Updated HOSTS variable in ' . self::FILE_PATH,
+                filesModified: [self::FILE_PATH],
+            );
+        } catch (RuntimeException $e) {
+            return WorkerResult::failure($e->getMessage());
+        }
+    }
+
+    /**
+     * @param array<\Shopsys\Cli\Config\CoreDomainConfig> $domains
+     * @return string
+     */
+    private function buildHostsValue(array $domains): string
+    {
+        if (count($domains) === 0) {
+            return '${HOST}';
+        }
+
+        $hosts = [];
+        $usedPrefixes = [];
+
+        foreach ($domains as $domain) {
+            if ($domain->id === 1) {
+                $hosts[] = '${HOST}';
+
+                continue;
+            }
+
+            $prefix = $this->getHostPrefix($domain, $usedPrefixes);
+            $usedPrefixes[] = $prefix;
+            $hosts[] = $prefix . '.${HOST}';
+        }
+
+        return implode(', ', $hosts);
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreDomainConfig $domain
+     * @param array<string> $usedPrefixes
+     * @return string
+     */
+    private function getHostPrefix(CoreDomainConfig $domain, array $usedPrefixes): string
+    {
+        if (!in_array($domain->locale, $usedPrefixes, true)) {
+            return $domain->locale;
+        }
+
+        // Locale already used, append domain ID for uniqueness
+        return $domain->locale . $domain->id;
+    }
+}

--- a/packages/cli/src/Worker/Backend/GitlabCiTestLocaleWorker.php
+++ b/packages/cli/src/Worker/Backend/GitlabCiTestLocaleWorker.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class GitlabCiTestLocaleWorker extends AbstractWorker
+{
+    private const string FILE_PATH = '.gitlab-ci.yml';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates TEST_LOCALE variable in .gitlab-ci.yml to match first domain locale';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 808;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        $firstDomainLocale = $config->domains[0]->locale;
+
+        $content = $this->fileHandler->readFile($filePath);
+
+        $pattern = '/TEST_LOCALE=\w+/';
+        $replacement = 'TEST_LOCALE=' . $firstDomainLocale;
+
+        $updatedContent = preg_replace($pattern, $replacement, $content, -1, $count);
+
+        if ($updatedContent === null) {
+            return WorkerResult::failure('Failed to update TEST_LOCALE variable in ' . self::FILE_PATH);
+        }
+
+        $this->fileHandler->writeFile($filePath, $updatedContent);
+
+        return WorkerResult::success(
+            sprintf('Updated %d TEST_LOCALE variable(s) to "%s" in %s', $count, $firstDomainLocale, self::FILE_PATH),
+            filesModified: [self::FILE_PATH],
+        );
+    }
+}

--- a/packages/cli/src/Worker/Backend/PrepareCurrencyWorker.php
+++ b/packages/cli/src/Worker/Backend/PrepareCurrencyWorker.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use CommerceGuys\Intl\Currency\CurrencyRepository;
+use CommerceGuys\Intl\Exception\UnknownCurrencyException;
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Model\TwigHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class PrepareCurrencyWorker extends AbstractWorker
+{
+    private const string MIGRATIONS_DIR = 'app/src/Migrations/';
+
+    private const string NEXT_CONFIG_FILE = 'storefront/next.config.js';
+
+    /**
+     * @var string[]
+     */
+    private array $existingCurrencyCodes;
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     * @param \Shopsys\Cli\Model\TwigHandler $twigHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+        private readonly TwigHandler $twigHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Set other selected currencies to database';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 976;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $this->existingCurrencyCodes = $this->getExistingCurrencyCodes($projectPath);
+
+        $migrationFilePath = $this->createDatabaseMigration($config, $projectPath);
+
+        if ($migrationFilePath === null) {
+            return WorkerResult::success('All selected currencies are already set');
+        }
+
+        return WorkerResult::success(
+            'Currencies prepared',
+            filesCreated: [$migrationFilePath],
+        );
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     * @return string|null
+     */
+    private function createDatabaseMigration(CoreProjectConfig $config, string $projectPath): ?string
+    {
+        $migrationName = 'Version' . date('YmdHis');
+        $migrationFilePath = self::MIGRATIONS_DIR . $migrationName . '.php';
+        $migrationFullFilePath = $projectPath . '/' . $migrationFilePath;
+
+        $currencyCodes = $config->getUniqueCurrencies();
+        $currencyCodes = array_filter(
+            $currencyCodes,
+            function ($currencyCode) {
+                return !in_array($currencyCode, $this->existingCurrencyCodes, true);
+            },
+        );
+
+        if (count($currencyCodes) === 0) {
+            return null;
+        }
+
+        $sqlStatements = $this->getCreateCurrencySqlStatements($currencyCodes);
+
+        $migrationContent = $this->twigHandler->render(
+            __DIR__ . '/resources/DBMigrationTemplate.php.twig',
+            [
+                'migrationClassName' => $migrationName,
+                'sqlStatements' => $sqlStatements,
+            ],
+        );
+
+        $this->fileHandler->writeFile($migrationFullFilePath, $migrationContent);
+
+        return $migrationFilePath;
+    }
+
+    /**
+     * @param string[] $currencyCodes
+     * @return string[]
+     */
+    private function getCreateCurrencySqlStatements(array $currencyCodes): array
+    {
+        $currencyRepository = new CurrencyRepository();
+        $sqlStatements = [];
+
+        foreach ($currencyCodes as $currencyCode) {
+            try {
+                $currencyMetadata = $currencyRepository->get($currencyCode);
+
+                $escapedName = addslashes($currencyMetadata->getName());
+                $escapedCode = addslashes($currencyMetadata->getCurrencyCode());
+
+                $sqlStatements[] = sprintf(
+                    '$this->sql(\'INSERT INTO currencies (name, code, exchange_rate, min_fraction_digits, rounding_type, rounding_places_price_without_vat)
+                    VALUES (\\\'%s\\\', \\\'%s\\\', %f, %d, \\\'%s\\\', %d)\');',
+                    $escapedName,
+                    $escapedCode,
+                    1,
+                    $currencyMetadata->getFractionDigits(),
+                    'integer',
+                    $currencyMetadata->getFractionDigits(),
+                );
+            } catch (UnknownCurrencyException $e) {
+                throw new RuntimeException(sprintf('Currency with code "%s" not found.', $currencyCode), 0, $e);
+            }
+        }
+
+        return $sqlStatements;
+    }
+
+    /**
+     * @param string $projectPath
+     * @return string[]
+     */
+    private function getExistingCurrencyCodes(string $projectPath): array
+    {
+        $filePath = $projectPath . '/' . self::NEXT_CONFIG_FILE;
+
+        $content = $this->fileHandler->readFile($filePath);
+
+        preg_match_all("/currencyCode:\s*['\"]([^'\"]+)['\"]/", $content, $matches);
+
+        return array_unique($matches[1]);
+    }
+}

--- a/packages/cli/src/Worker/Backend/RoutingFilesWorker.php
+++ b/packages/cli/src/Worker/Backend/RoutingFilesWorker.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+use Symfony\Component\Finder\Finder;
+
+final class RoutingFilesWorker extends AbstractWorker
+{
+    private const string ROUTING_DIR = 'app/config/shopsys-routing';
+    private const string ROUTING_FRONT_FILE_NAME_PATTERN = 'routing_front_*.yaml';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Creates routing_front_{locale}.yaml files for each unique locale';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 952;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filesCreated = [];
+
+        foreach ($config->getUniqueLocales() as $locale) {
+            $filePath = $this->getRoutingFilePath($locale);
+            $fullFilePath = $projectPath . '/' . $filePath;
+
+            if (file_exists($fullFilePath)) {
+                continue;
+            }
+
+            $this->fileHandler->copyFile(
+                $projectPath . '/' . $this->getRoutingFilePath('en'),
+                $fullFilePath,
+            );
+
+            $filesCreated[] = $filePath;
+        }
+
+        $filesDeleted = $this->deleteUnnecessaryRoutingFiles($config, $projectPath);
+
+        $hints = [];
+
+        if (count($filesCreated) > 0) {
+            $hints = [
+                'Remember to translate route paths in these files: ',
+                ...(array_map(static fn (string $fileName): string => ' - ' . $fileName, $filesCreated)),
+            ];
+        }
+
+        return WorkerResult::success(
+            'Routing files created',
+            filesCreated: $filesCreated,
+            filesDeleted: $filesDeleted,
+            hints: $hints,
+        );
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     * @return string[]
+     */
+    private function deleteUnnecessaryRoutingFiles(CoreProjectConfig $config, string $projectPath): array
+    {
+        $existingFiles = Finder::create()
+            ->files()
+            ->in($projectPath . '/' . self::ROUTING_DIR)
+            ->name(self::ROUTING_FRONT_FILE_NAME_PATTERN);
+
+        $filesDeleted = [];
+
+        foreach ($existingFiles as $existingFile) {
+            $locale = str_replace(
+                ['routing_front_', '.yaml'],
+                '',
+                $existingFile->getFilename(),
+            );
+
+            if (in_array($locale, $config->getUniqueLocales(), true)) {
+                continue;
+            }
+
+            $this->fileHandler->deleteFile($existingFile->getRealPath());
+            $filesDeleted[] = self::ROUTING_DIR . '/' . $existingFile->getFilename();
+        }
+
+        return $filesDeleted;
+    }
+
+    /**
+     * @param string $locale
+     * @return string
+     */
+    private function getRoutingFilePath(string $locale): string
+    {
+        return self::ROUTING_DIR . '/' . str_replace('*', $locale, self::ROUTING_FRONT_FILE_NAME_PATTERN);
+    }
+}

--- a/packages/cli/src/Worker/Backend/SocialNetworkConfigWorker.php
+++ b/packages/cli/src/Worker/Backend/SocialNetworkConfigWorker.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Backend;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Config\Section\SocialLoginSection;
+use Shopsys\Cli\Model\YamlHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class SocialNetworkConfigWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'app/config/packages/social_network_config.yaml';
+
+    /**
+     * @param \Shopsys\Cli\Model\YamlHandler $yamlHandler
+     */
+    public function __construct(
+        private readonly YamlHandler $yamlHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates social login enabledOnDomains in social_network_config.yaml';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 784;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        $data = $this->yamlHandler->readYaml($filePath);
+
+        if (!isset($data['parameters']['social_network_login_config']['providers'])) {
+            return WorkerResult::failure('No social login providers configured in social_network_config.yaml');
+        }
+
+        $enabledDomains = $this->buildEnabledDomainsMap($config);
+
+        foreach ($data['parameters']['social_network_login_config']['providers'] as $providerName => &$providerConfig) {
+            if (!array_key_exists($providerName, $enabledDomains)) {
+                return WorkerResult::failure(sprintf(
+                    'Provider "%s" missing in social_login configuration section',
+                    $providerName,
+                ));
+            }
+
+            $providerConfig['enabledOnDomains'] = $enabledDomains[$providerName];
+        }
+        unset($providerConfig);
+
+        $this->yamlHandler->writeYaml($filePath, $data, 6);
+
+        return WorkerResult::success(
+            'Updated social_network_config.yaml',
+            filesModified: [self::FILE_PATH],
+        );
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return array<string, array<int>>
+     */
+    private function buildEnabledDomainsMap(CoreProjectConfig $config): array
+    {
+        $enabledDomains = [
+            'facebook' => [],
+            'google' => [],
+            'seznam' => [],
+        ];
+
+        foreach ($config->domains as $domain) {
+            $socialLogin = $domain->getConfigSection(SocialLoginSection::class);
+
+            if ($socialLogin->facebook) {
+                $enabledDomains['facebook'][] = $domain->id;
+            }
+
+            if ($socialLogin->google) {
+                $enabledDomains['google'][] = $domain->id;
+            }
+
+            if ($socialLogin->seznam) {
+                $enabledDomains['seznam'][] = $domain->id;
+            }
+        }
+
+        return $enabledDomains;
+    }
+}

--- a/packages/cli/src/Worker/Backend/resources/DBMigrationTemplate.php.twig
+++ b/packages/cli/src/Worker/Backend/resources/DBMigrationTemplate.php.twig
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class {{ migrationClassName }} extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function up(Schema $schema): void
+    {
+{% for sqlStatement in sqlStatements %}
+        {{ sqlStatement }}
+{% endfor %}
+    }
+}

--- a/packages/cli/src/Worker/Backend/resources/elastic-locales.yaml
+++ b/packages/cli/src/Worker/Backend/resources/elastic-locales.yaml
@@ -1,0 +1,125 @@
+# Locale-specific Elasticsearch configuration
+# This file contains settings for stemming and stopwords per locale
+#
+# Available fields per locale:
+#   prefix: string - prefix for filter names (e.g., 'english' -> 'english_stop', 'english_stemmer')
+#   stemmer: string|null - stemmer language (null = no stemming)
+#   stopwords: string|array - stopwords language ('_english_') or custom array
+#   builtin_filters: array - plugin-provided token filters to use directly (e.g., ['polish_stem', 'polish_stop'])
+#                           When set, stemmer/stopwords are ignored and these filters are used in analyzer
+#   plugins: array - list of required Elasticsearch plugins (e.g., ['analysis-stempel'])
+
+locales:
+
+    bg:
+        prefix: bulgarian
+        stemmer: bulgarian
+        stopwords: _bulgarian_
+
+    cs:
+        prefix: czech
+        stemmer: czech
+        stopwords: _czech_
+
+    da:
+        prefix: danish
+        stemmer: danish
+        stopwords: _danish_
+
+    de:
+        prefix: german
+        stemmer: german
+        stopwords: _german_
+
+    el:
+        prefix: greek
+        stemmer: greek
+        stopwords: _greek_
+    en:
+        prefix: english
+        stemmer: english
+        stopwords: _english_
+
+    es:
+        prefix: spanish
+        stemmer: spanish
+        stopwords: _spanish_
+
+    fi:
+        prefix: finnish
+        stemmer: finnish
+        stopwords: _finnish_
+
+    fr:
+        prefix: french
+        stemmer: light_french
+        stopwords: _french_
+
+    hr:
+        prefix: croatian
+        stemmer: english # fallback to English stemmer
+        stopwords: [ ]
+
+    hu:
+        prefix: hungarian
+        stemmer: hungarian
+        stopwords: _hungarian_
+
+    it:
+        prefix: italian
+        stemmer: italian
+        stopwords: _italian_
+
+    nl:
+        prefix: dutch
+        stemmer: dutch
+        stopwords: _dutch_
+
+    no:
+        prefix: norwegian
+        stemmer: norwegian
+        stopwords: _norwegian_
+
+    pl:
+        builtin_filters:
+            - polish_stem
+            - polish_stop
+        plugins:
+            - analysis-stempel
+        prefix: polish
+
+    pt:
+        prefix: portuguese
+        stemmer: portuguese
+        stopwords: _portuguese_
+
+    ro:
+        prefix: romanian
+        stemmer: romanian
+        stopwords: _romanian_
+
+    sk:
+        prefix: slovak
+        stemmer: ~
+        stopwords: [ 'a','aby','aj','ak','ako','ale','alebo','and','ani','áno','asi','až','bez','bude','budem','budeš','budeme','budete','budú','by','bol','bola','boli','bolo','byť','cez','čo','či','ďalší','ďalšia','ďalšie','dnes','do','ho','ešte','for','i','ja','je','jeho','jej','ich','iba','iné','iný','som','si','sme','sú','k','kam','každý','každá','každé','každí','kde','keď','kto','ktorá','ktoré','ktorou','ktorý','ktorí','ku','lebo','len','ma','mať','má','máte','medzi','mi','mna','mne','mnou','musieť','môcť','môj','môže','my','na','nad','nám','náš','naši','nie','nech','než','nič','niektorý','nové','nový','nová','noví','o','od','odo','of','on','ona','ono','oni','ony','po','pod','podľa','pokiaľ','potom','práve','pre','prečo','preto','pretože','prvý','prvá','prvé','prví','pred','predo','pri','pýta','s','sa','so','svoje','svoj','svojich','svojím','svojími','ta','tak','takže','táto','teda','te','tě','ten','tento','the','tieto','tým','týmto','tiež','to','toto','toho','tohoto','tom','tomto','tomuto','tu','tú','túto','tvoj','ty','tvojími','už','v','vám','váš','vaše','vo','viac','však','všetok','vy','z','za','zo','že' ]
+
+
+    sl:
+        prefix: slovenian
+        stemmer: english # fallback to English stemmer
+        stopwords: [ ]
+
+    sv:
+        prefix: swedish
+        stemmer: swedish
+        stopwords: _swedish_
+
+    tr:
+        prefix: turkish
+        stemmer: turkish
+        stopwords: _turkish_
+
+    uk:
+        prefix: ukrainian
+        stemmer: english # fallback to English stemmer
+        stopwords: [ ]

--- a/packages/cli/src/Worker/Storefront/DomainsEnvWorker.php
+++ b/packages/cli/src/Worker/Storefront/DomainsEnvWorker.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Storefront;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class DomainsEnvWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'storefront/.env';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates DOMAIN_HOSTNAME_* and PUBLIC_GRAPHQL_ENDPOINT_* in storefront/.env';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 512;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        $content = $this->fileHandler->readFile($filePath);
+        $lines = explode("\n", $content);
+        $internalEndpointLine = null;
+
+        foreach ($lines as $index => $line) {
+            if (preg_match('/^DOMAIN_HOSTNAME_\d+=/', $line)) {
+                unset($lines[$index]);
+            }
+
+            if (preg_match('/^PUBLIC_GRAPHQL_ENDPOINT_HOSTNAME_\d+=/', $line)) {
+                unset($lines[$index]);
+            }
+
+            if (!str_starts_with($line, 'INTERNAL_ENDPOINT=')) {
+                continue;
+            }
+
+            $internalEndpointLine = $line;
+            unset($lines[$index]);
+        }
+
+        $domainHostnames = [];
+        $graphqlEndpoints = [];
+
+        foreach ($config->domains as $domain) {
+            $placeholderUrl = $this->getPlaceholderUrl($domain->id);
+            $domainHostnames[] = sprintf('DOMAIN_HOSTNAME_%d=%s', $domain->id, $placeholderUrl);
+            $graphqlUrl = rtrim($placeholderUrl, '/') . '/graphql/';
+            $graphqlEndpoints[] = sprintf('PUBLIC_GRAPHQL_ENDPOINT_HOSTNAME_%d=%s', $domain->id, $graphqlUrl);
+        }
+
+        $lines = [
+            ...$domainHostnames,
+            ...$graphqlEndpoints,
+            ...$lines,
+        ];
+
+        if ($internalEndpointLine !== null) {
+            $lines = [
+                $internalEndpointLine,
+                ...$lines,
+            ];
+        }
+
+        $this->fileHandler->writeFile($filePath, implode("\n", $lines));
+
+        return WorkerResult::success(
+            'Domains for storefront set',
+            filesModified: [self::FILE_PATH],
+        );
+    }
+
+    /**
+     * @param int $domainId
+     * @return string
+     */
+    private function getPlaceholderUrl(int $domainId): string
+    {
+        return sprintf('http://127.0.0.%d:8000/', $domainId);
+    }
+}

--- a/packages/cli/src/Worker/Storefront/DomainsPublicRuntimeConfigWorker.php
+++ b/packages/cli/src/Worker/Storefront/DomainsPublicRuntimeConfigWorker.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Storefront;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreDomainConfig;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Config\Section\MapSettingsSection;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class DomainsPublicRuntimeConfigWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'storefront/next.config.js';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates domains array in publicRuntimeConfig and remotePatterns in storefront/next.config.js';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 488;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        $content = $this->fileHandler->readFile($filePath);
+
+        $content = $this->replaceRemotePatterns($content, $config);
+        $content = $this->replaceDomainsArray($content, $config);
+
+        $this->fileHandler->writeFile($filePath, $content);
+
+        return WorkerResult::success(
+            'Updated next.config.js domains and remotePatterns',
+            filesModified: [self::FILE_PATH],
+        );
+    }
+
+    /**
+     * @param string $content
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return string
+     */
+    private function replaceRemotePatterns(string $content, CoreProjectConfig $config): string
+    {
+        $remotePatterns = $this->generateRemotePatterns($config);
+        $pattern = '/(remotePatterns:\s*)\[[\s\S]*?],/';
+        $replacement = '${1}' . $remotePatterns . ',';
+
+        $result = preg_replace($pattern, $replacement, $content);
+
+        if ($result === null) {
+            throw new RuntimeException('Unable to replace remotePatterns block in next.config.js');
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return string
+     */
+    private function generateRemotePatterns(CoreProjectConfig $config): string
+    {
+        $patterns = [];
+
+        foreach ($config->domains as $domain) {
+            $patterns[] = "            {\n                hostname: process.env.DOMAIN_HOSTNAME_{$domain->id},\n            }";
+        }
+
+        return "[\n" . implode(",\n", $patterns) . ",\n        ]";
+    }
+
+    /**
+     * @param string $content
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return string
+     */
+    private function replaceDomainsArray(string $content, CoreProjectConfig $config): string
+    {
+        $prototypeData = $this->extractDomainPrototype($content);
+        $domainsCode = $this->generateDomainsCode($config, $prototypeData);
+        $pattern = '/(domains:\s*)\[\n[\s\S]*?\n\s*]/';
+        $replacement = '${1}' . $domainsCode;
+
+        $result = preg_replace($pattern, $replacement, $content);
+
+        if ($result === null) {
+            throw new RuntimeException('Unable to replace domains block in next.config.js');
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $content
+     * @return array{prototype: string, closingIndent: string}
+     */
+    private function extractDomainPrototype(string $content): array
+    {
+        // Match first domain object only (ends with },) and closing bracket indentation
+        if (!preg_match('/domains:\s*\[\n((\s+)\{[\s\S]*?\n\2}),[\s\S]*?\n(\s*)],/', $content, $match)) {
+            throw new RuntimeException('Unable to find domains array in next.config.js');
+        }
+
+        return [
+            'prototype' => $match[1],
+            'closingIndent' => $match[3],
+        ];
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param array{prototype: string, closingIndent: string} $prototypeData
+     * @return string
+     */
+    private function generateDomainsCode(CoreProjectConfig $config, array $prototypeData): string
+    {
+        $domains = [];
+
+        foreach ($config->domains as $domain) {
+            $domains[] = $this->generateDomainFromPrototype($domain, $prototypeData['prototype']);
+        }
+
+        return "[\n" . implode(",\n", $domains) . ",\n" . $prototypeData['closingIndent'] . ']';
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreDomainConfig $domain
+     * @param string $prototype
+     * @return string
+     */
+    private function generateDomainFromPrototype(CoreDomainConfig $domain, string $prototype): string
+    {
+        $mapSettings = $domain->getConfigSection(MapSettingsSection::class);
+
+        $replacements = [
+            '/PUBLIC_GRAPHQL_ENDPOINT_HOSTNAME_\d+/' => 'PUBLIC_GRAPHQL_ENDPOINT_HOSTNAME_' . $domain->id,
+            '/DOMAIN_HOSTNAME_\d+/' => 'DOMAIN_HOSTNAME_' . $domain->id,
+            '/defaultLocale:\s*[\'"][\w-]+[\'"]/' => "defaultLocale: '" . $domain->locale . "'",
+            '/currencyCode:\s*[\'"][\w]+[\'"]/' => "currencyCode: '" . $domain->currencyCode . "'",
+            '/fallbackTimezone:\s*[\'"][\w\/]+[\'"]/' => "fallbackTimezone: '" . $domain->timezone . "'",
+            '/domainId:\s*\d+/' => 'domainId: ' . $domain->id,
+            '/latitude:\s*[\d.]+/' => 'latitude: ' . $mapSettings->latitude,
+            '/longitude:\s*[\d.]+/' => 'longitude: ' . $mapSettings->longitude,
+            '/zoom:\s*\d+/' => 'zoom: ' . $mapSettings->zoom,
+            "/includes\(['\"]\\d+['\"]\)/" => "includes('" . $domain->id . "')",
+            '/type:\s*[\'"][\w]+[\'"]/' => "type: '" . strtoupper($domain->type) . "'",
+        ];
+
+        $result = $prototype;
+
+        foreach ($replacements as $pattern => $replacement) {
+            $result = preg_replace($pattern, $replacement, $result);
+        }
+
+        return $result;
+    }
+}

--- a/packages/cli/src/Worker/Storefront/I18nLocalesWorker.php
+++ b/packages/cli/src/Worker/Storefront/I18nLocalesWorker.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Storefront;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class I18nLocalesWorker extends AbstractWorker
+{
+    private const string I18N_FILE_PATH = 'storefront/i18n.js';
+    private const string I18NEXT_PARSER_FILE_PATH = 'storefront/config/i18next-parser.config.js';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates locales array in storefront/config/i18next-parser.config.js and storefront/i18n.js';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 464;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $i18nFilePath = $projectPath . '/' . self::I18N_FILE_PATH;
+        $i18nContent = $this->fileHandler->readFile($i18nFilePath);
+
+        $i18nextParserFile = $projectPath . '/' . self::I18NEXT_PARSER_FILE_PATH;
+        $i18nextParserContent = $this->fileHandler->readFile($i18nextParserFile);
+
+        $implodedLocales = implode("', '", $config->getUniqueLocales());
+
+        $pattern = "/(\s*locales:\s*)\[[^]]*]/";
+
+        $newI18nContent = preg_replace(
+            $pattern,
+            '${1}' . "['default', '" . $implodedLocales . "']",
+            $i18nContent,
+        );
+        $this->fileHandler->writeFile(
+            $i18nFilePath,
+            $newI18nContent,
+        );
+
+        $newI18nextParserContent = preg_replace(
+            $pattern,
+            '${1}' . "['" . $implodedLocales . "']",
+            $i18nextParserContent,
+        );
+        $this->fileHandler->writeFile(
+            $i18nextParserFile,
+            $newI18nextParserContent,
+        );
+
+        return WorkerResult::success(
+            'Updated i18n locales configuration',
+            filesModified: [self::I18N_FILE_PATH, self::I18NEXT_PARSER_FILE_PATH],
+        );
+    }
+}

--- a/packages/cli/src/Worker/Storefront/MetatagSiteNameWorker.php
+++ b/packages/cli/src/Worker/Storefront/MetatagSiteNameWorker.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Storefront;
+
+use Override;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Config\Section\MetatagSiteNameSection;
+use Shopsys\Cli\Model\JsonHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class MetatagSiteNameWorker extends AbstractWorker
+{
+    private const string LOCALES_PATH = 'storefront/public/locales';
+
+    /**
+     * @param \Shopsys\Cli\Model\JsonHandler $jsonHandler
+     */
+    public function __construct(
+        private readonly JsonHandler $jsonHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Updates metatagSiteName in storefront locale common.json files';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 368;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $metatagSection = $config->getConfigSection(MetatagSiteNameSection::class);
+        $siteName = $metatagSection->siteName;
+
+        $localesPath = $projectPath . '/' . self::LOCALES_PATH;
+        $locales = $config->getUniqueLocales();
+
+        $filesModified = [];
+
+        foreach ($locales as $locale) {
+            $commonJsonPath = $localesPath . '/' . $locale . '/common.json';
+
+            if (!file_exists($commonJsonPath)) {
+                continue;
+            }
+
+            $data = $this->jsonHandler->readJson($commonJsonPath);
+            $data['metatagSiteName'] = $siteName;
+            $this->jsonHandler->writeJson($commonJsonPath, $data);
+
+            $filesModified[] = self::LOCALES_PATH . '/' . $locale . '/common.json';
+        }
+
+        if ($filesModified === []) {
+            return WorkerResult::success('No locale common.json files found to update');
+        }
+
+        return WorkerResult::success(
+            sprintf('Updated metatagSiteName to "%s" in %d locale file(s)', $siteName, count($filesModified)),
+            filesModified: $filesModified,
+        );
+    }
+}

--- a/packages/cli/src/Worker/Storefront/RoutesWorker.php
+++ b/packages/cli/src/Worker/Storefront/RoutesWorker.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Storefront;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class RoutesWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'storefront/config/routes.ts';
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $routesByLocale = [];
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Generates storefront/config/routes.ts with route mappings per domain';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 440;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+
+        $existingContent = $this->fileHandler->readFile($filePath);
+        $this->parseExistingRoutes($existingContent);
+
+        $routesContent = $this->generateRoutesContent($config);
+        $this->fileHandler->writeFile($filePath, $routesContent);
+
+        return WorkerResult::success(
+            'Generated routes.ts',
+            filesModified: [self::FILE_PATH],
+            hints: [
+                sprintf('Update route translations in "%s" for each locale.', self::FILE_PATH),
+            ],
+        );
+    }
+
+    /**
+     * Parses existing routes.ts and stores routes by locale (1st=en, 2nd=cs, 3rd=sk)
+     *
+     * @param string $content
+     */
+    private function parseExistingRoutes(string $content): void
+    {
+        $localeOrder = ['en', 'cs', 'sk'];
+
+        preg_match_all('/\{([^}]+)}/', $content, $matches);
+
+        if (count($matches[1]) === 0) {
+            throw new RuntimeException('Could not parse route objects from routes.ts');
+        }
+
+        foreach ($matches[1] as $index => $objectContent) {
+            $routes = $this->parseRouteObject($objectContent);
+            $locale = $localeOrder[$index] ?? 'en';
+            $this->routesByLocale[$locale] = $routes;
+        }
+    }
+
+    /**
+     * @param string $objectContent
+     * @return array<string, string>
+     */
+    private function parseRouteObject(string $objectContent): array
+    {
+        $routes = [];
+
+        preg_match_all("/'([^']+)':\s*'([^']+)'/", $objectContent, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $match) {
+            $routes[$match[1]] = $match[2];
+        }
+
+        return $routes;
+    }
+
+    /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return string
+     */
+    private function generateRoutesContent(CoreProjectConfig $config): string
+    {
+        $routeObjects = [];
+
+        foreach ($config->domains as $domain) {
+            $routes = $this->getRoutesForLocale($domain->locale);
+            $routeObjects[] = $this->formatRouteObject($routes);
+        }
+
+        $routesArrayContent = implode(",\n", $routeObjects);
+
+        return "export const routes = [\n" . $routesArrayContent . ",\n];\n";
+    }
+
+    /**
+     * @param string $locale
+     * @return array<string, string>
+     */
+    private function getRoutesForLocale(string $locale): array
+    {
+        return $this->routesByLocale[$locale] ?? $this->routesByLocale['en'] ?? throw new RuntimeException('English routes not found');
+    }
+
+    /**
+     * @param array<string, string> $routes
+     * @return string
+     */
+    private function formatRouteObject(array $routes): string
+    {
+        $lines = [];
+
+        foreach ($routes as $key => $value) {
+            $lines[] = sprintf("        '%s': '%s'", $key, $value);
+        }
+
+        return "    {\n" . implode(",\n", $lines) . ",\n    }";
+    }
+}

--- a/packages/cli/src/Worker/Storefront/StaticRewritePathsWorker.php
+++ b/packages/cli/src/Worker/Storefront/StaticRewritePathsWorker.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker\Storefront;
+
+use Override;
+use RuntimeException;
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Shopsys\Cli\Model\FileHandler;
+use Shopsys\Cli\Worker\AbstractWorker;
+use Shopsys\Cli\Worker\WorkerResult;
+
+final class StaticRewritePathsWorker extends AbstractWorker
+{
+    private const string FILE_PATH = 'storefront/config/staticRewritePaths.ts';
+
+    /**
+     * @param \Shopsys\Cli\Model\FileHandler $fileHandler
+     */
+    public function __construct(
+        private readonly FileHandler $fileHandler,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Generates storefront/config/staticRewritePaths.ts with URL-to-routes mapping';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 416;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult
+    {
+        $filePath = $projectPath . '/' . self::FILE_PATH;
+        $content = $this->fileHandler->readFile($filePath);
+
+        $lines = explode("\n", $content);
+        $newLines = $this->replaceMappingLines($lines, $config);
+
+        $this->fileHandler->writeFile($filePath, implode("\n", $newLines));
+
+        return WorkerResult::success(
+            'Generated staticRewritePaths.ts',
+            filesModified: [self::FILE_PATH],
+        );
+    }
+
+    /**
+     * @param array<string> $lines
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @return array<string>
+     */
+    private function replaceMappingLines(array $lines, CoreProjectConfig $config): array
+    {
+        $insertIndex = null;
+
+        foreach ($lines as $index => $line) {
+            if (str_contains($line, 'process.env.DOMAIN_HOSTNAME_')) {
+                $insertIndex ??= $index;
+                unset($lines[$index]);
+            }
+        }
+
+        if ($insertIndex === null) {
+            throw new RuntimeException('Could not find mapping lines in staticRewritePaths.ts');
+        }
+
+        $newMappingLines = [];
+
+        foreach ($config->domains as $index => $domain) {
+            $newMappingLines[] = $this->generateMappingLine($index, $domain->id);
+        }
+
+        $lines = array_values($lines);
+        array_splice($lines, $insertIndex, 0, $newMappingLines);
+
+        return $lines;
+    }
+
+    /**
+     * @param int $index
+     * @param int $domainId
+     * @return string
+     */
+    private function generateMappingLine(int $index, int $domainId): string
+    {
+        return sprintf(
+            '    [(nextConfig?.publicRuntimeConfig?.domains?.[%d]?.url || process.env.DOMAIN_HOSTNAME_%d) as string]: routes[%d],',
+            $index,
+            $domainId,
+            $index,
+        );
+    }
+}

--- a/packages/cli/src/Worker/WorkerInterface.php
+++ b/packages/cli/src/Worker/WorkerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker;
+
+use Shopsys\Cli\Model\ProjectConfiguration;
+
+interface WorkerInterface
+{
+    /**
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string;
+
+    /**
+     * @param \Shopsys\Cli\Model\ProjectConfiguration $config
+     * @param string $projectPath
+     * @return \Shopsys\Cli\Worker\WorkerResult
+     */
+    public function execute(ProjectConfiguration $config, string $projectPath): WorkerResult;
+
+    /**
+     * Higher priority workers run first
+     *
+     * @return int
+     */
+    public function getPriority(): int;
+}

--- a/packages/cli/src/Worker/WorkerInterface.php
+++ b/packages/cli/src/Worker/WorkerInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\Cli\Worker;
 
-use Shopsys\Cli\Model\ProjectConfiguration;
+use Shopsys\Cli\Config\CoreProjectConfig;
 
 interface WorkerInterface
 {
@@ -19,11 +19,11 @@ interface WorkerInterface
     public function getDescription(): string;
 
     /**
-     * @param \Shopsys\Cli\Model\ProjectConfiguration $config
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
      * @param string $projectPath
      * @return \Shopsys\Cli\Worker\WorkerResult
      */
-    public function execute(ProjectConfiguration $config, string $projectPath): WorkerResult;
+    public function execute(CoreProjectConfig $config, string $projectPath): WorkerResult;
 
     /**
      * Higher priority workers run first

--- a/packages/cli/src/Worker/WorkerResult.php
+++ b/packages/cli/src/Worker/WorkerResult.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker;
+
+final class WorkerResult
+{
+    /**
+     * @param bool $success
+     * @param string $message
+     * @param array<string> $filesModified
+     * @param array<string> $filesCreated
+     * @param array<string> $filesDeleted
+     * @param array<string> $hints
+     */
+    public function __construct(
+        public readonly bool $success,
+        public readonly string $message,
+        public readonly array $filesModified = [],
+        public readonly array $filesCreated = [],
+        public readonly array $filesDeleted = [],
+        public readonly array $hints = [],
+    ) {
+    }
+
+    /**
+     * @param string $message
+     * @param array<string> $filesModified
+     * @param array<string> $filesCreated
+     * @param array<string> $filesDeleted
+     * @param array<string> $hints
+     * @return self
+     */
+    public static function success(
+        string $message,
+        array $filesModified = [],
+        array $filesCreated = [],
+        array $filesDeleted = [],
+        array $hints = [],
+    ): self {
+        return new self(
+            success: true,
+            message: $message,
+            filesModified: $filesModified,
+            filesCreated: $filesCreated,
+            filesDeleted: $filesDeleted,
+            hints: $hints,
+        );
+    }
+
+    /**
+     * @param string $message
+     * @return self
+     */
+    public static function failure(string $message): self
+    {
+        return new self(
+            success: false,
+            message: $message,
+        );
+    }
+}

--- a/packages/cli/src/Worker/WorkerRunner.php
+++ b/packages/cli/src/Worker/WorkerRunner.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\Cli\Worker;
 
+use Shopsys\Cli\Config\CoreProjectConfig;
+use Throwable;
+
 final class WorkerRunner
 {
     /**
@@ -12,12 +15,12 @@ final class WorkerRunner
     private array $workers = [];
 
     /**
-     * @param iterable<\Shopsys\Cli\Worker\WorkerInterface> $taggedWorkers
+     * @param iterable<\Shopsys\Cli\Worker\WorkerInterface> $workers
      */
     public function __construct(
-        iterable $taggedWorkers,
+        iterable $workers,
     ) {
-        $this->loadWorkers($taggedWorkers);
+        $this->loadWorkers($workers);
     }
 
     /**
@@ -41,10 +44,76 @@ final class WorkerRunner
     }
 
     /**
+     * @param \Shopsys\Cli\Config\CoreProjectConfig $config
+     * @param string $projectPath
+     * @param callable(\Shopsys\Cli\Worker\WorkerInterface, \Shopsys\Cli\Worker\WorkerResult): void $progressCallback
+     * @return array<\Shopsys\Cli\Worker\WorkerResult>
+     */
+    public function run(
+        CoreProjectConfig $config,
+        string $projectPath,
+        ?callable $progressCallback = null,
+    ): array {
+        $results = [];
+
+        foreach ($this->workers as $worker) {
+            try {
+                $result = $worker->execute($config, $projectPath);
+            } catch (Throwable $e) {
+                $result = WorkerResult::failure(sprintf(
+                    'Error in %s: %s',
+                    $worker->getName(),
+                    $e->getMessage(),
+                ));
+            }
+
+            $results[] = $result;
+
+            if ($progressCallback !== null) {
+                $progressCallback($worker, $result);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * @return array<\Shopsys\Cli\Worker\WorkerInterface>
      */
     public function getWorkers(): array
     {
         return $this->workers;
+    }
+
+    /**
+     * @param array<\Shopsys\Cli\Worker\WorkerResult> $results
+     * @return bool
+     */
+    public function allSuccessful(array $results): bool
+    {
+        foreach ($results as $result) {
+            if (!$result->success) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<\Shopsys\Cli\Worker\WorkerResult> $results
+     * @return array<string>
+     */
+    public function collectHints(array $results): array
+    {
+        $hints = [];
+
+        foreach ($results as $result) {
+            foreach ($result->hints as $hint) {
+                $hints[] = $hint;
+            }
+        }
+
+        return $hints;
     }
 }

--- a/packages/cli/src/Worker/WorkerRunner.php
+++ b/packages/cli/src/Worker/WorkerRunner.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Cli\Worker;
+
+final class WorkerRunner
+{
+    /**
+     * @var array<\Shopsys\Cli\Worker\WorkerInterface>
+     */
+    private array $workers = [];
+
+    /**
+     * @param iterable<\Shopsys\Cli\Worker\WorkerInterface> $taggedWorkers
+     */
+    public function __construct(
+        iterable $taggedWorkers,
+    ) {
+        $this->loadWorkers($taggedWorkers);
+    }
+
+    /**
+     * @param iterable<\Shopsys\Cli\Worker\WorkerInterface> $taggedWorkers
+     */
+    private function loadWorkers(iterable $taggedWorkers): void
+    {
+        $workers = [];
+
+        foreach ($taggedWorkers as $worker) {
+            $workers[] = $worker;
+        }
+
+        // Sort workers by priority (higher priority runs first)
+        usort(
+            $workers,
+            static fn (WorkerInterface $a, WorkerInterface $b) => $b->getPriority() <=> $a->getPriority(),
+        );
+
+        $this->workers = $workers;
+    }
+
+    /**
+     * @return array<\Shopsys\Cli\Worker\WorkerInterface>
+     */
+    public function getWorkers(): array
+    {
+        return $this->workers;
+    }
+}

--- a/project-base/app/.gitignore
+++ b/project-base/app/.gitignore
@@ -32,3 +32,4 @@ yarn-error.log
 /.phpunit.cache
 
 /phing.phar
+/shopsys.phar

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -158,6 +158,10 @@
             "@auto-scripts",
             "@security-check"
         ],
+        "post-create-project-cmd": [
+            "php app/scripts/downloadShopsysCli.php",
+            "php app/shopsys.phar configure ."
+        ],
         "auto-scripts": {
             "php app/downloadPhing.php --phing-version=3.0.0": "script",
             "php phing clean": "script",
@@ -167,6 +171,7 @@
         "security-check": "security-checker security:check"
     },
     "config": {
+        "process-timeout": 1200,
         "preferred-install": "dist",
         "component-dir": "web/components",
         "sort-packages": true,

--- a/project-base/app/scripts/downloadShopsysCli.php
+++ b/project-base/app/scripts/downloadShopsysCli.php
@@ -1,0 +1,38 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$pharName = 'shopsys.phar';
+$pharPath = dirname(__DIR__) . '/' . $pharName;
+$baseUrl = 'https://github.com/shopsys/cli/releases';
+
+$tagOutput = shell_exec('git describe --tags --exact-match 2>/dev/null');
+$branchOutput = shell_exec('git rev-parse --abbrev-ref HEAD 2>/dev/null');
+$version = trim($tagOutput ?? $branchOutput ?? '');
+
+$downloaded = false;
+
+if ($version !== '') {
+    $versionedUrl = sprintf('%s/download/%s/%s', $baseUrl, $version, $pharName);
+    echo sprintf('Downloading %s from %s...%s', $pharName, $versionedUrl, PHP_EOL);
+    $downloaded = @copy($versionedUrl, $pharPath);
+
+    if (!$downloaded) {
+        echo sprintf('Version %s not found, falling back to latest release...%s', $version, PHP_EOL);
+    }
+}
+
+if (!$downloaded) {
+    $latestUrl = sprintf('%s/latest/download/%s', $baseUrl, $pharName);
+    echo sprintf('Downloading %s from %s...%s', $pharName, $latestUrl, PHP_EOL);
+    $downloaded = @copy($latestUrl, $pharPath);
+}
+
+if (!$downloaded) {
+    echo sprintf('Failed to download %s. Please check your network connection.%s', $pharName, PHP_EOL);
+    exit(1);
+}
+
+chmod($pharPath, 0755);
+echo sprintf('Successfully downloaded %s to %s%s', $pharName, $pharPath, PHP_EOL);

--- a/utils/releaser/config/release-candidate.php
+++ b/utils/releaser/config/release-candidate.php
@@ -24,6 +24,7 @@ use Shopsys\Releaser\ReleaseWorker\ReleaseCandidate\UpdateLicenseAcknowledgement
 use Shopsys\Releaser\ReleaseWorker\ReleaseCandidate\UpdateUpgradeReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\ReleaseCandidate\ValidateConflictsInComposerJsonReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\ReleaseCandidate\ValidateRequireFormatInComposerJsonReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\ReleaseCandidate\VerifyCliIsRunningReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\ReleaseCandidate\VerifyMinorUpgradeReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\VerifyInitialBranchReleaseWorker;
 
@@ -49,6 +50,7 @@ return [
     TestYourBranchLocallyReleaseWorker::class,
     ForceYourBranchSplitReleaseWorker::class,
     CheckShopsysInstallReleaseWorker::class,
+    VerifyCliIsRunningReleaseWorker::class,
     CheckPackagesGithubActionsBuildsAfterSplitReleaseWorker::class,
     VerifyMinorUpgradeReleaseWorker::class,
     SendBranchForReviewAndTestsReleaseWorker::class,

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/VerifyCliIsRunningReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/VerifyCliIsRunningReleaseWorker.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
+
+use Override;
+use PharIo\Version\Version;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+
+final class VerifyCliIsRunningReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @param \PharIo\Version\Version $version
+     * @param string $initialBranchName
+     * @return string
+     */
+    #[Override]
+    public function getDescription(
+        Version $version,
+        string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME,
+    ): string {
+        return '[Manually] Verify that Shopsys Cli is able to run on the new version';
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @param string $initialBranchName
+     */
+    #[Override]
+    public function work(
+        Version $version,
+        string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME,
+    ): void {
+        $this->symfonyStyle->note([
+            '1) Install composer dependencies in packages/cli',
+            '2) In some temporary directory use Cli to init a project',
+            sprintf('path-to-project/packages/cli init rc-project -b %s', $this->currentBranchName),
+            '3) Verify it finishes without errors.',
+        ]);
+        $this->confirm('Confirm the Shopsys Cli is able to run on the new version.');
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    protected function getAllowedStages(): array
+    {
+        return [Stage::RELEASE_CANDIDATE];
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

This PR introduces Shopsys CLI, a standalone CLI tool for automating the initialization and configuration of new Shopsys Platform projects.
Shopsys CLI eliminates manual setup work by providing interactive domain configuration, automatic file generation, and multi-domain setup capabilities.

- Adds a new packages/forge package with a CLI application
- Implements a worker-based architecture for modular, extensible configuration tasks
- Supports both interactive prompts and YAML-based configuration
- Provides extensible configuration sections for domain and project-level settings

CLI Commands:

- shopsys init [project-name] - Clone project-base and run configuration
- shopsys configure <path> - Configure an existing project (interactive or YAML)
- shopsys workers - List all available configuration workers

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)






































----
:globe_with_meridians: Live Preview:
  - https://mg-forge.odin.shopsys.cloud
  - https://cz.mg-forge.odin.shopsys.cloud
  - https://mg-forge.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770037029.344609 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-forge.odin.shopsys.cloud
  - https://cz.mg-forge.odin.shopsys.cloud
  - https://mg-forge.odin.shopsys.cloud/sk
<!-- Replace -->
