### PR TITLE
Product recalculation deduplication improvements

### DIFF
--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
@@ -9,7 +9,7 @@ use Redis;
 
 class ProductRecalculationDeduplicationFacade
 {
-    protected const int TTL = 10800;
+    protected const int TTL = 3600;
 
     public function __construct(
         protected readonly Redis $redisClient,

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
@@ -73,6 +73,7 @@ class ProductRecalculationDeduplicationFacade
 
         $exportScopesIndexedByProductIds = $this->doGetStoredExportScopes($productIdsWithMainVariants, $priority);
         $productIdsToDispatch = [];
+        $exportScopesToWrite = [];
 
         foreach ($exportScopesIndexedByProductIds as $productId => $storedScopesJson) {
             if ($storedScopesJson === false) {
@@ -80,18 +81,23 @@ class ProductRecalculationDeduplicationFacade
             }
 
             $updatedScopesJson = $this->updateScopesByRequestedScopes($requestedExportScopes, $storedScopesJson);
-            $exportScopesIndexedByProductIds[$productId] = $updatedScopesJson;
+
+            if ($storedScopesJson === false || $storedScopesJson !== $updatedScopesJson) {
+                $exportScopesToWrite[$productId] = $updatedScopesJson;
+            }
         }
 
-        $this->redisClient->hMset($this->getCacheKey($priority), $exportScopesIndexedByProductIds);
-        $this->redisClient->rawCommand(
-            'HEXPIRE',
-            $this->redisClient->getOption(Redis::OPT_PREFIX) . $this->getCacheKey($priority),
-            self::TTL,
-            'FIELDS',
-            count($exportScopesIndexedByProductIds),
-            ...array_keys($exportScopesIndexedByProductIds),
-        );
+        if ($exportScopesToWrite !== []) {
+            $this->redisClient->hMset($this->getCacheKey($priority), $exportScopesToWrite);
+            $this->redisClient->rawCommand(
+                'HEXPIRE',
+                $this->redisClient->getOption(Redis::OPT_PREFIX) . $this->getCacheKey($priority),
+                self::TTL,
+                'FIELDS',
+                count($exportScopesToWrite),
+                ...array_keys($exportScopesToWrite),
+            );
+        }
 
         return $productIdsToDispatch;
     }

--- a/upgrade-notes/backend_20260204_203228.md
+++ b/upgrade-notes/backend_20260204_203228.md
@@ -1,0 +1,3 @@
+#### Product recalculation deduplication improvements ([#4433](https://github.com/shopsys/shopsys/pull/4433))
+
+- `Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade::TTL` constant was changed from `10800` (3 hours) to `3600` (1 hour) override it in your project, if it does not suits your needs


### PR DESCRIPTION
#### Description, the reason for the PR

- previously, TTL of the record was updated every time a dispatch was called
- now TTL is updated only if scope changes, or a new message is published
- this prevents stale locks that could have occurred when product was dispatched in the TTL window
- lowered product recalculation lock TTL

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://mg-deduplication-fix.odin.shopsys.cloud
  - https://cz.mg-deduplication-fix.odin.shopsys.cloud
  - https://mg-deduplication-fix.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770746181.961719 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-deduplication-fix.odin.shopsys.cloud
  - https://cz.mg-deduplication-fix.odin.shopsys.cloud
  - https://mg-deduplication-fix.odin.shopsys.cloud/sk
<!-- Replace -->
