### PR TITLE
fixed add newly uploaded image in elfinder behavior

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -94,6 +94,7 @@ return ECSConfig::configure()
         include __DIR__ . '/project-base/app/ecs-skip-rules.php',
         [
             __DIR__ . '/packages/framework/tests/Test/Codeception/ActorInterface.php',
+            __DIR__ . '/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php',
             __DIR__ . '/packages/coding-standards/tests/Unit/**/wrong/*',
             __DIR__ . '/packages/coding-standards/tests/Unit/**/Wrong/*',
             __DIR__ . '/packages/coding-standards/tests/Unit/**/correct/*',

--- a/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
+++ b/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
@@ -196,6 +196,116 @@ class VolumeDriver extends Driver
 
         return $stat;
     }
+
+      /**
+     * Return content URL (for netmout volume driver)
+     * If file.url == 1 requests from JavaScript client with XHR
+     *
+     * @param string $hash    file hash
+     * @param array  $options options array
+     *
+     * @return boolean|string
+     * @author Naoki Sawada
+     */
+    #[Override]
+    public function getContentUrl($hash, $options = array())
+    {
+        if (($file = $this->file($hash)) === false) {
+            return false;
+        }
+        if (!empty($options['onetime']) && $this->options['onetimeUrl']) {
+            if (is_callable($this->options['onetimeUrl'])) {
+                return call_user_func_array($this->options['onetimeUrl'], array($file, $options, $this));
+            } else {
+                $ret = false;
+                if ($tmpdir = elFinder::getStaticVar('commonTempPath')) {
+                    if ($source = $this->open($hash)) {
+                        if ($_dat = tempnam($tmpdir, 'ELF')) {
+                            $token = md5($_dat . session_id());
+                            $dat = $tmpdir . DIRECTORY_SEPARATOR . 'ELF' . $token;
+                            if (rename($_dat, $dat)) {
+                                $info = stream_get_meta_data($source);
+                                if (!empty($info['uri'])) {
+                                    $tmp = $info['uri'];
+                                } else {
+                                    $tmp = tempnam($tmpdir, 'ELF');
+                                    if ($dest = fopen($tmp, 'wb')) {
+                                        if (!stream_copy_to_stream($source, $dest)) {
+                                            $tmp = false;
+                                        }
+                                        fclose($dest);
+                                    }
+                                }
+                                $this->close($source, $hash);
+                                if ($tmp) {
+                                    $info = array(
+                                        'file' => base64_encode($tmp),
+                                        'name' => $file['name'],
+                                        'mime' => $file['mime'],
+                                        'ts' => $file['ts']
+                                    );
+                                    if (file_put_contents($dat, json_encode($info))) {
+                                        $conUrl = elFinder::getConnectorUrl();
+                                        $ret = $conUrl . (strpos($conUrl, '?') !== false? '&' : '?') . 'cmd=file&onetime=1&target=' . $token;
+
+                                    }
+                                }
+                                if (!$ret) {
+                                    unlink($dat);
+                                }
+                            } else {
+                                unlink($_dat);
+                            }
+                        }
+                    }
+                }
+                return $ret;
+            }
+        }
+        if (empty($file['url']) && $this->URL) {
+            /* start fix for the double slash issue on the newly uploaded file - https://github.com/Studio-42/elFinder/issues/3725 */
+            $decoded = $this->decode($hash);
+
+            // safely strip root prefix if present
+            if (str_starts_with($decoded, $this->root)) {
+                $path = substr($decoded, strlen($this->root));
+            } else {
+                $path = $decoded;
+            }
+
+            // remove leading separator to avoid double slashes
+            $path = ltrim($path, '/');
+            $path = str_replace($this->separator, '/', $path);
+
+             if ($this->encoding) {
+                 $path = $this->convEncIn($path, true);
+             }
+
+             $path = str_replace('%2F', '/', rawurlencode($path));
+
+            return rtrim($this->URL, '/') . '/' . $path;
+            /* end fix */
+        } else {
+            $ret = false;
+            if (!empty($file['url']) && $file['url'] != 1) {
+                return $file['url'];
+            } else if (!empty($options['temporary']) && ($tempInfo = $this->getTempLinkInfo('temp_' . md5($hash . session_id())))) {
+                if (is_readable($tempInfo['path'])) {
+                    touch($tempInfo['path']);
+                    $ret = $tempInfo['url'] . '?' . rawurlencode($file['name']);
+                } else if ($source = $this->open($hash)) {
+                    if ($dest = fopen($tempInfo['path'], 'wb')) {
+                        if (stream_copy_to_stream($source, $dest)) {
+                            $ret = $tempInfo['url'] . '?' . rawurlencode($file['name']);
+                        }
+                        fclose($dest);
+                    }
+                    $this->close($source, $hash);
+                }
+            }
+            return $ret;
+        }
+    }
 }
 
 class_alias(VolumeDriver::class, 'elFinderVolumeFlysystem');

--- a/packages/framework/src/Component/Filesystem/MainFilesystemFactory.php
+++ b/packages/framework/src/Component/Filesystem/MainFilesystemFactory.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Filesystem;
 
+use League\Flysystem\Config;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\Visibility;
 use Override;
 
 class MainFilesystemFactory implements FilesystemFactoryInterface
@@ -26,6 +28,8 @@ class MainFilesystemFactory implements FilesystemFactoryInterface
     {
         $adapter = new LocalFilesystemAdapter($this->projectDir);
 
-        return new Filesystem($adapter);
+        return new Filesystem($adapter, [
+            Config::OPTION_DIRECTORY_VISIBILITY => Visibility::PUBLIC,
+        ]);
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

There were two main issues:

## 1.
On CI, where php-fpm and webserver share the content directory via volume (for example, `docker/conf/docker-compose.github-actions.review.simplified.yml.dist`).
If the admin created a folder in elfinder, the folder was created with strict permissions (0700). Due to a different uid in containers, webserver didn't had a permission to enter and read the content of the newly created folder -> the uploaded file didn't show up. 
Fixed by loosening permissions on the created folder.

## 2. 
Sometimes, when the image was added immediately after upload, it was added with a URL with an incorrect double slash, which causes problems, especially in combination with the CDN. 
This was caused by a bug in the latest version of the elfinder library - https://github.com/Studio-42/elFinder/issues/3725
Fixed by patching the volume driver method

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-wysiwyg-folder.odin.shopsys.cloud
  - https://cz.mg-wysiwyg-folder.odin.shopsys.cloud
  - https://mg-wysiwyg-folder.odin.shopsys.cloud/sk
<!-- Replace -->
