### PR TITLE
reverted movement of vendor and node_modules syncing from Mutagen to named volumes

### DIFF
--- a/.github/get-build-exit-code.sh
+++ b/.github/get-build-exit-code.sh
@@ -16,13 +16,13 @@ getBuildExitCodeBasedOnJobResults() {
     UNIT_TESTS_STOREFRONT_RESULT=${13}
     TESTS_STOREFRONT_ACCEPTANCE_REGENERATE_RESULT=${14}
     REGENERATION_STARTED=${15}
-    CHECK_UPGRADE_NOTES_RESULT=${15}
+    CHECK_UPGRADE_NOTES_RESULT=${16}
 
     if [[ "$BUILD_FORK_RESULT" == "success" ]]; then
         return 0
     fi
 
-    if [[ "$STANDARDS_RESULT" == "success" && "$TESTS_RESULT" == "success" && "$TESTS_CZECH_RESULT" == "success" && "$CHECK_DEMO_DATA_LIMITED_DOMAINS_RESULT" == "success" && "$TESTS_ACCEPTANCE_RESULT" == "success" && "$STANDARDS_STOREFRONT_RESULT" == "success" && "$TRANSLATIONS_DUMP_RESULT" == "success" && "$REVIEW_RESULT" == "success" && "$CHECK_CONSOLE_COMMANDS_RESULT" == "success" && (("$TESTS_STOREFRONT_ACCEPTANCE_RESULT" == "success" && "$REGENERATION_STARTED" == "false") || ("$TESTS_STOREFRONT_ACCEPTANCE_REGENERATE_RESULT" == "success" && "$REGENERATION_STARTED" == "true")) && "$UNIT_TESTS_STOREFRONT_RESULT" == "success" && "$TESTS_STOREFRONT_SMOKE_RESULT" == "success" && "$CHECK_UPGRADE_NOTES_RESULT" == "success"]]; then
+    if [[ "$STANDARDS_RESULT" == "success" && "$TESTS_RESULT" == "success" && "$TESTS_CZECH_RESULT" == "success" && "$CHECK_DEMO_DATA_LIMITED_DOMAINS_RESULT" == "success" && "$TESTS_ACCEPTANCE_RESULT" == "success" && "$STANDARDS_STOREFRONT_RESULT" == "success" && "$TRANSLATIONS_DUMP_RESULT" == "success" && "$REVIEW_RESULT" == "success" && "$CHECK_CONSOLE_COMMANDS_RESULT" == "success" && (("$TESTS_STOREFRONT_ACCEPTANCE_RESULT" == "success" && "$REGENERATION_STARTED" == "false") || ("$TESTS_STOREFRONT_ACCEPTANCE_REGENERATE_RESULT" == "success" && "$REGENERATION_STARTED" == "true")) && "$UNIT_TESTS_STOREFRONT_RESULT" == "success" && "$TESTS_STOREFRONT_SMOKE_RESULT" == "success" && "$CHECK_UPGRADE_NOTES_RESULT" == "success" ]]; then
         return 0
     else
         return 1

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1237,7 +1237,7 @@ jobs:
         if: |
             always()
         name: Build successful
-        needs: [tests-acceptance, standards, tests-unit-functional-smoke, tests-unit-functional-smoke-first-czech-domain, check-demo-data-limited-domains, standards-storefront, translations-dump-check, review, build-fork-docker-images, check-console-commands, tests-storefront-smoke, tests-storefront-acceptance, tests-storefront-acceptance-regenerate, push-regenerated-snapshots, unit-test-storefront,]
+        needs: [tests-acceptance, standards, tests-unit-functional-smoke, tests-unit-functional-smoke-first-czech-domain, check-demo-data-limited-domains, standards-storefront, translations-dump-check, review, build-fork-docker-images, check-console-commands, tests-storefront-smoke, tests-storefront-acceptance, tests-storefront-acceptance-regenerate, push-regenerated-snapshots, unit-test-storefront, check-upgrade-notes]
         runs-on: ubuntu-22.04
         env:
             BUILD_FORK_RESULT: ${{ needs.build-fork-docker-images.result }}
@@ -1263,5 +1263,5 @@ jobs:
                     ref: ${{ github.ref }}
             -   name: Build successful
                 run: |
-                    EXIT_CODE=`. .github/get-build-exit-code.sh && getBuildExitCodeBasedOnJobResults ${BUILD_FORK_RESULT} ${STANDARDS_RESULT} ${TESTS_RESULT} ${TESTS_CZECH_RESULT} ${CHECK_DEMO_DATA_LIMITED_DOMAINS_RESULT} ${TESTS_ACCEPTANCE_RESULT} ${STANDARDS_STOREFRONT_RESULT} ${TRANSLATIONS_DUMP_RESULT} ${REVIEW_RESULT} ${CHECK_CONSOLE_COMMANDS_RESULT} ${TESTS_STOREFRONT_SMOKE_RESULT} ${TESTS_STOREFRONT_ACCEPTANCE_RESULT} ${UNIT_TESTS_STOREFRONT_RESULT} ${TESTS_STOREFRONT_ACCEPTANCE_REGENERATE_RESULT} ${REGENERATION_STARTED} ${CHECH_UPGRADE_NOTES_RESULT} > /dev/null ; echo $?`
+                    EXIT_CODE=`. .github/get-build-exit-code.sh && getBuildExitCodeBasedOnJobResults ${BUILD_FORK_RESULT} ${STANDARDS_RESULT} ${TESTS_RESULT} ${TESTS_CZECH_RESULT} ${CHECK_DEMO_DATA_LIMITED_DOMAINS_RESULT} ${TESTS_ACCEPTANCE_RESULT} ${STANDARDS_STOREFRONT_RESULT} ${TRANSLATIONS_DUMP_RESULT} ${REVIEW_RESULT} ${CHECK_CONSOLE_COMMANDS_RESULT} ${TESTS_STOREFRONT_SMOKE_RESULT} ${TESTS_STOREFRONT_ACCEPTANCE_RESULT} ${UNIT_TESTS_STOREFRONT_RESULT} ${TESTS_STOREFRONT_ACCEPTANCE_REGENERATE_RESULT} ${REGENERATION_STARTED} ${CHECK_UPGRADE_NOTES_RESULT} > /dev/null ; echo $?`
                     exit "${EXIT_CODE}"

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -53,7 +53,6 @@ services:
             - dev # change to `- build` if you want to test application build
         volumes:
             - storefront:/home/node/app
-            - storefront-node-modules:/home/node/app/node_modules
         ports:
             - "3000:3000"
             - "9229:9229"
@@ -110,8 +109,6 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - php-fpm:/var/www/html
-            - php-fpm-vendor:/var/www/html/vendor
-            - php-fpm-node-modules:/var/www/html/node_modules
             - ./.git/:/var/www/html/.git:delegated
             - ~/.gitconfig:/home/www-data/.gitconfig
         environment:
@@ -136,8 +133,6 @@ services:
         container_name: shopsys-framework-php-consumer
         volumes:
             - php-fpm:/var/www/html
-            - php-fpm-vendor:/var/www/html/vendor
-            - php-fpm-node-modules:/var/www/html/node_modules
         entrypoint:
             - /bin/sh
             - project-base/app/docker/php-fpm/consumer-entrypoint.sh
@@ -251,10 +246,7 @@ services:
 
 volumes:
     php-fpm:
-    php-fpm-vendor:
-    php-fpm-node-modules:
     storefront:
-    storefront-node-modules:
     cypress-node-modules:
     elasticsearch-data:
         driver: local

--- a/docker/conf/mutagen.yml.dist
+++ b/docker/conf/mutagen.yml.dist
@@ -20,10 +20,8 @@ sync:
                 - ".npm-global"
                 - "elasticsearch-data"
                 - "nbproject"
-                - "node_modules"
                 - "postgres-data"
                 - "/storefront"
-                - "vendor"
         mode: "two-way-resolved"
 
     storefront:
@@ -34,7 +32,4 @@ sync:
                 defaultOwner: "id:1000"
                 defaultGroup: "id:1000"
                 defaultDirectoryMode: 0777
-        ignore:
-            paths:
-                - "node_modules"
         mode: "two-way-resolved"

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -56,7 +56,6 @@ services:
             - dev # change to `- build` if you want to test application build
         volumes:
             - storefront:/home/node/app
-            - storefront-node-modules:/home/node/app/node_modules
         ports:
             - "3000:3000"
             - "9229:9229"
@@ -111,8 +110,6 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - php-fpm:/var/www/html
-            - php-fpm-vendor:/var/www/html/vendor
-            - php-fpm-node-modules:/var/www/html/node_modules
             - ./.npm-global:/var/www/html/.npm-global
         environment:
             <<: *blackfire_environments
@@ -134,8 +131,6 @@ services:
         container_name: shopsys-framework-php-consumer
         volumes:
             - php-fpm:/var/www/html
-            - php-fpm-vendor:/var/www/html/vendor
-            - php-fpm-node-modules:/var/www/html/node_modules
         entrypoint:
             - /bin/sh
             - docker/php-fpm/consumer-entrypoint.sh
@@ -240,10 +235,7 @@ services:
 
 volumes:
     php-fpm:
-    php-fpm-vendor:
-    php-fpm-node-modules:
     storefront:
-    storefront-node-modules:
     cypress-node-modules:
     elasticsearch-data:
         driver: local

--- a/project-base/docker/conf/mutagen.yml.dist
+++ b/project-base/docker/conf/mutagen.yml.dist
@@ -20,10 +20,8 @@ sync:
                 - ".npm-global"
                 - "elasticsearch-data"
                 - "nbproject"
-                - "node_modules"
                 - "postgres-data"
                 - "storefront"
-                - "vendor"
         mode: "two-way-resolved"
 
     storefront:
@@ -34,7 +32,4 @@ sync:
                 defaultOwner: "id:1000"
                 defaultGroup: "id:1000"
                 defaultDirectoryMode: 0777
-        ignore:
-            paths:
-                - "node_modules"
         mode: "two-way-resolved"

--- a/upgrade-notes/backend_20260108_150059.md
+++ b/upgrade-notes/backend_20260108_150059.md
@@ -1,0 +1,3 @@
+#### reverted movement of vendor and node_modules syncing from Mutagen to named volumes ([#4381](https://github.com/shopsys/shopsys/pull/4381))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
In https://github.com/shopsys/shopsys/pull/4331 we moved synchronization of `node_modules` and `vendor` to named volumes in good faith it will improve performance. Sadly we have ommitted, that these folders than will be missing in local environment and thus in IDE. This is not good developer experience, so we are reverting this back.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-mutagen-revert-vendor-node-modules-sync.odin.shopsys.cloud
  - https://cz.tl-mutagen-revert-vendor-node-modules-sync.odin.shopsys.cloud
  - https://tl-mutagen-revert-vendor-node-modules-sync.odin.shopsys.cloud/sk
<!-- Replace -->
