### PR TITLE
Updated constraint classes and usages for Symfony 7 compatibility

### DIFF
--- a/.claude/agents/upgrade_notes_analyzer.md
+++ b/.claude/agents/upgrade_notes_analyzer.md
@@ -142,10 +142,15 @@ Analyzes PR diffs to identify breaking changes, feature movements, and scope.
 - Focus on WHAT to do, not WHY
 - Key test: "Will code break without manual changes?" → YES = include
 
+**Code example formatting:**
+- Use ` ```diff ``` ` for code blocks (preferred styling)
+- Use markdown tables for simple value mappings/replacements (e.g., old method → new method)
+- Show actual code from commits as examples, not generic placeholders
+
 **Critical:**
 - MOVEMENTS FIRST - never mark movement as "removed"
 - FQCN ALWAYS
-- #project-base-diff - if ANY project-base files changed
+- `- see #project-base-diff to update your project` - ONLY if there were any changes in `project-base/` folder
 - Constructor changes - ONLY for `new ClassName()`, NOT autowired
 
 **Real-World Example Patterns:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,10 @@ Login credentials for PostgreSQL are set in the `project-base/app/.env` file.
 - Framework packages should only be modified via the monorepo, not directly in `/packages/`
 - **Always use proper Docker commands**: `docker compose exec` for PHP/storefront commands, direct execution for git/make/system commands
 
+## Skills / Slash Commands
+
+When the user asks to generate upgrade notes, always use the `/generate-upgrade-notes` command instead of manually analyzing commits.
+
 ## Core Development Principles
 
 **ALWAYS follow these principles when writing or modifying code:**

--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,6 @@
         "gedmo/doctrine-extensions": "^3.22",
         "google/cloud-storage": "^1.10",
         "gopay/payments-sdk-php": "^1.7",
-        "gordalina/cachetool": "^9.2",
         "guzzlehttp/guzzle": "^7.5",
         "helios-ag/fm-elfinder-bundle": "^12.2",
         "heureka/overeno-zakazniky": "^4.0.1",

--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -195,7 +195,7 @@ final class ProductFormTypeExtension extends AbstractTypeExtension
         $basicInformationGroup->add('extId', IntegerType::class, [
             'required' => true,
             'constraints' => [
-                new Constraints\NotBlank(['message' => 'Please enter external ID']),
+                new Constraints\NotBlank(message: 'Please enter external ID'),
             ],
             'label' => 'External ID',
         ]);

--- a/docs/cookbook/create-advanced-grid.md
+++ b/docs/cookbook/create-advanced-grid.md
@@ -208,12 +208,12 @@ final class SalesmanFormType extends AbstractType
         $builder
             ->add('name', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
                 ],
             ])
             ->add('registeredAt', DatePickerType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter date of registration']),
+                    new Constraints\NotBlank(message: 'Please enter date of registration'),
                 ],
             ]);
     }

--- a/docs/extensibility/extending-form-from-plugin.md
+++ b/docs/extensibility/extending-form-from-plugin.md
@@ -38,10 +38,10 @@ final class HeurekaProductFormType extends AbstractType
             'entry_options' => [
                 'currency' => 'CZK',
                 'constraints' => [
-                    new MoneyRange([
-                        'min' => Money::zero(),
-                        'max' => Money::create(500),
-                    ]),
+                    new MoneyRange(
+                        min: Money::zero(),
+                        max: Money::create(500),
+                    ),
                 ],
             ],
         ]);

--- a/docs/introduction/translations.md
+++ b/docs/introduction/translations.md
@@ -80,10 +80,10 @@ t('Offer in feed');
 $executionContextInterface->addViolation('This message will be extracted into "validators" translation domain');
 
 // see Shopsys\FrameworkBundle\Component\Translation\ConstraintMessageExtractor
-new Constraint\Length([
-    'message' => 'This message will be extracted into "validators" translation domain',
-    'minMessage' => 'Actually, every option ending with "message" will be extracted',
-]);
+new Constraint\Length(
+    message: 'This message will be extracted into "validators" translation domain',
+    minMessage: 'Actually, every option ending with "message" will be extracted',
+);
 
 // see Shopsys\FrameworkBundle\Component\Translation\ConstraintMessagePropertyExtractor
 class MyConstraint extends \Symfony\Component\Validator\Constraint

--- a/docs/model/how-to-work-with-money.md
+++ b/docs/model/how-to-work-with-money.md
@@ -119,7 +119,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 $orderItemFormBuilder->add('priceWithVat', MoneyType::class, [
     'scale' => 6,
     'constraints' => [
-        new NotBlank(['message' => 'Please enter unit price with VAT']),
+        new NotBlank(message: 'Please enter unit price with VAT'),
     ],
 ]);
 ```
@@ -157,8 +157,8 @@ $priceTableFormBuilder->add($key, MoneyType::class, [
     'required' => true,
     'invalid_message' => 'Please enter price in correct format (a number with decimal separator)',
     'constraints' => [
-        new NotBlank(['message' => 'Please enter price']),
-        new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+        new NotBlank(message: 'Please enter price'),
+        new NotNegativeMoneyAmount(message: 'Price must be greater or equal to zero'),
     ],
 ]);
 ```
@@ -192,10 +192,10 @@ $zboziFeedProductFormBuilder->add('cpc', MultidomainType::class, [
     'entry_options' => [
         'currency' => 'CZK',
         'constraints' => [
-            new MoneyRange([
-                'min' => Money::create(1),
-                'max' => Money::create(500),
-            ]),
+            new MoneyRange(
+                min: Money::create(1),
+                max: Money::create(500),
+            ),
         ],
     ],
 ]);

--- a/ecs.php
+++ b/ecs.php
@@ -150,6 +150,7 @@ return ECSConfig::configure()
                 __DIR__ . '/packages/framework/src/Controller/Admin/CategorySeoController.php',
                 __DIR__ . '/packages/framework/src/Controller/Admin/PriceListController.php',
                 __DIR__ . '/packages/framework/src/Migrations/Version*.php',
+                __DIR__ . '/packages/framework/src/Form/FileUploadType.php',
                 __DIR__ . '/packages/framework/src/Form/Admin/*/*FormType.php',
                 __DIR__ . '/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php',
                 __DIR__ . '/packages/framework/src/Model/Customer/User/CustomerUserRepository.php',

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/correct/correct.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/correct/correct.php
@@ -57,10 +57,10 @@ final class ZboziProductFormType extends AbstractType
                 'entry_options' => [
                     'currency' => 'CZK',
                     'constraints' => [
-                        new MoneyRange([
-                            'min' => Money::create(1),
-                            'max' => Money::create(500),
-                        ]),
+                        new MoneyRange(
+                            min: Money::create(1),
+                            max: Money::create(500),
+                        ),
                     ],
                 ],
             ])
@@ -71,10 +71,10 @@ final class ZboziProductFormType extends AbstractType
                 'entry_options' => [
                     'currency' => 'CZK',
                     'constraints' => [
-                        new MoneyRange([
-                            'min' => Money::create(1),
-                            'max' => Money::create(500),
-                        ]),
+                        new MoneyRange(
+                            min: Money::create(1),
+                            max: Money::create(500),
+                        ),
                     ],
                 ],
             ])

--- a/packages/form-types-bundle/src/YesNoType.php
+++ b/packages/form-types-bundle/src/YesNoType.php
@@ -40,9 +40,9 @@ final class YesNoType extends AbstractType
             'required' => true,
             'placeholder' => false,
             'constraints' => [
-                new Constraints\NotNull([
-                    'message' => 'Please choose at least one option',
-                ]),
+                new Constraints\NotNull(
+                    message: 'Please choose at least one option',
+                ),
             ],
         ]);
     }

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -60,7 +60,6 @@
         "friendsofsymfony/ckeditor-bundle": "^2.1",
         "gopay/payments-sdk-php": "^1.7",
         "gedmo/doctrine-extensions": "^3.22",
-        "gordalina/cachetool": "^9.2",
         "guzzlehttp/guzzle": "^7.5",
         "helios-ag/fm-elfinder-bundle": "^12.2",
         "heureka/overeno-zakazniky": "^4.0.1",

--- a/packages/framework/src/Command/CleanOpcacheCommand.php
+++ b/packages/framework/src/Command/CleanOpcacheCommand.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use CacheTool\Adapter\FastCGI;
-use CacheTool\CacheTool;
 use Override;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
 
 #[AsCommand(
     name: 'shopsys:clean-opcache',
@@ -28,9 +28,12 @@ class CleanOpcacheCommand extends Command
         $symfonyStyle = new SymfonyStyle($input, $output);
         $symfonyStyle->info('Opcache cleaning...');
 
-        $adapter = new FastCGI();
-        $cache = CacheTool::factory($adapter);
-        $cache->opcache_reset();
+        $process = new Process(['cachetool', 'opcache:reset', '--fcgi=127.0.0.1:9000']);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
 
         $symfonyStyle->success('Done!');
 

--- a/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
+++ b/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
@@ -50,8 +50,9 @@ class RouteCsrfProtector implements EventSubscriberInterface
     {
         if ($this->isProtected($event)) {
             $request = $event->getRequest();
-            $csrfToken = $request->get(self::CSRF_TOKEN_REQUEST_PARAMETER);
-            $routeName = $request->get('_route');
+            $csrfToken = $request->query->get(self::CSRF_TOKEN_REQUEST_PARAMETER)
+                ?? $request->request->get(self::CSRF_TOKEN_REQUEST_PARAMETER);
+            $routeName = $request->attributes->get('_route');
 
             if ($csrfToken === null || !$this->isCsrfTokenValid($routeName, $csrfToken)) {
                 throw new BadRequestHttpException('Csrf token is invalid');

--- a/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
@@ -10,15 +10,17 @@ use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use Override;
 use PhpParser\Node;
-use PhpParser\Node\ArrayItem;
-use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitor\NameResolver;
+use ReflectionClass;
+use ReflectionException;
+use Shopsys\FrameworkBundle\Component\Translation\Exception\StringValueUnextractableException;
 use SplFileInfo;
 use Symfony\Component\Validator\Constraint;
 use Twig\Node\Node as TwigNode;
@@ -27,13 +29,11 @@ use Twig\Node\Node as TwigNode;
  * Extracts custom messages from constraint constructors for translation.
  *
  * Examples:
- *     new Constraint\NotBlank([
- *         'message' => 'This message will be extracted into "validators" translation domain',
- *     ]),
- *     new Constraint\Length([
- *         'max' => 50,
- *         'minMessage' => 'Actually, every option ending with "message" will be extracted',
- *     ])
+ *     new Constraint\NotBlank(message: 'This message will be extracted into "validators" translation domain');
+ *     new Constraint\Length(
+ *         max: 50,
+ *         minMessage: 'Actually, every option ending with "message" will be extracted',
+ *     );
  */
 class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
 {
@@ -44,6 +44,11 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     protected MessageCatalogue $catalogue;
 
     protected SplFileInfo $file;
+
+    /**
+     * @var array<string, array<int, string>>
+     */
+    protected array $constructorParameterNamesCache = [];
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Translation\PhpParserNodeHelper $phpParserNodeHelper
@@ -79,7 +84,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
 
         if ($node instanceof New_) {
             if ($this->isConstraintClass($node->class) && count($node->args) > 0) {
-                $this->extractMessagesFromOptions($node->args[0]->value);
+                $this->extractMessagesFromArgs($node->args, (string)$node->class);
             }
         }
 
@@ -96,31 +101,93 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @param \PhpParser\Node $optionsNode
+     * @param array<\PhpParser\Node\Arg|\PhpParser\Node\VariadicPlaceholder> $args
+     * @param string $constraintClassName
      */
-    protected function extractMessagesFromOptions(Node $optionsNode): void
+    protected function extractMessagesFromArgs(array $args, string $constraintClassName): void
     {
-        if ($optionsNode instanceof Array_) {
-            foreach ($optionsNode->items as $optionItemNode) {
-                if ($this->isMessageOptionItem($optionItemNode)) {
-                    $messageId = $this->phpParserNodeHelper->getConcatenatedStringValue($optionItemNode->value, $this->file);
-
-                    $message = new Message($messageId, $this->getTranslationDomain());
-                    $message->addSource(new FileSource($this->file->getFilename(), $optionItemNode->getLine()));
-
-                    $this->catalogue->add($message);
-                }
+        foreach ($args as $position => $arg) {
+            if (!$arg instanceof Arg) {
+                continue;
             }
+
+            if ($arg->name !== null) {
+                $paramName = $arg->name->name;
+            } elseif (isset($this->getConstructorParameterNames($constraintClassName)[$position])) {
+                $paramName = $this->getConstructorParameterNames($constraintClassName)[$position];
+            } else {
+                continue;
+            }
+
+            if (!$this->isMessageParamName($paramName)) {
+                continue;
+            }
+
+            try {
+                $messageId = $this->phpParserNodeHelper->getConcatenatedStringValue($arg->value, $this->file);
+            } catch (StringValueUnextractableException) {
+                continue;
+            }
+
+            $message = new Message($messageId, $this->getTranslationDomain());
+            $message->addSource(new FileSource($this->file->getFilename(), $arg->getLine()));
+
+            $this->catalogue->add($message);
         }
     }
 
     /**
-     * @param \PhpParser\Node\ArrayItem $node
+     * @param string $className
+     * @return array<int, string> Parameter names indexed by position
+     */
+    protected function getConstructorParameterNames(string $className): array
+    {
+        if (array_key_exists($className, $this->constructorParameterNamesCache)) {
+            return $this->constructorParameterNamesCache[$className];
+        }
+
+        try {
+            $reflectionClass = new ReflectionClass($className);
+            $constructor = $reflectionClass->getConstructor();
+
+            if ($constructor === null) {
+                $this->constructorParameterNamesCache[$className] = [];
+
+                return $this->constructorParameterNamesCache[$className];
+            }
+
+            $names = [];
+
+            foreach ($constructor->getParameters() as $position => $param) {
+                $names[$position] = $param->getName();
+            }
+
+            $this->constructorParameterNamesCache[$className] = $names;
+
+            return $this->constructorParameterNamesCache[$className];
+        } catch (ReflectionException) {
+            $this->constructorParameterNamesCache[$className] = [];
+
+            return $this->constructorParameterNamesCache[$className];
+        }
+    }
+
+    /**
+     * @param string $paramName
      * @return bool
      */
-    protected function isMessageOptionItem(ArrayItem $node): bool
+    protected function isMessageParamName(string $paramName): bool
     {
-        return $node->key instanceof String_ && strtolower(substr($node->key->value, -7)) === 'message';
+        return strtolower(substr($paramName, -7)) === 'message';
+    }
+
+    /**
+     * @param \PhpParser\Node\Identifier $name
+     * @return bool
+     */
+    protected function isMessageArgName(Identifier $name): bool
+    {
+        return $this->isMessageParamName($name->name);
     }
 
     /**

--- a/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
@@ -9,13 +9,17 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use Override;
+use PhpParser\Modifiers;
 use PhpParser\Node;
+use PhpParser\Node\Param;
 use PhpParser\Node\PropertyItem;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitor\NameResolver;
+use Shopsys\FrameworkBundle\Component\Translation\Exception\StringValueUnextractableException;
 use SplFileInfo;
 use Symfony\Component\Validator\Constraint;
 use Twig\Node\Node as TwigNode;
@@ -23,14 +27,21 @@ use Twig\Node\Node as TwigNode;
 /**
  * Extracts messages from public properties (with names ending "message") of custom constraints for translation.
  *
- * Example:
+ * Supports both regular properties and PHP 8 constructor-promoted properties:
+ *
+ *     // Regular properties:
  *     class MyConstraint extends Constraint
  *     {
  *         public $message = 'This value will be extracted.';
- *
  *         public $otherMessage = 'This value will also be extracted.';
+ *     }
  *
- *         public $differentProperty = 'This value will not be extracted (not a message).';
+ *     // Constructor-promoted properties:
+ *     class MyConstraint extends Constraint
+ *     {
+ *         public function __construct(
+ *             public string $message = 'This will also be extracted.',
+ *         ) {}
  *     }
  */
 class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVisitor
@@ -82,6 +93,10 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
             $this->extractMessagesFromProperty($node);
         }
 
+        if ($node instanceof ClassMethod && $node->name->name === '__construct' && $this->isInsideConstraintClass) {
+            $this->extractMessagesFromPromotedProperties($node);
+        }
+
         return null;
     }
 
@@ -114,7 +129,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     protected function extractMessagesFromProperty(Property $node): void
     {
         foreach ($node->props as $propertyProperty) {
-            if ($this->isMessagePropertyProperty($propertyProperty)) {
+            if ($this->isMessageProperty($propertyProperty)) {
                 $messageId = $this->phpParserNodeHelper->getConcatenatedStringValue($propertyProperty->default, $this->file);
 
                 $message = new Message($messageId, $this->getTranslationDomain());
@@ -129,9 +144,48 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
      * @param \PhpParser\Node\PropertyItem $node
      * @return bool
      */
-    protected function isMessagePropertyProperty(PropertyItem $node): bool
+    protected function isMessageProperty(PropertyItem $node): bool
     {
-        return strtolower(substr($node->name->toString(), -7)) === 'message';
+        return $this->isMessage($node->name->toString());
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\ClassMethod $node
+     */
+    protected function extractMessagesFromPromotedProperties(ClassMethod $node): void
+    {
+        foreach ($node->params as $param) {
+            if (!$this->isPublicPromotedMessageParam($param)) {
+                continue;
+            }
+
+            if ($param->default === null) {
+                continue;
+            }
+
+            try {
+                $messageId = $this->phpParserNodeHelper->getConcatenatedStringValue($param->default, $this->file);
+            } catch (StringValueUnextractableException) {
+                continue;
+            }
+
+            $message = new Message($messageId, $this->getTranslationDomain());
+            $message->addSource(new FileSource($this->file->getFilename(), $param->getLine()));
+
+            $this->catalogue->add($message);
+        }
+    }
+
+    /**
+     * @param \PhpParser\Node\Param $param
+     * @return bool
+     */
+    protected function isPublicPromotedMessageParam(Param $param): bool
+    {
+        $isPublic = ($param->flags & Modifiers::PUBLIC) !== 0;
+        $isMessageParam = $this->isMessage($param->var->name);
+
+        return $isPublic && $isMessageParam;
     }
 
     /**
@@ -168,5 +222,14 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast): null
     {
         return null;
+    }
+
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    protected function isMessage(string $propertyName): bool
+    {
+        return strtolower(substr($propertyName, -7)) === 'message';
     }
 }

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -504,7 +504,7 @@ class AdministratorController extends AdminBaseController
                 'row_attr' => ['class' => 'flex-column'],
                 'label_attr' => ['class' => 'col-xl-12'],
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter code']),
+                    new NotBlank(message: 'Please enter code'),
                     new Callback($twoFactorCodeValidationCallback),
                 ],
             ],

--- a/packages/framework/src/Controller/Admin/ArticleController.php
+++ b/packages/framework/src/Controller/Admin/ArticleController.php
@@ -231,7 +231,7 @@ class ArticleController extends AdminBaseController
     #[CanEdit]
     public function saveOrderingAction(Request $request): JsonResponse
     {
-        $this->articleFacade->saveOrdering($request->get('rowIdsByGridId'));
+        $this->articleFacade->saveOrdering($request->request->all('rowIdsByGridId'));
 
         $responseData = ['success' => true];
 

--- a/packages/framework/src/Controller/Admin/BestsellingProductController.php
+++ b/packages/framework/src/Controller/Admin/BestsellingProductController.php
@@ -73,9 +73,9 @@ class BestsellingProductController extends AdminBaseController
     #[CanView(methods: [HttpMethod::GET])]
     public function detailAction(Request $request): Response
     {
-        $categoryId = (int)$request->query->get('categoryId');
+        $categoryId = $request->query->getInt('categoryId');
         $category = $this->categoryFacade->getById($categoryId);
-        $domainId = (int)$request->get('domainId');
+        $domainId = $request->query->getInt('domainId');
 
         $products = $this->manualBestsellingProductFacade->getProductsIndexedByPosition(
             $category,

--- a/packages/framework/src/Controller/Admin/CategorySeoController.php
+++ b/packages/framework/src/Controller/Admin/CategorySeoController.php
@@ -119,7 +119,7 @@ class CategorySeoController extends AdminBaseController
         $form = $this->createCategorySeoFilterForm($category, $categorySeoFiltersData);
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid() && $request->get('is_for_backlink', false) === false) {
+        if ($form->isSubmitted() && $form->isValid() && !$request->query->getBoolean('is_for_backlink')) {
             return $this->redirect(
                 $this->getUrlWithCategoryIdAndAllQueryParameters(
                     'admin_categoryseo_newcombinations',
@@ -209,13 +209,13 @@ class CategorySeoController extends AdminBaseController
     #[CanView(methods: [HttpMethod::GET])]
     public function readyCombinationAction(Request $request, int $categoryId): Response
     {
-        $categorySeoFilterFormTypeAllQueries = $request->get('categorySeoFilterFormTypeAllQueries');
-        $selectedCategorySeoMixCombinationJson = $request->get('selectedCategorySeoMixCombinationJson');
+        $categorySeoFilterFormTypeAllQueries = $request->query->all('categorySeoFilterFormTypeAllQueries') ?: null;
+        $selectedCategorySeoMixCombinationJson = $request->query->get('selectedCategorySeoMixCombinationJson');
 
         if ($selectedCategorySeoMixCombinationJson === null) {
             // A little hack - when you need form sent data to create that same form - need for friendly URLs
-            $sentReadyCategorySeoCombinationFormData = $request->get('ready_category_seo_combination_form');
-            $selectedCategorySeoMixCombinationJson = $sentReadyCategorySeoCombinationFormData['selectedCategorySeoMixCombinationJson'];
+            $sentReadyCategorySeoCombinationFormData = $request->request->all('ready_category_seo_combination_form');
+            $selectedCategorySeoMixCombinationJson = $sentReadyCategorySeoCombinationFormData['selectedCategorySeoMixCombinationJson'] ?? null;
 
             $selectedCategorySeoMixCombination = $selectedCategorySeoMixCombinationJson === null ? null : $this->selectedCategorySeoMixCombinationFactory->createFromJson(
                 $selectedCategorySeoMixCombinationJson,

--- a/packages/framework/src/Controller/Admin/ComplaintController.php
+++ b/packages/framework/src/Controller/Admin/ComplaintController.php
@@ -151,8 +151,8 @@ class ComplaintController extends AdminBaseController
     public function getRuleFormAction(Request $request): Response
     {
         $ruleForm = $this->advancedSearchComplaintFacade->createRuleForm(
-            $request->get('filterName'),
-            $request->get('newIndex'),
+            $request->request->getString('filterName'),
+            $request->request->getString('newIndex'),
         );
 
         return $this->render('@ShopsysAdministration/content/complaint/advancedSearch/ruleForm.html.twig', [

--- a/packages/framework/src/Controller/Admin/ComplaintStatusController.php
+++ b/packages/framework/src/Controller/Admin/ComplaintStatusController.php
@@ -57,8 +57,7 @@ class ComplaintStatusController extends AdminBaseController
     #[CsrfProtection]
     public function deleteAction(Request $request, int $id): Response
     {
-        $newId = $request->get('newId');
-        $newId = $newId !== null ? (int)$newId : null;
+        $newId = $request->query->has('newId') ? $request->query->getInt('newId') : null;
 
         try {
             $complaintStatus = $this->complaintStatusFacade->getById($id);

--- a/packages/framework/src/Controller/Admin/FileUploadController.php
+++ b/packages/framework/src/Controller/Admin/FileUploadController.php
@@ -73,12 +73,11 @@ class FileUploadController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function deleteTemporaryFileAction(Request $request): JsonResponse
     {
-        $filename = $request->get('filename');
-
-        if ($filename === null) {
+        if (!$request->request->has('filename')) {
             return new JsonResponse(false);
         }
 
+        $filename = $request->request->getString('filename');
         $actionResult = $this->fileUpload->tryDeleteTemporaryFile($filename);
 
         return new JsonResponse($actionResult);

--- a/packages/framework/src/Controller/Admin/GridController.php
+++ b/packages/framework/src/Controller/Admin/GridController.php
@@ -33,10 +33,10 @@ class GridController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function getFormAction(Request $request): JsonResponse
     {
-        $rowId = $request->get('rowId') !== null ? json_decode($request->get('rowId')) : null;
+        $rowId = $request->request->has('rowId') ? json_decode($request->request->getString('rowId')) : null;
 
         $renderedFormRow = $this->inlineEditFacade->getRenderedFormRow(
-            $request->get('serviceName'),
+            $request->request->getString('serviceName'),
             $rowId,
         );
 
@@ -52,14 +52,15 @@ class GridController extends AdminBaseController
     public function saveFormAction(Request $request): JsonResponse
     {
         $responseData = [];
-        $rowId = $request->get('rowId') !== null ? json_decode($request->get('rowId')) : null;
+        $rowId = $request->request->has('rowId') ? json_decode($request->request->getString('rowId')) : null;
+        $serviceName = $request->request->getString('serviceName');
 
         try {
-            $rowId = $this->inlineEditFacade->saveFormData($request->get('serviceName'), $request, $rowId);
+            $rowId = $this->inlineEditFacade->saveFormData($serviceName, $request, $rowId);
 
             $responseData['success'] = true;
             $responseData['rowHtml'] = $this->inlineEditFacade->getRenderedRowHtml(
-                $request->get('serviceName'),
+                $serviceName,
                 $rowId,
             );
         } catch (InvalidFormDataException $e) {
@@ -80,8 +81,8 @@ class GridController extends AdminBaseController
     public function saveOrderingAction(Request $request): JsonResponse
     {
         $this->gridOrderingFacade->saveOrdering(
-            $request->get('entityClass'),
-            array_map('json_decode', $request->get('rowIds')),
+            $request->request->getString('entityClass'),
+            array_map('json_decode', $request->request->all('rowIds')),
         );
         $responseData = ['success' => true];
 

--- a/packages/framework/src/Controller/Admin/OrderController.php
+++ b/packages/framework/src/Controller/Admin/OrderController.php
@@ -319,8 +319,8 @@ class OrderController extends AdminBaseController
     public function getRuleFormAction(Request $request): Response
     {
         $ruleForm = $this->advancedSearchOrderFacade->createRuleForm(
-            $request->get('filterName'),
-            $request->get('newIndex'),
+            $request->request->getString('filterName'),
+            $request->request->getString('newIndex'),
         );
 
         return $this->render('@ShopsysAdministration/content/order/advancedSearch/ruleForm.html.twig', [

--- a/packages/framework/src/Controller/Admin/OrderStatusController.php
+++ b/packages/framework/src/Controller/Admin/OrderStatusController.php
@@ -57,7 +57,7 @@ class OrderStatusController extends AdminBaseController
     #[CsrfProtection]
     public function deleteAction(Request $request, int $id): Response
     {
-        $newId = $request->get('newId');
+        $newId = $request->query->has('newId') ? $request->query->getInt('newId') : null;
 
         try {
             $orderStatus = $this->orderStatusFacade->getById($id);

--- a/packages/framework/src/Controller/Admin/PriceListController.php
+++ b/packages/framework/src/Controller/Admin/PriceListController.php
@@ -96,10 +96,9 @@ class PriceListController extends AdminBaseController
     public function newAction(Request $request): Response
     {
         $priceListData = $this->priceListDataFactory->create();
-        $priceListData->domainId = $request->get(
-            'domainId',
-            $this->adminDomainFilterTabsFacade->getSelectedDomainId(static::DOMAIN_FILTER_NAMESPACE) ?? Domain::FIRST_DOMAIN_ID,
-        );
+        $priceListData->domainId = $request->query->has('domainId')
+            ? $request->query->getInt('domainId')
+            : ($this->adminDomainFilterTabsFacade->getSelectedDomainId(static::DOMAIN_FILTER_NAMESPACE) ?? Domain::FIRST_DOMAIN_ID);
 
         $form = $this->createForm(PriceListFormType::class, $priceListData, [
             'priceList' => null,

--- a/packages/framework/src/Controller/Admin/PricingGroupController.php
+++ b/packages/framework/src/Controller/Admin/PricingGroupController.php
@@ -66,8 +66,7 @@ class PricingGroupController extends AdminBaseController
     #[CsrfProtection]
     public function deleteAction(Request $request, int $id): Response
     {
-        $newId = $request->get('newId');
-        $newId = $newId !== null ? (int)$newId : null;
+        $newId = $request->query->has('newId') ? $request->query->getInt('newId') : null;
 
         try {
             $name = $this->pricingGroupFacade->getById($id)->getName();

--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -189,7 +189,7 @@ class ProductController extends AdminBaseController
 
         // Cannot call $form->handleRequest() because the GET forms are not handled in POST request.
         // See: https://github.com/symfony/symfony/issues/12244
-        $quickSearchForm->submit($request->get($quickSearchForm->getName()));
+        $quickSearchForm->submit($request->query->get($quickSearchForm->getName()));
 
         $massActionForm = $this->createForm(ProductMassActionFormType::class);
         $massActionForm->handleRequest($request);
@@ -273,8 +273,8 @@ class ProductController extends AdminBaseController
     public function getRuleFormAction(Request $request): Response
     {
         $ruleForm = $this->advancedSearchProductFacade->createRuleForm(
-            $request->get('filterName'),
-            $request->get('newIndex'),
+            $request->request->getString('filterName'),
+            $request->request->getString('newIndex'),
         );
 
         return $this->render('@ShopsysAdministration/content/product/advancedSearch/ruleForm.html.twig', [
@@ -359,8 +359,8 @@ class ProductController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function catnumExistsAction(Request $request): Response
     {
-        $catnum = $request->get('catnum');
-        $currentProductCatnum = $request->get('currentProductCatnum');
+        $catnum = $request->query->has('catnum') ? $request->query->getString('catnum') : null;
+        $currentProductCatnum = $request->query->getString('currentProductCatnum');
 
         if ($catnum === null || $catnum === $currentProductCatnum) {
             return new JsonResponse(false);
@@ -381,7 +381,7 @@ class ProductController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function productNamesByCatnumsAction(Request $request): JsonResponse
     {
-        $catnums = $request->get('catnums');
+        $catnums = $request->request->all('catnums');
 
         $response = [];
         $products = $this->productFacade->findAllByCatnums($catnums);

--- a/packages/framework/src/Controller/Admin/ProductPickerController.php
+++ b/packages/framework/src/Controller/Admin/ProductPickerController.php
@@ -147,8 +147,8 @@ class ProductPickerController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function basicProductPriceAction(Request $request): Response
     {
-        $productId = (int)$request->get('productId');
-        $domainId = (int)$request->get('domainId');
+        $productId = $request->request->getInt('productId');
+        $domainId = $request->request->getInt('domainId');
 
         $basicPrice = $this->productFacade->getProductPriceForDefaultPricingGroup(
             $this->productFacade->getById($productId),
@@ -172,7 +172,7 @@ class ProductPickerController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function productImageAction(Request $request): Response
     {
-        $productId = (int)$request->get('productId');
+        $productId = $request->request->getInt('productId');
 
         $product = $this->productFacade->getById($productId);
 

--- a/packages/framework/src/Controller/Admin/SearchAdminController.php
+++ b/packages/framework/src/Controller/Admin/SearchAdminController.php
@@ -31,7 +31,7 @@ class SearchAdminController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function searchAction(Request $request): Response
     {
-        $searchString = $request->get('search');
+        $searchString = $request->query->getString('search');
         $menu = $this->sideMenuBuilder->createMenu();
 
         $results = [];

--- a/packages/framework/src/Controller/Admin/UnitController.php
+++ b/packages/framework/src/Controller/Admin/UnitController.php
@@ -107,11 +107,7 @@ class UnitController extends AdminBaseController
     #[CsrfProtection]
     public function deleteAction(Request $request, int $id): Response
     {
-        $newId = $request->get('newId');
-
-        if ($newId !== null) {
-            $newId = (int)$newId;
-        }
+        $newId = $request->query->has('newId') ? $request->query->getInt('newId') : null;
 
         try {
             $fullName = $this->unitFacade->getById($id)->getName();

--- a/packages/framework/src/Controller/Admin/VatController.php
+++ b/packages/framework/src/Controller/Admin/VatController.php
@@ -101,7 +101,7 @@ class VatController extends AdminBaseController
     #[CsrfProtection]
     public function deleteAction(Request $request, int $id): Response
     {
-        $newId = $request->get('newId');
+        $newId = $request->query->has('newId') ? $request->query->getInt('newId') : null;
 
         try {
             $fullName = $this->vatFacade->getById($id)->getName();

--- a/packages/framework/src/Controller/Front/CustomerUploadedFileController.php
+++ b/packages/framework/src/Controller/Front/CustomerUploadedFileController.php
@@ -38,7 +38,7 @@ class CustomerUploadedFileController
         string $uploadedFilename,
     ): DownloadFileResponse {
         try {
-            $hash = $request->get('hash', '');
+            $hash = $request->query->getString('hash');
             $uploadedFile = $this->getCustomerUploadedFile($uploadedFilename, $uploadedFileId, $hash);
             $filePath = $this->customerUploadedFileFacade->getAbsoluteUploadedFileFilepath($uploadedFile);
 
@@ -61,7 +61,7 @@ class CustomerUploadedFileController
     public function viewAction(Request $request, int $uploadedFileId, string $uploadedFilename): StreamedResponse
     {
         try {
-            $hash = $request->get('hash', '');
+            $hash = $request->query->getString('hash');
             $uploadedFile = $this->getCustomerUploadedFile($uploadedFilename, $uploadedFileId, $hash);
             $filePath = $this->customerUploadedFileFacade->getAbsoluteUploadedFileFilepath($uploadedFile);
 

--- a/packages/framework/src/Form/AbstractFileUploadType.php
+++ b/packages/framework/src/Form/AbstractFileUploadType.php
@@ -92,7 +92,7 @@ final class AbstractFileUploadType extends AbstractType implements DataTransform
     {
         $fileConstraints = array_merge(
             [
-                new FileExtensionMaxLength(['limit' => 5]),
+                new FileExtensionMaxLength(limit: 5),
             ],
             $options['file_constraints'],
         );
@@ -104,7 +104,8 @@ final class AbstractFileUploadType extends AbstractType implements DataTransform
                 'allow_add' => true,
                 'constraints' => [
                     new Constraints\Callback(
-                        ['callback' => [$this, 'validateUploadedFiles'], 'payload' => $fileConstraints],
+                        callback: [$this, 'validateUploadedFiles'],
+                        payload: $fileConstraints,
                     ),
                 ],
             ])
@@ -113,9 +114,10 @@ final class AbstractFileUploadType extends AbstractType implements DataTransform
                 'allow_add' => true,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter the filename']),
+                        new Constraints\NotBlank(message: 'Please enter the filename'),
                         new Constraints\Length(
-                            ['max' => 245, 'maxMessage' => 'File name cannot be longer than {{ limit }} characters'],
+                            max: 245,
+                            maxMessage: 'File name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -73,24 +73,26 @@ final class AdministratorFormType extends AbstractType
         $builderSettingsGroup
             ->add('username', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter username']),
+                    new Constraints\NotBlank(message: 'Please enter username'),
                     new Constraints\Length(
-                        ['max' => 100, 'maxMessage' => 'Username cannot be longer than {{ limit }} characters'],
+                        max: 100,
+                        maxMessage: 'Username cannot be longer than {{ limit }} characters',
                     ),
-                    new UniqueEntityField([
-                        'entityInstance' => $adminToEdit,
-                        'message' => 'Administrator with user name "{{ value }}" is already registered',
-                        'fieldName' => 'username',
-                        'entityName' => Administrator::class,
-                    ]),
+                    new UniqueEntityField(
+                        entityInstance: $adminToEdit,
+                        message: 'Administrator with user name "{{ value }}" is already registered',
+                        fieldName: 'username',
+                        entityName: Administrator::class,
+                    ),
                 ],
                 'label' => 'Login name',
             ])
             ->add('realName', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter full name']),
+                    new Constraints\NotBlank(message: 'Please enter full name'),
                     new Constraints\Length(
-                        ['max' => 100, 'maxMessage' => 'Full name cannot be longer than {{ limit }} characters'],
+                        max: 100,
+                        maxMessage: 'Full name cannot be longer than {{ limit }} characters',
                     ),
                 ],
                 'label' => 'Full name',
@@ -98,17 +100,18 @@ final class AdministratorFormType extends AbstractType
             ->add('email', EmailType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Email(['message' => 'Please enter valid email']),
-                    new Constraints\NotBlank(['message' => 'Please enter email']),
+                    new Email(message: 'Please enter valid email'),
+                    new Constraints\NotBlank(message: 'Please enter email'),
                     new Constraints\Length(
-                        ['max' => 255, 'maxMessage' => 'Email cannot be longer than {{ limit }} characters'],
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
                     ),
-                    new UniqueEntityField([
-                        'entityInstance' => $adminToEdit,
-                        'message' => 'Administrator with email "{{ value }}" is already registered',
-                        'fieldName' => 'email',
-                        'entityName' => Administrator::class,
-                    ]),
+                    new UniqueEntityField(
+                        entityInstance: $adminToEdit,
+                        message: 'Administrator with email "{{ value }}" is already registered',
+                        fieldName: 'email',
+                        entityName: Administrator::class,
+                    ),
                 ],
                 'label' => 'Email',
             ]);

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorResetPasswordFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorResetPasswordFormType.php
@@ -36,8 +36,8 @@ final class AdministratorResetPasswordFormType extends AbstractType
                 'first_options' => [
                     'label' => 'Password',
                     'constraints' => [
-                        new Constraints\Regex(['pattern' => '/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{10,}$/', 'message' => '']),
-                        new Constraints\NotBlank(['message' => '']),
+                        new Constraints\Regex(pattern: '/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{10,}$/', message: ''),
+                        new Constraints\NotBlank(message: ''),
                     ],
                     'attr' => [
                         'data-js-set-password-input' => null,

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorRoleGroupFormType.php
@@ -27,9 +27,10 @@ final class AdministratorRoleGroupFormType extends AbstractType
     {
         $builder->add('name', TextType::class, [
             'constraints' => [
-                new Constraints\NotBlank(['message' => 'Please enter name']),
+                new Constraints\NotBlank(message: 'Please enter name'),
                 new Constraints\Length(
-                    ['max' => 100, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                    max: 100,
+                    maxMessage: 'Name cannot be longer than {{ limit }} characters',
                 ),
             ],
             'label' => 'Role name',

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -74,7 +74,7 @@ final class AdvertFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name of advertisement area']),
+                    new Constraints\NotBlank(message: 'Please enter name of advertisement area'),
                 ],
                 'label' => 'Name',
                 'help' => t('Name serves only for internal use within the administration.'),
@@ -88,7 +88,7 @@ final class AdvertFormType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose advertisement type']),
+                    new Constraints\NotBlank(message: 'Please choose advertisement type'),
                 ],
                 'label' => 'Type',
             ])
@@ -97,7 +97,7 @@ final class AdvertFormType extends AbstractType
                 'choices' => array_flip($this->advertPositionRegistry->getAllLabelsIndexedByNames()),
                 'placeholder' => '-- Choose area --',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose advertisement area']),
+                    new Constraints\NotBlank(message: 'Please choose advertisement area'),
                 ],
                 'label' => 'Area',
             ])
@@ -116,10 +116,10 @@ final class AdvertFormType extends AbstractType
                 'label' => 'Code',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter HTML code for advertisement area',
-                        'groups' => [self::VALIDATION_GROUP_TYPE_CODE],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter HTML code for advertisement area',
+                        groups: [self::VALIDATION_GROUP_TYPE_CODE],
+                    ),
                 ],
                 'row_attr' => [
                     'data-js-advert-type-content' => 'code',
@@ -140,10 +140,10 @@ final class AdvertFormType extends AbstractType
             ]);
 
         $imageConstraints = [
-            new MustUploadFile([
-                'message' => 'Choose image',
-                'groups' => [self::VALIDATION_GROUP_TYPE_IMAGE],
-            ]),
+            new MustUploadFile(
+                message: 'Choose image',
+                groups: [self::VALIDATION_GROUP_TYPE_IMAGE],
+            ),
         ];
 
         $builderImageGroup
@@ -152,13 +152,13 @@ final class AdvertFormType extends AbstractType
                 'image_entity_class' => Advert::class,
                 'image_type' => AdvertFacade::IMAGE_TYPE_WEB,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '15M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'constraints' => ($options['web_image_exists'] ? [] : $imageConstraints),
                 'label' => 'Upload new image',
@@ -172,13 +172,13 @@ final class AdvertFormType extends AbstractType
                 'image_entity_class' => Advert::class,
                 'image_type' => AdvertFacade::IMAGE_TYPE_MOBILE,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '15M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'constraints' => ($options['mobile_image_exists'] ? [] : $imageConstraints),
                 'label' => 'Upload image for mobile devices',

--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -74,7 +74,7 @@ final class ArticleFormType extends AbstractType
                     'choices' => $this->articleFacade->getAvailablePlacementChoices(),
                     'placeholder' => '-- Choose article position --',
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please choose article placement']),
+                        new Constraints\NotBlank(message: 'Please choose article placement'),
                     ],
                     'label' => 'Location',
                 ]);
@@ -93,7 +93,7 @@ final class ArticleFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter article name']),
+                    new Constraints\NotBlank(message: 'Please enter article name'),
                 ],
                 'label' => 'Name',
             ])
@@ -116,10 +116,10 @@ final class ArticleFormType extends AbstractType
             ->add('url', UrlType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter URL',
-                        'groups' => [self::VALIDATION_GROUP_TYPE_LINK],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter URL',
+                        groups: [self::VALIDATION_GROUP_TYPE_LINK],
+                    ),
                 ],
                 'label' => 'URL',
                 'trim' => true,
@@ -131,10 +131,10 @@ final class ArticleFormType extends AbstractType
                 'required' => true,
                 'allow_products' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter article content',
-                        'groups' => [self::VALIDATION_GROUP_TYPE_SITE],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter article content',
+                        groups: [self::VALIDATION_GROUP_TYPE_SITE],
+                    ),
                 ],
                 'label' => 'Content',
                 'row_attr' => [
@@ -144,7 +144,7 @@ final class ArticleFormType extends AbstractType
             ->add('createdAt', DatePickerType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter date of creation']),
+                    new Constraints\NotBlank(message: 'Please enter date of creation'),
                 ],
                 'label' => 'Creation date',
                 'row_attr' => [

--- a/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
+++ b/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
@@ -28,11 +28,11 @@ final class BestsellingProductFormType extends AbstractType
                 'label' => 'Bestselling products',
                 'error_bubbling' => true,
                 'constraints' => [
-                    new Constraints\UniqueCollection([
-                        'allowEmpty' => true,
-                        'message' => 'You entered same product twice. In list of bestsellers can be product only once. '
+                    new Constraints\UniqueCollection(
+                        allowEmpty: true,
+                        message: 'You entered same product twice. In list of bestsellers can be product only once. '
                             . 'Please correct it and then save form again.',
-                    ]),
+                    ),
                 ],
             ])
             ->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogArticleFormType.php
@@ -130,7 +130,7 @@ final class BlogArticleFormType extends AbstractType
                 'required' => false,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\Length(['max' => 255, 'maxMessage' => 'Heading (H1) cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(max: 255, maxMessage: 'Heading (H1) cannot be longer than {{ limit }} characters'),
                     ],
                 ],
                 'options_by_domain_id' => $seoH1OptionsByDomainId,
@@ -176,7 +176,7 @@ final class BlogArticleFormType extends AbstractType
                 'entry_options' => [
                     'required' => false,
                     'constraints' => [
-                        new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(max: 255, maxMessage: 'Name cannot be longer than {{ limit }} characters'),
                     ],
                 ],
                 'label' => 'Name',
@@ -196,7 +196,7 @@ final class BlogArticleFormType extends AbstractType
             ->add('publishDate', DatePickerType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter date of creation']),
+                    new Constraints\NotBlank(message: 'Please enter date of creation'),
                 ],
                 'label' => 'Date of publication',
                 'data' => $blogArticle === null ? $this->clock->now() : $blogArticle->getPublishDate(),
@@ -268,13 +268,13 @@ final class BlogArticleFormType extends AbstractType
                 'image_entity_class' => BlogArticle::class,
                 'image_type' => null,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '15M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'label' => 'Upload image',
                 'entity' => $options['blogArticle'],

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -128,7 +128,7 @@ final class BlogCategoryFormType extends AbstractType
                 'entry_options' => [
                     'required' => false,
                     'constraints' => [
-                        new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(max: 255, maxMessage: 'Name cannot be longer than {{ limit }} characters'),
                     ],
                 ],
                 'label' => 'Name',
@@ -219,7 +219,7 @@ final class BlogCategoryFormType extends AbstractType
                 'required' => false,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\Length(['max' => 255, 'maxMessage' => 'Heading (H1) cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(max: 255, maxMessage: 'Heading (H1) cannot be longer than {{ limit }} characters'),
                     ],
                 ],
                 'options_by_domain_id' => $seoH1OptionsByDomainId,
@@ -286,13 +286,13 @@ final class BlogCategoryFormType extends AbstractType
             ->add('image', ImageUploadType::class, [
                 'required' => false,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '15M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'label' => 'Upload image',
                 'entity' => $options['blogCategory'],

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -124,7 +124,8 @@ final class CategoryFormType extends AbstractType
                     'required' => false,
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -186,7 +187,8 @@ final class CategoryFormType extends AbstractType
                 'entry_options' => [
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Heading (H1) cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Heading (H1) cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -222,13 +224,13 @@ final class CategoryFormType extends AbstractType
                 'required' => false,
                 'image_entity_class' => Category::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'label' => 'Upload image',
                 'entity' => $options['category'],

--- a/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
@@ -87,7 +87,7 @@ final class ComplaintFormType extends AbstractType
                 'attr' => [
                     'novalidate' => 'novalidate',
                 ],
-                'constraints' => [new Constraints\Callback([$this, 'validateQuantityIsLessOrEqualThanOrdered'])],
+                'constraints' => [new Constraints\Callback(callback: [$this, 'validateQuantityIsLessOrEqualThanOrdered'])],
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
@@ -160,20 +160,20 @@ final class ComplaintFormType extends AbstractType
             ->add('bankAccountNumber', TextType::class, [
                 'label' => 'Bank account number',
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter bank account number',
-                        'groups' => [static::VALIDATION_GROUP_TYPE_MONEY_RETURN],
-                    ]),
-                    new Constraints\Length([
-                        'max' => 34,
-                        'maxMessage' => 'Bank account number cannot be longer than {{ limit }} characters',
-                        'groups' => [static::VALIDATION_GROUP_TYPE_MONEY_RETURN],
-                    ]),
-                    new Constraints\Regex([
-                        'pattern' => '/^[a-zA-Z0-9\/\-]+$/',
-                        'message' => 'Bank account number can contain only letters, numbers, slashes and dashes',
-                        'groups' => [static::VALIDATION_GROUP_TYPE_MONEY_RETURN],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter bank account number',
+                        groups: [static::VALIDATION_GROUP_TYPE_MONEY_RETURN],
+                    ),
+                    new Constraints\Length(
+                        max: 34,
+                        maxMessage: 'Bank account number cannot be longer than {{ limit }} characters',
+                        groups: [static::VALIDATION_GROUP_TYPE_MONEY_RETURN],
+                    ),
+                    new Constraints\Regex(
+                        pattern: '/^[a-zA-Z0-9\/\-]+$/',
+                        message: 'Bank account number can contain only letters, numbers, slashes and dashes',
+                        groups: [static::VALIDATION_GROUP_TYPE_MONEY_RETURN],
+                    ),
                 ],
                 'row_attr' => [
                     'data-js-complaint-bank-account-number' => null,
@@ -191,12 +191,12 @@ final class ComplaintFormType extends AbstractType
             ->add('email', TextType::class, [
                 'label' => 'Email',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter email']),
-                    new Email(['message' => 'Please enter valid email']),
-                    new Constraints\Length([
-                        'max' => 255,
-                        'maxMessage' => 'Email cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter email'),
+                    new Email(message: 'Please enter valid email'),
+                    new Constraints\Length(
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ]);
 
@@ -218,84 +218,75 @@ final class ComplaintFormType extends AbstractType
                 'label' => 'First name',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter first name of contact person',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'First name of contact person cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter first name of contact person'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'First name of contact person cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryLastName', TextType::class, [
                 'label' => 'Last name',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter last name of contact person',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Last name of contact person cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter last name of contact person'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Last name of contact person cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryCompanyName', TextType::class, [
                 'label' => 'Company',
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryTelephone', TextType::class, [
                 'label' => 'Telephone',
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Telephone number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryStreet', TextType::class, [
                 'label' => 'Street',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter street',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter street'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Street name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryCity', TextType::class, [
                 'label' => 'City',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter city',
-                    ]),
-                    new Constraints\Length(['max' => 100,
-                        'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter city'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'City name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryPostcode', TextType::class, [
                 'label' => 'Postcode',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter zip code',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter zip code'),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Zip code cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('deliveryCountry', ChoiceType::class, [
@@ -305,7 +296,7 @@ final class ComplaintFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose country']),
+                    new Constraints\NotBlank(message: 'Please choose country'),
                 ],
             ]);
 

--- a/packages/framework/src/Form/Admin/Complaint/ComplaintItemFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/ComplaintItemFormType.php
@@ -31,14 +31,15 @@ final class ComplaintItemFormType extends AbstractType
             ])
             ->add('description', TextareaType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter description']),
+                    new Constraints\NotBlank(message: 'Please enter description'),
                 ],
             ])
             ->add('quantity', IntegerType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter quantity']),
+                    new Constraints\NotBlank(message: 'Please enter quantity'),
                     new Constraints\GreaterThan(
-                        ['value' => 0, 'message' => 'Quantity must be greater than {{ compared_value }}'],
+                        value: 0,
+                        message: 'Quantity must be greater than {{ compared_value }}',
                     ),
                 ],
             ]);

--- a/packages/framework/src/Form/Admin/Complaint/Status/ComplaintStatusFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/Status/ComplaintStatusFormType.php
@@ -24,9 +24,10 @@ final class ComplaintStatusFormType extends AbstractType
             ->add('name', LocalizedType::class, [
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter complaint status name in all languages']),
+                        new Constraints\NotBlank(message: 'Please enter complaint status name in all languages'),
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Status name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Status name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],

--- a/packages/framework/src/Form/Admin/Country/CountryFormType.php
+++ b/packages/framework/src/Form/Admin/Country/CountryFormType.php
@@ -54,9 +54,10 @@ final class CountryFormType extends AbstractType
                 'entry_options' => [
                     'required' => true,
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter country name']),
+                        new Constraints\NotBlank(message: 'Please enter country name'),
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Country name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Country name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -65,14 +66,15 @@ final class CountryFormType extends AbstractType
             ->add('code', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter country code']),
+                    new Constraints\NotBlank(message: 'Please enter country code'),
                     new Constraints\Length(
-                        ['max' => 2, 'maxMessage' => 'Country code cannot be longer than {{ limit }} characters'],
+                        max: 2,
+                        maxMessage: 'Country code cannot be longer than {{ limit }} characters',
                     ),
-                    new NotInArray([
-                        'array' => $this->getOtherCountryCodes(),
-                        'message' => 'Country code with this code already exists',
-                    ]),
+                    new NotInArray(
+                        array: $this->getOtherCountryCodes(),
+                        message: 'Country code with this code already exists',
+                    ),
                 ],
                 'label' => 'Code',
                 'help_html' => true,
@@ -92,8 +94,8 @@ final class CountryFormType extends AbstractType
                     ),
                     'required' => false,
                     'constraints' => [
-                        new Constraints\Type(['type' => 'numeric']),
-                        new Constraints\GreaterThanOrEqual(['value' => 0]),
+                        new Constraints\Type(type: 'numeric'),
+                        new Constraints\GreaterThanOrEqual(value: 0),
                     ],
                 ],
                 'required' => false,

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressAndRelatedInfoFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressAndRelatedInfoFormType.php
@@ -61,9 +61,9 @@ final class BillingAddressAndRelatedInfoFormType extends AbstractType
             ->setDefaults([
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new UniqueBillingAddress([
-                        'errorPath' => 'companyNumber',
-                    ]),
+                    new UniqueBillingAddress(
+                        errorPath: 'companyNumber',
+                    ),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -65,41 +65,41 @@ final class BillingAddressFormType extends AbstractType
                     ->add('companyName', TextType::class, [
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter company name',
-                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
-                            ]),
-                            new Constraints\Length([
-                                'max' => 100,
-                                'maxMessage' => 'Company name cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter company name',
+                                groups: [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                            ),
+                            new Constraints\Length(
+                                max: 100,
+                                maxMessage: 'Company name cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                            ),
                         ],
                         'label' => 'Company',
                     ])
                     ->add('companyNumber', TextType::class, [
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter identification number',
-                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
-                            ]),
-                            new Constraints\Length([
-                                'max' => 50,
-                                'maxMessage' => 'Identification number cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter identification number',
+                                groups: [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                            ),
+                            new Constraints\Length(
+                                max: 50,
+                                maxMessage: 'Identification number cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                            ),
                         ],
                         'label' => 'Company number',
                     ])
                     ->add('companyTaxNumber', TextType::class, [
                         'required' => false,
                         'constraints' => [
-                            new Constraints\Length([
-                                'max' => 50,
-                                'maxMessage' => 'Tax number cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
-                            ]),
+                            new Constraints\Length(
+                                max: 50,
+                                maxMessage: 'Tax number cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                            ),
                         ],
                         'label' => 'Tax number',
                     ]),
@@ -113,39 +113,39 @@ final class BillingAddressFormType extends AbstractType
             ->add('street', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter street',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter street',
+                    ),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Street name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Street',
             ])
             ->add('city', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter city',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter city',
+                    ),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'City name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'City',
             ])
             ->add('postcode', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter zip code',
-                    ]),
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter zip code',
+                    ),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Zip code cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Postcode',
             ])
@@ -155,9 +155,9 @@ final class BillingAddressFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please choose country',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please choose country',
+                    ),
                 ],
                 'label' => 'Country',
             ]);

--- a/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
@@ -38,65 +38,65 @@ final class DeliveryAddressFormType extends AbstractType
             ->add('firstName', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter first name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter first name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'First name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'First name',
             ])
             ->add('lastName', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter last name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter last name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Last name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Last name',
             ])
             ->add('companyName', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Company name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Company name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Company',
             ])
             ->add('street', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter street']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter street'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Street name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Street',
             ])
             ->add('city', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter city']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter city'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'City name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'City',
             ])
             ->add('postcode', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter postcode']),
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter postcode'),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Zip code cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Postcode',
             ])
@@ -110,10 +110,10 @@ final class DeliveryAddressFormType extends AbstractType
             ->add('telephone', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Telephone number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Telephone',
             ])

--- a/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
@@ -38,9 +38,10 @@ final class CustomerUserRoleGroupFormType extends AbstractType
             'label' => 'Role group name',
             'entry_options' => [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter role name']),
+                    new Constraints\NotBlank(message: 'Please enter role name'),
                     new Constraints\Length(
-                        ['max' => 100, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                        max: 100,
+                        maxMessage: 'Name cannot be longer than {{ limit }} characters',
                     ),
                 ],
             ],

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -152,33 +152,33 @@ final class CustomerUserFormType extends AbstractType
         $builderPersonalDataGroup
             ->add('firstName', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter first name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter first name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'First name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'First name',
             ])
             ->add('lastName', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter last name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter last name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Last name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Last name',
             ])
             ->add('email', EmailType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter email']),
-                    new Constraints\Length([
-                        'max' => 255,
-                        'maxMessage' => 'Email cannot be longer than {{ limit }} characters',
-                    ]),
-                    new Email(['message' => 'Please enter valid email']),
-                    new Constraints\Callback([$this, 'validateUniqueEmail']),
+                    new Constraints\NotBlank(message: 'Please enter email'),
+                    new Constraints\Length(
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
+                    ),
+                    new Email(message: 'Please enter valid email'),
+                    new Constraints\Callback(callback: [$this, 'validateUniqueEmail']),
                 ],
                 'label' => 'Email',
             ]);
@@ -194,10 +194,10 @@ final class CustomerUserFormType extends AbstractType
             ->add('telephone', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Telephone number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Telephone',
             ]);
@@ -286,18 +286,18 @@ final class CustomerUserFormType extends AbstractType
                 'attr' => ['novalidate' => 'novalidate'],
                 'renders_in_own_card' => true,
                 'constraints' => [
-                    new FieldsAreNotIdentical([
-                        'field1' => 'email',
-                        'field2' => 'password',
-                        'errorPath' => 'password',
-                        'message' => 'Password cannot be same as email',
-                    ]),
-                    new NotIdenticalToEmailLocalPart([
-                        'password' => 'password',
-                        'email' => 'email',
-                        'errorPath' => 'password',
-                        'message' => 'Password cannot be same as part of email before at sign',
-                    ]),
+                    new FieldsAreNotIdentical(
+                        field1: 'email',
+                        field2: 'password',
+                        errorPath: 'password',
+                        message: 'Password cannot be same as email',
+                    ),
+                    new NotIdenticalToEmailLocalPart(
+                        password: 'password',
+                        email: 'email',
+                        errorPath: 'password',
+                        message: 'Password cannot be same as part of email before at sign',
+                    ),
                 ],
                 'renderSaveButton' => false,
                 'allowEditSystemData' => true,

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserUpdateFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserUpdateFormType.php
@@ -79,9 +79,9 @@ final class CustomerUserUpdateFormType extends AbstractType
                 'empty_data' => $this->customerUserUpdateDataFactory->create(),
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new UniqueBillingAddress([
-                        'errorPath' => 'billingAddressData.companyNumber',
-                    ]),
+                    new UniqueBillingAddress(
+                        errorPath: 'billingAddressData.companyNumber',
+                    ),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Domain/DomainFormType.php
+++ b/packages/framework/src/Form/Admin/Domain/DomainFormType.php
@@ -33,13 +33,13 @@ final class DomainFormType extends AbstractType
             ->add(self::FIELD_ICON, ImageUploadType::class, [
                 'required' => false,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png'],
-                        'mimeTypesMessage' => 'Image can be only in PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png'],
+                        mimeTypesMessage: 'Image can be only in PNG format',
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'info_text' => t('The optimal size of the icon is 46x26 px. Only PNG format is allowed.'),
             ])

--- a/packages/framework/src/Form/Admin/FriendlyUrl/FriendlyUrlFormType.php
+++ b/packages/framework/src/Form/Admin/FriendlyUrl/FriendlyUrlFormType.php
@@ -67,10 +67,10 @@ final class FriendlyUrlFormType extends AbstractType
             )
             ->add('redirectTo', TextType::class, [
                 'constraints' => [
-                    new Regex([
-                        'pattern' => '/^(\/)|(https?:\/\/).*$/',
-                        'message' => 'Redirect target must be relative path (with leading slash) or absolute path starting by protocol (http:// or https://)',
-                    ]),
+                    new Regex(
+                        pattern: '/^(\/)|(https?:\/\/).*$/',
+                        message: 'Redirect target must be relative path (with leading slash) or absolute path starting by protocol (http:// or https://)',
+                    ),
                 ],
             ])
             ->add(
@@ -107,7 +107,7 @@ final class FriendlyUrlFormType extends AbstractType
             'data_class' => FriendlyUrlData::class,
             'attr' => ['novalidate' => 'novalidate'],
             'constraints' => [
-                new Callback([$this, 'checkRedirectValidity']),
+                new Callback(callback: [$this, 'checkRedirectValidity']),
             ],
         ]);
     }

--- a/packages/framework/src/Form/Admin/GiftPlan/GiftPlanFormType.php
+++ b/packages/framework/src/Form/Admin/GiftPlan/GiftPlanFormType.php
@@ -71,8 +71,8 @@ final class GiftPlanFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name of gift plan']),
-                    new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
+                    new Constraints\NotBlank(message: 'Please enter name of gift plan'),
+                    new Constraints\Length(max: 255, maxMessage: 'Name cannot be longer than {{ limit }} characters'),
                 ],
                 'label' => 'Name',
                 'help' => t('Name serves only for internal use within the administration.'),
@@ -80,7 +80,7 @@ final class GiftPlanFormType extends AbstractType
             ->add('giftProduct', ProductType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose gift product']),
+                    new Constraints\NotBlank(message: 'Please choose gift product'),
                 ],
                 'label' => 'Gift product',
             ])

--- a/packages/framework/src/Form/Admin/GiftPlan/GiftPriceSettingFormType.php
+++ b/packages/framework/src/Form/Admin/GiftPlan/GiftPriceSettingFormType.php
@@ -27,8 +27,8 @@ final class GiftPriceSettingFormType extends AbstractType
             'scale' => 6,
             'currency' => $options['currency_code'],
             'constraints' => [
-                new NotBlank(['message' => 'Please enter price']),
-                new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+                new NotBlank(message: 'Please enter price'),
+                new NotNegativeMoneyAmount(message: 'Price must be greater or equal to zero'),
             ],
             'label' => 'Gift price (with VAT)',
         ]);

--- a/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
+++ b/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
@@ -31,11 +31,11 @@ final class HeurekaShopCertificationFormType extends AbstractType
             ->add('heurekaApiKey', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'min' => 32,
-                        'max' => 32,
-                        'exactMessage' => 'Heureka API must be {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        min: 32,
+                        max: 32,
+                        exactMessage: 'Heureka API must be {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Code of service Heureka - Verified by Customer',
                 'help' => t('Enter 32-digit code which will be sent to server') . ' ' . $options['server_name'],

--- a/packages/framework/src/Form/Admin/Holidays/HolidaysImportFormType.php
+++ b/packages/framework/src/Form/Admin/Holidays/HolidaysImportFormType.php
@@ -58,14 +58,14 @@ final class HolidaysImportFormType extends AbstractType
                     '%supportedCountriesUrl%' => 'https://github.com/spatie/holidays#supported-countries',
                 ]),
                 'constraints' => [
-                    new NotBlank(['message' => 'Please select a country']),
+                    new NotBlank(message: 'Please select a country'),
                 ],
             ])
             ->add('year', IntegerType::class, [
                 'label' => 'Year',
                 'required' => true,
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter a year']),
+                    new NotBlank(message: 'Please enter a year'),
                 ],
             ])
             ->add('import', ActionBarType::class, [
@@ -77,7 +77,7 @@ final class HolidaysImportFormType extends AbstractType
                 'label' => 'Import for domain',
                 'required' => true,
                 'constraints' => [
-                    new Callback(['callback' => [$this, 'validateSelectedDomains']]),
+                    new Callback(callback: [$this, 'validateSelectedDomains']),
                 ],
             ]);
         }

--- a/packages/framework/src/Form/Admin/LegalConditions/TermsAndConditionsSettingFormType.php
+++ b/packages/framework/src/Form/Admin/LegalConditions/TermsAndConditionsSettingFormType.php
@@ -59,12 +59,12 @@ final class TermsAndConditionsSettingFormType extends AbstractType
                 'required' => true,
                 'label' => 'Withdrawal deadline (days)',
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter withdrawal deadline.',
-                    ]),
-                    new Constraints\Positive([
-                        'message' => 'Withdrawal deadline must be a positive number.',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter withdrawal deadline.',
+                    ),
+                    new Constraints\Positive(
+                        message: 'Withdrawal deadline must be a positive number.',
+                    ),
                 ],
             ])
             ->add('withdrawalInstructions', CKEditorType::class, [
@@ -76,9 +76,9 @@ final class TermsAndConditionsSettingFormType extends AbstractType
                     WithdrawalSettingFacade::VARIABLE_ORDER_DETAIL_URL => t('Order detail URL address'),
                 ],
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter withdrawal instructions.',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter withdrawal instructions.',
+                    ),
                 ],
             ]);
 

--- a/packages/framework/src/Form/Admin/Login/LoginFormType.php
+++ b/packages/framework/src/Form/Admin/Login/LoginFormType.php
@@ -26,12 +26,12 @@ final class LoginFormType extends AbstractType
         $builder
             ->add('username', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter login']),
+                    new Constraints\NotBlank(message: 'Please enter login'),
                 ],
             ])
             ->add('password', PasswordType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter password']),
+                    new Constraints\NotBlank(message: 'Please enter password'),
                 ],
             ])
             ->add('login', SubmitType::class);

--- a/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
@@ -32,14 +32,14 @@ final class MailSettingFormType extends AbstractType
         $builderSettingsGroup
             ->add('email', EmailType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter email']),
-                    new Email(['message' => 'Please enter valid email']),
+                    new Constraints\NotBlank(message: 'Please enter email'),
+                    new Email(message: 'Please enter valid email'),
                 ],
                 'label' => 'Main administrator email',
             ])
             ->add('name', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter full name']),
+                    new Constraints\NotBlank(message: 'Please enter full name'),
                 ],
                 'label' => 'Email name',
             ]);

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
@@ -53,7 +53,8 @@ final class MailTemplateFormType extends AbstractType
                 'constraints' => [
                     new Email(),
                     new Constraints\Length(
-                        ['max' => 255, 'maxMessage' => 'Email cannot be longer than {{ limit }} characters'],
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
                     ),
                 ],
             ])
@@ -77,11 +78,11 @@ final class MailTemplateFormType extends AbstractType
                 'label' => 'Upload attachment',
                 'required' => false,
                 'file_constraints' => [
-                    new Constraints\File([
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded file is too large ({{ size }} {{ suffix }}). '
+                    new Constraints\File(
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded file is too large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'entity' => $mailTemplate,
                 'file_entity_class' => MailTemplate::class,
@@ -109,21 +110,21 @@ final class MailTemplateFormType extends AbstractType
     {
         $subjectConstraints = [];
 
-        $subjectConstraints[] = new Constraints\NotBlank([
-            'message' => 'Please enter subject',
-            'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
-        ]);
-        $subjectConstraints[] = new Constraints\Length([
-            'max' => 255,
-            'maxMessage' => 'Email subject cannot be longer than {{ limit }} characters',
-        ]);
+        $subjectConstraints[] = new Constraints\NotBlank(
+            message: 'Please enter subject',
+            groups: [static::VALIDATION_GROUP_SEND_MAIL],
+        );
+        $subjectConstraints[] = new Constraints\Length(
+            max: 255,
+            maxMessage: 'Email subject cannot be longer than {{ limit }} characters',
+        );
 
         foreach ($options['required_subject_variables'] as $variableName) {
-            $subjectConstraints[] = new Contains([
-                'needle' => $variableName,
-                'message' => 'Variable {{ needle }} is required',
-                'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
-            ]);
+            $subjectConstraints[] = new Contains(
+                needle: $variableName,
+                message: 'Variable {{ needle }} is required',
+                groups: [static::VALIDATION_GROUP_SEND_MAIL],
+            );
         }
 
         return $subjectConstraints;
@@ -137,17 +138,17 @@ final class MailTemplateFormType extends AbstractType
     {
         $bodyConstraints = [];
 
-        $bodyConstraints[] = new Constraints\NotBlank([
-            'message' => 'Please enter email content',
-            'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
-        ]);
+        $bodyConstraints[] = new Constraints\NotBlank(
+            message: 'Please enter email content',
+            groups: [static::VALIDATION_GROUP_SEND_MAIL],
+        );
 
         foreach ($options['required_body_variables'] as $variableName) {
-            $bodyConstraints[] = new Contains([
-                'needle' => $variableName,
-                'message' => 'Variable {{ needle }} is required',
-                'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
-            ]);
+            $bodyConstraints[] = new Contains(
+                needle: $variableName,
+                message: 'Variable {{ needle }} is required',
+                groups: [static::VALIDATION_GROUP_SEND_MAIL],
+            );
         }
 
         return $bodyConstraints;

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateSendFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateSendFormType.php
@@ -44,8 +44,8 @@ final class MailTemplateSendFormType extends AbstractType
                 'required' => true,
                 'data' => $currentAdministrator->getEmail(),
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter email address']),
-                    new Email(['message' => 'Please enter valid email']),
+                    new NotBlank(message: 'Please enter email address'),
+                    new Email(message: 'Please enter valid email'),
                 ],
             ]);
 
@@ -54,7 +54,7 @@ final class MailTemplateSendFormType extends AbstractType
                 ->add('entityIdentifier', IntegerType::class, [
                     'label' => $labelForEntityIdentifier,
                     'required' => true,
-                    'constraints' => new NotBlank(['message' => 'Please enter an ID']),
+                    'constraints' => new NotBlank(message: 'Please enter an ID'),
                 ]);
         }
 

--- a/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
+++ b/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
@@ -60,14 +60,14 @@ final class NavigationItemFormType extends AbstractType
                 'label' => 'Name',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter navigation item name']),
+                    new Constraints\NotBlank(message: 'Please enter navigation item name'),
                 ],
             ])
             ->add('url', TextType::class, [
                 'label' => 'Link URL',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter link URL']),
+                    new Constraints\NotBlank(message: 'Please enter link URL'),
                 ],
             ]);
         $this->addColumnFields($builder);

--- a/packages/framework/src/Form/Admin/NotificationBar/NotificationBarFormType.php
+++ b/packages/framework/src/Form/Admin/NotificationBar/NotificationBarFormType.php
@@ -54,13 +54,13 @@ final class NotificationBarFormType extends AbstractType
                 'required' => false,
                 'label' => 'Content',
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter notification bar content']),
+                    new NotBlank(message: 'Please enter notification bar content'),
                 ],
             ])
             ->add('rgbColor', ColorPickerType::class, [
                 'label' => 'Background color',
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter notification bar background color']),
+                    new NotBlank(message: 'Please enter notification bar background color'),
                 ],
             ])
             ->add('validityFrom', DateTimeType::class, [
@@ -85,13 +85,13 @@ final class NotificationBarFormType extends AbstractType
                 'image_entity_class' => NotificationBar::class,
                 'image_type' => null,
                 'file_constraints' => [
-                    new Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '15M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'entity' => $options['notification_bar'],
                 'label' => 'Upload new image',
@@ -120,7 +120,7 @@ final class NotificationBarFormType extends AbstractType
                 'data_class' => NotificationBarData::class,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Callback([$this, 'checkDateValidity']),
+                    new Callback(callback: [$this, 'checkDateValidity']),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Order/OrderFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderFormType.php
@@ -279,9 +279,7 @@ final class OrderFormType extends AbstractType
                 'label' => 'Tracking number',
                 'required' => false,
                 'constraints' => [
-                    new Length([
-                        'max' => 100,
-                    ]),
+                    new Length(max: 100),
                 ],
             ])
             ->add('deliveredAt', DateTimeType::class, [
@@ -316,42 +314,42 @@ final class OrderFormType extends AbstractType
             ->add('firstName', TextType::class, [
                 'label' => 'First name',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter first name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter first name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'First name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('lastName', TextType::class, [
                 'label' => 'Last name',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter last name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter last name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Last name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('email', EmailType::class, [
                 'label' => 'Email',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter email']),
-                    new Email(['message' => 'Please enter valid email']),
-                    new Constraints\Length([
-                        'max' => 255,
-                        'maxMessage' => 'Email cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter email'),
+                    new Email(message: 'Please enter valid email'),
+                    new Constraints\Length(
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('telephone', TextType::class, [
                 'label' => 'Telephone',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter telephone number']),
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter telephone number'),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Telephone number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ]);
 
@@ -373,30 +371,30 @@ final class OrderFormType extends AbstractType
                 'label' => 'Company name',
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Company name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Company name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('companyNumber', TextType::class, [
                 'label' => 'Company number',
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 50,
-                        'maxMessage' => 'Identification number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 50,
+                        maxMessage: 'Identification number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('companyTaxNumber', TextType::class, [
                 'label' => 'Tax number',
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 50,
-                        'maxMessage' => 'Tax number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 50,
+                        maxMessage: 'Tax number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ]);
 
@@ -418,31 +416,31 @@ final class OrderFormType extends AbstractType
             ->add('street', TextType::class, [
                 'label' => 'Street',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter street']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter street'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Street name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('city', TextType::class, [
                 'label' => 'City',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter city']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter city'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'City name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('postcode', TextType::class, [
                 'label' => 'Postcode',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter zip code']),
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter zip code'),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Zip code cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('country', ChoiceType::class, [
@@ -451,7 +449,7 @@ final class OrderFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose country']),
+                    new Constraints\NotBlank(message: 'Please choose country'),
                 ],
             ]);
 
@@ -491,96 +489,97 @@ final class OrderFormType extends AbstractType
                         'label' => 'First name',
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter first name of contact person',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
-                            new Constraints\Length([
-                                'max' => 100,
-                                'maxMessage' => 'First name of contact person cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter first name of contact person',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
+                            new Constraints\Length(
+                                max: 100,
+                                maxMessage: 'First name of contact person cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryLastName', TextType::class, [
                         'label' => 'Last name',
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter last name of contact person',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
-                            new Constraints\Length([
-                                'max' => 100,
-                                'maxMessage' => 'Last name of contact person cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter last name of contact person',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
+                            new Constraints\Length(
+                                max: 100,
+                                maxMessage: 'Last name of contact person cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryCompanyName', TextType::class, [
                         'label' => 'Company',
                         'required' => false,
                         'constraints' => [
-                            new Constraints\Length([
-                                'max' => 100,
-                                'maxMessage' => 'Name cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\Length(
+                                max: 100,
+                                maxMessage: 'Name cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryTelephone', TextType::class, [
                         'label' => 'Telephone',
                         'required' => false,
                         'constraints' => [
-                            new Constraints\Length([
-                                'max' => 30,
-                                'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\Length(
+                                max: 30,
+                                maxMessage: 'Telephone number cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryStreet', TextType::class, [
                         'label' => 'Street',
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter street',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
-                            new Constraints\Length([
-                                'max' => 100,
-                                'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter street',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
+                            new Constraints\Length(
+                                max: 100,
+                                maxMessage: 'Street name cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryCity', TextType::class, [
                         'label' => 'City',
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter city',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
-                            new Constraints\Length(['max' => 100,
-                                'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter city',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
+                            new Constraints\Length(
+                                max: 100,
+                                maxMessage: 'City name cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryPostcode', TextType::class, [
                         'label' => 'Postcode',
                         'required' => true,
                         'constraints' => [
-                            new Constraints\NotBlank([
-                                'message' => 'Please enter zip code',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
-                            new Constraints\Length([
-                                'max' => 30,
-                                'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
-                            ]),
+                            new Constraints\NotBlank(
+                                message: 'Please enter zip code',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
+                            new Constraints\Length(
+                                max: 30,
+                                maxMessage: 'Zip code cannot be longer than {{ limit }} characters',
+                                groups: [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                            ),
                         ],
                     ])
                     ->add('deliveryCountry', ChoiceType::class, [
@@ -590,7 +589,7 @@ final class OrderFormType extends AbstractType
                         'choice_label' => 'name',
                         'choice_value' => 'id',
                         'constraints' => [
-                            new Constraints\NotBlank(['message' => 'Please choose country']),
+                            new Constraints\NotBlank(message: 'Please choose country'),
                         ],
                     ]),
             );

--- a/packages/framework/src/Form/Admin/Order/OrderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderItemFormType.php
@@ -43,45 +43,45 @@ final class OrderItemFormType extends AbstractType
         $builder
             ->add('name', TextType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
                 ],
             ])
             ->add('catnum', TextType::class, [
                 'constraints' => [
-                    new Constraints\Length(['max' => '255']),
+                    new Constraints\Length(max: 255),
                 ],
             ])
             ->add('unitPriceWithVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter unit price with VAT']),
+                    new Constraints\NotBlank(message: 'Please enter unit price with VAT'),
                 ],
             ])
             ->add('unitPriceWithoutVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter unit price without VAT',
-                        'groups' => [self::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter unit price without VAT',
+                        groups: [self::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
+                    ),
                 ],
             ])
             ->add('totalPriceWithVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter total price with VAT',
-                        'groups' => [self::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter total price with VAT',
+                        groups: [self::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
+                    ),
                 ],
             ])
             ->add('totalPriceWithoutVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter total price without VAT',
-                        'groups' => [self::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter total price without VAT',
+                        groups: [self::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
+                    ),
                 ],
             ])
             ->add(
@@ -94,20 +94,21 @@ final class OrderItemFormType extends AbstractType
             ->add('vatPercent', NumberType::class, [
                 'input' => 'string',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
+                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
                 ],
             ])
             ->add('quantity', IntegerType::class, [
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter quantity']),
+                    new Constraints\NotBlank(message: 'Please enter quantity'),
                     new Constraints\GreaterThan(
-                        ['value' => 0, 'message' => 'Quantity must be greater than {{ compared_value }}'],
+                        value: 0,
+                        message: 'Quantity must be greater than {{ compared_value }}',
                     ),
                 ],
             ])
             ->add('unitName', TextType::class, [
                 'constraints' => [
-                    new Constraints\Length(['max' => 10]),
+                    new Constraints\Length(max: 10),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Order/OrderPaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderPaymentFormType.php
@@ -37,22 +37,22 @@ final class OrderPaymentFormType extends AbstractType
             ->add('unitPriceWithVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter unit price with VAT']),
+                    new Constraints\NotBlank(message: 'Please enter unit price with VAT'),
                 ],
             ])
             ->add('vatPercent', NumberType::class, [
                 'input' => 'string',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter unit price without VAT']),
+                    new Constraints\NotBlank(message: 'Please enter unit price without VAT'),
                 ],
             ])
             ->add('unitPriceWithoutVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter price',
-                        'groups' => [OrderItemFormType::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter price',
+                        groups: [OrderItemFormType::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
+                    ),
                 ],
             ])
             ->add(

--- a/packages/framework/src/Form/Admin/Order/OrderTransportFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderTransportFormType.php
@@ -37,22 +37,22 @@ final class OrderTransportFormType extends AbstractType
             ->add('unitPriceWithVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter unit price without VAT']),
+                    new Constraints\NotBlank(message: 'Please enter unit price without VAT'),
                 ],
             ])
             ->add('vatPercent', NumberType::class, [
                 'input' => 'string',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
+                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
                 ],
             ])
             ->add('unitPriceWithoutVat', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter price',
-                        'groups' => [OrderItemFormType::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter price',
+                        groups: [OrderItemFormType::VALIDATION_GROUP_NOT_USING_PRICE_CALCULATION],
+                    ),
                 ],
             ])
             ->add(

--- a/packages/framework/src/Form/Admin/Order/OrderWithdrawalFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderWithdrawalFormType.php
@@ -31,59 +31,59 @@ final class OrderWithdrawalFormType extends AbstractType
                 'label' => 'First name',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter first name',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter first name',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'First name cannot be longer than {{ limit }} characters',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
                 ],
             ])
             ->add('lastName', TextType::class, [
                 'label' => 'Last name',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter last name',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter last name',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Last name cannot be longer than {{ limit }} characters',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
                 ],
             ])
             ->add('email', EmailType::class, [
                 'label' => 'Email',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please enter email',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
-                    new Email([
-                        'message' => 'Please enter valid email',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
-                    new Constraints\Length([
-                        'max' => 255,
-                        'maxMessage' => 'Email cannot be longer than {{ limit }} characters',
-                        'groups' => [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please enter email',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
+                    new Email(
+                        message: 'Please enter valid email',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
+                    new Constraints\Length(
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
+                        groups: [self::VALIDATION_GROUP_WITHDRAWAL_REQUIRED],
+                    ),
                 ],
             ])
             ->add('telephone', TextType::class, [
                 'label' => 'Phone',
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Phone number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Phone number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('note', TextareaType::class, [

--- a/packages/framework/src/Form/Admin/Order/Status/OrderStatusFormType.php
+++ b/packages/framework/src/Form/Admin/Order/Status/OrderStatusFormType.php
@@ -25,9 +25,10 @@ final class OrderStatusFormType extends AbstractType
             ->add('name', LocalizedType::class, [
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter order status name in all languages']),
+                        new Constraints\NotBlank(message: 'Please enter order status name in all languages'),
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Status name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Status name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -85,7 +85,8 @@ final class PaymentFormType extends AbstractType
                     'required' => false,
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -212,13 +213,13 @@ final class PaymentFormType extends AbstractType
                 'label' => 'Upload image',
                 'image_entity_class' => Payment::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'entity' => $payment,
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
@@ -278,8 +279,8 @@ final class PaymentFormType extends AbstractType
                 'data_class' => PaymentData::class,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Callback([$this, 'validateGopayPaymentMethod']),
-                    new Callback([$this, 'validateBankTransferType']),
+                    new Callback(callback: [$this, 'validateGopayPaymentMethod']),
+                    new Callback(callback: [$this, 'validateBankTransferType']),
                 ],
             ]);
     }
@@ -317,10 +318,10 @@ final class PaymentFormType extends AbstractType
                     ->atPath('accountNumberByDomainId[' . $domainId . ']')
                     ->validate(
                         $accountNumber,
-                        new Constraints\Length([
-                            'max' => 50,
-                            'maxMessage' => 'Account number cannot be longer than {{ limit }} characters.',
-                        ]),
+                        new Constraints\Length(
+                            max: 50,
+                            maxMessage: 'Account number cannot be longer than {{ limit }} characters.',
+                        ),
                     );
             }
 
@@ -340,15 +341,13 @@ final class PaymentFormType extends AbstractType
                 $context->getValidator()
                     ->inContext($context)
                     ->atPath('ibanByDomainId[' . $domainId . ']')
-                    ->validate($iban, new Constraints\Iban([
-                        'message' => 'Please enter a valid IBAN.',
-                    ]))
+                    ->validate($iban, new Constraints\Iban(message: 'Please enter a valid IBAN.'))
                     ->validate(
                         $iban,
-                        new Constraints\Length([
-                            'max' => 50,
-                            'maxMessage' => 'IBAN cannot be longer than {{ limit }} characters',
-                        ]),
+                        new Constraints\Length(
+                            max: 50,
+                            maxMessage: 'IBAN cannot be longer than {{ limit }} characters',
+                        ),
                     );
             }
 
@@ -370,10 +369,10 @@ final class PaymentFormType extends AbstractType
                     ->atPath('bicSwiftByDomainId[' . $domainId . ']')
                     ->validate(
                         $bicSwift,
-                        new Constraints\Length([
-                            'max' => 50,
-                            'maxMessage' => 'BIC/Swift cannot be longer than {{ limit }} characters.',
-                        ]),
+                        new Constraints\Length(
+                            max: 50,
+                            maxMessage: 'BIC/Swift cannot be longer than {{ limit }} characters.',
+                        ),
                     );
             }
         }

--- a/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionType.php
+++ b/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionType.php
@@ -61,9 +61,9 @@ final class PaymentTransactionType extends AbstractType
                 'novalidate' => 'novalidate',
             ],
             'constraints' => [
-                new Constraints\Callback([
-                    'callback' => [$this, 'maximalRefundAmountValidation'],
-                ]),
+                new Constraints\Callback(
+                    callback: [$this, 'maximalRefundAmountValidation'],
+                ),
             ],
         ]);
     }

--- a/packages/framework/src/Form/Admin/PriceList/ImportPriceListFormType.php
+++ b/packages/framework/src/Form/Admin/PriceList/ImportPriceListFormType.php
@@ -73,11 +73,11 @@ final class ImportPriceListFormType extends AbstractType
                 'label' => 'Name',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter product list name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Product list name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter product list name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Product list name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'attr' => [
                     'class' => 'js-import-price-list-name',
@@ -87,7 +87,7 @@ final class ImportPriceListFormType extends AbstractType
                 'label' => 'Valid from',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter valid from date']),
+                    new Constraints\NotBlank(message: 'Please enter valid from date'),
                 ],
                 'attr' => [
                     'class' => 'js-import-price-list-valid-from',
@@ -97,7 +97,7 @@ final class ImportPriceListFormType extends AbstractType
                 'label' => 'Valid to',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter valid to date']),
+                    new Constraints\NotBlank(message: 'Please enter valid to date'),
                 ],
                 'attr' => [
                     'class' => 'js-import-price-list-valid-to',
@@ -106,18 +106,18 @@ final class ImportPriceListFormType extends AbstractType
             ->add('csvFile', BasicFileUploadType::class, [
                 'required' => true,
                 'constraints' => [
-                    new MustUploadFile(['message' => 'Please upload a CSV file']),
+                    new MustUploadFile(message: 'Please upload a CSV file'),
                 ],
                 'info_text' => t('CSV file must be in UTF-8 encoding with columns "{{ columns }}". A comma is recommended as a column delimiter and a dot (.) as a decimal separator.', [
                     '{{ columns }}' => implode('", "', $this->priceListCsvColumnsEnum->getAllCases()),
                 ]),
                 'file_constraints' => [
-                    new Constraints\File([
-                        'maxSize' => '2M',
-                        'extensions' => ['csv' => ['text/csv', 'text/plain']],
-                        'maxSizeMessage' => 'Uploaded file is too large ({{ size }} {{ suffix }}). '
+                    new Constraints\File(
+                        maxSize: '2M',
+                        extensions: ['csv' => ['text/csv', 'text/plain']],
+                        maxSizeMessage: 'Uploaded file is too large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'label' => 'CSV file',
             ]);
@@ -138,7 +138,7 @@ final class ImportPriceListFormType extends AbstractType
             ->setDefaults([
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Constraints\Callback([$this, 'checkDateValidity']),
+                    new Constraints\Callback(callback: [$this, 'checkDateValidity']),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/PriceList/PriceListFormType.php
+++ b/packages/framework/src/Form/Admin/PriceList/PriceListFormType.php
@@ -61,25 +61,25 @@ final class PriceListFormType extends AbstractType
             ->add('name', TextType::class, [
                 'label' => 'Name',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter product list name']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Product list name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter product list name'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Product list name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('validFrom', DateTimeType::class, [
                 'label' => 'Valid from',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter valid from date']),
+                    new Constraints\NotBlank(message: 'Please enter valid from date'),
                 ],
             ])
             ->add('validTo', DateTimeType::class, [
                 'label' => 'Valid to',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter valid to date']),
+                    new Constraints\NotBlank(message: 'Please enter valid to date'),
                 ],
             ])
             ->add('priceListProductPricesData', PriceListProductsPickerType::class, [
@@ -106,7 +106,7 @@ final class PriceListFormType extends AbstractType
                 'data_class' => PriceListData::class,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Constraints\Callback([$this, 'checkDateValidity']),
+                    new Constraints\Callback(callback: [$this, 'checkDateValidity']),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/PriceList/PriceListProductPickerType.php
+++ b/packages/framework/src/Form/Admin/PriceList/PriceListProductPickerType.php
@@ -40,8 +40,8 @@ final class PriceListProductPickerType extends AbstractType
             'required' => true,
             'invalid_message' => 'Please enter price in correct format (positive number with decimal separator)',
             'constraints' => [
-                new Constraints\NotBlank(['message' => 'Please enter price']),
-                new PositiveMoneyAmount(['message' => 'Price must be greater to zero']),
+                new Constraints\NotBlank(message: 'Please enter price'),
+                new PositiveMoneyAmount(message: 'Price must be greater to zero'),
             ],
         ]);
 

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -46,20 +46,21 @@ final class CurrencyFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
                     new Constraints\Length(
-                        ['max' => 50, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                        max: 50,
+                        maxMessage: 'Name cannot be longer than {{ limit }} characters',
                     ),
                 ],
             ])
             ->add('code', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter currency code']),
-                    new Constraints\Choice([
-                        'choices' => $possibleCurrencyCodes,
-                        'message' => 'Please enter valid 3-digit currency code according to ISO 4217 standard (uppercase)',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter currency code'),
+                    new Constraints\Choice(
+                        choices: $possibleCurrencyCodes,
+                        message: 'Please enter valid 3-digit currency code according to ISO 4217 standard (uppercase)',
+                    ),
                 ],
             ])
             ->add('exchangeRate', NumberType::class, [
@@ -69,14 +70,14 @@ final class CurrencyFormType extends AbstractType
                     'readonly' => $options['is_default_currency'],
                 ],
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter currency exchange rate']),
+                    new Constraints\NotBlank(message: 'Please enter currency exchange rate'),
                     new Constraints\GreaterThan(0),
                 ],
             ])
             ->add('minFractionDigits', NumberType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter currency minimum fraction digits']),
+                    new Constraints\NotBlank(message: 'Please enter currency minimum fraction digits'),
                     new Constraints\GreaterThanOrEqual(0),
                     new Constraints\LessThanOrEqual(CurrencyFormatterFactory::MAXIMUM_FRACTION_DIGITS),
                 ],
@@ -93,7 +94,7 @@ final class CurrencyFormType extends AbstractType
             ->add('roundingPlacesPriceWithoutVat', NumberType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter number of rounding places for price without VAT']),
+                    new Constraints\NotBlank(message: 'Please enter number of rounding places for price without VAT'),
                     new Constraints\GreaterThanOrEqual(0),
                     new Constraints\LessThanOrEqual(Currency::MAX_ROUNDING_PLACES_PRICE_WITHOUT_VAT),
                 ],

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencySettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencySettingsFormType.php
@@ -37,7 +37,7 @@ final class CurrencySettingsFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter default currency']),
+                    new Constraints\NotBlank(message: 'Please enter default currency'),
                 ],
             ])
             ->add('domainDefaultCurrencies', CollectionType::class, [
@@ -49,7 +49,7 @@ final class CurrencySettingsFormType extends AbstractType
                     'choice_label' => 'name',
                     'choice_value' => 'id',
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter default currency']),
+                        new Constraints\NotBlank(message: 'Please enter default currency'),
                     ],
                 ],
             ])

--- a/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupFormType.php
@@ -25,7 +25,7 @@ final class PricingGroupFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter pricing group name']),
+                    new Constraints\NotBlank(message: 'Please enter pricing group name'),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Group/PricingGroupSettingsFormType.php
@@ -38,7 +38,7 @@ final class PricingGroupSettingsFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter default pricing group']),
+                    new Constraints\NotBlank(message: 'Please enter default pricing group'),
                 ],
             ])
             ->add('save', SubmitType::class, [

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -89,9 +89,10 @@ final class BrandFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
                     new Constraints\Length(
-                        ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                        max: 255,
+                        maxMessage: 'Name cannot be longer than {{ limit }} characters',
                     ),
                 ],
                 'label' => 'Name',
@@ -141,13 +142,13 @@ final class BrandFormType extends AbstractType
                 'required' => false,
                 'image_entity_class' => Brand::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        maxSize: '2M',
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                    ),
                 ],
                 'entity' => $brand,
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),

--- a/packages/framework/src/Form/Admin/Product/Flag/FlagFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Flag/FlagFormType.php
@@ -33,9 +33,10 @@ final class FlagFormType extends AbstractType
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter flag name in all languages']),
+                        new Constraints\NotBlank(message: 'Please enter flag name in all languages'),
                         new Constraints\Length(
-                            ['max' => 100, 'maxMessage' => 'Flag name cannot be longer than {{ limit }} characters'],
+                            max: 100,
+                            maxMessage: 'Flag name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -49,7 +50,7 @@ final class FlagFormType extends AbstractType
             ->add('rgbColor', ColorPickerType::class, [
                 'label' => 'Color',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter flag color']),
+                    new Constraints\NotBlank(message: 'Please enter flag color'),
                 ],
             ])
             ->add('visible', YesNoType::class, [

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
@@ -51,9 +51,10 @@ final class ParameterFormType extends AbstractType
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter parameter name']),
+                        new Constraints\NotBlank(message: 'Please enter parameter name'),
                         new Constraints\Length(
-                            ['max' => 100, 'maxMessage' => 'Parameter name cannot be longer than {{ limit }} characters'],
+                            max: 100,
+                            maxMessage: 'Parameter name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -75,7 +76,7 @@ final class ParameterFormType extends AbstractType
                 'label' => 'Ordering priority',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter parameter ordering priority']),
+                    new Constraints\NotBlank(message: 'Please enter parameter ordering priority'),
                 ],
                 'help' => t(
                     'This is used for ordering of parameters on product detail and ordering of parameters on search page when using Luigi\'s Box. For ordering of parameters in filter use settings in the category.',
@@ -106,7 +107,7 @@ final class ParameterFormType extends AbstractType
                 'data_class' => ParameterData::class,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Constraints\Callback([$this, 'validateUniqueParameterName']),
+                    new Constraints\Callback(callback: [$this, 'validateUniqueParameterName']),
                 ],
             ])
             ->setRequired(['parameter'])

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
@@ -43,9 +43,10 @@ final class ParameterGroupFormType extends AbstractType
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter parameter group name']),
+                        new Constraints\NotBlank(message: 'Please enter parameter group name'),
                         new Constraints\Length(
-                            ['max' => 100, 'maxMessage' => 'Parameter group name cannot be longer than {{ limit }} characters'],
+                            max: 100,
+                            maxMessage: 'Parameter group name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -67,7 +68,7 @@ final class ParameterGroupFormType extends AbstractType
                 'data_class' => ParameterGroupData::class,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Constraints\Callback([$this, 'validateUniqueParameterGroupName']),
+                    new Constraints\Callback(callback: [$this, 'validateUniqueParameterGroupName']),
                 ],
             ])
             ->setRequired(['parameterGroup'])

--- a/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
@@ -49,7 +49,7 @@ final class ProductParameterValueFormType extends AbstractType
                 },
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose parameter']),
+                    new Constraints\NotBlank(message: 'Please choose parameter'),
                 ],
                 'group_by' => function (Parameter $parameter) {
                     return $this->getGroupName($parameter);
@@ -58,18 +58,19 @@ final class ProductParameterValueFormType extends AbstractType
             ->add('valueTextsByLocale', LocalizedType::class, [
                 'required' => true,
                 'main_constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter parameter value']),
+                    new Constraints\NotBlank(message: 'Please enter parameter value'),
                 ],
                 'entry_options' => [
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Parameter value cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Parameter value cannot be longer than {{ limit }} characters',
                         ),
-                        new Constraints\Type([
-                            'type' => 'numeric',
-                            'message' => 'Parameter value must be numeric',
-                            'groups' => [static::VALIDATION_GROUP_TYPE_SLIDER],
-                        ]),
+                        new Constraints\Type(
+                            type: 'numeric',
+                            message: 'Parameter value must be numeric',
+                            groups: [static::VALIDATION_GROUP_TYPE_SLIDER],
+                        ),
                     ],
                 ],
             ]);

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueConversionFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueConversionFormType.php
@@ -38,16 +38,17 @@ final class ParameterValueConversionFormType extends AbstractType
     {
         $constraints = [
             new Constraints\Length(
-                ['max' => 255, 'maxMessage' => 'Parameter value cannot be longer than {{ limit }} characters'],
+                max: 255,
+                maxMessage: 'Parameter value cannot be longer than {{ limit }} characters',
             ),
-            new Constraints\NotBlank(['message' => 'Please enter parameter value']),
+            new Constraints\NotBlank(message: 'Please enter parameter value'),
         ];
 
         if (isset($options['type'])) {
-            $constraints[] = new Constraints\Type([
-                'type' => $options['type'],
-                'message' => 'Parameter value must be of type {{ type }}',
-            ]);
+            $constraints[] = new Constraints\Type(
+                type: $options['type'],
+                message: 'Parameter value must be of type {{ type }}',
+            );
         }
 
         $builder

--- a/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/Value/ParameterValueFormType.php
@@ -32,18 +32,18 @@ final class ParameterValueFormType extends AbstractType
             'info_text' => t('The icon takes precedence over the RGB color value. You can upload a PNG, JPG, GIF, or SVG file.'),
             'required' => false,
             'file_constraints' => [
-                new Constraints\File([
-                    'maxSize' => '2M',
-                    'maxSizeMessage' => 'Uploaded file is too large ({{ size }} {{ suffix }}). '
+                new Constraints\File(
+                    maxSize: '2M',
+                    maxSizeMessage: 'Uploaded file is too large ({{ size }} {{ suffix }}). '
                         . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
-                    'extensions' => [
+                    extensions: [
                         'png' => 'image/png',
                         'jpg' => 'image/jpeg',
                         'jpeg' => 'image/jpeg',
                         'gif' => 'image/gif',
                         'svg' => 'image/svg+xml',
                     ],
-                ]),
+                ),
             ],
             'entity' => $options['entity'],
             'file_entity_class' => ParameterValue::class,

--- a/packages/framework/src/Form/Admin/Product/Price/PricesByPricingGroupsType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/PricesByPricingGroupsType.php
@@ -40,7 +40,7 @@ final class PricesByPricingGroupsType extends AbstractType
                 'required' => false,
                 'invalid_message' => 'Please enter price in correct format (positive number with decimal separator)',
                 'constraints' => [
-                    new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+                    new NotNegativeMoneyAmount(message: 'Price must be greater or equal to zero'),
                 ],
                 'label' => $pricingGroup->getName(),
             ]);

--- a/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
@@ -42,7 +42,7 @@ final class ProductPricesWithVatSelectType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
+                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
                 ],
                 'label' => 'VAT',
             ])

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -113,7 +113,7 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\Length(['max' => 255, 'maxMessage' => 'Product prefix name cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(max: 255, maxMessage: 'Product prefix name cannot be longer than {{ limit }} characters'),
                     ],
                 ],
                 'label' => 'Name prefix',
@@ -124,7 +124,8 @@ final class ProductFormType extends AbstractType
                 'entry_options' => [
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Product name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Product name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -135,7 +136,7 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\Length(['max' => 255, 'maxMessage' => 'Product suffix name cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(max: 255, maxMessage: 'Product suffix name cannot be longer than {{ limit }} characters'),
                     ],
                 ],
                 'label' => 'Name suffix',
@@ -222,8 +223,8 @@ final class ProductFormType extends AbstractType
             'required' => true,
             'constraints' => [
                 new Constraints\NotBlank(),
-                new Constraints\Length(['max' => 100, 'maxMessage' => 'Catalog number cannot be longer than {{ limit }} characters']),
-                new UniqueProductCatnum(['product' => $product]),
+                new Constraints\Length(max: 100, maxMessage: 'Catalog number cannot be longer than {{ limit }} characters'),
+                new UniqueProductCatnum(product: $product),
             ],
             'disabled' => $this->isProductMainVariant($product),
             'attr' => [
@@ -237,7 +238,8 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length(
-                        ['max' => 100, 'maxMessage' => 'Part number cannot be longer than {{ limit }} characters'],
+                        max: 100,
+                        maxMessage: 'Part number cannot be longer than {{ limit }} characters',
                     ),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
@@ -248,7 +250,8 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length(
-                        ['max' => 100, 'maxMessage' => 'EAN cannot be longer than {{ limit }} characters'],
+                        max: 100,
+                        maxMessage: 'EAN cannot be longer than {{ limit }} characters',
                     ),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
@@ -463,9 +466,9 @@ final class ProductFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank([
-                        'message' => 'Please choose unit',
-                    ]),
+                    new Constraints\NotBlank(
+                        message: 'Please choose unit',
+                    ),
                 ],
                 'label' => 'Unit',
             ]);
@@ -719,7 +722,8 @@ final class ProductFormType extends AbstractType
                 'entry_options' => [
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Variant alias cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Variant alias cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -787,9 +791,9 @@ final class ProductFormType extends AbstractType
                 'allow_delete' => true,
                 'entry_type' => ProductParameterValueFormType::class,
                 'constraints' => [
-                    new UniqueProductParameters([
-                        'message' => 'Parameter {{ parameterName }} is used more than once',
-                    ]),
+                    new UniqueProductParameters(
+                        message: 'Parameter {{ parameterName }} is used more than once',
+                    ),
                 ],
                 'error_bubbling' => false,
                 'label' => false,
@@ -814,13 +818,13 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'image_entity_class' => Product::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        maxSize: '2M',
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                    ),
                 ],
                 'entity' => $options['product'],
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
@@ -927,11 +931,11 @@ final class ProductFormType extends AbstractType
                 'required' => false,
                 'file_entity_class' => Product::class,
                 'file_constraints' => [
-                    new Constraints\File([
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded file is too large ({{ size }} {{ suffix }}). '
+                    new Constraints\File(
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded file is too large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'entity' => $options['product'],
                 'label' => 'Files',

--- a/packages/framework/src/Form/Admin/Product/ProductPromotionXyType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductPromotionXyType.php
@@ -32,7 +32,8 @@ final class ProductPromotionXyType extends AbstractType
                         ],
                     ),
                     new Constraints\GreaterThan(
-                        ['value' => 0, 'message' => 'Quantity must be greater than {{ compared_value }}'],
+                        value: 0,
+                        message: 'Quantity must be greater than {{ compared_value }}',
                     ),
                 ],
             ])
@@ -46,7 +47,8 @@ final class ProductPromotionXyType extends AbstractType
                         ],
                     ),
                     new Constraints\GreaterThan(
-                        ['value' => 0, 'message' => 'Quantity must be greater than {{ compared_value }}'],
+                        value: 0,
+                        message: 'Quantity must be greater than {{ compared_value }}',
                     ),
                 ],
             ]);

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitFormType.php
@@ -27,9 +27,10 @@ final class UnitFormType extends AbstractType
                 'required' => true,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter unit name in all languages']),
+                        new Constraints\NotBlank(message: 'Please enter unit name in all languages'),
                         new Constraints\Length(
-                            ['max' => 10, 'maxMessage' => 'Unit name cannot be longer than {{ limit }} characters'],
+                            max: 10,
+                            maxMessage: 'Unit name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],

--- a/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Unit/UnitSettingFormType.php
@@ -39,7 +39,7 @@ final class UnitSettingFormType extends AbstractType
                 'choice_value' => 'id',
                 'help' => t('Default unit will be used when creating new product'),
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose default unit']),
+                    new Constraints\NotBlank(message: 'Please choose default unit'),
                 ],
             ])
             ->add('save', SubmitType::class, [

--- a/packages/framework/src/Form/Admin/Product/VideoTokenType.php
+++ b/packages/framework/src/Form/Admin/Product/VideoTokenType.php
@@ -25,9 +25,9 @@ final class VideoTokenType extends AbstractType
         $builder->add('videoToken', TextType::class, [
             'required' => true,
             'constraints' => [
-                new Constraints\NotBlank([
-                    'message' => 'Please enter video ID',
-                ]),
+                new Constraints\NotBlank(
+                    message: 'Please enter video ID',
+                ),
             ],
             'label' => 'Youtube ID',
         ]);
@@ -38,7 +38,8 @@ final class VideoTokenType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Constraints\Length(
-                        ['max' => 245, 'maxMessage' => 'Description cannot be longer than {{ limit }} characters'],
+                        max: 245,
+                        maxMessage: 'Description cannot be longer than {{ limit }} characters',
                     ),
                 ],
             ],

--- a/packages/framework/src/Form/Admin/PromoCode/Constraint/UniqueFlags.php
+++ b/packages/framework/src/Form/Admin/PromoCode/Constraint/UniqueFlags.php
@@ -4,9 +4,42 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Admin\PromoCode\Constraint;
 
+use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueFlags extends Constraint
 {
-    public string $message = 'Flag "{{ flagName }}" is selected multiple times.';
+    /**
+     * @param array<string, mixed>|null $options
+     * @param string $message
+     * @param array<string>|null $groups
+     * @param mixed $payload
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?array $options = null,
+        public string $message = 'Flag "{{ flagName }}" is selected multiple times.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagType.php
@@ -38,9 +38,7 @@ final class PromoCodeFlagType extends AbstractType
             'choice_label' => 'name',
             'choice_value' => 'id',
             'constraints' => [
-                new NotBlank([
-                    'message' => 'Please choose flag',
-                ]),
+                new NotBlank(message: 'Please choose flag'),
             ],
         ]);
 
@@ -53,9 +51,7 @@ final class PromoCodeFlagType extends AbstractType
             'expanded' => true,
             'multiple' => false,
             'constraints' => [
-                new NotBlank([
-                    'message' => 'Please choose type of limitation',
-                ]),
+                new NotBlank(message: 'Please choose type of limitation'),
             ],
         ]);
 

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
@@ -115,9 +115,7 @@ final class PromoCodeFormType extends AbstractType
                     'label' => 'Promo code',
                     'required' => true,
                     'constraints' => [
-                        new Constraints\NotBlank([
-                            'message' => 'Please enter promo code',
-                        ]),
+                        new Constraints\NotBlank(message: 'Please enter promo code'),
                     ],
                 ]);
         }
@@ -168,15 +166,15 @@ final class PromoCodeFormType extends AbstractType
         $discountOptions = [
             'required' => true,
             'constraints' => [
-                new Constraints\NotBlank([
-                    'message' => 'Please enter discount percentage',
-                    'groups' => [self::VALIDATION_GROUP_TYPE_PERCENT, self::VALIDATION_GROUP_TYPE_NOMINAL],
-                ]),
-                new Constraints\Range([
-                    'min' => 0,
-                    'max' => 100,
-                    'groups' => [self::VALIDATION_GROUP_TYPE_PERCENT, self::VALIDATION_GROUP_TYPE_NOMINAL],
-                ]),
+                new Constraints\NotBlank(
+                    message: 'Please enter discount percentage',
+                    groups: [self::VALIDATION_GROUP_TYPE_PERCENT, self::VALIDATION_GROUP_TYPE_NOMINAL],
+                ),
+                new Constraints\Range(
+                    min: 0,
+                    max: 100,
+                    groups: [self::VALIDATION_GROUP_TYPE_PERCENT, self::VALIDATION_GROUP_TYPE_NOMINAL],
+                ),
             ],
             'invalid_message' => 'Please enter number.',
             'label' => 'Discount (%)',
@@ -199,11 +197,11 @@ final class PromoCodeFormType extends AbstractType
                 'allow_delete' => true,
                 'error_bubbling' => false,
                 'constraints' => [
-                    new Constraints\Count([
-                        'min' => 1,
-                        'minMessage' => 'Please enter at least one discount limit',
-                        'groups' => [self::VALIDATION_GROUP_TYPE_PERCENT, self::VALIDATION_GROUP_TYPE_NOMINAL],
-                    ]),
+                    new Constraints\Count(
+                        min: 1,
+                        minMessage: 'Please enter at least one discount limit',
+                        groups: [self::VALIDATION_GROUP_TYPE_PERCENT, self::VALIDATION_GROUP_TYPE_NOMINAL],
+                    ),
                 ],
             ]),
         );
@@ -345,12 +343,8 @@ final class PromoCodeFormType extends AbstractType
                 'label' => 'Number of generated promo codes',
                 'required' => true,
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter the quantity.',
-                    ]),
-                    new Positive([
-                        'message' => 'Please enter the positive value.',
-                    ]),
+                    new NotBlank(message: 'Please enter the quantity.'),
+                    new Positive(message: 'Please enter the positive value.'),
                 ],
                 'invalid_message' => 'Please enter the whole number.',
             ]);
@@ -372,7 +366,7 @@ final class PromoCodeFormType extends AbstractType
                 'mass_generate' => false,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Constraints\Callback([$this, 'validateUniquePromoCodeByDomain']),
+                    new Constraints\Callback(callback: [$this, 'validateUniquePromoCodeByDomain']),
                 ],
                 'validation_groups' => static function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeLimitType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeLimitType.php
@@ -40,10 +40,10 @@ final class PromoCodeLimitType extends AbstractType
     {
         $builder->add('fromPrice', NumberType::class, [
             'constraints' => [
-                new Constraints\NotBlank([
-                    'message' => 'Please enter limit from',
-                    'groups' => [PromoCodeFormType::VALIDATION_GROUP_TYPE_PERCENT, PromoCodeFormType::VALIDATION_GROUP_TYPE_NOMINAL],
-                ]),
+                new Constraints\NotBlank(
+                    message: 'Please enter limit from',
+                    groups: [PromoCodeFormType::VALIDATION_GROUP_TYPE_PERCENT, PromoCodeFormType::VALIDATION_GROUP_TYPE_NOMINAL],
+                ),
             ],
             'scale' => 6,
         ]);
@@ -54,18 +54,18 @@ final class PromoCodeLimitType extends AbstractType
             $constraint->groups = [PromoCodeFormType::VALIDATION_GROUP_TYPE_PERCENT];
         }
 
-        $options['constraints'][] = new Constraints\NotBlank([
-            'groups' => [PromoCodeFormType::VALIDATION_GROUP_TYPE_NOMINAL],
-        ]);
-        $options['constraints'][] = new Constraints\GreaterThanOrEqual([
-            'groups' => [PromoCodeFormType::VALIDATION_GROUP_TYPE_NOMINAL],
-            'value' => 1,
-        ]);
-        $options['constraints'][] = new Constraints\Regex([
-            'groups' => PromoCodeFormType::VALIDATION_GROUP_TYPE_PERCENT,
-            'pattern' => '/^\d+$/',
-            'message' => 'Please enter a whole number.',
-        ]);
+        $options['constraints'][] = new Constraints\NotBlank(
+            groups: [PromoCodeFormType::VALIDATION_GROUP_TYPE_NOMINAL],
+        );
+        $options['constraints'][] = new Constraints\GreaterThanOrEqual(
+            value: 1,
+            groups: [PromoCodeFormType::VALIDATION_GROUP_TYPE_NOMINAL],
+        );
+        $options['constraints'][] = new Constraints\Regex(
+            pattern: '/^\d+$/',
+            message: 'Please enter a whole number.',
+            groups: [PromoCodeFormType::VALIDATION_GROUP_TYPE_PERCENT],
+        );
         $options['scale'] = 6;
         $builder->add(
             'discount',

--- a/packages/framework/src/Form/Admin/SalesRepresentative/SalesRepresentativeFormType.php
+++ b/packages/framework/src/Form/Admin/SalesRepresentative/SalesRepresentativeFormType.php
@@ -53,41 +53,41 @@ final class SalesRepresentativeFormType extends AbstractType
             ->add('firstName', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'First name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'First name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'First name',
             ])
             ->add('lastName', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Last name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Last name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Last name',
             ])
             ->add('email', EmailType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 255,
-                        'maxMessage' => 'Email cannot be longer than {{ limit }} characters',
-                    ]),
-                    new Email(['message' => 'Please enter valid email']),
+                    new Constraints\Length(
+                        max: 255,
+                        maxMessage: 'Email cannot be longer than {{ limit }} characters',
+                    ),
+                    new Email(message: 'Please enter valid email'),
                 ],
                 'label' => 'Email',
             ])
             ->add('telephone', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Telephone number cannot be longer than {{ limit }} characters',
+                    ),
                 ],
                 'label' => 'Telephone',
             ]);
@@ -101,13 +101,13 @@ final class SalesRepresentativeFormType extends AbstractType
                 'required' => false,
                 'image_entity_class' => SalesRepresentative::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg'],
-                        'mimeTypesMessage' => 'Image can be only in JPG or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+                        mimeTypesMessage: 'Image can be only in JPG or PNG format',
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'label' => 'Upload image',
                 'entity' => $options['salesRepresentative'],

--- a/packages/framework/src/Form/Admin/Seo/HreflangSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/HreflangSettingFormType.php
@@ -59,11 +59,11 @@ final class HreflangSettingFormType extends AbstractType
                     'multiple' => true,
                     'expanded' => true,
                     'constraints' => [
-                        new Callback(['callback' => [$this, 'validateLanguageUniquenessInCollectionItems']]),
-                        new Count([
-                            'min' => 2,
-                            'minMessage' => 'At least two domains must be selected',
-                        ]),
+                        new Callback(callback: [$this, 'validateLanguageUniquenessInCollectionItems']),
+                        new Count(
+                            min: 2,
+                            minMessage: 'At least two domains must be selected',
+                        ),
                     ],
                 ],
                 'required' => false,
@@ -71,7 +71,7 @@ final class HreflangSettingFormType extends AbstractType
                 'error_bubbling' => false,
                 'allow_delete' => true,
                 'constraints' => [
-                    new Callback(['callback' => [$this, 'validateDomainUniqueness']]),
+                    new Callback(callback: [$this, 'validateDomainUniqueness']),
                 ],
             ])
             ->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Form/Admin/Seo/SeoPageFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoPageFormType.php
@@ -88,10 +88,10 @@ final class SeoPageFormType extends AbstractType
         foreach ($this->domain->getAll() as $domain) {
             $optionsByDomainId[$domain->getId()] = [
                 'constraints' => [
-                    new UniqueSeoPageSlug([
-                        'ignoredSeoPage' => $seoPage,
-                        'domainId' => $domain->getId(),
-                    ]),
+                    new UniqueSeoPageSlug(
+                        ignoredSeoPage: $seoPage,
+                        domainId: $domain->getId(),
+                    ),
                 ],
             ];
         }
@@ -102,7 +102,7 @@ final class SeoPageFormType extends AbstractType
                 'required' => true,
                 'disabled' => $seoPage !== null,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter page name']),
+                    new Constraints\NotBlank(message: 'Please enter page name'),
                 ],
             ])
             ->add('pageSlugsIndexedByDomainId', MultidomainType::class, [
@@ -113,11 +113,11 @@ final class SeoPageFormType extends AbstractType
                 'options_by_domain_id' => $optionsByDomainId,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter page URL']),
-                        new Constraints\Regex([
-                            'pattern' => '/^[\w_\-\/]+$/',
-                            'message' => 'Slug can contain only letters, numbers, hyphens, underscores and slashes',
-                        ]),
+                        new Constraints\NotBlank(message: 'Please enter page URL'),
+                        new Constraints\Regex(
+                            pattern: '/^[\w_\-\/]+$/',
+                            message: 'Slug can contain only letters, numbers, hyphens, underscores and slashes',
+                        ),
                     ],
                 ],
             ]);
@@ -156,7 +156,7 @@ final class SeoPageFormType extends AbstractType
                 'entry_type' => UrlType::class,
                 'entry_options' => [
                     'constraints' => [
-                        new Constraints\Url(['message' => 'Link must be valid URL address']),
+                        new Constraints\Url(message: 'Link must be valid URL address'),
                     ],
                 ],
                 'required' => false,
@@ -199,13 +199,13 @@ final class SeoPageFormType extends AbstractType
                 'image_entity_class' => SeoPage::class,
                 'image_type' => SeoPageFacade::IMAGE_TYPE_OG,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '15M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'entity' => $seoPage,
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),

--- a/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
@@ -54,20 +54,20 @@ final class SeoSettingFormType extends AbstractType
             ->add('title', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new NotInArray([
-                        'array' => array_diff($titlesOnOtherDomains, [null]),
-                        'message' => 'Same title is used on another domain',
-                    ]),
+                    new NotInArray(
+                        array: array_diff($titlesOnOtherDomains, [null]),
+                        message: 'Same title is used on another domain',
+                    ),
                 ],
                 'label' => 'Headline',
             ])
             ->add('titleAddOn', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new NotInArray([
-                        'array' => array_diff($titleAddOnsOnOtherDomains, [null]),
-                        'message' => 'Same title complement is used on another domain',
-                    ]),
+                    new NotInArray(
+                        array: array_diff($titleAddOnsOnOtherDomains, [null]),
+                        message: 'Same title complement is used on another domain',
+                    ),
                 ],
                 'label' => 'Complement to title',
                 'help' => t(
@@ -77,10 +77,10 @@ final class SeoSettingFormType extends AbstractType
             ->add('metaDescription', TextareaType::class, [
                 'required' => false,
                 'constraints' => [
-                    new NotInArray([
-                        'array' => array_diff($descriptionsOnOtherDomains, [null]),
-                        'message' => 'Same description is used on another domain',
-                    ]),
+                    new NotInArray(
+                        array: array_diff($descriptionsOnOtherDomains, [null]),
+                        message: 'Same description is used on another domain',
+                    ),
                 ],
                 'label' => 'Meta description',
             ]);

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -39,7 +39,7 @@ final class SliderItemFormType extends AbstractType
         $imageConstraints = [];
 
         if ($options['scenario'] === self::SCENARIO_CREATE) {
-            $imageConstraints[] = new Constraints\NotBlank(['message' => 'Please choose image']);
+            $imageConstraints[] = new Constraints\NotBlank(message: 'Please choose image');
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
@@ -70,7 +70,7 @@ final class SliderItemFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
                 ],
                 'label' => 'Name',
                 'help' => t('Name serves only for internal use within the administration'),
@@ -78,7 +78,7 @@ final class SliderItemFormType extends AbstractType
             ->add('link', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter link']),
+                    new Constraints\NotBlank(message: 'Please enter link'),
                 ],
                 'label' => 'Link',
             ])
@@ -89,7 +89,7 @@ final class SliderItemFormType extends AbstractType
             ->add('rgbBackgroundColor', ColorPickerType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter description box background color']),
+                    new Constraints\NotBlank(message: 'Please enter description box background color'),
                 ],
                 'label' => 'Description background color',
             ])
@@ -97,12 +97,12 @@ final class SliderItemFormType extends AbstractType
                 'required' => true,
                 'scale' => 2,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter description box opacity']),
-                    new Constraints\Range([
-                        'min' => 0,
-                        'max' => 1,
-                        'notInRangeMessage' => 'Opacity must be between {{ min }} and {{ max }}',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter description box opacity'),
+                    new Constraints\Range(
+                        min: 0,
+                        max: 1,
+                        notInRangeMessage: 'Opacity must be between {{ min }} and {{ max }}',
+                    ),
                 ],
                 'label' => 'Description opacity',
             ])
@@ -120,13 +120,13 @@ final class SliderItemFormType extends AbstractType
                 'constraints' => $imageConstraints,
                 'image_entity_class' => SliderItem::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg'],
-                        'mimeTypesMessage' => 'Image can be only in JPG or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+                        mimeTypesMessage: 'Image can be only in JPG or PNG format',
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'label' => 'Upload image',
                 'entity' => $options['slider_item'],

--- a/packages/framework/src/Form/Admin/Stock/ProductStockFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/ProductStockFormType.php
@@ -26,10 +26,10 @@ final class ProductStockFormType extends AbstractType
                 'placeholder' => '0',
             ],
             'constraints' => [
-                new Constraints\Regex([
-                    'pattern' => '/^-?\d+$/',
-                    'message' => 'Quantity must be an integer',
-                ]),
+                new Constraints\Regex(
+                    pattern: '/^-?\d+$/',
+                    message: 'Quantity must be an integer',
+                ),
             ],
         ]);
     }

--- a/packages/framework/src/Form/Admin/Stock/StockFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/StockFormType.php
@@ -60,8 +60,8 @@ final class StockFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter warehouse name']),
-                    new Constraints\Length(['max' => 255, 'maxMessage' => 'Warehouse name cannot be longer than {{ limit }} characters']),
+                    new Constraints\NotBlank(message: 'Please enter warehouse name'),
+                    new Constraints\Length(max: 255, maxMessage: 'Warehouse name cannot be longer than {{ limit }} characters'),
                 ],
                 'label' => 'Name',
             ])
@@ -73,8 +73,8 @@ final class StockFormType extends AbstractType
                 'required' => false,
                 'label' => 'External bridge ID',
                 'constraints' => [
-                    new Constraints\Length(['max' => 255, 'maxMessage' => 'External bridge ID cannot be longer than {{ limit }} characters']),
-                    new Constraints\Callback([$this, 'sameStockExternalIdValidation']),
+                    new Constraints\Length(max: 255, maxMessage: 'External bridge ID cannot be longer than {{ limit }} characters'),
+                    new Constraints\Callback(callback: [$this, 'sameStockExternalIdValidation']),
                 ],
             ])
             ->add('note', TextType::class, [

--- a/packages/framework/src/Form/Admin/Stock/StockSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Stock/StockSettingsFormType.php
@@ -45,8 +45,8 @@ final class StockSettingsFormType extends AbstractType
                 'label' => 'Days for transfer between warehouses',
                 'constraints' => [
                     new Constraints\NotBlank(),
-                    new Constraints\Regex(['pattern' => '/^\d+$/']),
-                    new Constraints\GreaterThanOrEqual(['value' => 0]),
+                    new Constraints\Regex(pattern: '/^\d+$/'),
+                    new Constraints\GreaterThanOrEqual(value: 0),
                 ],
             ]);
 
@@ -59,9 +59,9 @@ final class StockSettingsFormType extends AbstractType
                 'label' => 'Number of delivery days for out of stock products in XML feeds',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotNull([
-                        'message' => 'Please enter the number of delivery days.',
-                    ]),
+                    new Constraints\NotNull(
+                        message: 'Please enter the number of delivery days.',
+                    ),
                 ],
             ])
             ->add('feedDeliveryDaysForOutOfStockProductsInfo', MessageType::class, [

--- a/packages/framework/src/Form/Admin/Store/ClosedDayFormType.php
+++ b/packages/framework/src/Form/Admin/Store/ClosedDayFormType.php
@@ -46,7 +46,7 @@ final class ClosedDayFormType extends AbstractType
                 'label' => 'Date',
                 'widget' => 'single_text',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter date']),
+                    new Constraints\NotBlank(message: 'Please enter date'),
                 ],
                 'view_timezone' => null,
             ])
@@ -54,8 +54,8 @@ final class ClosedDayFormType extends AbstractType
                 'required' => true,
                 'label' => 'Name',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
-                    new Constraints\Length(['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
+                    new Constraints\Length(max: 255, maxMessage: 'Name cannot be longer than {{ limit }} characters'),
                 ],
             ])
             ->add('excludedStores', ChoiceType::class, [

--- a/packages/framework/src/Form/Admin/Store/OpeningHours/OpeningHoursRangeFormType.php
+++ b/packages/framework/src/Form/Admin/Store/OpeningHours/OpeningHoursRangeFormType.php
@@ -33,7 +33,7 @@ final class OpeningHoursRangeFormType extends AbstractType
             'widget' => 'single_text',
             'label' => false,
             'constraints' => [
-                new Constraints\NotBlank(['message' => 'Please enter time']),
+                new Constraints\NotBlank(message: 'Please enter time'),
             ],
         ];
 

--- a/packages/framework/src/Form/Admin/Store/StoreFormType.php
+++ b/packages/framework/src/Form/Admin/Store/StoreFormType.php
@@ -106,9 +106,10 @@ final class StoreFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter name']),
+                    new Constraints\NotBlank(message: 'Please enter name'),
                     new Constraints\Length(
-                        ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                        max: 255,
+                        maxMessage: 'Name cannot be longer than {{ limit }} characters',
                     ),
                 ],
                 'label' => 'Name',
@@ -122,9 +123,10 @@ final class StoreFormType extends AbstractType
                 'required' => false,
                 'constraints' => [
                     new Constraints\Length(
-                        ['max' => 255, 'maxMessage' => 'External ID cannot be longer than {{ limit }} characters'],
+                        max: 255,
+                        maxMessage: 'External ID cannot be longer than {{ limit }} characters',
                     ),
-                    new Constraints\Callback([$this, 'sameStoreExternalIdValidation']),
+                    new Constraints\Callback(callback: [$this, 'sameStoreExternalIdValidation']),
                 ],
                 'label' => 'External ID',
             ])
@@ -217,33 +219,33 @@ final class StoreFormType extends AbstractType
                 'label' => 'Street',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter street']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter street'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'Street name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('city', TextType::class, [
                 'label' => 'City',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter city']),
-                    new Constraints\Length([
-                        'max' => 100,
-                        'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter city'),
+                    new Constraints\Length(
+                        max: 100,
+                        maxMessage: 'City name cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('postcode', TextType::class, [
                 'label' => 'Postcode',
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter zip code']),
-                    new Constraints\Length([
-                        'max' => 30,
-                        'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                    ]),
+                    new Constraints\NotBlank(message: 'Please enter zip code'),
+                    new Constraints\Length(
+                        max: 30,
+                        maxMessage: 'Zip code cannot be longer than {{ limit }} characters',
+                    ),
                 ],
             ])
             ->add('country', ChoiceType::class, [
@@ -253,7 +255,7 @@ final class StoreFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please choose country']),
+                    new Constraints\NotBlank(message: 'Please choose country'),
                 ],
             ]);
 
@@ -272,7 +274,7 @@ final class StoreFormType extends AbstractType
             ->setDefaults([
                 'data_class' => StoreData::class,
                 'attr' => ['novalidate' => 'novalidate'],
-                'constraints' => new Constraints\Callback([$this, 'validateOpeningHours']),
+                'constraints' => new Constraints\Callback(callback: [$this, 'validateOpeningHours']),
             ]);
     }
 
@@ -310,13 +312,13 @@ final class StoreFormType extends AbstractType
             'required' => false,
             'image_entity_class' => Store::class,
             'file_constraints' => [
-                new Constraints\Image([
-                    'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                    'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                    'maxSize' => '2M',
-                    'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                new Constraints\Image(
+                    maxSize: '2M',
+                    mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                    maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                         . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                ]),
+                    mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                ),
             ],
             'label' => 'Upload image',
             'entity' => $options['store'],

--- a/packages/framework/src/Form/Admin/Superadmin/InputPriceTypeFormType.php
+++ b/packages/framework/src/Form/Admin/Superadmin/InputPriceTypeFormType.php
@@ -30,7 +30,7 @@ final class InputPriceTypeFormType extends AbstractType
                     t('Including VAT') => PricingSetting::PRICE_TYPE_WITH_VAT,
                 ],
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter entry price type']),
+                    new Constraints\NotBlank(message: 'Please enter entry price type'),
                 ],
             ])
             ->add('sellingPriceType', ChoiceType::class, [
@@ -40,7 +40,7 @@ final class InputPriceTypeFormType extends AbstractType
                     t('Including VAT') => PricingSetting::PRICE_TYPE_WITH_VAT,
                 ],
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter selling price type']),
+                    new Constraints\NotBlank(message: 'Please enter selling price type'),
                 ],
             ])
             ->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Form/Admin/Superadmin/MailWhitelistFormType.php
+++ b/packages/framework/src/Form/Admin/Superadmin/MailWhitelistFormType.php
@@ -62,7 +62,7 @@ final class MailWhitelistFormType extends AbstractType
                 'error_bubbling' => false,
                 'allow_delete' => true,
                 'constraints' => [
-                    new Constraints\All([
+                    new Constraints\All(constraints: [
                         new WhitelistPattern(),
                     ]),
                 ],

--- a/packages/framework/src/Form/Admin/Transport/Price/PriceWithLimitType.php
+++ b/packages/framework/src/Form/Admin/Transport/Price/PriceWithLimitType.php
@@ -38,7 +38,7 @@ final class PriceWithLimitType extends AbstractType
             ->add('price', MoneyType::class, [
                 'scale' => 6,
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter price']),
+                    new NotBlank(message: 'Please enter price'),
                 ],
                 'label' => $this->inputPriceLabelExtension->getInputPriceLabel(),
             ])

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -78,7 +78,8 @@ final class TransportFormType extends AbstractType
                     'required' => false,
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -115,12 +116,8 @@ final class TransportFormType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new NotBlank(),
-                    new Constraints\GreaterThanOrEqual([
-                        'value' => 0,
-                    ]),
-                    new Constraints\Regex([
-                        'pattern' => '/^\d+$/',
-                    ]),
+                    new Constraints\GreaterThanOrEqual(value: 0),
+                    new Constraints\Regex(pattern: '/^\d+$/'),
                 ],
                 'label' => 'Days until delivery',
             ]);
@@ -176,13 +173,13 @@ final class TransportFormType extends AbstractType
                 'label' => 'Upload image',
                 'image_entity_class' => Transport::class,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
-                        'mimeTypesMessage' => 'Image can be only in JPG, GIF or PNG format',
-                        'maxSize' => '2M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],
+                        mimeTypesMessage: 'Image can be only in JPG, GIF or PNG format',
+                        maxSize: '2M',
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                    ),
                 ],
                 'entity' => $transport,
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
@@ -197,9 +194,7 @@ final class TransportFormType extends AbstractType
                 'label' => 'Tracking URL',
                 'required' => false,
                 'constraints' => [
-                    new Length([
-                        'max' => 255,
-                    ]),
+                    new Length(max: 255),
                 ],
             ])
             ->add('trackingUrlVariables', DisplayVariablesType::class, [
@@ -256,7 +251,7 @@ final class TransportFormType extends AbstractType
                 'data_class' => TransportData::class,
                 'attr' => ['novalidate' => 'novalidate'],
                 'constraints' => [
-                    new Constraints\Callback([$this, 'validateTransportPricesOnDomain']),
+                    new Constraints\Callback(callback: [$this, 'validateTransportPricesOnDomain']),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
+++ b/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
@@ -73,14 +73,14 @@ final class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
                 ->add(self::FIELD_PRICE_LIMIT, MoneyType::class, [
                     'required' => true,
                     'constraints' => [
-                        new NotNegativeMoneyAmount([
-                            'message' => 'Price must be greater or equal to zero',
-                            'groups' => [static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
-                        ]),
-                        new Constraints\NotBlank([
-                            'message' => 'Please enter price',
-                            'groups' => [static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
-                        ]),
+                        new NotNegativeMoneyAmount(
+                            message: 'Price must be greater or equal to zero',
+                            groups: [static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
+                        ),
+                        new Constraints\NotBlank(
+                            message: 'Please enter price',
+                            groups: [static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
+                        ),
                     ],
                     'scale' => 6,
                 ]);

--- a/packages/framework/src/Form/Admin/UploadedFile/UploadedFileFormType.php
+++ b/packages/framework/src/Form/Admin/UploadedFile/UploadedFileFormType.php
@@ -32,9 +32,10 @@ final class UploadedFileFormType extends AbstractType
             $builder->add('name', TextType::class, [
                 'label' => 'Filename',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter the filename']),
+                    new Constraints\NotBlank(message: 'Please enter the filename'),
                     new Constraints\Length(
-                        ['max' => 245, 'maxMessage' => 'File name cannot be longer than {{ limit }} characters'],
+                        max: 245,
+                        maxMessage: 'File name cannot be longer than {{ limit }} characters',
                     ),
                 ],
             ]);
@@ -47,7 +48,8 @@ final class UploadedFileFormType extends AbstractType
                     'required' => false,
                     'constraints' => [
                         new Constraints\Length(
-                            ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                            max: 255,
+                            maxMessage: 'Name cannot be longer than {{ limit }} characters',
                         ),
                     ],
                 ],
@@ -65,11 +67,11 @@ final class UploadedFileFormType extends AbstractType
             'multiple' => $isNew,
             'with_names_inputs' => $isNew,
             'file_constraints' => [
-                new Constraints\File([
-                    'maxSize' => '2M',
-                    'maxSizeMessage' => 'Uploaded file is too large ({{ size }} {{ suffix }}). '
+                new Constraints\File(
+                    maxSize: '2M',
+                    maxSizeMessage: 'Uploaded file is too large ({{ size }} {{ suffix }}). '
                         . 'Maximum size of an file is {{ limit }} {{ suffix }}.',
-                ]),
+                ),
             ],
             'label' => $isNew ? false : t('Replace file'),
         ]);

--- a/packages/framework/src/Form/Admin/Vat/VatFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatFormType.php
@@ -29,9 +29,10 @@ final class VatFormType extends AbstractType
             ->add('name', TextType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter VAT name']),
+                    new Constraints\NotBlank(message: 'Please enter VAT name'),
                     new Constraints\Length(
-                        ['max' => 50, 'maxMessage' => 'VAT name cannot be longer than {{ limit }} characters'],
+                        max: 50,
+                        maxMessage: 'VAT name cannot be longer than {{ limit }} characters',
                     ),
                 ],
             ])
@@ -44,7 +45,7 @@ final class VatFormType extends AbstractType
                 ],
                 'invalid_message' => 'Please enter VAT in correct format.',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
+                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
@@ -40,7 +40,7 @@ final class VatSettingsFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter default VAT']),
+                    new Constraints\NotBlank(message: 'Please enter default VAT'),
                 ],
                 'label' => 'Default VAT rate',
             ])

--- a/packages/framework/src/Form/ColorPickerType.php
+++ b/packages/framework/src/Form/ColorPickerType.php
@@ -29,10 +29,10 @@ final class ColorPickerType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $mandatoryConstraints = [
-            new Regex([
-                'pattern' => '/^#[a-fA-F0-9]{6}$/',
-                'message' => 'Color must be a valid hexadecimal code (e.g., #3333ff)',
-            ]),
+            new Regex(
+                pattern: '/^#[a-fA-F0-9]{6}$/',
+                message: 'Color must be a valid hexadecimal code (e.g., #3333ff)',
+            ),
         ];
 
         $resolver->setNormalizer(

--- a/packages/framework/src/Form/Constraints/Contains.php
+++ b/packages/framework/src/Form/Constraints/Contains.php
@@ -5,23 +5,43 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class Contains extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $needle
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public string $needle,
+        ?array $options = null,
+        public string $needle = '',
         public string $message = 'Field must contain {{ needle }}.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
+
+        if ($this->needle === '') {
+            throw new MissingOptionsException(
+                sprintf('The option "needle" must be set for constraint "%s".', static::class),
+                ['needle'],
+            );
+        }
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/Contains.php
+++ b/packages/framework/src/Form/Constraints/Contains.php
@@ -9,18 +9,27 @@ use Symfony\Component\Validator\Constraint;
 
 class Contains extends Constraint
 {
-    public string $message = 'Field must contain {{ needle }}.';
-
-    public ?string $needle = null;
+    /**
+     * @param string $needle
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $needle,
+        public string $message = 'Field must contain {{ needle }}.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getRequiredOptions(): array
+    public function getTargets(): string|array
     {
-        return [
-            'needle',
-        ];
+        return self::PROPERTY_CONSTRAINT;
     }
 }

--- a/packages/framework/src/Form/Constraints/Country.php
+++ b/packages/framework/src/Form/Constraints/Country.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class Country extends Constraint
@@ -19,18 +21,28 @@ class Country extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param int|null $domainId
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Country with code {{ country_code }} does not exists. Available country codes are {{ available_country_codes }}.',
         public ?int $domainId = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/Country.php
+++ b/packages/framework/src/Form/Constraints/Country.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class Country extends Constraint
 {
     public const string INVALID_COUNTRY_ERROR = '9080a4de-347f-48c7-a41a-b4cc46a5146d';
-
-    public string $message = 'Country with code {{ country_code }} does not exists. Available country codes are {{ available_country_codes }}.';
 
     /**
      * @var array<string, string>
@@ -19,5 +18,27 @@ class Country extends Constraint
         self::INVALID_COUNTRY_ERROR => 'INVALID_COUNTRY_ERROR',
     ];
 
-    public ?int $domainId = null;
+    /**
+     * @param string $message
+     * @param int|null $domainId
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Country with code {{ country_code }} does not exists. Available country codes are {{ available_country_codes }}.',
+        public ?int $domainId = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/Email.php
+++ b/packages/framework/src/Form/Constraints/Email.php
@@ -5,21 +5,33 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class Email extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'This value is not a valid email address.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/Email.php
+++ b/packages/framework/src/Form/Constraints/Email.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class Email extends Constraint
 {
-    public string $message = 'This value is not a valid email address.';
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'This value is not a valid email address.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/FieldsAreNotIdentical.php
+++ b/packages/framework/src/Form/Constraints/FieldsAreNotIdentical.php
@@ -4,15 +4,36 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class FieldsAreNotIdentical extends Constraint
 {
-    public string $field1;
+    /**
+     * @param string $field1
+     * @param string $field2
+     * @param string $errorPath
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $field1,
+        public string $field2,
+        public string $errorPath,
+        public string $message = 'Fields must not be identical',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public string $field2;
-
-    public string $errorPath;
-
-    public string $message = 'Fields must not be identical';
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/FieldsAreNotIdentical.php
+++ b/packages/framework/src/Form/Constraints/FieldsAreNotIdentical.php
@@ -5,27 +5,39 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class FieldsAreNotIdentical extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $field1
      * @param string $field2
      * @param string $errorPath
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public string $field1,
-        public string $field2,
-        public string $errorPath,
+        ?array $options = null,
+        public string $field1 = '',
+        public string $field2 = '',
+        public string $errorPath = '',
         public string $message = 'Fields must not be identical',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/FileAllowedExtension.php
+++ b/packages/framework/src/Form/Constraints/FileAllowedExtension.php
@@ -9,30 +9,27 @@ use Symfony\Component\Validator\Constraint;
 
 class FileAllowedExtension extends Constraint
 {
-    public string $message = 'File extension {{ value }} is not between allowed extension. Allowed extensions are {{ extensions }}.';
-
     /**
-     * @var string[]
+     * @param array<string> $extensions
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
      */
-    public array $extensions;
-
-    /**
-     * {@inheritdoc}
-     */
-    #[Override]
-    public function getRequiredOptions(): array
-    {
-        return [
-            'extensions',
-        ];
+    public function __construct(
+        public array $extensions,
+        public string $message = 'File extension {{ value }} is not between allowed extension. Allowed extensions are {{ extensions }}.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
     }
 
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getDefaultOption(): ?string
+    public function getTargets(): string|array
     {
-        return 'extensions';
+        return self::PROPERTY_CONSTRAINT;
     }
 }

--- a/packages/framework/src/Form/Constraints/FileAllowedExtension.php
+++ b/packages/framework/src/Form/Constraints/FileAllowedExtension.php
@@ -5,23 +5,35 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class FileAllowedExtension extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param array<string> $extensions
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public array $extensions,
+        ?array $options = null,
+        public array $extensions = [],
         public string $message = 'File extension {{ value }} is not between allowed extension. Allowed extensions are {{ extensions }}.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/FileExtensionMaxLength.php
+++ b/packages/framework/src/Form/Constraints/FileExtensionMaxLength.php
@@ -5,23 +5,35 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class FileExtensionMaxLength extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param int $limit
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public int $limit,
+        ?array $options = null,
+        public int $limit = 0,
         public string $message = 'File extension {{ value }} is too long. It should have {{ limit }} character or less.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/FileExtensionMaxLength.php
+++ b/packages/framework/src/Form/Constraints/FileExtensionMaxLength.php
@@ -9,27 +9,27 @@ use Symfony\Component\Validator\Constraint;
 
 class FileExtensionMaxLength extends Constraint
 {
-    public string $message = 'File extension {{ value }} is too long. It should have {{ limit }} character or less.';
-
-    public int $limit;
-
     /**
-     * {@inheritdoc}
+     * @param int $limit
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
      */
-    #[Override]
-    public function getRequiredOptions(): array
-    {
-        return [
-            'limit',
-        ];
+    public function __construct(
+        public int $limit,
+        public string $message = 'File extension {{ value }} is too long. It should have {{ limit }} character or less.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
     }
 
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getDefaultOption(): ?string
+    public function getTargets(): string|array
     {
-        return 'limit';
+        return self::PROPERTY_CONSTRAINT;
     }
 }

--- a/packages/framework/src/Form/Constraints/MoneyRange.php
+++ b/packages/framework/src/Form/Constraints/MoneyRange.php
@@ -4,33 +4,34 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
-use function get_class;
-use function gettype;
-use function is_object;
 
 class MoneyRange extends Constraint
 {
-    public string $minMessage = 'The amount of money should be {{ limit }} or more.';
-
-    public string $maxMessage = 'The amount of money should be {{ limit }} or less.';
-
-    public Money|null $min = null;
-
-    public Money|null $max = null;
-
     /**
-     * @param array $options
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $min
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $max
+     * @param string $minMessage
+     * @param string $maxMessage
+     * @param array|null $groups
+     * @param mixed $payload
      */
-    public function __construct(array $options)
-    {
-        $this->validateMoneyOrNullOption('min', $options);
-        $this->validateMoneyOrNullOption('max', $options);
+    public function __construct(
+        public ?Money $min = null,
+        public ?Money $max = null,
+        public string $minMessage = 'The amount of money should be {{ limit }} or more.',
+        public string $maxMessage = 'The amount of money should be {{ limit }} or less.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        $this->validateMoneyOrNullOption('min', $min);
+        $this->validateMoneyOrNullOption('max', $max);
 
-        parent::__construct($options);
+        parent::__construct([], $groups, $payload);
 
         if ($this->min === null && $this->max === null) {
             $message = sprintf('Either option "min" or "max" must be given for constraint "%s".', self::class);
@@ -41,15 +42,13 @@ class MoneyRange extends Constraint
 
     /**
      * @param string $optionName
-     * @param array $options
+     * @param mixed $value
      */
-    protected function validateMoneyOrNullOption(string $optionName, array $options): void
+    protected function validateMoneyOrNullOption(string $optionName, mixed $value): void
     {
-        if (!isset($options[$optionName])) {
+        if ($value === null) {
             return;
         }
-
-        $value = $options[$optionName];
 
         if (!($value instanceof Money)) {
             $message = sprintf(
@@ -62,5 +61,14 @@ class MoneyRange extends Constraint
 
             throw new ConstraintDefinitionException($message);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
     }
 }

--- a/packages/framework/src/Form/Constraints/MoneyRange.php
+++ b/packages/framework/src/Form/Constraints/MoneyRange.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
@@ -13,14 +15,17 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
 class MoneyRange extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $min
      * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $max
      * @param string $minMessage
      * @param string $maxMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public ?Money $min = null,
         public ?Money $max = null,
         public string $minMessage = 'The amount of money should be {{ limit }} or more.',
@@ -28,10 +33,17 @@ class MoneyRange extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
         $this->validateMoneyOrNullOption('min', $min);
         $this->validateMoneyOrNullOption('max', $max);
 
-        parent::__construct([], $groups, $payload);
+        parent::__construct($options, $groups, $payload);
 
         if ($this->min === null && $this->max === null) {
             $message = sprintf('Either option "min" or "max" must be given for constraint "%s".', self::class);

--- a/packages/framework/src/Form/Constraints/MustUploadFile.php
+++ b/packages/framework/src/Form/Constraints/MustUploadFile.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class MustUploadFile extends Constraint
 {
-    public string $message = 'Please upload a file.';
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Please upload a file.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/MustUploadFile.php
+++ b/packages/framework/src/Form/Constraints/MustUploadFile.php
@@ -5,21 +5,33 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class MustUploadFile extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Please upload a file.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/NotIdenticalToEmailLocalPart.php
+++ b/packages/framework/src/Form/Constraints/NotIdenticalToEmailLocalPart.php
@@ -5,27 +5,39 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class NotIdenticalToEmailLocalPart extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $password
      * @param string $email
      * @param string $errorPath
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public string $password,
-        public string $email,
-        public string $errorPath,
+        ?array $options = null,
+        public string $password = '',
+        public string $email = '',
+        public string $errorPath = '',
         public string $message = 'Password cannot be local part of email.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/NotIdenticalToEmailLocalPart.php
+++ b/packages/framework/src/Form/Constraints/NotIdenticalToEmailLocalPart.php
@@ -4,15 +4,36 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class NotIdenticalToEmailLocalPart extends Constraint
 {
-    public string $password;
+    /**
+     * @param string $password
+     * @param string $email
+     * @param string $errorPath
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $password,
+        public string $email,
+        public string $errorPath,
+        public string $message = 'Password cannot be local part of email.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public string $email;
-
-    public string $errorPath;
-
-    public string $message = 'Password cannot be local part of email.';
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/NotInArray.php
+++ b/packages/framework/src/Form/Constraints/NotInArray.php
@@ -11,18 +11,27 @@ use Traversable;
 
 class NotInArray extends Constraint
 {
-    public string $message = 'Value must not be neither of following: {{ array }}';
-
-    public array|Traversable|ArrayAccess $array = [];
+    /**
+     * @param array|\Traversable|\ArrayAccess $array
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public array|Traversable|ArrayAccess $array,
+        public string $message = 'Value must not be neither of following: {{ array }}',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}
      */
     #[Override]
-    public function getRequiredOptions(): array
+    public function getTargets(): string|array
     {
-        return [
-            'array',
-        ];
+        return self::PROPERTY_CONSTRAINT;
     }
 }

--- a/packages/framework/src/Form/Constraints/NotInArray.php
+++ b/packages/framework/src/Form/Constraints/NotInArray.php
@@ -6,24 +6,36 @@ namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use ArrayAccess;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 use Traversable;
 
 class NotInArray extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param array|\Traversable|\ArrayAccess $array
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public array|Traversable|ArrayAccess $array,
+        ?array $options = null,
+        public array|Traversable|ArrayAccess $array = [],
         public string $message = 'Value must not be neither of following: {{ array }}',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/NotNegativeMoneyAmount.php
+++ b/packages/framework/src/Form/Constraints/NotNegativeMoneyAmount.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class NotNegativeMoneyAmount extends Constraint
 {
-    public string $message = 'Amount of money should be greater than or equal to zero.';
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Amount of money should be greater than or equal to zero.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/NotNegativeMoneyAmount.php
+++ b/packages/framework/src/Form/Constraints/NotNegativeMoneyAmount.php
@@ -5,21 +5,33 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class NotNegativeMoneyAmount extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Amount of money should be greater than or equal to zero.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/NotSelectedDomainToShow.php
+++ b/packages/framework/src/Form/Constraints/NotSelectedDomainToShow.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class NotSelectedDomainToShow extends Constraint
 {
-    public string $message = 'You have to select any domain.';
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'You have to select any domain.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/NotSelectedDomainToShow.php
+++ b/packages/framework/src/Form/Constraints/NotSelectedDomainToShow.php
@@ -5,21 +5,33 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class NotSelectedDomainToShow extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'You have to select any domain.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/PositiveMoneyAmount.php
+++ b/packages/framework/src/Form/Constraints/PositiveMoneyAmount.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class PositiveMoneyAmount extends Constraint
 {
-    public string $message = 'Amount of money should be greater to zero.';
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Amount of money should be greater to zero.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/PositiveMoneyAmount.php
+++ b/packages/framework/src/Form/Constraints/PositiveMoneyAmount.php
@@ -5,21 +5,33 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class PositiveMoneyAmount extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Amount of money should be greater to zero.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueBillingAddress.php
+++ b/packages/framework/src/Form/Constraints/UniqueBillingAddress.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueBillingAddress extends Constraint
@@ -19,18 +21,28 @@ class UniqueBillingAddress extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $errorPath
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public string $errorPath,
+        ?array $options = null,
+        public string $errorPath = '',
         public string $message = 'Billing address company number {{ company_number }} already exists for domain {{ domain_id }}.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueBillingAddress.php
+++ b/packages/framework/src/Form/Constraints/UniqueBillingAddress.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueBillingAddress extends Constraint
 {
     public const string DUPLICATE_BILLING_ADDRESS = 'dc6b5879-cb7a-423b-bd97-d9c667d96fd5';
-
-    public string $message = 'Billing address company number {{ company_number }} already exists for domain {{ domain_id }}.';
-
-    public string $errorPath;
 
     /**
      * @var array<string, string>
@@ -20,4 +17,28 @@ class UniqueBillingAddress extends Constraint
     protected const array ERROR_NAMES = [
         self::DUPLICATE_BILLING_ADDRESS => 'DUPLICATE_BILLING_ADDRESS',
     ];
+
+    /**
+     * @param string $errorPath
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $errorPath,
+        public string $message = 'Billing address company number {{ company_number }} already exists for domain {{ domain_id }}.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::CLASS_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueCollection.php
+++ b/packages/framework/src/Form/Constraints/UniqueCollection.php
@@ -5,25 +5,37 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueCollection extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param array|null $fields
      * @param bool $allowEmpty
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Values are duplicate.',
         public ?array $fields = null,
         public bool $allowEmpty = false,
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueCollection.php
+++ b/packages/framework/src/Form/Constraints/UniqueCollection.php
@@ -4,16 +4,34 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueCollection extends Constraint
 {
-    public string $message = 'Values are duplicate.';
+    /**
+     * @param string $message
+     * @param array|null $fields
+     * @param bool $allowEmpty
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Values are duplicate.',
+        public ?array $fields = null,
+        public bool $allowEmpty = false,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
-     * @var mixed[]|null
+     * {@inheritdoc}
      */
-    public ?array $fields = null;
-
-    public bool $allowEmpty = false;
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueEmail.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmail.php
@@ -4,13 +4,34 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueEmail extends Constraint
 {
-    public string $message = 'Email {{ email }} is already registered';
+    /**
+     * @param string $message
+     * @param string|null $ignoredEmail
+     * @param int|null $domainId
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Email {{ email }} is already registered',
+        public ?string $ignoredEmail = null,
+        public ?int $domainId = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public ?string $ignoredEmail = null;
-
-    public ?int $domainId = null;
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueEmail.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmail.php
@@ -5,25 +5,37 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueEmail extends Constraint
 {
     /**
-     * @param string $message
+     * @param array<string, mixed>|null $options
      * @param string|null $ignoredEmail
      * @param int|null $domainId
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
+     * @param string $message
      */
+    #[HasNamedArguments]
     public function __construct(
-        public string $message = 'Email {{ email }} is already registered',
+        ?array $options = null,
         public ?string $ignoredEmail = null,
         public ?int $domainId = null,
         ?array $groups = null,
         mixed $payload = null,
+        public string $message = 'Email {{ email }} is already registered',
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueEntityField.php
+++ b/packages/framework/src/Form/Constraints/UniqueEntityField.php
@@ -5,27 +5,39 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueEntityField extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $fieldName
      * @param string $entityName
      * @param string $message
      * @param object|null $entityInstance
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
-        public string $fieldName,
-        public string $entityName,
+        ?array $options = null,
+        public string $fieldName = '',
+        public string $entityName = '',
         public string $message = 'The "{{ value }}" value of "{{ fieldName }}" field must be unique',
         public ?object $entityInstance = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct(null, $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueEntityField.php
+++ b/packages/framework/src/Form/Constraints/UniqueEntityField.php
@@ -4,15 +4,36 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueEntityField extends Constraint
 {
-    public string $message = 'The "{{ value }}" value of "{{ fieldName }}" field must be unique';
+    /**
+     * @param string $fieldName
+     * @param string $entityName
+     * @param string $message
+     * @param object|null $entityInstance
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $fieldName,
+        public string $entityName,
+        public string $message = 'The "{{ value }}" value of "{{ fieldName }}" field must be unique',
+        public ?object $entityInstance = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+    }
 
-    public string $fieldName;
-
-    public string $entityName;
-
-    public ?object $entityInstance = null;
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueProductCatnum.php
+++ b/packages/framework/src/Form/Constraints/UniqueProductCatnum.php
@@ -5,24 +5,36 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Model\Product\Product;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueProductCatnum extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Product with entered catalog number already exists',
         public ?Product $product = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueProductCatnum.php
+++ b/packages/framework/src/Form/Constraints/UniqueProductCatnum.php
@@ -4,12 +4,33 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueProductCatnum extends Constraint
 {
-    public string $message = 'Product with entered catalog number already exists';
+    /**
+     * @param string $message
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Product with entered catalog number already exists',
+        public ?Product $product = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public ?Product $product = null;
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueProductParameters.php
+++ b/packages/framework/src/Form/Constraints/UniqueProductParameters.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueProductParameters extends Constraint
 {
-    public string $message = 'Product parameters are duplicate.';
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Product parameters are duplicate.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueProductParameters.php
+++ b/packages/framework/src/Form/Constraints/UniqueProductParameters.php
@@ -5,21 +5,33 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueProductParameters extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Product parameters are duplicate.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueSeoPageSlug.php
+++ b/packages/framework/src/Form/Constraints/UniqueSeoPageSlug.php
@@ -5,26 +5,38 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Model\Seo\Page\SeoPage;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueSeoPageSlug extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param \Shopsys\FrameworkBundle\Model\Seo\Page\SeoPage|null $ignoredSeoPage
      * @param int|null $domainId
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Seo page with slug {{ pageSlug }} already exists',
         public ?SeoPage $ignoredSeoPage = null,
         public ?int $domainId = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueSeoPageSlug.php
+++ b/packages/framework/src/Form/Constraints/UniqueSeoPageSlug.php
@@ -4,14 +4,35 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Shopsys\FrameworkBundle\Model\Seo\Page\SeoPage;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueSeoPageSlug extends Constraint
 {
-    public string $message = 'Seo page with slug {{ pageSlug }} already exists';
+    /**
+     * @param string $message
+     * @param \Shopsys\FrameworkBundle\Model\Seo\Page\SeoPage|null $ignoredSeoPage
+     * @param int|null $domainId
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Seo page with slug {{ pageSlug }} already exists',
+        public ?SeoPage $ignoredSeoPage = null,
+        public ?int $domainId = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public ?SeoPage $ignoredSeoPage = null;
-
-    public ?int $domainId = null;
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/UniqueSlugsOnDomains.php
+++ b/packages/framework/src/Form/Constraints/UniqueSlugsOnDomains.php
@@ -5,23 +5,35 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueSlugsOnDomains extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param string $messageDuplicate
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Address {{ url }} already exists.',
         public string $messageDuplicate = 'Address {{ url }} can be entered only once.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/UniqueSlugsOnDomains.php
+++ b/packages/framework/src/Form/Constraints/UniqueSlugsOnDomains.php
@@ -4,11 +4,32 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class UniqueSlugsOnDomains extends Constraint
 {
-    public string $message = 'Address {{ url }} already exists.';
+    /**
+     * @param string $message
+     * @param string $messageDuplicate
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Address {{ url }} already exists.',
+        public string $messageDuplicate = 'Address {{ url }} can be entered only once.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public string $messageDuplicate = 'Address {{ url }} can be entered only once.';
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/Constraints/WhitelistPattern.php
+++ b/packages/framework/src/Form/Constraints/WhitelistPattern.php
@@ -5,23 +5,35 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class WhitelistPattern extends Constraint
 {
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param string $blankMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Invalid whitelist pattern.',
         public string $blankMessage = 'Please enter whitelist pattern.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/framework/src/Form/Constraints/WhitelistPattern.php
+++ b/packages/framework/src/Form/Constraints/WhitelistPattern.php
@@ -4,11 +4,32 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class WhitelistPattern extends Constraint
 {
-    public string $message = 'Invalid whitelist pattern.';
+    /**
+     * @param string $message
+     * @param string $blankMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Invalid whitelist pattern.',
+        public string $blankMessage = 'Please enter whitelist pattern.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public string $blankMessage = 'Please enter whitelist pattern.';
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/framework/src/Form/FileUploadType.php
+++ b/packages/framework/src/Form/FileUploadType.php
@@ -95,9 +95,10 @@ final class FileUploadType extends AbstractType
                     'entry_type' => TextType::class,
                     'entry_options' => [
                         'constraints' => [
-                            new Constraints\NotBlank(['message' => 'Please enter the filename']),
+                            new Constraints\NotBlank(message: 'Please enter the filename'),
                             new Constraints\Length(
-                                ['max' => 245, 'maxMessage' => 'File name cannot be longer than {{ limit }} characters'],
+                                max: 245,
+                                maxMessage: 'File name cannot be longer than {{ limit }} characters',
                             ),
                         ],
                     ],
@@ -131,9 +132,10 @@ final class FileUploadType extends AbstractType
                     'allow_add' => true,
                     'entry_options' => [
                         'constraints' => [
-                            new Constraints\NotBlank(['message' => 'Please enter the filename']),
+                            new Constraints\NotBlank(message: 'Please enter the filename'),
                             new Constraints\Length(
-                                ['max' => 255, 'maxMessage' => 'Name cannot be longer than {{ limit }} characters'],
+                                max: 255,
+                                maxMessage: 'Name cannot be longer than {{ limit }} characters',
                             ),
                         ],
                     ],

--- a/packages/framework/src/Form/HoneyPotType.php
+++ b/packages/framework/src/Form/HoneyPotType.php
@@ -30,7 +30,7 @@ final class HoneyPotType extends AbstractType
         $resolver->setDefaults([
             'mapped' => false,
             'required' => false,
-            'constraints' => new Constraints\Blank(['message' => 'This field must be empty']),
+            'constraints' => new Constraints\Blank(message: 'This field must be empty'),
         ]);
     }
 }

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -63,7 +63,7 @@ final class ImageUploadType extends AbstractType
 
                 return array_merge(
                     [
-                        new FileAllowedExtension(['extensions' => $options['extensions']]),
+                        new FileAllowedExtension(extensions: $options['extensions']),
                     ],
                     $fileConstraints,
                 );
@@ -125,10 +125,10 @@ final class ImageUploadType extends AbstractType
                     'label' => '',
                     'entry_options' => [
                         'constraints' => [
-                            new Assert\Length([
-                                'max' => 245,
-                                'maxMessage' => 'File name cannot be longer than {{ limit }} characters',
-                            ]),
+                            new Assert\Length(
+                                max: 245,
+                                maxMessage: 'File name cannot be longer than {{ limit }} characters',
+                            ),
                         ],
                     ],
                 ],
@@ -141,10 +141,10 @@ final class ImageUploadType extends AbstractType
                         'label' => false,
                         'entry_options' => [
                             'constraints' => [
-                                new Assert\Length([
-                                    'max' => 245,
-                                    'maxMessage' => 'File name cannot be longer than {{ limit }} characters',
-                                ]),
+                                new Assert\Length(
+                                    max: 245,
+                                    maxMessage: 'File name cannot be longer than {{ limit }} characters',
+                                ),
                             ],
                         ],
                     ],

--- a/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
+++ b/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
@@ -79,7 +79,7 @@ final class PriceAndVatTableByDomainsType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
+                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
                 ],
                 'label' => 'VAT',
             ]);
@@ -89,8 +89,8 @@ final class PriceAndVatTableByDomainsType extends AbstractType
                 'required' => true,
                 'invalid_message' => 'Please enter price in correct format (positive number with decimal separator)',
                 'constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter price']),
-                    new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+                    new Constraints\NotBlank(message: 'Please enter price'),
+                    new NotNegativeMoneyAmount(message: 'Price must be greater or equal to zero'),
                 ],
                 'label' => 'Price',
             ]);

--- a/packages/framework/src/Form/TransportInputPricesType.php
+++ b/packages/framework/src/Form/TransportInputPricesType.php
@@ -39,7 +39,7 @@ final class TransportInputPricesType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [
-                    new NotBlank(['message' => 'Please enter VAT rate']),
+                    new NotBlank(message: 'Please enter VAT rate'),
                 ],
                 'label' => 'VAT',
             ])

--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
@@ -32,8 +32,7 @@ class AdvancedSearchProductFacade
      */
     public function createAdvancedSearchForm(Request $request)
     {
-        $rawRulesData = $request->get(static::RULES_FORM_NAME);
-        $rulesData = is_array($rawRulesData) ? $rawRulesData : [];
+        $rulesData = $request->query->all(static::RULES_FORM_NAME);
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(ProductNameFilter::NAME, $rulesData);
 
         return $this->advancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesFormData);
@@ -71,8 +70,6 @@ class AdvancedSearchProductFacade
      */
     public function isAdvancedSearchFormSubmitted(Request $request)
     {
-        $rulesData = $request->get(static::RULES_FORM_NAME);
-
-        return $rulesData !== null;
+        return $request->query->has(static::RULES_FORM_NAME);
     }
 }

--- a/packages/framework/src/Model/AdvancedSearchComplaint/AdvancedSearchComplaintFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchComplaint/AdvancedSearchComplaintFacade.php
@@ -44,8 +44,7 @@ class AdvancedSearchComplaintFacade
      */
     public function createAdvancedSearchComplaintForm(Request $request): FormInterface
     {
-        $rawRulesData = $request->get(static::RULES_FORM_NAME);
-        $rulesData = is_array($rawRulesData) ? $rawRulesData : [];
+        $rulesData = $request->query->all(static::RULES_FORM_NAME);
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(
             ComplaintNumberFilter::NAME,
             $rulesData,
@@ -137,8 +136,6 @@ class AdvancedSearchComplaintFacade
      */
     public function isAdvancedSearchComplaintFormSubmitted(Request $request): bool
     {
-        $rulesData = $request->get(static::RULES_FORM_NAME);
-
-        return $rulesData !== null;
+        return $request->query->has(static::RULES_FORM_NAME);
     }
 }

--- a/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
@@ -35,8 +35,7 @@ class AdvancedSearchOrderFacade
      */
     public function createAdvancedSearchOrderForm(Request $request)
     {
-        $rawRulesData = $request->get(static::RULES_FORM_NAME);
-        $rulesData = is_array($rawRulesData) ? $rawRulesData : [];
+        $rulesData = $request->query->all(static::RULES_FORM_NAME);
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(
             OrderPriceFilterWithVatFilter::NAME,
             $rulesData,
@@ -77,8 +76,6 @@ class AdvancedSearchOrderFacade
      */
     public function isAdvancedSearchOrderFormSubmitted(Request $request)
     {
-        $rulesData = $request->get(static::RULES_FORM_NAME);
-
-        return $rulesData !== null;
+        return $request->query->has(static::RULES_FORM_NAME);
     }
 }

--- a/packages/framework/tests/Unit/Component/Constraints/FileExtensionMaxLengthValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/FileExtensionMaxLengthValidatorTest.php
@@ -25,10 +25,10 @@ class FileExtensionMaxLengthValidatorTest extends ConstraintValidatorTestCase
     {
         $file = new File(__DIR__ . '/' . 'non-existent.file', false);
 
-        $constraint = new FileExtensionMaxLength([
-            'limit' => 4,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new FileExtensionMaxLength(
+            limit: 4,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($file, $constraint);
         $this->assertNoViolation();
@@ -38,10 +38,10 @@ class FileExtensionMaxLengthValidatorTest extends ConstraintValidatorTestCase
     {
         $file = new File(__DIR__ . '/' . 'non-existent.file', false);
 
-        $constraint = new FileExtensionMaxLength([
-            'limit' => 3,
-            'message' => 'myMessage',
-        ]);
+        $constraint = new FileExtensionMaxLength(
+            limit: 3,
+            message: 'myMessage',
+        );
 
         $this->validator->validate($file, $constraint);
 

--- a/packages/framework/tests/Unit/Component/Translation/ConstraintMessageExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConstraintMessageExtractorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Translation;
+
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Translation\ConstraintMessageExtractor;
+use Shopsys\FrameworkBundle\Component\Translation\PhpParserNodeHelper;
+use SplFileInfo;
+
+class ConstraintMessageExtractorTest extends TestCase
+{
+    public function testMessagesAreExtractedFromConstraintsWithNamedArguments(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/ConstraintUsageClass.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $this->assertCatalogueHasMessage($actualCatalogue, 'NotBlank message', 'validators', 13);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Length min message', 'validators', 15);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Length max message', 'validators', 16);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Length exact message', 'validators', 17);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'GreaterThan message', 'validators', 21);
+    }
+
+    public function testMessagesAreExtractedFromConstraintsWithPositionalArguments(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/ConstraintUsageClass.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Positional NotBlank message', 'validators', 27);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Positional Length min message', 'validators', 28);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Positional Length max message', 'validators', 28);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Positional GreaterThan message', 'validators', 29);
+    }
+
+    public function testMessagesAreExtractedFromConstraintsWithMixedArguments(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/ConstraintUsageClass.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Mixed Length min message', 'validators', 34);
+        $this->assertCatalogueHasMessage($actualCatalogue, 'Mixed GreaterThan message', 'validators', 35);
+    }
+
+    public function testAllMessagesAreExtracted(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/ConstraintUsageClass.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $this->assertCount(11, $actualCatalogue->getDomain('validators')->all());
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @return \JMS\TranslationBundle\Model\MessageCatalogue
+     */
+    private function extract(SplFileInfo $file): MessageCatalogue
+    {
+        $phpParserNodeHelper = new PhpParserNodeHelper();
+        $extractor = new ConstraintMessageExtractor($phpParserNodeHelper);
+
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.3'));
+        $ast = $parser->parse(file_get_contents($file->getPathname()));
+
+        $catalogue = new MessageCatalogue();
+        $extractor->visitPhpFile($file, $catalogue, $ast);
+
+        return $catalogue;
+    }
+
+    /**
+     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
+     * @param string $messageId
+     * @param string $domain
+     * @param int $line
+     */
+    private function assertCatalogueHasMessage(
+        MessageCatalogue $catalogue,
+        string $messageId,
+        string $domain,
+        int $line,
+    ): void {
+        $this->assertTrue(
+            $catalogue->has(new Message($messageId, $domain)),
+            sprintf('Catalogue should have message "%s" in domain "%s"', $messageId, $domain),
+        );
+
+        $message = $catalogue->get($messageId, $domain);
+        $sources = $message->getSources();
+
+        $foundLine = false;
+
+        foreach ($sources as $source) {
+            if ($source instanceof FileSource && $source->getLine() === $line) {
+                $foundLine = true;
+
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $foundLine,
+            sprintf('Message "%s" should have source at line %d', $messageId, $line),
+        );
+    }
+}

--- a/packages/framework/tests/Unit/Component/Translation/ConstraintMessagePropertyExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConstraintMessagePropertyExtractorTest.php
@@ -46,6 +46,25 @@ class ConstraintMessagePropertyExtractorTest extends TestCase
         $this->assertEquals($expectedCatalogue, $actualCatalogue);
     }
 
+    public function testMessagesAreExtractedFromPromotedProperties(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/ConstraintWithPromotedProperties.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $expectedCatalogue = new MessageCatalogue();
+
+        $message = new Message('Promoted message will be extracted.', 'validators');
+        $message->addSource(new FileSource($file->getFilename(), 19));
+        $expectedCatalogue->add($message);
+
+        $message = new Message('Another promoted message.', 'validators');
+        $message->addSource(new FileSource($file->getFilename(), 20));
+        $expectedCatalogue->add($message);
+
+        $this->assertEquals($expectedCatalogue, $actualCatalogue);
+    }
+
     /**
      * @param \SplFileInfo $file
      * @return \JMS\TranslationBundle\Model\MessageCatalogue

--- a/packages/framework/tests/Unit/Component/Translation/Resources/ConstraintUsageClass.php
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/ConstraintUsageClass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Translation\Resources;
+
+use Symfony\Component\Validator\Constraints;
+
+class ConstraintUsageClass
+{
+    public function constraintsWithMessages(): void
+    {
+        new Constraints\NotBlank(message: 'NotBlank message');
+        new Constraints\Length(
+            minMessage: 'Length min message',
+            maxMessage: 'Length max message',
+            exactMessage: 'Length exact message',
+        );
+        new Constraints\GreaterThan(
+            value: 0,
+            message: 'GreaterThan message',
+        );
+    }
+
+    public function constraintsWithPositionalArguments(): void
+    {
+        new Constraints\NotBlank(null, 'Positional NotBlank message');
+        new Constraints\Length(null, 5, 100, null, null, null, null, 'Positional Length min message', 'Positional Length max message');
+        new Constraints\GreaterThan(0, null, 'Positional GreaterThan message');
+    }
+
+    public function constraintsWithMixedPositionalAndNamed(): void
+    {
+        new Constraints\Length(null, 5, minMessage: 'Mixed Length min message');
+        new Constraints\GreaterThan(0, message: 'Mixed GreaterThan message');
+    }
+}

--- a/packages/framework/tests/Unit/Component/Translation/Resources/ConstraintWithPromotedProperties.php
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/ConstraintWithPromotedProperties.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Translation\Resources;
+
+use Symfony\Component\Validator\Constraint;
+
+class ConstraintWithPromotedProperties extends Constraint
+{
+    /**
+     * @param string $message
+     * @param string $otherMessage
+     * @param string $differentProperty
+     * @param array|null $groups
+     * @param mixed|null $payload
+     */
+    public function __construct(
+        public string $message = 'Promoted message will be extracted.',
+        public string $otherMessage = 'Another promoted message.',
+        public string $differentProperty = 'This will not be extracted.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}

--- a/packages/frontend-api/src/Component/Constraints/ComplaintResolution.php
+++ b/packages/frontend-api/src/Component/Constraints/ComplaintResolution.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class ComplaintResolution extends Constraint
@@ -21,18 +23,28 @@ class ComplaintResolution extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $selectedComplaintResolutionNotSupportedMessage
      * @param string $selecteComplaintResolutionRequiresBankAccountFilledMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $selectedComplaintResolutionNotSupportedMessage = 'Selected complaint resolution is not supported',
         public string $selecteComplaintResolutionRequiresBankAccountFilledMessage = 'Selected complaint resolution requires bank account number to be filled',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/ComplaintResolution.php
+++ b/packages/frontend-api/src/Component/Constraints/ComplaintResolution.php
@@ -12,10 +12,6 @@ class ComplaintResolution extends Constraint
     public const string SELECTED_COMPLAINT_RESOLUTION_NOT_SUPPORTED_ERROR = 'a05b7eae-364b-4a77-a2db-b37398c417b1';
     public const string SELECTED_COMPLAINT_RESOLUTION_REQUIRES_BANK_ACCOUNT_NUMBER_FILLED_ERROR = 'aea614ec-f673-432d-8eec-ac3f43b4ea60';
 
-    public string $selectedComplaintResolutionNotSupportedMessage = 'Selected complaint resolution is not supported';
-
-    public string $selecteComplaintResolutionRequiresBankAccountFilledMessage = 'Selected complaint resolution requires bank account number to be filled';
-
     /**
      * @var array<string, string>
      */
@@ -23,6 +19,21 @@ class ComplaintResolution extends Constraint
         self::SELECTED_COMPLAINT_RESOLUTION_NOT_SUPPORTED_ERROR => 'SELECTED_COMPLAINT_RESOLUTION_NOT_SUPPORTED_ERROR',
         self::SELECTED_COMPLAINT_RESOLUTION_REQUIRES_BANK_ACCOUNT_NUMBER_FILLED_ERROR => 'SELECTED_COMPLAINT_RESOLUTION_REQUIRES_BANK_ACCOUNT_FILLED_ERROR',
     ];
+
+    /**
+     * @param string $selectedComplaintResolutionNotSupportedMessage
+     * @param string $selecteComplaintResolutionRequiresBankAccountFilledMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $selectedComplaintResolutionNotSupportedMessage = 'Selected complaint resolution is not supported',
+        public string $selecteComplaintResolutionRequiresBankAccountFilledMessage = 'Selected complaint resolution requires bank account number to be filled',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroup.php
+++ b/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroup.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
@@ -21,16 +23,26 @@ class CustomerUserRoleGroup extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Customer role group not found.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroup.php
+++ b/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroup.php
@@ -13,14 +13,25 @@ class CustomerUserRoleGroup extends Constraint
 {
     public const CUSTOMER_USER_ROLE_GROUP_NOT_FOUND = 'cd01e1cc-a902-497a-94ee-4de24f4d853e';
 
-    public string $message = 'Customer role group not found.';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::CUSTOMER_USER_ROLE_GROUP_NOT_FOUND => 'CUSTOMER_USER_ROLE_GROUP_NOT_FOUND',
     ];
+
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Customer role group not found.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroupAllowEdit.php
+++ b/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroupAllowEdit.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
@@ -23,18 +25,28 @@ class CustomerUserRoleGroupAllowEdit extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
      * @param string $messageForLastCustomerUser
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Customer role group cannot be changed.',
         public string $messageForLastCustomerUser = 'Customer role group cannot be changed for last customer user.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroupAllowEdit.php
+++ b/packages/frontend-api/src/Component/Constraints/CustomerUserRoleGroupAllowEdit.php
@@ -14,10 +14,6 @@ class CustomerUserRoleGroupAllowEdit extends Constraint
     public const CUSTOMER_USER_ROLE_GROUP_CANNOT_BE_CHANGED = '8af342d1-9034-4995-a8cf-60375ca499bf';
     public const LAST_CUSTOMER_USER_ROLE_GROUP_CANNOT_BE_CHANGED = '03ae06a9-2ebd-4376-ad5c-f8e6a7991733';
 
-    public string $message = 'Customer role group cannot be changed.';
-
-    public string $messageForLastCustomerUser = 'Customer role group cannot be changed for last customer user.';
-
     /**
      * @var array<string, string>
      */
@@ -25,6 +21,21 @@ class CustomerUserRoleGroupAllowEdit extends Constraint
         self::CUSTOMER_USER_ROLE_GROUP_CANNOT_BE_CHANGED => 'CUSTOMER_USER_ROLE_GROUP_CANNOT_BE_CHANGED',
         self::LAST_CUSTOMER_USER_ROLE_GROUP_CANNOT_BE_CHANGED => 'LAST_CUSTOMER_USER_ROLE_GROUP_CANNOT_BE_CHANGED',
     ];
+
+    /**
+     * @param string $message
+     * @param string $messageForLastCustomerUser
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Customer role group cannot be changed.',
+        public string $messageForLastCustomerUser = 'Customer role group cannot be changed for last customer user.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/DeliveryAddressUuid.php
+++ b/packages/frontend-api/src/Component/Constraints/DeliveryAddressUuid.php
@@ -11,14 +11,25 @@ class DeliveryAddressUuid extends Constraint
 {
     public const LOGIN_REQUIRED_ERROR = '9dcda0d3-7264-4c5f-9b35-f5b155f997f9';
 
-    public string $loginRequiredErrorMessage = 'You must be logged in if you want to provide the delivery address UUID in the order input';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::LOGIN_REQUIRED_ERROR => 'LOGIN_REQUIRED_ERROR',
     ];
+
+    /**
+     * @param string $loginRequiredErrorMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $loginRequiredErrorMessage = 'You must be logged in if you want to provide the delivery address UUID in the order input',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/DeliveryAddressUuid.php
+++ b/packages/frontend-api/src/Component/Constraints/DeliveryAddressUuid.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class DeliveryAddressUuid extends Constraint
@@ -19,16 +21,26 @@ class DeliveryAddressUuid extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $loginRequiredErrorMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $loginRequiredErrorMessage = 'You must be logged in if you want to provide the delivery address UUID in the order input',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/FileUpload.php
+++ b/packages/frontend-api/src/Component/Constraints/FileUpload.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class FileUpload extends Constraint
@@ -23,15 +25,18 @@ class FileUpload extends Constraint
     ];
 
     /**
-     * @param array|string $mimeTypes
+     * @param array<string, mixed>|null $options
+     * @param array<string>|string $mimeTypes
      * @param int|null $maxSize
      * @param string $mimeTypesMessage
      * @param string $maxSizeMessage
      * @param string $uploadErrorMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public array|string $mimeTypes = 'image/*',
         public ?int $maxSize = null,
         public string $mimeTypesMessage = 'Type of file {{ fileName }} is unsupported.',
@@ -40,7 +45,14 @@ class FileUpload extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/FileUpload.php
+++ b/packages/frontend-api/src/Component/Constraints/FileUpload.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 class FileUpload extends Constraint
@@ -21,13 +22,33 @@ class FileUpload extends Constraint
         self::MIMETYPE_ERROR => 'MIMETYPE_ERROR',
     ];
 
-    public array|string $mimeTypes = 'image/*';
+    /**
+     * @param array|string $mimeTypes
+     * @param int|null $maxSize
+     * @param string $mimeTypesMessage
+     * @param string $maxSizeMessage
+     * @param string $uploadErrorMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public array|string $mimeTypes = 'image/*',
+        public ?int $maxSize = null,
+        public string $mimeTypesMessage = 'Type of file {{ fileName }} is unsupported.',
+        public string $maxSizeMessage = 'The file {{ fileName }} is too big.',
+        public string $uploadErrorMessage = 'Error occurred while uploading file.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
-    public int|null $maxSize = null;
-
-    public string $mimeTypesMessage = 'Type of file {{ fileName }} is unsupported.';
-
-    public string $maxSizeMessage = 'The file {{ fileName }} is too big.';
-
-    public string $uploadErrorMessage = 'Error occurred while uploading file.';
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/packages/frontend-api/src/Component/Constraints/PaymentInCart.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInCart.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class PaymentInCart extends Constraint
@@ -21,18 +23,28 @@ class PaymentInCart extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $unavailablePaymentMessage
      * @param string $invalidPaymentTransportCombinationMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $unavailablePaymentMessage = 'Payment with provided UUID is not available',
         public string $invalidPaymentTransportCombinationMessage = 'The payment is not allowed in combination with already selected transport',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/PaymentInCart.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInCart.php
@@ -12,10 +12,6 @@ class PaymentInCart extends Constraint
     public const UNAVAILABLE_PAYMENT_ERROR = '49287486-fd4a-40e7-b64a-e45fd60b3732';
     public const INVALID_PAYMENT_TRANSPORT_COMBINATION_ERROR = '6b165c10-e644-495a-b5fa-b2bdcadf2670';
 
-    public string $unavailablePaymentMessage = 'Payment with provided UUID is not available';
-
-    public string $invalidPaymentTransportCombinationMessage = 'The payment is not allowed in combination with already selected transport';
-
     /**
      * @var array<string, string>
      */
@@ -23,6 +19,21 @@ class PaymentInCart extends Constraint
         self::UNAVAILABLE_PAYMENT_ERROR => 'UNAVAILABLE_PAYMENT_ERROR',
         self::INVALID_PAYMENT_TRANSPORT_COMBINATION_ERROR => 'INVALID_PAYMENT_TRANSPORT_COMBINATION_ERROR',
     ];
+
+    /**
+     * @param string $unavailablePaymentMessage
+     * @param string $invalidPaymentTransportCombinationMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $unavailablePaymentMessage = 'Payment with provided UUID is not available',
+        public string $invalidPaymentTransportCombinationMessage = 'The payment is not allowed in combination with already selected transport',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/PaymentInExistingOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInExistingOrder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class PaymentInExistingOrder extends Constraint
@@ -23,20 +25,30 @@ class PaymentInExistingOrder extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $unavailablePaymentMessage
      * @param string $unchangeablePaymentMessage
      * @param string $invalidPaymentSwiftMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $unavailablePaymentMessage = 'Payment {{ paymentUuid }} is not available for order {{ orderUuid }}',
         public string $unchangeablePaymentMessage = 'Payment cannot be changed',
         public string $invalidPaymentSwiftMessage = 'Payment {{ paymentUuid }} cannot be used with SWIFT {{ swift }}',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/PaymentInExistingOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInExistingOrder.php
@@ -13,12 +13,6 @@ class PaymentInExistingOrder extends Constraint
     public const UNCHANGEABLE_PAYMENT_ERROR = '80144e07-46ed-46a2-8437-7399319856fa';
     public const INVALID_PAYMENT_SWIFT_ERROR = 'c0d72eae-593e-4b8b-946a-41ca67057c39';
 
-    public string $unavailablePaymentMessage = 'Payment {{ paymentUuid }} is not available for order {{ orderUuid }}';
-
-    public string $unchangeablePaymentMessage = 'Payment cannot be changed';
-
-    public string $invalidPaymentSwiftMessage = 'Payment {{ paymentUuid }} cannot be used with SWIFT {{ swift }}';
-
     /**
      * @var array<string, string>
      */
@@ -27,6 +21,23 @@ class PaymentInExistingOrder extends Constraint
         self::UNCHANGEABLE_PAYMENT_ERROR => 'UNCHANGEABLE_PAYMENT_ERROR',
         self::INVALID_PAYMENT_SWIFT_ERROR => 'INVALID_PAYMENT_SWIFT_ERROR',
     ];
+
+    /**
+     * @param string $unavailablePaymentMessage
+     * @param string $unchangeablePaymentMessage
+     * @param string $invalidPaymentSwiftMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $unavailablePaymentMessage = 'Payment {{ paymentUuid }} is not available for order {{ orderUuid }}',
+        public string $unchangeablePaymentMessage = 'Payment cannot be changed',
+        public string $invalidPaymentSwiftMessage = 'Payment {{ paymentUuid }} cannot be used with SWIFT {{ swift }}',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/PaymentInOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInOrder.php
@@ -13,12 +13,6 @@ class PaymentInOrder extends Constraint
     public const UNAVAILABLE_PAYMENT_ERROR = '84f20917-3db3-454a-8fb5-a1035f46d883';
     public const CHANGED_PAYMENT_PRICE_ERROR = 'd94d726c-1974-4f9b-91e1-8b9da132ff0a';
 
-    public string $paymentNotSetMessage = 'Payment must be set in cart before sending the order';
-
-    public string $unavailablePaymentMessage = 'Payment with provided UUID is not available';
-
-    public string $changedPaymentPriceMessage = 'Selected payment price has changed';
-
     /**
      * @var array<string, string>
      */
@@ -27,6 +21,23 @@ class PaymentInOrder extends Constraint
         self::UNAVAILABLE_PAYMENT_ERROR => 'UNAVAILABLE_PAYMENT_ERROR',
         self::CHANGED_PAYMENT_PRICE_ERROR => 'CHANGED_PAYMENT_PRICE_ERROR',
     ];
+
+    /**
+     * @param string $paymentNotSetMessage
+     * @param string $unavailablePaymentMessage
+     * @param string $changedPaymentPriceMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $paymentNotSetMessage = 'Payment must be set in cart before sending the order',
+        public string $unavailablePaymentMessage = 'Payment with provided UUID is not available',
+        public string $changedPaymentPriceMessage = 'Selected payment price has changed',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/PaymentInOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInOrder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class PaymentInOrder extends Constraint
@@ -23,20 +25,30 @@ class PaymentInOrder extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $paymentNotSetMessage
      * @param string $unavailablePaymentMessage
      * @param string $changedPaymentPriceMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $paymentNotSetMessage = 'Payment must be set in cart before sending the order',
         public string $unavailablePaymentMessage = 'Payment with provided UUID is not available',
         public string $changedPaymentPriceMessage = 'Selected payment price has changed',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/PaymentTransportRelation.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentTransportRelation.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
@@ -21,16 +23,26 @@ class PaymentTransportRelation extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $invalidCombinationMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $invalidCombinationMessage = 'Please choose a valid combination of transport and payment',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/PaymentTransportRelation.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentTransportRelation.php
@@ -13,14 +13,25 @@ class PaymentTransportRelation extends Constraint
 {
     public const INVALID_COMBINATION_ERROR = '46ccd6d3-61e7-4a34-a42a-b13b92291e28';
 
-    public string $invalidCombinationMessage = 'Please choose a valid combination of transport and payment';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::INVALID_COMBINATION_ERROR => 'INVALID_COMBINATION_ERROR',
     ];
+
+    /**
+     * @param string $invalidCombinationMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $invalidCombinationMessage = 'Please choose a valid combination of transport and payment',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/ProductInOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/ProductInOrder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class ProductInOrder extends Constraint
@@ -19,16 +21,26 @@ class ProductInOrder extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $noProductInOrderMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $noProductInOrderMessage = 'There are no products in the cart',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/ProductInOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/ProductInOrder.php
@@ -11,14 +11,25 @@ class ProductInOrder extends Constraint
 {
     public const NO_PRODUCT_IN_ORDER_ERROR = '2e34acd7-7266-4057-ab1a-4ee997f3d2a5';
 
-    public string $noProductInOrderMessage = 'There are no products in the cart';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::NO_PRODUCT_IN_ORDER_ERROR => 'NO_PRODUCT_IN_ORDER_ERROR',
     ];
+
+    /**
+     * @param string $noProductInOrderMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $noProductInOrderMessage = 'There are no products in the cart',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/PromoCode.php
+++ b/packages/frontend-api/src/Component/Constraints/PromoCode.php
@@ -20,22 +20,6 @@ class PromoCode extends Constraint
     public const ALREADY_APPLIED_PROMO_CODE_ERROR = 'bde9e59e-6881-460e-8501-7f5e9a57a266';
     public const LIMIT_NOT_REACHED_ERROR = '3f94ee5e-b496-441b-9744-d8b6375000e6';
 
-    public string $invalidMessage = 'The promo code is not valid or it has been already used. Check it, please.';
-
-    public string $notYetValidMessage = 'The promo code is not valid yet. Check it, please.';
-
-    public string $noLongerValidMessage = 'The promo code is no longer valid. Check it, please.';
-
-    public string $noRelationToProductsInCartMessage = 'The promo code is not applicable to any of the products in your cart. Check it, please.';
-
-    public string $forRegisteredCustomerUsersOnlyMessage = 'Promo code is available for registered customers only.';
-
-    public string $notAvailableForCustomerUserPricingGroupMessage = 'Promo code is not available for your pricing group. Maybe you forgot to log in.';
-
-    public string $alreadyAppliedPromoCodeMessage = 'Promo code is already applied in the current cart.';
-
-    public string $limitNotReachedMessage = 'The promo code can only be used for a higher total price.';
-
     /**
      * @var array<string, string>
      */
@@ -49,6 +33,33 @@ class PromoCode extends Constraint
         self::ALREADY_APPLIED_PROMO_CODE_ERROR => 'ALREADY_APPLIED_PROMO_CODE_ERROR',
         self::LIMIT_NOT_REACHED_ERROR => 'LIMIT_NOT_REACHED_ERROR',
     ];
+
+    /**
+     * @param string $invalidMessage
+     * @param string $notYetValidMessage
+     * @param string $noLongerValidMessage
+     * @param string $noRelationToProductsInCartMessage
+     * @param string $forRegisteredCustomerUsersOnlyMessage
+     * @param string $notAvailableForCustomerUserPricingGroupMessage
+     * @param string $alreadyAppliedPromoCodeMessage
+     * @param string $limitNotReachedMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $invalidMessage = 'The promo code is not valid or it has been already used. Check it, please.',
+        public string $notYetValidMessage = 'The promo code is not valid yet. Check it, please.',
+        public string $noLongerValidMessage = 'The promo code is no longer valid. Check it, please.',
+        public string $noRelationToProductsInCartMessage = 'The promo code is not applicable to any of the products in your cart. Check it, please.',
+        public string $forRegisteredCustomerUsersOnlyMessage = 'Promo code is available for registered customers only.',
+        public string $notAvailableForCustomerUserPricingGroupMessage = 'Promo code is not available for your pricing group. Maybe you forgot to log in.',
+        public string $alreadyAppliedPromoCodeMessage = 'Promo code is already applied in the current cart.',
+        public string $limitNotReachedMessage = 'The promo code can only be used for a higher total price.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/PromoCode.php
+++ b/packages/frontend-api/src/Component/Constraints/PromoCode.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
@@ -35,6 +37,7 @@ class PromoCode extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $invalidMessage
      * @param string $notYetValidMessage
      * @param string $noLongerValidMessage
@@ -43,10 +46,12 @@ class PromoCode extends Constraint
      * @param string $notAvailableForCustomerUserPricingGroupMessage
      * @param string $alreadyAppliedPromoCodeMessage
      * @param string $limitNotReachedMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $invalidMessage = 'The promo code is not valid or it has been already used. Check it, please.',
         public string $notYetValidMessage = 'The promo code is not valid yet. Check it, please.',
         public string $noLongerValidMessage = 'The promo code is no longer valid. Check it, please.',
@@ -58,7 +63,14 @@ class PromoCode extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/TransportInCart.php
+++ b/packages/frontend-api/src/Component/Constraints/TransportInCart.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class TransportInCart extends Constraint
@@ -27,15 +29,18 @@ class TransportInCart extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $unavailableTransportMessage
      * @param string $unavailablePickupPlaceMessage
      * @param string $weightLimitExceededMessage
      * @param string $missingPickupPlaceIdentifierMessage
      * @param string $invalidTransportPaymentCombinationMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $unavailableTransportMessage = 'Transport with provided UUID is not available',
         public string $unavailablePickupPlaceMessage = 'Pickup place with provided UUID is not available',
         public string $weightLimitExceededMessage = 'Selected transport weight limit has been exceeded',
@@ -44,7 +49,14 @@ class TransportInCart extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/TransportInCart.php
+++ b/packages/frontend-api/src/Component/Constraints/TransportInCart.php
@@ -15,16 +15,6 @@ class TransportInCart extends Constraint
     public const MISSING_PICKUP_PLACE_IDENTIFIER_ERROR = '7c12df56-2fb7-4782-b8d7-5755cf53fd3a';
     public const INVALID_TRANSPORT_PAYMENT_COMBINATION_ERROR = 'd96b9e7d-f532-4249-8d50-c77e3a67a4cf';
 
-    public string $unavailableTransportMessage = 'Transport with provided UUID is not available';
-
-    public string $unavailablePickupPlaceMessage = 'Pickup place with provided UUID is not available';
-
-    public string $weightLimitExceededMessage = 'Selected transport weight limit has been exceeded';
-
-    public string $missingPickupPlaceIdentifierMessage = 'Selected transport needs to have pickup place identifier set';
-
-    public string $invalidTransportPaymentCombinationMessage = 'The transport is not allowed in combination with already selected payment';
-
     /**
      * @var array<string, string>
      */
@@ -35,6 +25,27 @@ class TransportInCart extends Constraint
         self::MISSING_PICKUP_PLACE_IDENTIFIER_ERROR => 'MISSING_PICKUP_PLACE_IDENTIFIER_ERROR',
         self::INVALID_TRANSPORT_PAYMENT_COMBINATION_ERROR => 'INVALID_TRANSPORT_PAYMENT_COMBINATION_ERROR',
     ];
+
+    /**
+     * @param string $unavailableTransportMessage
+     * @param string $unavailablePickupPlaceMessage
+     * @param string $weightLimitExceededMessage
+     * @param string $missingPickupPlaceIdentifierMessage
+     * @param string $invalidTransportPaymentCombinationMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $unavailableTransportMessage = 'Transport with provided UUID is not available',
+        public string $unavailablePickupPlaceMessage = 'Pickup place with provided UUID is not available',
+        public string $weightLimitExceededMessage = 'Selected transport weight limit has been exceeded',
+        public string $missingPickupPlaceIdentifierMessage = 'Selected transport needs to have pickup place identifier set',
+        public string $invalidTransportPaymentCombinationMessage = 'The transport is not allowed in combination with already selected payment',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/TransportInOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/TransportInOrder.php
@@ -16,18 +16,6 @@ class TransportInOrder extends Constraint
     public const WEIGHT_LIMIT_EXCEEDED_ERROR = 'b1eb2af1-2e7a-4463-aa5e-fb2bf82a30ef';
     public const MISSING_PICKUP_PLACE_IDENTIFIER_ERROR = '72cfdb60-9779-4903-a845-57e14b730795';
 
-    public string $transportNotSetMessage = 'Transport must be set in cart before sending the order';
-
-    public string $transportUnavailableMessage = 'Selected transport is not available';
-
-    public string $changedTransportPriceMessage = 'Selected transport price has changed';
-
-    public string $pickupPlaceUnavailableMessage = 'Selected pickup place is not available';
-
-    public string $weightLimitExceeded = 'Selected transport weight limit has been exceeded';
-
-    public string $missingPickupPlaceIdentifierMessage = 'Selected transport needs to have pickup place identifier set';
-
     /**
      * @var array<string, string>
      */
@@ -39,6 +27,29 @@ class TransportInOrder extends Constraint
         self::WEIGHT_LIMIT_EXCEEDED_ERROR => 'WEIGHT_LIMIT_EXCEEDED_ERROR',
         self::MISSING_PICKUP_PLACE_IDENTIFIER_ERROR => 'MISSING_PICKUP_PLACE_IDENTIFIER_ERROR',
     ];
+
+    /**
+     * @param string $transportNotSetMessage
+     * @param string $transportUnavailableMessage
+     * @param string $changedTransportPriceMessage
+     * @param string $pickupPlaceUnavailableMessage
+     * @param string $weightLimitExceeded
+     * @param string $missingPickupPlaceIdentifierMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $transportNotSetMessage = 'Transport must be set in cart before sending the order',
+        public string $transportUnavailableMessage = 'Selected transport is not available',
+        public string $changedTransportPriceMessage = 'Selected transport price has changed',
+        public string $pickupPlaceUnavailableMessage = 'Selected pickup place is not available',
+        public string $weightLimitExceeded = 'Selected transport weight limit has been exceeded',
+        public string $missingPickupPlaceIdentifierMessage = 'Selected transport needs to have pickup place identifier set',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/TransportInOrder.php
+++ b/packages/frontend-api/src/Component/Constraints/TransportInOrder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 class TransportInOrder extends Constraint
@@ -29,16 +31,19 @@ class TransportInOrder extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $transportNotSetMessage
      * @param string $transportUnavailableMessage
      * @param string $changedTransportPriceMessage
      * @param string $pickupPlaceUnavailableMessage
      * @param string $weightLimitExceeded
      * @param string $missingPickupPlaceIdentifierMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $transportNotSetMessage = 'Transport must be set in cart before sending the order',
         public string $transportUnavailableMessage = 'Selected transport is not available',
         public string $changedTransportPriceMessage = 'Selected transport price has changed',
@@ -48,7 +53,14 @@ class TransportInOrder extends Constraint
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/UniqueBillingAddressApi.php
+++ b/packages/frontend-api/src/Component/Constraints/UniqueBillingAddressApi.php
@@ -13,14 +13,25 @@ class UniqueBillingAddressApi extends Constraint
 {
     public const DUPLICATE_BILLING_ADDRESS = '9732bc5c-7b8e-404b-ac8c-a1c810f6a045';
 
-    public string $message = 'Billing address company number {{ company_number }} already exists. Contact customer support.';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::DUPLICATE_BILLING_ADDRESS => 'DUPLICATE_BILLING_ADDRESS',
     ];
+
+    /**
+     * @param string $message
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $message = 'Billing address company number {{ company_number }} already exists. Contact customer support.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Component/Constraints/UniqueBillingAddressApi.php
+++ b/packages/frontend-api/src/Component/Constraints/UniqueBillingAddressApi.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
@@ -21,16 +23,26 @@ class UniqueBillingAddressApi extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $message
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $message = 'Billing address company number {{ company_number }} already exists. Contact customer support.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/Watchdog.php
+++ b/packages/frontend-api/src/Component/Constraints/Watchdog.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
@@ -25,20 +27,30 @@ class Watchdog extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $notAvailableInquiry
      * @param string $notAvailableMainVariant
      * @param string $productNotFound
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $notAvailableInquiry = 'Watchdog is not available for product inquiry.',
         public string $notAvailableMainVariant = 'Watchdog is not available for product main variant.',
         public string $productNotFound = 'Product not found.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/Watchdog.php
+++ b/packages/frontend-api/src/Component/Constraints/Watchdog.php
@@ -15,12 +15,6 @@ class Watchdog extends Constraint
     public const MAIN_VARIANT_ERROR = 'a59f8293-2803-4571-b307-2b4ce72d39b4';
     public const PRODUCT_NOT_FOUND_ERROR = '8bbd03a5-48be-40fa-8c0f-5e3b1202adfd';
 
-    public string $notAvailableInquiry = 'Watchdog is not available for product inquiry.';
-
-    public string $notAvailableMainVariant = 'Watchdog is not available for product main variant.';
-
-    public string $productNotFound = 'Product not found.';
-
     /**
      * @var array<string, string>
      */
@@ -29,6 +23,23 @@ class Watchdog extends Constraint
         self::MAIN_VARIANT_ERROR => 'MAIN_VARIANT_ERROR',
         self::PRODUCT_NOT_FOUND_ERROR => 'PRODUCT_NOT_FOUND_ERROR',
     ];
+
+    /**
+     * @param string $notAvailableInquiry
+     * @param string $notAvailableMainVariant
+     * @param string $productNotFound
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $notAvailableInquiry = 'Watchdog is not available for product inquiry.',
+        public string $notAvailableMainVariant = 'Watchdog is not available for product main variant.',
+        public string $productNotFound = 'Product not found.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/packages/frontend-api/src/Model/SocialNetwork/SocialNetworkFacade.php
+++ b/packages/frontend-api/src/Model/SocialNetwork/SocialNetworkFacade.php
@@ -122,12 +122,12 @@ class SocialNetworkFacade
     protected function validateDataFromSocialNetwork(Profile $userProfile): void
     {
         $violations = $this->validator->validate($userProfile->email, [
-            new NotBlank(['message' => 'Email is not filled']),
-            new Length([
-                'max' => 255,
-                'maxMessage' => 'Email cannot be longer than {{ limit }} characters',
-            ]),
-            new Email(['message' => 'Email is not valid']),
+            new NotBlank(message: 'Email is not filled'),
+            new Length(
+                max: 255,
+                maxMessage: 'Email cannot be longer than {{ limit }} characters',
+            ),
+            new Email(message: 'Email is not valid'),
         ]);
 
         if (count($violations) > 0) {

--- a/packages/http-smoke-testing/src/HttpSmokeTestCase.php
+++ b/packages/http-smoke-testing/src/HttpSmokeTestCase.php
@@ -59,7 +59,7 @@ abstract class HttpSmokeTestCase extends KernelTestCase
 
         $requestDataSet->executeCallsDuringTestExecution(static::$kernel->getContainer());
 
-        $request->attributes->add($requestDataSet->getParameters());
+        $request->query->add($requestDataSet->getParameters());
 
         $response = $this->handleRequest($request);
 

--- a/packages/product-feed-heureka/src/Form/HeurekaProductFormType.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaProductFormType.php
@@ -38,10 +38,10 @@ final class HeurekaProductFormType extends AbstractType
             'entry_options' => [
                 'currency' => 'CZK',
                 'constraints' => [
-                    new MoneyRange([
-                        'min' => Money::zero(),
-                        'max' => Money::create(500),
-                    ]),
+                    new MoneyRange(
+                        min: Money::zero(),
+                        max: Money::create(500),
+                    ),
                 ],
             ],
         ]);

--- a/packages/product-feed-luigis-box/src/Form/LuigisBoxSettingFormType.php
+++ b/packages/product-feed-luigis-box/src/Form/LuigisBoxSettingFormType.php
@@ -26,10 +26,10 @@ final class LuigisBoxSettingFormType extends AbstractType
                 'label' => t('Luigi\'s Box rank'),
                 'required' => true,
                 'constraints' => [
-                    new Constraints\NotNull([
-                        'message' => 'Please enter the Luigi\'s Box rank.',
-                    ]),
-                    new Constraints\Range(['min' => 1, 'max' => 15]),
+                    new Constraints\NotNull(
+                        message: 'Please enter the Luigi\'s Box rank.',
+                    ),
+                    new Constraints\Range(min: 1, max: 15),
                 ],
             ])
             ->add('luigisBoxRankInfo', MessageType::class, [

--- a/packages/product-feed-zbozi/src/Form/ZboziProductFormType.php
+++ b/packages/product-feed-zbozi/src/Form/ZboziProductFormType.php
@@ -47,10 +47,10 @@ final class ZboziProductFormType extends AbstractType
                 'entry_options' => [
                     'currency' => 'CZK',
                     'constraints' => [
-                        new MoneyRange([
-                            'min' => Money::create(1),
-                            'max' => Money::create(500),
-                        ]),
+                        new MoneyRange(
+                            min: Money::create(1),
+                            max: Money::create(500),
+                        ),
                     ],
                 ],
             ])
@@ -63,10 +63,10 @@ final class ZboziProductFormType extends AbstractType
                 'entry_options' => [
                     'currency' => 'CZK',
                     'constraints' => [
-                        new MoneyRange([
-                            'min' => Money::create(1),
-                            'max' => Money::create(500),
-                        ]),
+                        new MoneyRange(
+                            min: Money::create(1),
+                            max: Money::create(500),
+                        ),
                     ],
                 ],
             ])

--- a/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
@@ -49,13 +49,13 @@ final class SliderItemFormTypeExtension extends AbstractTypeExtension
                 'image_entity_class' => SliderItem::class,
                 'image_type' => SliderItemFacade::IMAGE_TYPE_WEB,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg'],
-                        'mimeTypesMessage' => 'Image can be only in JPG or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        maxSize: '15M',
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                        mimeTypesMessage: 'Image can be only in JPG or PNG format',
+                    ),
                 ],
                 'label' => t('Upload image'),
                 'entity' => $options['slider_item'],
@@ -71,13 +71,13 @@ final class SliderItemFormTypeExtension extends AbstractTypeExtension
                 'image_entity_class' => SliderItem::class,
                 'image_type' => SliderItemFacade::IMAGE_TYPE_MOBILE,
                 'file_constraints' => [
-                    new Constraints\Image([
-                        'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg'],
-                        'mimeTypesMessage' => 'Image can be only in JPG or PNG format',
-                        'maxSize' => '15M',
-                        'maxSizeMessage' => 'Uploaded image is to large ({{ size }} {{ suffix }}). '
+                    new Constraints\Image(
+                        maxSize: '15M',
+                        mimeTypes: ['image/png', 'image/jpg', 'image/jpeg'],
+                        maxSizeMessage: 'Uploaded image is to large ({{ size }} {{ suffix }}). '
                             . 'Maximum size of an image is {{ limit }} {{ suffix }}.',
-                    ]),
+                        mimeTypesMessage: 'Image can be only in JPG or PNG format',
+                    ),
                 ],
                 'label' => t('Upload image for mobile devices'),
                 'entity' => $options['slider_item'],
@@ -96,7 +96,7 @@ final class SliderItemFormTypeExtension extends AbstractTypeExtension
             'required' => true,
             'label' => t('GTM ID'),
             'constraints' => [
-                new Constraints\NotBlank(['message' => 'Please enter GTM ID']),
+                new Constraints\NotBlank(message: 'Please enter GTM ID'),
             ],
             'attr' => ['placeholder' => t('e.g. Sale-04-20-2020')],
         ])->add('gtmCreative', TextType::class, [

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/ExistingEmail.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/ExistingEmail.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\FrontendApi\Model\Component\Constraints;
 
 use Attribute;
+use Override;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -12,12 +13,32 @@ class ExistingEmail extends Constraint
 {
     public const USER_WITH_EMAIL_DOES_NOT_EXIST_ERROR = 'd1bf5f27-fe92-424c-bb58-df90cc7637b1';
 
-    public string $invalidMessage = 'User with provided email address does not exist.';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::USER_WITH_EMAIL_DOES_NOT_EXIST_ERROR => 'USER_WITH_EMAIL_DOES_NOT_EXIST_ERROR',
     ];
+
+    /**
+     * @param string $invalidMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $invalidMessage = 'User with provided email address does not exist.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getTargets(): string|array
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/ExistingEmail.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/ExistingEmail.php
@@ -6,6 +6,8 @@ namespace App\FrontendApi\Model\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -21,16 +23,26 @@ class ExistingEmail extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $invalidMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $invalidMessage = 'User with provided email address does not exist.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/ParameterFilter.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/ParameterFilter.php
@@ -6,6 +6,8 @@ namespace App\FrontendApi\Model\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_CLASS)]
@@ -23,18 +25,28 @@ class ParameterFilter extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $valuesNotSupportedForSliderTypeMessage
      * @param string $minMaxNotSupportedForNonSliderTypeMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $valuesNotSupportedForSliderTypeMessage = 'An array of values is not supported as an input for "%type%" type parameter. Use "%minimalValue%" and "%maximalValue%" instead.',
         public string $minMaxNotSupportedForNonSliderTypeMessage = 'Minimal and maximal value are not supported as an input for other than "%type%" type parameter. Use "%values%" instead.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/ParameterFilter.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/ParameterFilter.php
@@ -14,10 +14,6 @@ class ParameterFilter extends Constraint
     public const VALUES_NOT_SUPPORTED_FOR_SLIDER_TYPE_ERROR = '83a312e6-4433-494d-9687-00d4a4908432';
     public const MIN_MAX_NOT_SUPPORTED_FOR_NON_SLIDER_TYPE_ERROR = '06d34255-50cb-44ad-b07f-2d643962ad04';
 
-    public string $valuesNotSupportedForSliderTypeMessage = 'An array of values is not supported as an input for "%type%" type parameter. Use "%minimalValue%" and "%maximalValue%" instead.';
-
-    public string $minMaxNotSupportedForNonSliderTypeMessage = 'Minimal and maximal value are not supported as an input for other than "%type%" type parameter. Use "%values%" instead.';
-
     /**
      * @var array<string, string>
      */
@@ -25,6 +21,21 @@ class ParameterFilter extends Constraint
         self::VALUES_NOT_SUPPORTED_FOR_SLIDER_TYPE_ERROR => 'VALUES_NOT_SUPPORTED_FOR_SLIDER_TYPE_ERROR',
         self::MIN_MAX_NOT_SUPPORTED_FOR_NON_SLIDER_TYPE_ERROR => 'MIN_MAX_NOT_SUPPORTED_FOR_NON_SLIDER_TYPE_ERROR',
     ];
+
+    /**
+     * @param string $valuesNotSupportedForSliderTypeMessage
+     * @param string $minMaxNotSupportedForNonSliderTypeMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $valuesNotSupportedForSliderTypeMessage = 'An array of values is not supported as an input for "%type%" type parameter. Use "%minimalValue%" and "%maximalValue%" instead.',
+        public string $minMaxNotSupportedForNonSliderTypeMessage = 'Minimal and maximal value are not supported as an input for other than "%type%" type parameter. Use "%values%" instead.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/ResetPasswordHash.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/ResetPasswordHash.php
@@ -6,6 +6,8 @@ namespace App\FrontendApi\Model\Component\Constraints;
 
 use Attribute;
 use Override;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 #[Attribute(Attribute::TARGET_CLASS)]
@@ -21,16 +23,26 @@ class ResetPasswordHash extends Constraint
     ];
 
     /**
+     * @param array<string, mixed>|null $options
      * @param string $invalidMessage
-     * @param array|null $groups
+     * @param array<string>|null $groups
      * @param mixed $payload
      */
+    #[HasNamedArguments]
     public function __construct(
+        ?array $options = null,
         public string $invalidMessage = 'Provided hash is not valid.',
         ?array $groups = null,
         mixed $payload = null,
     ) {
-        parent::__construct([], $groups, $payload);
+        if (is_array($options)) {
+            DeprecationHelper::trigger(
+                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+                static::class,
+            );
+        }
+
+        parent::__construct($options, $groups, $payload);
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/ResetPasswordHash.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/ResetPasswordHash.php
@@ -13,14 +13,25 @@ class ResetPasswordHash extends Constraint
 {
     public const INVALID_HASH_ERROR = '82016a50-34c6-4b78-a21d-f9dc5bb47215';
 
-    public string $invalidMessage = 'Provided hash is not valid.';
-
     /**
      * @var array<string, string>
      */
     protected const array ERROR_NAMES = [
         self::INVALID_HASH_ERROR => 'INVALID_HASH_ERROR',
     ];
+
+    /**
+     * @param string $invalidMessage
+     * @param array|null $groups
+     * @param mixed $payload
+     */
+    public function __construct(
+        public string $invalidMessage = 'Provided hash is not valid.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 
     /**
      * {@inheritdoc}

--- a/upgrade-notes/backend_20260122_140000.md
+++ b/upgrade-notes/backend_20260122_140000.md
@@ -1,0 +1,88 @@
+#### Updated constraint classes and usages for Symfony 7 compatibility ([#4409](https://github.com/shopsys/shopsys/pull/4409))
+
+- if you have extended or created custom constraint classes, update them to use constructor-promoted properties instead of public properties with `getRequiredOptions()` like this:
+
+    ```diff
+    class Contains extends Constraint
+    {
+    -    public string $message = 'Field must contain {{ needle }}.';
+    -
+    -    public ?string $needle = null;
+    -
+    -    /**
+    -     * {@inheritdoc}
+    -     */
+    -    #[Override]
+    -    public function getRequiredOptions(): array
+    -    {
+    -        return [
+    -            'needle',
+    -        ];
+    -    }
+    +    /**
+    +     * @param array<string, mixed>|null $options
+    +     * @param string $needle
+    +     * @param string $message
+    +     * @param array|null $groups
+    +     * @param mixed $payload
+    +     */
+    +    #[HasNamedArguments]
+    +    public function __construct(
+    +        ?array $options = null,
+    +        public string $needle,
+    +        public string $message = 'Field must contain {{ needle }}.',
+    +        ?array $groups = null,
+    +        mixed $payload = null,
+    +    ) {
+    +        if (is_array($options)) {
+    +            DeprecationHelper::trigger(
+    +                'Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.',
+    +                static::class,
+    +            );
+    +        }
+    +
+    +        parent::__construct($options, $groups, $payload);
+    +    }
+    +
+    +    /**
+    +     * {@inheritdoc}
+    +     */
+    +    #[Override]
+    +    public function getTargets(): string|array
+    +    {
+    +        return self::PROPERTY_CONSTRAINT;
+    +    }
+    }
+    ```
+
+    - follow [Rector upgrade guide](https://docs.shopsys.com/en/18.0/project/upgrade-your-project-with-rector/) with the following setlists:
+        - `ConstraintOptionsToNamedArgumentsRector::class`
+
+- update all constraint instantiations to use named parameters instead of associative arrays like this:
+    ```diff
+    - new UniqueEntityField([
+    -     'entityInstance' => $adminToEdit,
+    -     'message' => 'Administrator with user name "{{ value }}" is already registered',
+    -     'fieldName' => 'username',
+    -     'entityName' => Administrator::class,
+    - ])
+    + new UniqueEntityField(
+    +     entityInstance: $adminToEdit,
+    +     message: 'Administrator with user name "{{ value }}" is already registered',
+    +     fieldName: 'username',
+    +     entityName: Administrator::class,
+    + )
+    ```
+- replace deprecated `$request->get()` with specific property bag accessors
+
+    | Old Usage                                     | New Usage                              |
+    | --------------------------------------------- | -------------------------------------- |
+    | `$request->get('param')` for query string     | `$request->query->get('param')`        |
+    | `$request->get('param')` for POST data        | `$request->request->get('param')`      |
+    | `$request->get('param')` for route attributes | `$request->attributes->get('param')`   |
+    | `(int)$request->get('param')`                 | `$request->query->getInt('param')`     |
+    | `(bool)$request->get('param')`                | `$request->query->getBoolean('param')` |
+    | `$request->get('param') !== null`             | `$request->query->has('param')`        |
+    | `$request->get('arrayParam')` for arrays      | `$request->request->all('arrayParam')` |
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- replaced depreacated `Request::get()` with specific property bag accessors
- updated constraint classes to use constructor-promoted properties instead of public properties
- updated all constraint instantiations to use named parameters instead of associative arrays
- replaced composer dependency gordalina/cachetool with phar installation in the php-image

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-update-code-to-compliancy-with-symfony-7.odin.shopsys.cloud
  - https://cz.tl-update-code-to-compliancy-with-symfony-7.odin.shopsys.cloud
  - https://tl-update-code-to-compliancy-with-symfony-7.odin.shopsys.cloud/sk
<!-- Replace -->
