### PR TITLE
replace mutagen ignore relative paths with absolute paths

### DIFF
--- a/docker/conf/mutagen.yml.dist
+++ b/docker/conf/mutagen.yml.dist
@@ -18,10 +18,10 @@ sync:
                 - ".DS_Store"
                 - ".idea"
                 - ".npm-global"
+                - "/project-base/app/var/postgres-data"
+                - "/project-base/storefront"
                 - "elasticsearch-data"
                 - "nbproject"
-                - "postgres-data"
-                - "/storefront"
         mode: "two-way-resolved"
 
     storefront:

--- a/project-base/docker/conf/mutagen.yml.dist
+++ b/project-base/docker/conf/mutagen.yml.dist
@@ -18,10 +18,9 @@ sync:
                 - ".DS_Store"
                 - ".idea"
                 - ".npm-global"
+                - "/var/postgres-data"
                 - "elasticsearch-data"
                 - "nbproject"
-                - "postgres-data"
-                - "storefront"
         mode: "two-way-resolved"
 
     storefront:

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -12,8 +12,6 @@ RUN apk add --no-cache shadow
 
 RUN if [[ -n "$node_uid" && "$node_uid" -ne 1000 ]]; then usermod -u $node_uid node && chown -R node $HOME_DIR; fi;
 
-RUN mkdir -p $APP_DIR/node_modules && chown node:node $APP_DIR/node_modules
-
 USER node
 WORKDIR $APP_DIR
 

--- a/upgrade-notes/backend_20260121_174457.md
+++ b/upgrade-notes/backend_20260121_174457.md
@@ -1,0 +1,4 @@
+#### replace mutagen ignore relative paths with absolute paths ([#4403](https://github.com/shopsys/shopsys/pull/4403))
+
+- relative ignore paths in `mutagen.yml.dist` were converted to absolute paths to prevent ignoring unintended directories (e.g., `/docs/storefront` was being ignored due to relative `/storefront` pattern)
+- see #project-base-diff to update your project


### PR DESCRIPTION
Convert relative ignore paths to absolute in mutagen.yml.dist to prevent ignoring unintended directories (e.g., /docs/storefront)

#### Description, the reason for the PR
... 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















----
:globe_with_meridians: Live Preview:
  - https://jm-mutagen-ignore-paths.odin.shopsys.cloud
  - https://cz.jm-mutagen-ignore-paths.odin.shopsys.cloud
  - https://jm-mutagen-ignore-paths.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1769161852.098169 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-mutagen-ignore-paths.odin.shopsys.cloud
  - https://cz.jm-mutagen-ignore-paths.odin.shopsys.cloud
  - https://jm-mutagen-ignore-paths.odin.shopsys.cloud/sk
<!-- Replace -->
