### PR TITLE
updated admin category tree toggle button

### DIFF
--- a/packages/administration/templates/form/type/BlogCategoryCheckboxType.html.twig
+++ b/packages/administration/templates/form/type/BlogCategoryCheckboxType.html.twig
@@ -1,9 +1,9 @@
 {% block blog_category_checkbox_widget %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' js-category-tree-form-item-checkbox'}) %}
     <div class="tree-item-content">
-        <div class="tree-item-label text-truncate">
+        <div class="tree-item-label">
             <div class="d-flex gap-2 align-items-baseline">
-                <div class="w-3 h-3 ">
+                <div class="w-3 h-3 flex-shrink-0">
                     <div class="js-category-tree-form-item-icon"></div>
                 </div>
                 {{ block('checkbox_widget') }}

--- a/packages/administration/templates/form/type/CategoryCheckboxType.html.twig
+++ b/packages/administration/templates/form/type/CategoryCheckboxType.html.twig
@@ -1,9 +1,9 @@
 {% block category_checkbox_widget %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' js-category-tree-form-item-checkbox'}) %}
     <div class="tree-item-content">
-        <div class="tree-item-label text-truncate">
+        <div class="tree-item-label">
             <div class="d-flex gap-2 align-items-baseline">
-                <div class="w-3 h-3 ">
+                <div class="w-3 h-3 flex-shrink-0">
                     <div class="js-category-tree-form-item-icon"></div>
                 </div>
                 {{ block('checkbox_widget') }}

--- a/upgrade-notes/backend_20260206_130942.md
+++ b/upgrade-notes/backend_20260206_130942.md
@@ -1,0 +1,4 @@
+#### Category tree responsive ([#4438](https://github.com/shopsys/shopsys/pull/4438))
+
+- fixed responsive for category tree open/close button
+- if your project includes more than two domains or locales, or reaches the maximum category level, it is recommended to use a two-column layout. To achieve this, customize the templates `packages/administration/templates/form/type/MultidomainType.html.twig` and `packages/administration/templates/form/type/LocalizedType.html.twig` by refining the `columnClass` logic.


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed responsive for category tree open/close button.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3827-fix-admin-tree.odin.shopsys.cloud
  - https://cz.tc-ssp-3827-fix-admin-tree.odin.shopsys.cloud
  - https://tc-ssp-3827-fix-admin-tree.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1771314326.163919 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3827-fix-admin-tree.odin.shopsys.cloud
  - https://cz.tc-ssp-3827-fix-admin-tree.odin.shopsys.cloud
  - https://tc-ssp-3827-fix-admin-tree.odin.shopsys.cloud/sk
<!-- Replace -->
