### PR TITLE
withdrawal request email for customer is now sent only once

### DIFF
--- a/packages/framework/src/Model/Order/Withdrawal/Messenger/WithdrawalRequestMessageHandler.php
+++ b/packages/framework/src/Model/Order/Withdrawal/Messenger/WithdrawalRequestMessageHandler.php
@@ -6,10 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Order\Withdrawal\Messenger;
 
 use Exception;
 use Psr\Log\LoggerInterface;
-use Shopsys\FrameworkBundle\Model\Order\Mail\OrderMailFacade;
 use Shopsys\FrameworkBundle\Model\Order\Mail\WithdrawalAdminMailFacade;
-use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade;
-use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTypeEnum;
 use Shopsys\FrameworkBundle\Model\Order\Withdrawal\WithdrawalRequestFacade;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -17,11 +14,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 class WithdrawalRequestMessageHandler
 {
     public function __construct(
-        protected readonly OrderMailFacade $orderMailFacade,
         protected readonly WithdrawalAdminMailFacade $withdrawalAdminMailFacade,
         protected readonly WithdrawalRequestFacade $withdrawalRequestFacade,
         protected readonly LoggerInterface $logger,
-        protected readonly OrderStatusFacade $orderStatusFacade,
     ) {
     }
 
@@ -29,18 +24,13 @@ class WithdrawalRequestMessageHandler
     {
         try {
             $withdrawalRequest = $this->withdrawalRequestFacade->getById($message->withdrawalRequestId);
-            $withdrawnOrderStatus = $this->orderStatusFacade->getByType(OrderStatusTypeEnum::TYPE_WITHDRAWN);
 
-            $this->orderMailFacade->sendEmail($withdrawalRequest->getOrder(), $withdrawnOrderStatus);
-            $this->logger->info('Withdrawal request email prepared to be sent to customer', [
-                'withdrawalRequestId' => $message->withdrawalRequestId,
-            ]);
             $this->withdrawalAdminMailFacade->sendEmail($withdrawalRequest);
             $this->logger->info('Withdrawal request email prepared to be sent to admin', [
                 'withdrawalRequestId' => $message->withdrawalRequestId,
             ]);
         } catch (Exception $exception) {
-            $this->logger->error('Preparing withdrawal request emails failed', [
+            $this->logger->error('Preparing withdrawal request email for admin failed', [
                 'withdrawalRequestId' => $message->withdrawalRequestId,
                 'exception' => $exception,
             ]);


### PR DESCRIPTION
#### Description, the reason for the PR
So far, two mails were sent by mistake - one for order status change, second explicitly within WithdrawalRequestMessageHandler

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-witdrawal-mail.odin.shopsys.cloud
  - https://cz.rv-witdrawal-mail.odin.shopsys.cloud
  - https://rv-witdrawal-mail.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770796571.006889 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-witdrawal-mail.odin.shopsys.cloud
  - https://cz.rv-witdrawal-mail.odin.shopsys.cloud
  - https://rv-witdrawal-mail.odin.shopsys.cloud/sk
<!-- Replace -->
