### PR TITLE
MkDocs: Force live-reload locally

### DIFF
--- a/docker/mkdocs/Dockerfile
+++ b/docker/mkdocs/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /var/www/html
 
-CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000"]
+CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000", "--livereload"]


### PR DESCRIPTION
#### Description, the reason for the PR

- fixes the issue when the documentation preview was not updated locally due to an issue in the click library
- this is a workaround for this issue https://github.com/mkdocs/mkdocs/issues/4032

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-fix-mkdocs-reload.odin.shopsys.cloud
  - https://cz.mg-fix-mkdocs-reload.odin.shopsys.cloud
  - https://mg-fix-mkdocs-reload.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1769176335.510879 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-mkdocs-reload.odin.shopsys.cloud
  - https://cz.mg-fix-mkdocs-reload.odin.shopsys.cloud
  - https://mg-fix-mkdocs-reload.odin.shopsys.cloud/sk
<!-- Replace -->
