### PR TITLE
docs: fix broken links and update config

### DIFF
--- a/docs/_hooks/replace_links.py
+++ b/docs/_hooks/replace_links.py
@@ -1,2 +1,2 @@
 def on_page_markdown(markdown, **kwargs):
-    return markdown.replace('{{github.link}}', 'https://github.com/shopsys/shopsys/blob/' + str(kwargs['config']['current_version']))
+    return markdown.replace('{{github.link}}', 'https://github.com/shopsys/shopsys/blob/' + str(kwargs['config']['extra']['current_version']))

--- a/docs/administration/crud-controller/index.md
+++ b/docs/administration/crud-controller/index.md
@@ -4,7 +4,7 @@ The Crud Controller is a powerful tool that allows you to easily design a UI for
 
 It's designed to speed up the development of the administration interface and provide a consistent user experience. At the same time, it's flexible enough to allow for customizations.
 
-Crud controller is built using known Shopsys components like [Grid](../grid.md) and Symfony components.
+Crud controller is built using known Shopsys components like [Grid](../internal-grid/index.md) and Symfony components.
 
 ## Getting started
 - [Creating a new Crud Controller](getting-started/creating-a-new-crud-controller.md)

--- a/docs/administration/datagrid/index.md
+++ b/docs/administration/datagrid/index.md
@@ -2,7 +2,7 @@
 
 The Datagrid is a component that allows you to display a list of records as a table.
 
-This component is built on top of the [Grid](./internal-grid/index.md) component and provides easier configuration. It can also be used as a standalone component outside of the Crud Controller.
+This component is built on top of the [Grid](../internal-grid/index.md) component and provides easier configuration. It can also be used as a standalone component outside of the Crud Controller.
 
 - [Configuration](./configuration.md)
   - [Fields](./fields.md)

--- a/docs/administration/internal-grid/grid-data-sources.md
+++ b/docs/administration/internal-grid/grid-data-sources.md
@@ -10,6 +10,8 @@ As a data source, the [Grid Component](index.md) requires an implementation of [
 - [`ArrayWithPaginationDataSourceFactory`]({{github.link}}/packages/framework/src/Component/Grid/ArrayWithPaginationDataSourceFactory.php)
 - [`MoneyConvertingDataSourceDecoratorFactory`]({{github.link}}/packages/framework/src/Component/Grid/MoneyConvertingDataSourceDecoratorFactory.php)
 
+## [`QueryBuilderDataSource`]({{github.link}}/packages/framework/src/Component/Grid/QueryBuilderDataSource.php)
+
 The most commonly used data source is created from Doctrine Query Builder.
 
 ### Example of usage
@@ -29,7 +31,7 @@ $queryBuilder->select('p')
 $dataSource = $this->queryBuilderDataSourceFactory->create($queryBuilder, 'p.id');
 ```
 
-QueryBuilderDataSource contains a third default parameter $hint which is pre-set to SortableNullsWalker::class as a way to sort null values to the beginning in the case of ASC sorting, or to the end in the case of DESC sorting.
+QueryBuilderDataSource contains a third default parameter `$hint` which is pre-set to `SortableNullsWalker::class` as a way to sort null values to the beginning in the case of ASC sorting, or to the end in the case of DESC sorting.
 This default setting overrides the default behavior of postgreSQL and in the case of large tables can cause the query to slow down.
 For this case and after considering all options, it is possible to set the hint to NULL and thus keep the default behavior of postgreSQL to speed up the query.
 
@@ -70,7 +72,7 @@ $dataSource = $this->queryBuilderWithRowManipulatorDataSourceFactory->create(
 );
 ```
 
-As in the case of QueryBuilderDataSource, it is possible to change the setting of the $hint parameter, see [`QueryBuilderDataSource`](#querybuilderdatasource).
+As in the case of `QueryBuilderDataSource`, it is possible to change the setting of the `$hint` parameter, see [`QueryBuilderDataSource`](#querybuilderdatasource).
 
 ### Tips for optimal usage QueryBuilderDataSource or QueryBuilderWithRowManipulatorDataSource
 

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -84,7 +84,7 @@ Most important build command for production. Cleans cache, installs composer dep
 
 !!! tip
 
-    More about how to install and deploy your application in production can be found in [Installation Using Docker on Production Server](../installation/installation-using-docker-on-production-server.md)
+    More about how to install and deploy your application in production can be found in [Installation Using Kubernetes on Production Server](../installation/installation-using-kubernetes-on-production-server.md)
 
 #### build-demo-ci
 

--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -19,11 +19,11 @@ If you want to show Cron overview table for non-superadmin users you need add pa
 
 ## Default Cron Commands
 
-There is some prepared configuration in a file [`app/config/cron.yaml`]({github.link}}/project-base/app/config/cron.yaml) in `project-base`.
+There is some prepared configuration in a file [`app/config/cron.yaml`]({{github.link}}/project-base/app/config/cron.yaml) in `project-base`.
 
 !!! note
 
-    Hours set in [`app/config/cron.yaml`]({github.link}}/project-base/app/config/cron.yaml) are consider to be in timezone set in `shopsys.cron_timezone` parameter in [`config/parameters_common.yaml`]({{github.link}}/project-base/app/config/parameters_common.yaml) file.
+    Hours set in [`app/config/cron.yaml`]({{github.link}}/project-base/app/config/cron.yaml) are consider to be in timezone set in `shopsys.cron_timezone` parameter in [`config/parameters_common.yaml`]({{github.link}}/project-base/app/config/parameters_common.yaml) file.
 
 ## Running Cron Jobs
 

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -62,7 +62,7 @@ See how to install Shopsys Platform in production and how to proceed when deploy
 
 Every administrator can switch the administration locale to any of the locales defined by the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml` configuration.
 The first locale in the list is the default one.
-This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
+This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#37-locale-in-administration).
 
 ## What are the differences between "listable", "sellable", "offered" and "visible" products?
 

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -278,7 +278,7 @@ The value is then used for setting [`default_locale` Symfony parameter](https://
 
 !!! note
 
-    Default application locale in test environment is set to first domain locale except administration where is respected [`admin_locale` setting](#36-locale-in-administration)
+    Default application locale in test environment is set to first domain locale except administration where is respected [`admin_locale` setting](#37-locale-in-administration)
 
 ### 4. Change the url address for an existing domain
 

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -48,7 +48,7 @@ When you install new project, locales are set like this
 - `B2B - SK` _(3rd domain)_: `sk`
 - administration: `en`
 
-In case you want to change domain locale read [locale settings](./how-to-set-up-domains-and-locales.md#3-locale-settings) or in case you want to change default administration locale read [locale in administration](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
+In case you want to change domain locale read [locale settings](./how-to-set-up-domains-and-locales.md#3-locale-settings) or in case you want to change default administration locale read [locale in administration](./how-to-set-up-domains-and-locales.md#37-locale-in-administration).
 
 ## Set up domain type
 

--- a/docs/model/elasticsearch.md
+++ b/docs/model/elasticsearch.md
@@ -75,7 +75,7 @@ If you need to change the data that are exported into Elasticsearch, overwrite a
 ## Use of Elasticsearch
 
 You can learn more about [Product searching](../model/front-end-product-searching.md) in a separate article.
-[Sorting](../introduction/how-to-set-up-domains-and-locales.md#37-sorting-in-different-locales) is done with the help of [ICU analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html)
+[Sorting](../introduction/how-to-set-up-domains-and-locales.md#38-sorting-in-different-locales) is done with the help of [ICU analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html)
 which ensures that alphabetical sorting is correct for every language and its set of rules.
 
 ### Adding new index

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
-current_version: 19.0
+extra:
+    current_version: 19.0
 
 extra_css:
     - _theme/main.css

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/UpdateVersionInDocsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/UpdateVersionInDocsReleaseWorker.php
@@ -61,9 +61,10 @@ final class UpdateVersionInDocsReleaseWorker extends AbstractShopsysReleaseWorke
      */
     private function replaceCurrentVersionInMkdocsConfig(string $fileContent): string
     {
+        // the "current_version" is under the "extra" key in mkdocs.yml, so it has indentation
         $updatedFileContent = preg_replace(
-            '/current_version: .+$/m',
-            'current_version: ' . $this->currentBranchName,
+            '/^(\s*)current_version: .+$/m',
+            '$1current_version: ' . $this->currentBranchName,
             $fileContent,
         );
 


### PR DESCRIPTION
#### Description, the reason for the PR
There were a few warnings in the `mkdocs` logs:
```
mkdocs-1  | WARNING -  Config value 'current_version': Unrecognised configuration name: current_version
mkdocs-1  | WARNING -  Doc file 'administration/crud-controller/index.md' contains a link '../grid.md', but the target 'administration/grid.md' is not found among documentation files.
mkdocs-1  | WARNING -  Doc file 'administration/datagrid/index.md' contains a link './internal-grid/index.md', but the target 'administration/datagrid/internal-grid/index.md' is not found among documentation files.
mkdocs-1  | WARNING -  Doc file 'introduction/console-commands-for-application-management-phing-targets.md' contains a link '../installation/installation-using-docker-on-production-server.md', but the target 'installation/installation-using-docker-on-production-server.md' is not found among documentation files.
mkdocs-1  | WARNING -  Doc file 'introduction/cron.md' contains a link '{github.link}}/project-base/app/config/cron.yaml', but the target 'introduction/{github.link}}/project-base/app/config/cron.yaml' is not found among documentation files.
mkdocs-1  | WARNING -  Doc file 'introduction/cron.md' contains a link '{github.link}}/project-base/app/config/cron.yaml', but the target 'introduction/{github.link}}/project-base/app/config/cron.yaml' is not found among documentation files.
mkdocs-1  | INFO    -  Doc file 'administration/internal-grid/grid-data-sources.md' contains a link '#querybuilderdatasource', but there is no such anchor on this page.
mkdocs-1  | INFO    -  Doc file 'introduction/faq-and-common-issues.md' contains a link './how-to-set-up-domains-and-locales.md#36-locale-in-administration', but the doc 'introduction/how-to-set-up-domains-and-locales.md' does not contain an anchor '#36-locale-in-administration'.
mkdocs-1  | INFO    -  Doc file 'introduction/how-to-set-up-domains-and-locales.md' contains a link '#36-locale-in-administration', but there is no such anchor on this page.
mkdocs-1  | INFO    -  Doc file 'introduction/start-building-your-application.md' contains a link './how-to-set-up-domains-and-locales.md#36-locale-in-administration', but the doc 'introduction/how-to-set-up-domains-and-locales.md' does not contain an anchor '#36-locale-in-administration'.
mkdocs-1  | INFO    -  Doc file 'model/elasticsearch.md' contains a link '../introduction/how-to-set-up-domains-and-locales.md#37-sorting-in-different-locales', but the doc 'introduction/how-to-set-up-domains-and-locales.md' does not contain an anchor '#37-sorting-in-different-locales'.
```
#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-mkdocs.odin.shopsys.cloud
  - https://cz.rv-mkdocs.odin.shopsys.cloud
  - https://rv-mkdocs.odin.shopsys.cloud/sk
<!-- Replace -->
