### PR TITLE
move a DB migration from project-base to the framework package

### DIFF
--- a/packages/framework/src/Migrations/Version20251217100000.php
+++ b/packages/framework/src/Migrations/Version20251217100000.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Migrations;
+namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Override;
@@ -16,6 +16,8 @@ class Version20251217100000 extends AbstractMigration
     #[Override]
     public function up(Schema $schema): void
     {
-        $this->sql('ALTER TABLE slider_items ADD route_name VARCHAR(255) DEFAULT NULL');
+        if ($this->isAppMigrationNotInstalledRemoveIfExists('Version20251217100000')) {
+            $this->sql('ALTER TABLE slider_items ADD route_name VARCHAR(255) DEFAULT NULL');
+        }
     }
 }

--- a/upgrade-notes/backend_20260113_144418.md
+++ b/upgrade-notes/backend_20260113_144418.md
@@ -1,0 +1,3 @@
+#### move a DB migration from project-base to the framework package ([#4388](https://github.com/shopsys/shopsys/pull/4388))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The migration was added to project-base by mistake in https://github.com/shopsys/shopsys/pull/4337
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
<!-- SLACK_TIMESTAMP: 1768394340.730669 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-migration.odin.shopsys.cloud
  - https://cz.rv-fix-migration.odin.shopsys.cloud
  - https://rv-fix-migration.odin.shopsys.cloud/sk
<!-- Replace -->
