### PR TITLE
fix price list import

### DIFF
--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -84,6 +84,13 @@ class FileUpload
         return $this->getTemporaryDirectory() . '/' . $this->transformStringHelper->safeFilename($temporaryFilename);
     }
 
+    public function getTemporaryFilepathForMountManager(string $temporaryFilename): string
+    {
+        return $this->transformStringHelper->removeDriveLetterFromPath(
+            $this->getTemporaryFilepath($temporaryFilename),
+        );
+    }
+
     public function getAbsoluteTemporaryFilepath(string $temporaryFilename): string
     {
         return $this->parameterBag->get('kernel.project_dir') . $this->getTemporaryDirectory() . '/' . $this->transformStringHelper->safeFilename($temporaryFilename);
@@ -140,9 +147,7 @@ class FileUpload
         $filesForUpload = $entity->getTemporaryFilesForUpload();
 
         foreach ($filesForUpload as $key => $fileForUpload) {
-            $sourceFilepath = $this->transformStringHelper->removeDriveLetterFromPath(
-                $this->getTemporaryFilepath($fileForUpload->getTemporaryFilename()),
-            );
+            $sourceFilepath = $this->getTemporaryFilepathForMountManager($fileForUpload->getTemporaryFilename());
             $originalFilename = $this->fileNamingConvention->getFilenameByNamingConvention(
                 $fileForUpload->getNameConventionType(),
                 $fileForUpload->getTemporaryFilename(),

--- a/packages/framework/src/Model/PriceList/PriceListFacade.php
+++ b/packages/framework/src/Model/PriceList/PriceListFacade.php
@@ -150,8 +150,7 @@ class PriceListFacade
         $importResult = $this->importPriceListResultFactory->create();
         $csvEncoder = new CsvEncoder();
 
-        $path = $this->fileUpload->getAbsoluteTemporaryFilepath(reset($uploadedFileData->uploadedFiles));
-        $fileContent = file_get_contents($path);
+        $fileContent = $this->getFileContent($uploadedFileData);
 
         if ($fileContent === false) {
             $importResult->addError(1, t('Cannot read file.'));
@@ -183,40 +182,7 @@ class PriceListFacade
 
         foreach ($data as $row) {
             $line++;
-
-            $row = $this->preProcessCsvRow($row);
-            $violations = $this->validator->validate($row, $constraints);
-
-            foreach ($violations as $violation) {
-                $importResult->addWarning($line, $violation->getMessage());
-            }
-
-            if ($violations->count() > 0) {
-                continue;
-            }
-
-            $product = $this->productFacade->findByCatnum($row[PriceListCsvColumnsEnum::PRODUCT_CATNUM]);
-
-            if ($product === null) {
-                $importResult->addWarning(
-                    $line,
-                    t(
-                        'Product with catnum {{ catnum }} not found',
-                        ['{{ catnum }}' => $row[PriceListCsvColumnsEnum::PRODUCT_CATNUM]],
-                        Translator::VALIDATOR_TRANSLATION_DOMAIN,
-                    ),
-                );
-
-                continue;
-            }
-
-            $priceListData->priceListProductPricesData[] = $this->priceListProductPriceDataFactory->create(
-                $product,
-                Money::create($row[PriceListCsvColumnsEnum::PRICE]),
-                $priceListData->domainId,
-            );
-
-            $importResult->increaseSuccessfulCount();
+            $this->processCsvRow($row, $constraints, $importResult, $priceListData, $line);
         }
 
         if ($priceListData->id) {
@@ -304,5 +270,58 @@ class PriceListFacade
         $row[PriceListCsvColumnsEnum::PRICE] = str_replace(',', '.', $row[PriceListCsvColumnsEnum::PRICE]);
 
         return $row;
+    }
+
+    protected function processCsvRow(
+        array $rawRow,
+        Constraints\Collection $constraints,
+        ImportPriceListResult $importResult,
+        PriceListData $priceListData,
+        int $line,
+    ): void {
+        $row = $this->preProcessCsvRow($rawRow);
+        $violations = $this->validator->validate($row, $constraints);
+
+        foreach ($violations as $violation) {
+            $importResult->addWarning($line, $violation->getMessage());
+        }
+
+        if ($violations->count() > 0) {
+            return;
+        }
+
+        $product = $this->productFacade->findByCatnum($row[PriceListCsvColumnsEnum::PRODUCT_CATNUM]);
+
+        if ($product === null) {
+            $importResult->addWarning(
+                $line,
+                t(
+                    'Product with catnum {{ catnum }} not found',
+                    ['{{ catnum }}' => $row[PriceListCsvColumnsEnum::PRODUCT_CATNUM]],
+                    Translator::VALIDATOR_TRANSLATION_DOMAIN,
+                ),
+            );
+
+            return;
+        }
+
+        $priceListData->priceListProductPricesData[] = $this->priceListProductPriceDataFactory->create(
+            $product,
+            Money::create($row[PriceListCsvColumnsEnum::PRICE]),
+            $priceListData->domainId,
+        );
+
+        $importResult->increaseSuccessfulCount();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileData $uploadedFileData
+     * @return false|string
+     */
+    protected function getFileContent(UploadedFileData $uploadedFileData): string|false
+    {
+        $path = $this->fileUpload->getAbsoluteTemporaryFilepath(reset($uploadedFileData->uploadedFiles));
+
+        return file_get_contents($path);
     }
 }

--- a/packages/framework/src/Model/PriceList/PriceListFacade.php
+++ b/packages/framework/src/Model/PriceList/PriceListFacade.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\PriceList;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
+use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
@@ -17,6 +18,7 @@ use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPrio
 use Symfony\Component\Serializer\Encoder\CsvEncoder;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Throwable;
 
 class PriceListFacade
 {
@@ -32,6 +34,7 @@ class PriceListFacade
         protected readonly PriceListProductPriceDataFactory $priceListProductPriceDataFactory,
         protected readonly ProductFacade $productFacade,
         protected readonly ImportPriceListResultFactory $importPriceListResultFactory,
+        protected readonly MountManager $mountManager,
     ) {
     }
 
@@ -150,9 +153,9 @@ class PriceListFacade
         $importResult = $this->importPriceListResultFactory->create();
         $csvEncoder = new CsvEncoder();
 
-        $fileContent = $this->getFileContent($uploadedFileData);
-
-        if ($fileContent === false) {
+        try {
+            $fileContent = $this->getFileContent($uploadedFileData);
+        } catch (Throwable) {
             $importResult->addError(1, t('Cannot read file.'));
 
             return $importResult;
@@ -314,14 +317,10 @@ class PriceListFacade
         $importResult->increaseSuccessfulCount();
     }
 
-    /**
-     * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileData $uploadedFileData
-     * @return false|string
-     */
-    protected function getFileContent(UploadedFileData $uploadedFileData): string|false
+    protected function getFileContent(UploadedFileData $uploadedFileData): string
     {
-        $path = $this->fileUpload->getAbsoluteTemporaryFilepath(reset($uploadedFileData->uploadedFiles));
+        $path = $this->fileUpload->getTemporaryFilepathForMountManager(reset($uploadedFileData->uploadedFiles));
 
-        return file_get_contents($path);
+        return $this->mountManager->read('main://' . $path);
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
When using an abstract filesystem (S3, e.g.), it was not possible to import a price list from CSV because of `file_get_contents` method usage. This is fixed now.

Moreover, `PriceListFacade::importPriceList()` method was refactored into more sub-methods to ease the method extension.

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://rv-fix-pricelist-import.odin.shopsys.cloud
  - https://cz.rv-fix-pricelist-import.odin.shopsys.cloud
  - https://rv-fix-pricelist-import.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770820011.910639 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-pricelist-import.odin.shopsys.cloud
  - https://cz.rv-fix-pricelist-import.odin.shopsys.cloud
  - https://rv-fix-pricelist-import.odin.shopsys.cloud/sk
<!-- Replace -->
