### PR TITLE
product recalculations now don't wait for full batch size, but process nearly immediately

### DIFF
--- a/packages/framework/src/Component/Messenger/Batch/BatchHandlerWithTimeLimitTrait.php
+++ b/packages/framework/src/Component/Messenger/Batch/BatchHandlerWithTimeLimitTrait.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger\Batch;
+
+use Symfony\Component\Messenger\Handler\Acknowledger;
+
+trait BatchHandlerWithTimeLimitTrait
+{
+    /**
+     * @var array<int, array{0: object, 1: \Symfony\Component\Messenger\Handler\Acknowledger}>
+     */
+    protected array $jobs = [];
+
+    protected ?int $batchStartedAt = null;
+
+    /**
+     * @param bool $force
+     */
+    public function flush(bool $force): void
+    {
+        if (!$force && !$this->shouldFlush()) {
+            return;
+        }
+
+        if ($this->jobs === []) {
+            $this->batchStartedAt = null;
+
+            return;
+        }
+
+        $jobs = $this->jobs;
+        $this->jobs = [];
+        $this->batchStartedAt = null;
+        $this->process($jobs);
+    }
+
+    /**
+     * @param object $message
+     * @param \Symfony\Component\Messenger\Handler\Acknowledger|null $ack
+     * @return mixed
+     */
+    protected function handle(object $message, ?Acknowledger $ack): mixed
+    {
+        if ($ack === null) {
+            $ack = new Acknowledger(get_debug_type($this));
+            $this->jobs[] = [$message, $ack];
+            $this->batchStartedAt ??= hrtime(true);
+            $this->flush(true);
+
+            return $ack->getResult();
+        }
+
+        $this->jobs[] = [$message, $ack];
+        $this->batchStartedAt ??= hrtime(true);
+
+        if (!$this->shouldFlush()) {
+            return count($this->jobs);
+        }
+
+        $this->flush(true);
+
+        return 0;
+    }
+
+    /**
+     * @return bool
+     */
+    /**
+     * @return bool
+     */
+    protected function shouldFlush(): bool
+    {
+        if ($this->jobs === []) {
+            return false;
+        }
+
+        if ($this->getBatchSize() <= count($this->jobs)) {
+            return true;
+        }
+
+        if ($this->batchStartedAt === null) {
+            return false;
+        }
+
+        $maxWaitMilliseconds = $this->getMaxWaitMilliseconds();
+
+        if ($maxWaitMilliseconds <= 0) {
+            return false;
+        }
+
+        return hrtime(true) - $this->batchStartedAt >= $maxWaitMilliseconds * 1000000;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getBatchSize(): int
+    {
+        return 10;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getMaxWaitMilliseconds(): int
+    {
+        return 2000;
+    }
+
+    /**
+     * Completes the jobs in the list.
+     *
+     * @param list<array{0: object, 1: \Symfony\Component\Messenger\Handler\Acknowledger}> $jobs
+     */
+    abstract protected function process(array $jobs): void;
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
 use Psr\Log\LoggerInterface;
+use Shopsys\FrameworkBundle\Component\Messenger\Batch\BatchHandlerWithTimeLimitTrait;
 use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
-use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 use Throwable;
 
 class ProductRecalculationMessageHandler implements BatchHandlerInterface
 {
-    use BatchHandlerTrait;
+    use BatchHandlerWithTimeLimitTrait;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationFacade $productRecalculationFacade
@@ -35,7 +35,10 @@ class ProductRecalculationMessageHandler implements BatchHandlerInterface
     }
 
     /**
-     * @param array $jobs
+     * @param array<int, array{
+     *     0: \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage,
+     *     1: \Symfony\Component\Messenger\Handler\Acknowledger,
+     * }> $jobs
      */
     protected function process(array $jobs): void
     {


### PR DESCRIPTION
#### Description, the reason for the PR

- Since https://github.com/symfony/symfony/pull/62872 the default batch handler waits for the batch size to be full before processing. That's problematic because when only a single message is dispatched, it waits a really long time to be processed
- Introduced Time-based batch handler. It waits max for 2s and if no message is added to the batch, it procesess it immediately.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-time-batch-consumer.odin.shopsys.cloud
  - https://cz.mg-time-batch-consumer.odin.shopsys.cloud
  - https://mg-time-batch-consumer.odin.shopsys.cloud/sk
<!-- Replace -->
