### PR TITLE
fixed GoPay gateway visibility broken by incorrect router event signatures

### DIFF
--- a/project-base/storefront/components/Layout/RouteAccessibilityManager.tsx
+++ b/project-base/storefront/components/Layout/RouteAccessibilityManager.tsx
@@ -7,7 +7,7 @@ export const RouteAccessibilityManager: FC<{ children: ReactNode }> = ({ childre
     const updatePageLoadingState = useSessionStore((s) => s.updatePageLoadingState);
 
     const handleRouteChangeStart = useCallback(
-        (options: { shallow: boolean }) => {
+        (_url: string, options: { shallow: boolean }) => {
             const { shallow } = options;
 
             if (shallow) {
@@ -23,7 +23,7 @@ export const RouteAccessibilityManager: FC<{ children: ReactNode }> = ({ childre
     );
 
     const handleRouteChangeComplete = useCallback(
-        (options: { shallow: boolean }) => {
+        (_url: string, options: { shallow: boolean }) => {
             const { shallow } = options;
 
             if (shallow) {
@@ -38,7 +38,7 @@ export const RouteAccessibilityManager: FC<{ children: ReactNode }> = ({ childre
     );
 
     const handleRouteChangeError = useCallback(
-        (options: { shallow: boolean }) => {
+        (_err: Error, _url: string, options: { shallow: boolean }) => {
             const { shallow } = options;
 
             if (shallow) {

--- a/upgrade-notes/storefront_20251229_130242.md
+++ b/upgrade-notes/storefront_20251229_130242.md
@@ -5,3 +5,4 @@
 - removed unused exports, imports, components, utils, hooks, types, and function parameters
 - removed unused dependencies
 - see #project-base-diff to update your project
+- see also #project-base-diff of [#4387](https://github.com/shopsys/shopsys/pull/4387) with an additional fix


### PR DESCRIPTION
#### Description, the reason for the PR
Next.js router events pass parameters positionally `(url, { shallow })` but commit f38f401 (introduced in https://github.com/shopsys/shopsys/pull/4358) removed the url parameter thinking it was unused. This caused the shallow flag to be undefined, making RouteAccessibilityManager incorrectly set page loading state during GoPay's shallow navigation, which hid the payment gateway
<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-gopay.odin.shopsys.cloud
  - https://cz.rv-fix-gopay.odin.shopsys.cloud
  - https://rv-fix-gopay.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1768393121.900299 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-gopay.odin.shopsys.cloud
  - https://cz.rv-fix-gopay.odin.shopsys.cloud
  - https://rv-fix-gopay.odin.shopsys.cloud/sk
<!-- Replace -->
