### PR TITLE
demo data: all mail templates are sent for order status change

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -160,7 +160,7 @@ class MailTemplateDataFixture extends AbstractReferenceFixture implements Depend
     private function createOrderProcessedMailTemplate(string $locale, ObjectManager $manager, int $domainId): void
     {
         $mailTemplateData = $this->mailTemplateDataFactory->create();
-        $mailTemplateData->sendMail = false;
+        $mailTemplateData->sendMail = true;
 
         $mailTemplateData->subject = t('
             Your order no. {number} is being processed
@@ -196,7 +196,7 @@ class MailTemplateDataFixture extends AbstractReferenceFixture implements Depend
     private function createOrderFinishedMailTemplate(string $locale, ObjectManager $manager, int $domainId): void
     {
         $mailTemplateData = $this->mailTemplateDataFactory->create();
-        $mailTemplateData->sendMail = false;
+        $mailTemplateData->sendMail = true;
 
         $mailTemplateData->subject = t('
             Your order no. {number} has been completed
@@ -232,7 +232,7 @@ class MailTemplateDataFixture extends AbstractReferenceFixture implements Depend
     private function createOrderCanceledMailTemplate(string $locale, ObjectManager $manager, int $domainId): void
     {
         $mailTemplateData = $this->mailTemplateDataFactory->create();
-        $mailTemplateData->sendMail = false;
+        $mailTemplateData->sendMail = true;
 
         $mailTemplateData->subject = t('
             Your order no. {number} has been cancelled

--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -292,7 +292,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $orderData->status = $this->getReference(OrderStatusDataFixture::ORDER_STATUS_NEW, OrderStatus::class);
         $orderData->firstName = 'firstName';
         $orderData->lastName = 'lastName';
-        $orderData->email = 'email';
+        $orderData->email = 'email@example.com';
         $orderData->telephone = 'telephone';
         $orderData->companyName = null;
         $orderData->companyNumber = null;

--- a/upgrade-notes/backend_20260117_144537.md
+++ b/upgrade-notes/backend_20260117_144537.md
@@ -1,0 +1,3 @@
+#### send all order status change mail templates in demo data ([#4397](https://github.com/shopsys/shopsys/pull/4397))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

All mail templates created in demo data and related to order status change are now sent by default.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-mail-order-send-always.odin.shopsys.cloud
  - https://cz.mg-mail-order-send-always.odin.shopsys.cloud
  - https://mg-mail-order-send-always.odin.shopsys.cloud/sk
<!-- Replace -->
