### PR TITLE
Mailer now supports Closures as variables

### DIFF
--- a/packages/framework/src/Model/Administrator/Mail/ResetPasswordMail.php
+++ b/packages/framework/src/Model/Administrator/Mail/ResetPasswordMail.php
@@ -48,18 +48,18 @@ class ResetPasswordMail implements MessageFactoryInterface
     }
 
     /**
-     * @return string[]
+     * @return array<string, \Closure>
      */
     protected function getBodyValuesIndexedByVariableName(ResetPasswordInterface $administrator, int $domainId): array
     {
         return [
-            self::VARIABLE_EMAIL => htmlspecialchars($administrator->getEmail(), ENT_QUOTES),
-            self::VARIABLE_NEW_PASSWORD_URL => $this->newPasswordUrlProvider->getNewPasswordUrl($administrator, $domainId, 'admin_administrator_set-new-password'),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($administrator->getEmail(), ENT_QUOTES),
+            self::VARIABLE_NEW_PASSWORD_URL => fn () => $this->newPasswordUrlProvider->getNewPasswordUrl($administrator, $domainId, 'admin_administrator_set-new-password'),
         ];
     }
 
     /**
-     * @return string[]
+     * @return array<string, \Closure>
      */
     protected function getSubjectValuesIndexedByVariableName(
         ResetPasswordInterface $administrator,

--- a/packages/framework/src/Model/Administrator/Mail/TwoFactorAuthenticationMail.php
+++ b/packages/framework/src/Model/Administrator/Mail/TwoFactorAuthenticationMail.php
@@ -38,7 +38,9 @@ class TwoFactorAuthenticationMail implements MessageFactoryInterface
             $template->getSubject(),
             $this->setting->getForDomain(MailSetting::MAIN_ADMIN_MAIL, $template->getDomainId()),
             $this->setting->getForDomain(MailSetting::MAIN_ADMIN_MAIL_NAME, $template->getDomainId()),
-            [self::VARIABLE_AUTHENTICATION_CODE => $administrator->getEmailAuthCode()],
+            [
+                self::VARIABLE_AUTHENTICATION_CODE => fn () => $administrator->getEmailAuthCode(),
+            ],
         );
     }
 }

--- a/packages/framework/src/Model/Complaint/Mail/ComplaintMail.php
+++ b/packages/framework/src/Model/Complaint/Mail/ComplaintMail.php
@@ -62,28 +62,30 @@ class ComplaintMail implements MessageFactoryInterface
         return static::MAIL_TEMPLATE_NAME_PREFIX . $complaintStatus->getId();
     }
 
+    /**
+     * @return array<string, \Closure>
+     */
     protected function getVariablesReplacementsForBody(Complaint $complaint): array
     {
-        $complaintDomainId = $complaint->getDomainId();
-
-        $router = $this->domainRouterFactory->getRouter($complaintDomainId);
-
         return [
-            self::VARIABLE_COMPLAINT_NUMBER => htmlspecialchars($complaint->getNumber(), ENT_QUOTES),
-            self::VARIABLE_COMPLAINT_DETAIL_URL => $this->getComplaintDetailUrl($complaint),
-            self::VARIABLE_ORDER_NUMBER => htmlspecialchars($complaint->getOrderNumberOrManualDocumentNumber(), ENT_QUOTES),
-            self::VARIABLE_DATE => $this->getFormattedDateTime($complaint),
-            self::VARIABLE_URL => $router->generate('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
-            self::VARIABLE_COMPLAINT_RESOLUTION => array_search($complaint->getResolution(), $this->complaintResolutionEnum->getAllIndexedByTranslationsForCustomer(), true),
+            self::VARIABLE_COMPLAINT_NUMBER => fn () => htmlspecialchars($complaint->getNumber(), ENT_QUOTES),
+            self::VARIABLE_COMPLAINT_DETAIL_URL => fn () => $this->getComplaintDetailUrl($complaint),
+            self::VARIABLE_ORDER_NUMBER => fn () => htmlspecialchars($complaint->getOrderNumberOrManualDocumentNumber(), ENT_QUOTES),
+            self::VARIABLE_DATE => fn () => $this->getFormattedDateTime($complaint),
+            self::VARIABLE_URL => fn () => $this->domainRouterFactory->getRouter($complaint->getDomainId())->generate('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            self::VARIABLE_COMPLAINT_RESOLUTION => fn () => array_search($complaint->getResolution(), $this->complaintResolutionEnum->getAllIndexedByTranslationsForCustomer(), true),
         ];
     }
 
+    /**
+     * @return array<string, \Closure>
+     */
     protected function getVariablesReplacementsForSubject(Complaint $complaint): array
     {
         return [
-            self::VARIABLE_COMPLAINT_NUMBER => $complaint->getNumber(),
-            self::VARIABLE_ORDER_NUMBER => $complaint->getOrderNumberOrManualDocumentNumber(),
-            self::VARIABLE_DATE => $this->getFormattedDateTime($complaint),
+            self::VARIABLE_COMPLAINT_NUMBER => fn () => $complaint->getNumber(),
+            self::VARIABLE_ORDER_NUMBER => fn () => $complaint->getOrderNumberOrManualDocumentNumber(),
+            self::VARIABLE_DATE => fn () => $this->getFormattedDateTime($complaint),
         ];
     }
 

--- a/packages/framework/src/Model/Customer/Mail/CustomerActivationMail.php
+++ b/packages/framework/src/Model/Customer/Mail/CustomerActivationMail.php
@@ -46,18 +46,18 @@ class CustomerActivationMail implements MessageFactoryInterface
     }
 
     /**
-     * @return string[]
+     * @return array<string, \Closure>
      */
     protected function getBodyValuesIndexedByVariableName(ResetPasswordInterface $customerUser, int $domainId): array
     {
         return [
-            self::VARIABLE_EMAIL => htmlspecialchars($customerUser->getEmail(), ENT_QUOTES),
-            self::VARIABLE_ACTIVATION_URL => $this->newPasswordUrlProvider->getNewPasswordUrl($customerUser, $domainId, 'front_registration_set_new_password'),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($customerUser->getEmail(), ENT_QUOTES),
+            self::VARIABLE_ACTIVATION_URL => fn () => $this->newPasswordUrlProvider->getNewPasswordUrl($customerUser, $domainId, 'front_registration_set_new_password'),
         ];
     }
 
     /**
-     * @return string[]
+     * @return array<string, \Closure>
      */
     protected function getSubjectValuesIndexedByVariableName(
         ResetPasswordInterface $customerUser,

--- a/packages/framework/src/Model/Customer/Mail/RegistrationMail.php
+++ b/packages/framework/src/Model/Customer/Mail/RegistrationMail.php
@@ -47,16 +47,19 @@ class RegistrationMail implements MessageFactoryInterface
         );
     }
 
+    /**
+     * @return array<string, \Closure>
+     */
     protected function getVariablesReplacements(CustomerUser $customerUser): array
     {
         $router = $this->domainRouterFactory->getRouter($customerUser->getDomainId());
 
         return [
-            self::VARIABLE_FIRST_NAME => htmlspecialchars($customerUser->getFirstName(), ENT_QUOTES),
-            self::VARIABLE_LAST_NAME => htmlspecialchars($customerUser->getLastName(), ENT_QUOTES),
-            self::VARIABLE_EMAIL => htmlspecialchars($customerUser->getEmail(), ENT_QUOTES),
-            self::VARIABLE_URL => $router->generate('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
-            self::VARIABLE_LOGIN_PAGE => $router->generate('front_login', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            self::VARIABLE_FIRST_NAME => fn () => htmlspecialchars($customerUser->getFirstName(), ENT_QUOTES),
+            self::VARIABLE_LAST_NAME => fn () => htmlspecialchars($customerUser->getLastName(), ENT_QUOTES),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($customerUser->getEmail(), ENT_QUOTES),
+            self::VARIABLE_URL => fn () => $router->generate('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            self::VARIABLE_LOGIN_PAGE => fn () => $router->generate('front_login', [], UrlGeneratorInterface::ABSOLUTE_URL),
         ];
     }
 }

--- a/packages/framework/src/Model/Customer/Mail/ResetPasswordMail.php
+++ b/packages/framework/src/Model/Customer/Mail/ResetPasswordMail.php
@@ -45,18 +45,18 @@ class ResetPasswordMail implements MessageFactoryInterface
     }
 
     /**
-     * @return string[]
+     * @return array<string, \Closure>
      */
     protected function getBodyValuesIndexedByVariableName(ResetPasswordInterface $customerUser, int $domainId): array
     {
         return [
-            self::VARIABLE_EMAIL => htmlspecialchars($customerUser->getEmail(), ENT_QUOTES),
-            self::VARIABLE_NEW_PASSWORD_URL => $this->newPasswordUrlProvider->getNewPasswordUrl($customerUser, $domainId, 'front_registration_set_new_password'),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($customerUser->getEmail(), ENT_QUOTES),
+            self::VARIABLE_NEW_PASSWORD_URL => fn () => $this->newPasswordUrlProvider->getNewPasswordUrl($customerUser, $domainId, 'front_registration_set_new_password'),
         ];
     }
 
     /**
-     * @return string[]
+     * @return array<string, \Closure>
      */
     protected function getSubjectValuesIndexedByVariableName(
         ResetPasswordInterface $customerUser,

--- a/packages/framework/src/Model/Inquiry/Mail/InquiryMail.php
+++ b/packages/framework/src/Model/Inquiry/Mail/InquiryMail.php
@@ -75,43 +75,43 @@ class InquiryMail
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, \Closure>
      */
     protected function getSubjectVariablesReplacements(Inquiry $inquiry): array
     {
         return [
-            self::VARIABLE_FULL_NAME => htmlspecialchars($inquiry->getFullName(), ENT_QUOTES),
-            self::VARIABLE_EMAIL => htmlspecialchars($inquiry->getEmail(), ENT_QUOTES),
-            self::VARIABLE_TELEPHONE => htmlspecialchars($inquiry->getTelephone(), ENT_QUOTES),
-            self::VARIABLE_COMPANY_NAME => $this->mailerHelper->escapeOptionalString($inquiry->getCompanyName()),
-            self::VARIABLE_COMPANY_NUMBER => $this->mailerHelper->escapeOptionalString($inquiry->getCompanyNumber()),
-            self::VARIABLE_COMPANY_TAX_NUMBER => $this->mailerHelper->escapeOptionalString($inquiry->getCompanyTaxNumber()),
-            self::VARIABLE_PRODUCT_NAME => $this->mailerHelper->escapeOptionalString($inquiry->getProduct()?->getName()),
-            self::VARIABLE_PRODUCT_CATALOG_NUMBER => htmlspecialchars($inquiry->getProductCatnum(), ENT_QUOTES),
+            self::VARIABLE_FULL_NAME => fn () => htmlspecialchars($inquiry->getFullName(), ENT_QUOTES),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($inquiry->getEmail(), ENT_QUOTES),
+            self::VARIABLE_TELEPHONE => fn () => htmlspecialchars($inquiry->getTelephone(), ENT_QUOTES),
+            self::VARIABLE_COMPANY_NAME => fn () => $this->mailerHelper->escapeOptionalString($inquiry->getCompanyName()),
+            self::VARIABLE_COMPANY_NUMBER => fn () => $this->mailerHelper->escapeOptionalString($inquiry->getCompanyNumber()),
+            self::VARIABLE_COMPANY_TAX_NUMBER => fn () => $this->mailerHelper->escapeOptionalString($inquiry->getCompanyTaxNumber()),
+            self::VARIABLE_PRODUCT_NAME => fn () => $this->mailerHelper->escapeOptionalString($inquiry->getProduct()?->getName()),
+            self::VARIABLE_PRODUCT_CATALOG_NUMBER => fn () => htmlspecialchars($inquiry->getProductCatnum(), ENT_QUOTES),
         ];
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, \Closure>
      */
     protected function getBodyVariablesReplacements(Inquiry $inquiry): array
     {
         return [
             ...$this->getSubjectVariablesReplacements($inquiry),
-            self::VARIABLE_NOTE => $this->mailerHelper->escapeOptionalString($inquiry->getNote()),
-            self::VARIABLE_PRODUCT_URL => $this->getProductUrl($inquiry),
-            self::VARIABLE_PRODUCT_IMAGE => $this->productImageFacade->getProductImageUrl($inquiry->getProduct(), $inquiry->getDomainId()),
+            self::VARIABLE_NOTE => fn () => $this->mailerHelper->escapeOptionalString($inquiry->getNote()),
+            self::VARIABLE_PRODUCT_URL => fn () => $this->getProductUrl($inquiry),
+            self::VARIABLE_PRODUCT_IMAGE => fn () => $this->productImageFacade->getProductImageUrl($inquiry->getProduct(), $inquiry->getDomainId()),
         ];
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, \Closure>
      */
     protected function getBodyVariablesReplacementsForAdmin(Inquiry $inquiry): array
     {
         return [
             ...$this->getBodyVariablesReplacements($inquiry),
-            self::VARIABLE_ADMIN_INQUIRY_DETAIL_URL => $this->administrationRouter->generate(
+            self::VARIABLE_ADMIN_INQUIRY_DETAIL_URL => fn () => $this->administrationRouter->generate(
                 'admin_inquiry_detail',
                 ['id' => $inquiry->getId()],
                 UrlGeneratorInterface::ABSOLUTE_URL,

--- a/packages/framework/src/Model/Mail/Mailer.php
+++ b/packages/framework/src/Model/Mail/Mailer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Mail;
 
+use Closure;
 use League\Flysystem\FilesystemOperationFailed;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -98,11 +99,19 @@ class Mailer
     }
 
     /**
-     * @param string[] $variablesKeysAndValues
+     * @param array<string, string|\Closure> $variablesKeysAndValues
      */
     protected function replaceVariables(string $string, array $variablesKeysAndValues): string
     {
-        return strtr($string, $variablesKeysAndValues);
+        $resolvedReplacements = [];
+
+        foreach ($variablesKeysAndValues as $key => $value) {
+            if (str_contains($string, $key)) {
+                $resolvedReplacements[$key] = $value instanceof Closure ? (string)($value() ?? '') : $value;
+            }
+        }
+
+        return strtr($string, $resolvedReplacements);
     }
 
     protected function replaceVariableImagesPaths(string $body): string

--- a/packages/framework/src/Model/Mail/MessageData.php
+++ b/packages/framework/src/Model/Mail/MessageData.php
@@ -7,15 +7,15 @@ namespace Shopsys\FrameworkBundle\Model\Mail;
 class MessageData
 {
     /**
-     * @var string[]
+     * @var array<string, string|\Closure>
      */
     public array $variablesReplacementsForSubject;
 
     /**
      * @param string|array<string> $toEmail
      * @param string|array<string>|null $bccEmail
-     * @param string[] $variablesReplacementsForBody
-     * @param string[] $variablesReplacementsForSubject
+     * @param array<string, string|\Closure> $variablesReplacementsForBody
+     * @param array<string, string|\Closure> $variablesReplacementsForSubject
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile[] $attachments
      */
     public function __construct(

--- a/packages/framework/src/Model/Order/Mail/OrderMail.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMail.php
@@ -119,42 +119,46 @@ class OrderMail implements MessageFactoryInterface
         return null;
     }
 
+    /**
+     * @return array<string, \Closure>
+     */
     protected function getVariablesReplacementsForBody(Order $order): array
     {
-        $router = $this->domainRouterFactory->getRouter($order->getDomainId());
-
         $orderItemTotalPricesById = $this->orderItemPriceCalculation->calculateTotalPricesIndexedById(
             $order->getItems(),
         );
 
         return [
-            self::VARIABLE_NUMBER => htmlspecialchars($order->getNumber(), ENT_QUOTES),
-            self::VARIABLE_DATE => $this->getFormattedDateTime($order),
-            self::VARIABLE_URL => $router->generate('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
-            self::VARIABLE_TRANSPORT => htmlspecialchars($order->getTransportItem()->getName(), ENT_QUOTES),
-            self::VARIABLE_PAYMENT => htmlspecialchars($order->getPaymentItem()->getName(), ENT_QUOTES),
-            self::VARIABLE_TOTAL_PRICE_WITH_VAT => $this->getFormattedPriceWithVat($order),
-            self::VARIABLE_TOTAL_PRICE_WITHOUT_VAT => $this->getFormattedPriceWithoutVat($order),
-            self::VARIABLE_BILLING_ADDRESS => $this->getBillingAddressHtmlTable($order),
-            self::VARIABLE_DELIVERY_ADDRESS => $this->getDeliveryAddressHtmlTable($order),
-            self::VARIABLE_NOTE => $this->getNoteHtml($order),
-            self::VARIABLE_PRODUCTS => $this->getProductsHtmlTable($order, $orderItemTotalPricesById),
-            self::VARIABLE_ORDER_DETAIL_URL => $this->orderUrlGenerator->getOrderDetailUrl($order),
-            self::VARIABLE_TRANSPORT_INSTRUCTIONS => $this->getTransportInstructionsHtml($order),
-            self::VARIABLE_PAYMENT_INSTRUCTIONS => $this->getPaymentInstructionsHtml($order),
-            self::VARIABLE_TRACKING_INSTRUCTIONS => $this->getTrackingInstructions($order),
-            self::VARIABLE_TRANSPORT_INFO => $this->getTransportInfoHtml($order, $orderItemTotalPricesById),
-            self::VARIABLE_PAYMENT_INFO => $this->getPaymentInfoHtml($order, $orderItemTotalPricesById),
-            self::VARIABLE_ROUNDING_INFO => $this->getRoundingInfoHtml($order, $orderItemTotalPricesById),
-            self::VARIABLE_ADDRESSES => $this->getAddressesHtml($order),
+            self::VARIABLE_NUMBER => fn () => htmlspecialchars($order->getNumber(), ENT_QUOTES),
+            self::VARIABLE_DATE => fn () => $this->getFormattedDateTime($order),
+            self::VARIABLE_URL => fn () => $this->domainRouterFactory->getRouter($order->getDomainId())->generate('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            self::VARIABLE_TRANSPORT => fn () => htmlspecialchars($order->getTransportItem()->getName(), ENT_QUOTES),
+            self::VARIABLE_PAYMENT => fn () => htmlspecialchars($order->getPaymentItem()->getName(), ENT_QUOTES),
+            self::VARIABLE_TOTAL_PRICE_WITH_VAT => fn () => $this->getFormattedPriceWithVat($order),
+            self::VARIABLE_TOTAL_PRICE_WITHOUT_VAT => fn () => $this->getFormattedPriceWithoutVat($order),
+            self::VARIABLE_BILLING_ADDRESS => fn () => $this->getBillingAddressHtmlTable($order),
+            self::VARIABLE_DELIVERY_ADDRESS => fn () => $this->getDeliveryAddressHtmlTable($order),
+            self::VARIABLE_NOTE => fn () => $this->getNoteHtml($order),
+            self::VARIABLE_PRODUCTS => fn () => $this->getProductsHtmlTable($order, $orderItemTotalPricesById),
+            self::VARIABLE_ORDER_DETAIL_URL => fn () => $this->orderUrlGenerator->getOrderDetailUrl($order),
+            self::VARIABLE_TRANSPORT_INSTRUCTIONS => fn () => $this->getTransportInstructionsHtml($order),
+            self::VARIABLE_PAYMENT_INSTRUCTIONS => fn () => $this->getPaymentInstructionsHtml($order),
+            self::VARIABLE_TRACKING_INSTRUCTIONS => fn () => $this->getTrackingInstructions($order),
+            self::VARIABLE_TRANSPORT_INFO => fn () => $this->getTransportInfoHtml($order, $orderItemTotalPricesById),
+            self::VARIABLE_PAYMENT_INFO => fn () => $this->getPaymentInfoHtml($order, $orderItemTotalPricesById),
+            self::VARIABLE_ROUNDING_INFO => fn () => $this->getRoundingInfoHtml($order, $orderItemTotalPricesById),
+            self::VARIABLE_ADDRESSES => fn () => $this->getAddressesHtml($order),
         ];
     }
 
+    /**
+     * @return array<string, \Closure>
+     */
     protected function getVariablesReplacementsForSubject(Order $order): array
     {
         return [
-            self::VARIABLE_NUMBER => $order->getNumber(),
-            self::VARIABLE_DATE => $this->getFormattedDateTime($order),
+            self::VARIABLE_NUMBER => fn () => $order->getNumber(),
+            self::VARIABLE_DATE => fn () => $this->getFormattedDateTime($order),
         ];
     }
 

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMail.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMail.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Mail\MailTemplate;
 use Shopsys\FrameworkBundle\Model\Mail\MessageData;
 use Shopsys\FrameworkBundle\Model\Mail\MessageFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Mail\Setting\MailSetting;
+use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PersonalDataAccessMail implements MessageFactoryInterface
@@ -42,30 +43,30 @@ class PersonalDataAccessMail implements MessageFactoryInterface
             $template->getSubject(),
             $this->setting->getForDomain(MailSetting::MAIN_ADMIN_MAIL, $this->domain->getId()),
             $this->setting->getForDomain(MailSetting::MAIN_ADMIN_MAIL_NAME, $this->domain->getId()),
-            $this->getBodyValuesIndexedByVariableName(
-                $this->getVariablePersonalDataAccessUrl(
-                    $personalDataAccessRequest->getHash(),
-                ),
-                $personalDataAccessRequest->getEmail(),
-                $this->domain->getName(),
-            ),
-            $this->getSubjectValuesIndexedByVariableName($this->domain->getName()),
+            $this->getBodyValuesIndexedByVariableName($personalDataAccessRequest),
+            $this->getSubjectValuesIndexedByVariableName(),
         );
     }
 
-    protected function getBodyValuesIndexedByVariableName(string $url, string $email, string $domainName): array
+    /**
+     * @return array<string, \Closure>
+     */
+    protected function getBodyValuesIndexedByVariableName(PersonalDataAccessRequest $personalDataAccessRequest): array
     {
         return [
-            self::VARIABLE_URL => $url,
-            self::VARIABLE_EMAIL => htmlspecialchars($email, ENT_QUOTES),
-            self::VARIABLE_DOMAIN => htmlspecialchars($domainName, ENT_QUOTES),
+            self::VARIABLE_URL => fn () => $this->getVariablePersonalDataAccessUrl($personalDataAccessRequest->getHash()),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($personalDataAccessRequest->getEmail(), ENT_QUOTES),
+            self::VARIABLE_DOMAIN => fn () => htmlspecialchars($this->domain->getName(), ENT_QUOTES),
         ];
     }
 
-    protected function getSubjectValuesIndexedByVariableName(string $domainName): array
+    /**
+     * @return array<string, \Closure>
+     */
+    protected function getSubjectValuesIndexedByVariableName(): array
     {
         return [
-            self::VARIABLE_DOMAIN => $domainName,
+            self::VARIABLE_DOMAIN => fn () => $this->domain->getName(),
         ];
     }
 

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataExportMail.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataExportMail.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Mail\MailTemplate;
 use Shopsys\FrameworkBundle\Model\Mail\MessageData;
 use Shopsys\FrameworkBundle\Model\Mail\MessageFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Mail\Setting\MailSetting;
+use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest;
 use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataExportFacade;
 
 class PersonalDataExportMail implements MessageFactoryInterface
@@ -43,30 +44,30 @@ class PersonalDataExportMail implements MessageFactoryInterface
             $template->getSubject(),
             $this->setting->getForDomain(MailSetting::MAIN_ADMIN_MAIL, $this->domain->getId()),
             $this->setting->getForDomain(MailSetting::MAIN_ADMIN_MAIL_NAME, $this->domain->getId()),
-            $this->getBodyValuesIndexedByVariableName(
-                $this->getVariablePersonalDataAccessUrl(
-                    $personalDataAccessRequest->getHash(),
-                ),
-                $personalDataAccessRequest->getEmail(),
-                $this->domain->getName(),
-            ),
-            $this->getSubjectValuesIndexedByVariableName($this->domain->getName()),
+            $this->getBodyValuesIndexedByVariableName($personalDataAccessRequest),
+            $this->getSubjectValuesIndexedByVariableName(),
         );
     }
 
-    protected function getBodyValuesIndexedByVariableName(string $url, string $email, string $domainName): array
+    /**
+     * @return array<string, \Closure>
+     */
+    protected function getBodyValuesIndexedByVariableName(PersonalDataAccessRequest $personalDataAccessRequest): array
     {
         return [
-            self::VARIABLE_URL => $url,
-            self::VARIABLE_EMAIL => htmlspecialchars($email, ENT_QUOTES),
-            self::VARIABLE_DOMAIN => htmlspecialchars($domainName, ENT_QUOTES),
+            self::VARIABLE_URL => fn () => $this->getVariablePersonalDataAccessUrl($personalDataAccessRequest->getHash()),
+            self::VARIABLE_EMAIL => fn () => htmlspecialchars($personalDataAccessRequest->getEmail(), ENT_QUOTES),
+            self::VARIABLE_DOMAIN => fn () => htmlspecialchars($this->domain->getName(), ENT_QUOTES),
         ];
     }
 
-    protected function getSubjectValuesIndexedByVariableName(string $domainName): array
+    /**
+     * @return array<string, \Closure>
+     */
+    protected function getSubjectValuesIndexedByVariableName(): array
     {
         return [
-            self::VARIABLE_DOMAIN => $domainName,
+            self::VARIABLE_DOMAIN => fn () => $this->domain->getName(),
         ];
     }
 

--- a/packages/framework/src/Model/Watchdog/Mail/WatchdogMail.php
+++ b/packages/framework/src/Model/Watchdog/Mail/WatchdogMail.php
@@ -66,17 +66,17 @@ class WatchdogMail
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, \Closure>
      */
     protected function getSubjectVariablesReplacements(Product $product, string $locale): array
     {
         return [
-            self::VARIABLE_PRODUCT_NAME => $this->mailerHelper->escapeOptionalString($product->getName($locale)),
+            self::VARIABLE_PRODUCT_NAME => fn () => $this->mailerHelper->escapeOptionalString($product->getName($locale)),
         ];
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, \Closure>
      */
     protected function getBodyVariablesReplacements(Product $product, int $domainId): array
     {
@@ -84,9 +84,9 @@ class WatchdogMail
 
         return [
             ...$this->getSubjectVariablesReplacements($product, $locale),
-            self::VARIABLE_PRODUCT_URL => $this->getProductUrl($product, $domainId),
-            self::VARIABLE_PRODUCT_IMAGE => $this->productImageFacade->getProductImageUrl($product, $domainId),
-            self::VARIABLE_PRODUCT_QUANTITY => $this->getProductQuantity($product, $domainId, $locale),
+            self::VARIABLE_PRODUCT_URL => fn () => $this->getProductUrl($product, $domainId),
+            self::VARIABLE_PRODUCT_IMAGE => fn () => $this->productImageFacade->getProductImageUrl($product, $domainId),
+            self::VARIABLE_PRODUCT_QUANTITY => fn () => $this->getProductQuantity($product, $domainId, $locale),
         ];
     }
 

--- a/project-base/app/src/Model/Order/Mail/OrderMail.php
+++ b/project-base/app/src/Model/Order/Mail/OrderMail.php
@@ -9,7 +9,7 @@ use Shopsys\FrameworkBundle\Model\Order\Mail\OrderMail as BaseOrderMail;
 /**
  * @property \App\Component\Setting\Setting $setting
  * @method \Shopsys\FrameworkBundle\Model\Mail\MessageData createMessage(\App\Model\Mail\MailTemplate $mailTemplate, \App\Model\Order\Order $order)
- * @method array getVariablesReplacementsForSubject(\App\Model\Order\Order $order)
+ * @method array<string,\Closure> getVariablesReplacementsForSubject(\App\Model\Order\Order $order)
  * @method string getFormattedPriceWithVat(\App\Model\Order\Order $order)
  * @method string getFormattedDateTime(\App\Model\Order\Order $order)
  * @method string getDeliveryAddressHtmlTable(\App\Model\Order\Order $order)
@@ -20,7 +20,7 @@ use Shopsys\FrameworkBundle\Model\Order\Mail\OrderMail as BaseOrderMail;
  * @method static \App\Model\Mail\MailTemplate|null findMailTemplateForOrderStatus(\App\Model\Mail\MailTemplate[] $mailTemplates, \App\Model\Order\Status\OrderStatus $orderStatus)
  * @method __construct(\App\Component\Setting\Setting $setting, \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory, \Twig\Environment $twig, \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation $orderItemPriceCalculation, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Twig\PriceExtension $priceExtension, \Shopsys\FrameworkBundle\Twig\DateTimeFormatterExtension $dateTimeFormatterExtension, \Shopsys\FrameworkBundle\Model\Order\OrderUrlGenerator $orderUrlGenerator, \Shopsys\FrameworkBundle\Twig\HiddenPriceExtension $hiddenPriceExtension, \Shopsys\FrameworkBundle\Model\Payment\PaymentInstructionFacade $paymentInstructionFacade, \Shopsys\FrameworkBundle\Model\Mail\MailDisplayPriceResolver $mailDisplayPriceResolver, \Shopsys\FrameworkBundle\Model\Order\Withdrawal\WithdrawalRequestFacade $withdrawalRequestFacade)
  * @method static string getMailTemplateNameByStatus(\App\Model\Order\Status\OrderStatus $orderStatus)
- * @method array getVariablesReplacementsForBody(\App\Model\Order\Order $order)
+ * @method array<string,\Closure> getVariablesReplacementsForBody(\App\Model\Order\Order $order)
  * @method string|null getTrackingInstructions(\App\Model\Order\Order $order)
  * @method string getBillingAddressHtmlTable(\App\Model\Order\Order $order)
  * @method string|null getNoteHtml(\App\Model\Order\Order $order)

--- a/upgrade-notes/backend_20260207_112025.md
+++ b/upgrade-notes/backend_20260207_112025.md
@@ -1,0 +1,13 @@
+#### Mailer now supports Closures as variables ([#4443](https://github.com/shopsys/shopsys/pull/4443))
+
+- all mail template classes in the framework package now define their variables as `\Closure` instances instead of plain `string` values for lazy evaluation
+    - `Shopsys\FrameworkBundle\Model\Mail\Mailer::replaceVariables()` now handles both `string` and `\Closure` values
+    - if you override any of the methods in `*Mail` classes that set `MessageData::$variablesReplacementsForBody` or `$variablesReplacementsForSubject`, your code will continue to work
+    - however, we recommend updating them to also use `\Closure` for variable values to benefit from lazy evaluation
+    - the same recommendation applies to any custom mail template classes in your project
+    - the change is basically simple like this:
+    ```diff
+    - self::VARIABLE_NAME => $this->resolveVariable(),
+    + self::VARIABLE_NAME => fn () => $this->resolveVariable(),
+    ```
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Originally, all the available mail variables were always evaluated, regardless of whether they were actually used in the given mail template. 

From now on, only the actually used variables are evaluated, which leads to improved performance and mitigates the side effects of premature evaluation.

_**An example of buggy behavior that is fixed now**: payment instructions for a bank transfer payment method are adding a QR code to the mail template, and the attachment (embed) was added to the mail even if the payment instructions variable was not used in the template at all._
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://rv-mail-variables.odin.shopsys.cloud
  - https://cz.rv-mail-variables.odin.shopsys.cloud
  - https://rv-mail-variables.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770821812.200699 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-mail-variables.odin.shopsys.cloud
  - https://cz.rv-mail-variables.odin.shopsys.cloud
  - https://rv-mail-variables.odin.shopsys.cloud/sk
<!-- Replace -->
