### PR TITLE
fixed php-fpm configuration

### DIFF
--- a/project-base/app/docker/php-fpm/production-www.conf
+++ b/project-base/app/docker/php-fpm/production-www.conf
@@ -7,8 +7,6 @@ log_level = warning
 
 [www]
 
-listen = 127.0.0.1:9000
-
 pm = dynamic
 pm.max_children = 100
 pm.start_servers = 25

--- a/project-base/gitlab/php-fpm-conf/ci-www.conf
+++ b/project-base/gitlab/php-fpm-conf/ci-www.conf
@@ -7,8 +7,6 @@
 user = www-data
 group = www-data
 
-listen = 127.0.0.1:9000
-
 pm = dynamic
 pm.max_children = 10
 pm.start_servers = 1

--- a/upgrade-notes/backend_20260120_114201.md
+++ b/upgrade-notes/backend_20260120_114201.md
@@ -1,0 +1,3 @@
+#### fixed php-fpm configuration ([#4401](https://github.com/shopsys/shopsys/pull/4401))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- listen was always overwritten by PHP basic configuration and we did not know it
- PHP moved listen to different file, that was alphabetically before our config that caused our wrong definition of listen to be applied (https://github.com/docker-library/php/pull/1635)
- this was causing acceptance tests fails on 502 error from webserver

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-php-fpm-listen.odin.shopsys.cloud
  - https://cz.tl-fix-php-fpm-listen.odin.shopsys.cloud
  - https://tl-fix-php-fpm-listen.odin.shopsys.cloud/sk
<!-- Replace -->
