### PR TITLE
filtered seo category for limited user

### DIFF
--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMix.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMix.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 
 #[ORM\Table(name: 'ready_category_seo_mixes')]
 #[ORM\UniqueConstraint(name: 'selected_category_seo_mix_combination_json', columns: ['selected_category_seo_mix_combination_json'])]
@@ -189,6 +190,17 @@ class ReadyCategorySeoMix
     public function setOrdering($ordering)
     {
         $this->ordering = $ordering;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPriceBasedOrdering(): bool
+    {
+        return in_array($this->ordering, [
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC,
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC,
+        ], true);
     }
 
     /**

--- a/packages/frontend-api/src/Model/Category/ReadyCategorySeoMixBatchLoader.php
+++ b/packages/frontend-api/src/Model/Category/ReadyCategorySeoMixBatchLoader.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMix;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleResolver;
 
 class ReadyCategorySeoMixBatchLoader
 {
@@ -18,12 +19,14 @@ class ReadyCategorySeoMixBatchLoader
      * @param \Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade $readyCategorySeoMixFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleResolver $customerUserRoleResolver
      */
     public function __construct(
         protected readonly PromiseAdapter $promiseAdapter,
         protected readonly ReadyCategorySeoMixFacade $readyCategorySeoMixFacade,
         protected readonly Domain $domain,
         protected readonly FriendlyUrlFacade $friendlyUrlFacade,
+        protected readonly CustomerUserRoleResolver $customerUserRoleResolver,
     ) {
     }
 
@@ -35,9 +38,15 @@ class ReadyCategorySeoMixBatchLoader
     {
         $allReadyCategorySeoMixes = $this->readyCategorySeoMixFacade->getAllIndexedByCategoryId($categoryIds, $this->domain->getCurrentDomainConfig());
 
+        $canSeePrices = $this->customerUserRoleResolver->canCurrentCustomerUserSeePrices();
+
         $result = [];
 
         foreach ($allReadyCategorySeoMixes as $readyCategorySeoMixes) {
+            $filteredMixes = $canSeePrices
+                ? $readyCategorySeoMixes
+                : array_filter($readyCategorySeoMixes, fn (ReadyCategorySeoMix $mix) => !$mix->hasPriceBasedOrdering());
+
             $result[] = array_map(
                 fn (ReadyCategorySeoMix $readyCategorySeoMix) => [
                     'name' => $readyCategorySeoMix->getH1(),
@@ -47,7 +56,7 @@ class ReadyCategorySeoMixBatchLoader
                         $readyCategorySeoMix->getId(),
                     ),
                 ],
-                $readyCategorySeoMixes,
+                $filteredMixes,
             );
         }
 

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoryQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoryQuery.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
 use Shopsys\FrameworkBundle\Model\CategorySeo\Exception\ReadyCategorySeoMixNotFoundException;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMix;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleResolver;
 use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\Exception\ParameterNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\Exception\ParameterValueNotFoundException;
@@ -24,6 +25,7 @@ use Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterFacade;
 use Shopsys\FrontendApiBundle\Model\Resolver\AbstractQuery;
 use Shopsys\FrontendApiBundle\Model\Resolver\Category\Exception\CategoryNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Resolver\Category\Exception\ReadyCategorySeoMixNotFoundUserError;
+use Shopsys\FrontendApiBundle\Model\Resolver\Customer\Error\CustomerUserAccessDeniedUserError;
 use Shopsys\FrontendApiBundle\Model\Resolver\Products\ProductOrderingModeProvider;
 
 class CategoryQuery extends AbstractQuery
@@ -37,6 +39,7 @@ class CategoryQuery extends AbstractQuery
      * @param \Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterFacade $productFilterFacade
      * @param \Shopsys\FrontendApiBundle\Model\Resolver\Products\ProductOrderingModeProvider $productOrderingModeProvider
      * @param \Shopsys\FrameworkBundle\Component\String\TransformStringHelper $transformStringHelper
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleResolver $customerUserRoleResolver
      */
     public function __construct(
         protected readonly CategoryFacade $categoryFacade,
@@ -47,6 +50,7 @@ class CategoryQuery extends AbstractQuery
         protected readonly ProductFilterFacade $productFilterFacade,
         protected readonly ProductOrderingModeProvider $productOrderingModeProvider,
         protected readonly TransformStringHelper $transformStringHelper,
+        protected readonly CustomerUserRoleResolver $customerUserRoleResolver,
     ) {
     }
 
@@ -136,6 +140,10 @@ class CategoryQuery extends AbstractQuery
                     $readyCategorySeoMix = $this->readyCategorySeoMixFacade->getById($friendlyUrl->getEntityId());
                 } catch (ReadyCategorySeoMixNotFoundException) {
                     throw new ReadyCategorySeoMixNotFoundUserError(sprintf('ReadyCategorySeoMix with URL slug "%s" does not exist.', $urlSlug));
+                }
+
+                if ($readyCategorySeoMix->hasPriceBasedOrdering() && !$this->customerUserRoleResolver->canCurrentCustomerUserSeePrices()) {
+                    throw new CustomerUserAccessDeniedUserError('Access to this SEO category is denied.');
                 }
 
                 $matchingReadyCategorySeoMix = $this->findMatchingReadyCategorySeoMix($info, $readyCategorySeoMix->getCategory());

--- a/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
@@ -258,6 +258,41 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
             t('title of New computers with USB seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
             t('meta description of New computers with USB seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
         );
+
+        $this->createPriceBasedSeoMixForB2bDomains();
+    }
+
+    private function createPriceBasedSeoMixForB2bDomains(): void
+    {
+        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataDomains() as $domainConfig) {
+            if (!$domainConfig->isB2b()) {
+                continue;
+            }
+
+            $domainId = $domainConfig->getId();
+            $locale = $domainConfig->getLocale();
+
+            $categoryTv = $this->getReference(CategoryDataFixture::CATEGORY_TV, Category::class);
+            $selectedCategorySeoMixCombinationArray = [
+                'domainId' => $domainId,
+                'categoryId' => $categoryTv->getId(),
+                'flagId' => null,
+                'ordering' => ProductListOrderingConfig::ORDER_BY_PRICE_ASC,
+                'parameterValueIdsByParameterIds' => [],
+            ];
+
+            $this->createReadyCategorySeoMix(
+                $this->selectedCategorySeoMixCombinationFactory->createFromArray($selectedCategorySeoMixCombinationArray),
+                t('TV, audio from the cheapest', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+                ['televize-audio-nejlevnejsi-b2b'],
+                $domainId,
+                self::READY_CATEGORY_SEO_TV_FROM_CHEAPEST,
+                t('description of TV, audio from the cheapest seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+                t('short description of TV, audio from the cheapest seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+                t('title of TV, audio from the cheapest seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+                t('meta description of TV, audio from the cheapest seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+            );
+        }
     }
 
     /**

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CategorySeo/CategorySeoWithLimitedUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CategorySeo/CategorySeoWithLimitedUserTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\FunctionalB2b\CategorySeo;
+
+use App\DataFixtures\Demo\CompanyDataFixture;
+use App\DataFixtures\Demo\ReadyCategorySeoDataFixture;
+use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMix;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Tests\FrontendApiBundle\Test\GraphQlB2bDomainWithLoginTestCase;
+
+final class CategorySeoWithLimitedUserTest extends GraphQlB2bDomainWithLoginTestCase
+{
+    public const string DEFAULT_USER_EMAIL = CompanyDataFixture::B2B_COMPANY_CATALOG_USER_EMAIL;
+
+    /**
+     * @inject
+     */
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function testLimitedUserDoesNotSeePriceBasedSeoCategories(): void
+    {
+        $readyCategorySeoMix = $this->getReferenceForDomain(
+            ReadyCategorySeoDataFixture::READY_CATEGORY_SEO_TV_FROM_CHEAPEST,
+            $this->domain->getId(),
+            ReadyCategorySeoMix::class,
+        );
+
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../../Functional/CategorySeo/graphql/CategorySeoWithLinks.graphql',
+            ['urlSlug' => $this->urlGenerator->generate('front_product_list', ['id' => $readyCategorySeoMix->getCategory()->getId()])],
+        );
+
+        $data = $this->getResponseDataForGraphQlType($response, 'category');
+        $seoMixSlugs = array_column($data['readyCategorySeoMixLinks'], 'slug');
+
+        $expectedSlug = $this->urlGenerator->generate('front_category_seo', ['id' => $readyCategorySeoMix->getId()]);
+
+        $this->assertNotContains($expectedSlug, $seoMixSlugs, 'Price-based SEO category should not be visible for limited user');
+    }
+
+    public function testLimitedUserCannotAccessPriceBasedSeoCategoryDirectly(): void
+    {
+        $readyCategorySeoMix = $this->getReferenceForDomain(
+            ReadyCategorySeoDataFixture::READY_CATEGORY_SEO_TV_FROM_CHEAPEST,
+            $this->domain->getId(),
+            ReadyCategorySeoMix::class,
+        );
+
+        $urlSlug = $this->urlGenerator->generate('front_category_seo', ['id' => $readyCategorySeoMix->getId()]);
+
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../../Functional/CategorySeo/graphql/CategorySeo.graphql',
+            ['urlSlug' => $urlSlug],
+        );
+
+        $this->assertAccessDeniedError($response);
+    }
+}

--- a/upgrade-notes/backend_20260114_085419.md
+++ b/upgrade-notes/backend_20260114_085419.md
@@ -1,0 +1,4 @@
+#### Seo category for limited user ([#4389](https://github.com/shopsys/shopsys/pull/4389))
+
+- a limited user can no longer see SEO categories that contain a price filter
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
A limited user can no longer see SEO categories that contain a price filter. This prevents sorting products by price.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2739-seo-category-for-limited-user.odin.shopsys.cloud
  - https://cz.tc-ssp-2739-seo-category-for-limited-user.odin.shopsys.cloud
  - https://tc-ssp-2739-seo-category-for-limited-user.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1769497603.253669 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2739-seo-category-for-limited-user.odin.shopsys.cloud
  - https://cz.tc-ssp-2739-seo-category-for-limited-user.odin.shopsys.cloud
  - https://tc-ssp-2739-seo-category-for-limited-user.odin.shopsys.cloud/sk
<!-- Replace -->
