### PR TITLE
fixed print domain after install on mac

### DIFF
--- a/project-base/scripts/install.sh
+++ b/project-base/scripts/install.sh
@@ -10,7 +10,7 @@ docker compose exec -T php-fpm composer install
 docker compose exec -T php-fpm ./phing db-create test-db-create frontend-api-generate-new-keys build-demo-dev-quick
 
 DOMAINS_URLS_FILE="$DIR/../app/config/domains_urls.yaml"
-DOMAIN_URLS=($(grep -oP 'url:\s*\K\S+' "$DOMAINS_URLS_FILE"))
+DOMAIN_URLS=($(awk '/url:/ {print $2}' "$DOMAINS_URLS_FILE"))
 
 FIRST_DOMAIN_URL="${DOMAIN_URLS[0]}"
 

--- a/upgrade-notes/backend_20260102_142531.md
+++ b/upgrade-notes/backend_20260102_142531.md
@@ -1,3 +1,3 @@
 #### few simple tweaks and fixes ([#4364](https://github.com/shopsys/shopsys/pull/4364))
 
-- see #project-base-diff to update your project
+- see #project-base-diff and #project-base-diff-4383 to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

On MacOS, the `grep -P` option does not exist. This PR replaces the usage of grep with awk, which works properly.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-fix-domains-mac.odin.shopsys.cloud
  - https://cz.mg-fix-domains-mac.odin.shopsys.cloud
  - https://mg-fix-domains-mac.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1768321667.075209 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-domains-mac.odin.shopsys.cloud
  - https://cz.mg-fix-domains-mac.odin.shopsys.cloud
  - https://mg-fix-domains-mac.odin.shopsys.cloud/sk
<!-- Replace -->
