### PR TITLE
[SSP-3796] Fix product availability store count

### DIFF
--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityFacade.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityFacade.php
@@ -65,12 +65,15 @@ class ProductAvailabilityFacade
         }
 
         $productStocks = $this->productStockFacade->getProductStocksByProduct($product);
+        $storeCountsByStockId = $this->storeFacade->getStoreCountsByDomainIdIndexedByStockId($domainId);
 
         $count = 0;
 
         foreach ($productStocks as $productStock) {
+            $stock = $productStock->getStock();
+
             if ($productStock->getProductQuantity() > 0 && $productStock->getStock()->isEnabled($domainId)) {
-                $count += count($productStock->getStock()->getStores());
+                $count += $storeCountsByStockId[$stock->getId()] ?? 0;
             }
         }
 

--- a/packages/framework/src/Model/Store/StoreFacade.php
+++ b/packages/framework/src/Model/Store/StoreFacade.php
@@ -126,6 +126,14 @@ class StoreFacade
     }
 
     /**
+     * @return int[]
+     */
+    public function getStoreCountsByDomainIdIndexedByStockId(int $domainId): array
+    {
+        return $this->storeRepository->getStoreCountsByDomainIdIndexedByStockId($domainId);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData[] $openingHoursDataArray
      * @return \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours[]
      */

--- a/packages/framework/src/Model/Store/StoreRepository.php
+++ b/packages/framework/src/Model/Store/StoreRepository.php
@@ -134,4 +134,28 @@ class StoreRepository
 
         return $queryBuilder->getQuery()->execute();
     }
+
+    /**
+     * @return int[]
+     */
+    public function getStoreCountsByDomainIdIndexedByStockId(int $domainId): array
+    {
+        $rows = $this->getQueryBuilder()
+            ->select('IDENTITY(s.stock) AS stockId, COUNT(s.id) AS storeCount')
+            ->where('s.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
+            ->groupBy('s.stock')
+            ->getQuery()
+            ->getArrayResult();
+
+        $result = [];
+
+        foreach ($rows as $row) {
+            if ($row['stockId'] !== null) {
+                $result[$row['stockId']] = $row['storeCount'];
+            }
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
The original number returned by `getAvailableStoresCount` did not take into account the visibility by domain of related stores, which resulted in contradicting information displayed to customer.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-3796-fix-product-availability-store-count.odin.shopsys.cloud
  - https://cz.jm-ssp-3796-fix-product-availability-store-count.odin.shopsys.cloud
  - https://jm-ssp-3796-fix-product-availability-store-count.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773950168.353269 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-3796-fix-product-availability-store-count.odin.shopsys.cloud
  - https://cz.jm-ssp-3796-fix-product-availability-store-count.odin.shopsys.cloud
  - https://jm-ssp-3796-fix-product-availability-store-count.odin.shopsys.cloud/sk
<!-- Replace -->
