### PR TITLE
[14-5] pin jquery version to 3.x major

### DIFF
--- a/UPGRADE-14.5-tech.md
+++ b/UPGRADE-14.5-tech.md
@@ -220,3 +220,7 @@ For commands not covered by Make targets (e.g., `exec`, `logs`, `restart`), use 
     -   remove the service definition from your `config/services.yaml` if you have it defined there
     -   the service is now marked as lazy to prevent calling Redis during builds on CI
 -   see #project-base-diff to update your project
+
+#### pin jQuery version to 3.x major ([#4428](https://github.com/shopsys/shopsys/pull/4428))
+
+-   see #project-base-diff to update your project

--- a/project-base/app/package.json
+++ b/project-base/app/package.json
@@ -69,6 +69,7 @@
         "grapesjs-preset-newsletter": "^0.2.21",
         "grapesjs-preset-webpage": "^1.0.2",
         "intersection-observer": "^0.11.0",
+        "jquery": "^3.7.1",
         "jquery-hoverintent": "^1.10.1",
         "jquery-ui": "1.12.1",
         "jquery-ui-touch-punch": "^0.2.3",


### PR DESCRIPTION
#### Description, the reason for the PR

The recently released version 4 is not compatible with some plugins we use (namely widget)

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-14-5-pin-jquery.odin.shopsys.cloud
  - https://cz.mg-14-5-pin-jquery.odin.shopsys.cloud
<!-- Replace -->
