### PR TITLE
ensure friendly url slug is always url-encoded

### DIFF
--- a/packages/administration/templates/form/type/FriendlyUrlType.html.twig
+++ b/packages/administration/templates/form/type/FriendlyUrlType.html.twig
@@ -17,5 +17,6 @@
             </div>
         </div>
         {{ form_errors(form.slug) }}
+        {{ form_help(form.slug) }}
     </div>
 {% endblock %}

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrl.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrl.php
@@ -77,7 +77,7 @@ class FriendlyUrl
         $this->routeName = $routeName;
         $this->entityId = $entityId;
         $this->domainId = $domainId;
-        $this->slug = $slug;
+        $this->slug = FriendlyUrlSlugNormalizer::normalize($slug);
         $this->main = false;
     }
 

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
@@ -74,29 +74,16 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
         array $parameters,
         int $referenceType,
     ): string {
-        $compiledRoute = RouteCompiler::compile($route);
-
-        $tokens = [
-            [
-                0 => 'text',
-                1 => '/' . $friendlyUrl->getSlug(),
-            ],
-        ];
-
-        return $this->doGenerate(
-            $compiledRoute->getVariables(),
-            $route->getDefaults(),
-            $route->getRequirements(),
-            $tokens,
-            $parameters,
+        return $this->getGeneratedUrlBySlug(
             $routeName,
+            $route,
+            $friendlyUrl->getSlug(),
+            $parameters,
             $referenceType,
-            $compiledRoute->getHostTokens(),
-            $route->getSchemes(),
         );
     }
 
-    public function getGeneratedUrlBySlug(
+    protected function getGeneratedUrlBySlug(
         string $routeName,
         Route $route,
         string $slug,
@@ -108,7 +95,7 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
         $tokens = [
             [
                 0 => 'text',
-                1 => '/' . $slug,
+                1 => '/' . $this->getSlugForGeneration($slug),
             ],
         ];
 
@@ -149,5 +136,10 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
 
             throw new RouteNotFoundException($message, 0, $e);
         }
+    }
+
+    protected function getSlugForGeneration(string $slug): string
+    {
+        return rawurldecode($slug);
     }
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRepository.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRepository.php
@@ -41,7 +41,7 @@ class FriendlyUrlRepository
         return $this->getFriendlyUrlRepository()->findOneBy(
             [
                 'domainId' => $domainId,
-                'slug' => $slug,
+                'slug' => FriendlyUrlSlugNormalizer::normalize($slug),
             ],
         );
     }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlSlugNormalizer.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlSlugNormalizer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
+
+class FriendlyUrlSlugNormalizer
+{
+    public static function normalize(string $slug): string
+    {
+        $decodedSlug = rawurldecode($slug);
+        $decodedSlugSegments = explode('/', $decodedSlug);
+
+        $encodedSlugSegments = array_map(
+            static fn (string $segment): string => rawurlencode($segment),
+            $decodedSlugSegments,
+        );
+
+        return implode('/', $encodedSlugSegments);
+    }
+}

--- a/packages/framework/src/Form/Constraints/UniqueSlugsOnDomainsValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueSlugsOnDomainsValidator.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Form\Constraints;
 use Override;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlSlugNormalizer;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\UrlListData;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Validator\Constraint;
@@ -60,7 +61,7 @@ class UniqueSlugsOnDomainsValidator extends ConstraintValidator
         foreach ($values as $urlData) {
             $domainId = $urlData[UrlListData::FIELD_DOMAIN];
             $domainConfig = $this->domain->getDomainConfigById($domainId);
-            $slug = $urlData[UrlListData::FIELD_SLUG];
+            $slug = FriendlyUrlSlugNormalizer::normalize((string)$urlData[UrlListData::FIELD_SLUG]);
 
             $domainRouter = $this->domainRouterFactory->getRouter($domainId);
 
@@ -88,7 +89,7 @@ class UniqueSlugsOnDomainsValidator extends ConstraintValidator
 
         foreach ($values as $urlData) {
             $domainId = $urlData[UrlListData::FIELD_DOMAIN];
-            $slug = $urlData[UrlListData::FIELD_SLUG];
+            $slug = FriendlyUrlSlugNormalizer::normalize((string)$urlData[UrlListData::FIELD_SLUG]);
 
             if (!array_key_exists($domainId, $slugsCountByDomainId)) {
                 $slugsCountByDomainId[$domainId] = [];

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form;
 
 use Override;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlSlugNormalizer;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\UrlListData;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class FriendlyUrlType extends AbstractType
 {
@@ -33,10 +36,7 @@ final class FriendlyUrlType extends AbstractType
             'help' => t('If the slug contains non-ASCII characters (e.g. "café"), encode it as URL-encoded form (e.g. "caf%C3%A9"). You can use https://www.urlencoder.org/.'),
             'constraints' => [
                 new Constraints\NotBlank(),
-                new Constraints\Regex(
-                    pattern: static::SLUG_REGEX,
-                    message: 'Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/.',
-                ),
+                new Constraints\Callback(callback: [$this, 'validateSlugEncoding']),
             ],
         ]);
     }
@@ -49,5 +49,24 @@ final class FriendlyUrlType extends AbstractType
                 'limit_domains_by_ids' => [],
             ])
             ->setAllowedTypes('limit_domains_by_ids', 'array');
+    }
+
+    public function validateSlugEncoding(mixed $slug, ExecutionContextInterface $context): void
+    {
+        if (!is_string($slug) || $slug === '') {
+            return;
+        }
+
+        if (preg_match(static::SLUG_REGEX, $slug) === 1) {
+            return;
+        }
+
+        $context->buildViolation(
+            t('Slug containing non-ASCII characters must be URL-encoded. The encoded value of "%enteredValue%" is "%normalizedValue%".', [
+                '%enteredValue%' => $slug,
+                '%normalizedValue%' => FriendlyUrlSlugNormalizer::normalize($slug),
+            ], Translator::VALIDATOR_TRANSLATION_DOMAIN),
+        )
+            ->addViolation();
     }
 }

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints;
 
 final class FriendlyUrlType extends AbstractType
 {
-    protected const string SLUG_REGEX = '/^[\w_\-\/]+$/';
+    public const string SLUG_REGEX = '/^(?:[A-Za-z0-9_\-\/]|%[0-9A-Fa-f]{2})+$/';
 
     #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -30,9 +30,13 @@ final class FriendlyUrlType extends AbstractType
             'attr' => [
                 'placeholder' => 'slug',
             ],
+            'help' => t('If the slug contains non-ASCII characters (e.g. "café"), encode it as URL-encoded form (e.g. "caf%C3%A9"). You can use https://www.urlencoder.org/.'),
             'constraints' => [
                 new Constraints\NotBlank(),
-                new Constraints\Regex(static::SLUG_REGEX),
+                new Constraints\Regex(
+                    pattern: static::SLUG_REGEX,
+                    message: 'Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/.',
+                ),
             ],
         ]);
     }

--- a/packages/framework/src/Form/UrlListType.php
+++ b/packages/framework/src/Form/UrlListType.php
@@ -20,9 +20,12 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 
 final class UrlListType extends AbstractType
 {
+    private const string UNIQUE_SLUGS_VALIDATION_GROUP = 'UniqueSlugs';
+
     public function __construct(
         private readonly FriendlyUrlFacade $friendlyUrlFacade,
         private readonly DomainRouterFactory $domainRouterFactory,
@@ -48,7 +51,9 @@ final class UrlListType extends AbstractType
                 'limit_domains_by_ids' => $this->domain->getAdminEnabledDomainIds($options['limit_domains_by_ids']),
             ],
             'constraints' => [
-                new UniqueSlugsOnDomains(),
+                new UniqueSlugsOnDomains(
+                    groups: [self::UNIQUE_SLUGS_VALIDATION_GROUP],
+                ),
             ],
         ]);
 
@@ -114,6 +119,7 @@ final class UrlListType extends AbstractType
                 'route_name' => null,
                 'entity_id' => null,
                 'limit_domains_by_ids' => [],
+                'validation_groups' => new GroupSequence(['Default', self::UNIQUE_SLUGS_VALIDATION_GROUP]),
             ])
             ->setAllowedTypes('limit_domains_by_ids', 'array');
     }

--- a/packages/framework/src/Migrations/Version20260207120000.php
+++ b/packages/framework/src/Migrations/Version20260207120000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlSlugNormalizer;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20260207120000 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $friendlyUrlsResult = $this->sql(
+            'SELECT domain_id, slug, route_name, entity_id, main, redirect_to, redirect_code, last_modification
+             FROM friendly_urls',
+        );
+
+        while (($row = $friendlyUrlsResult->fetchAssociative()) !== false) {
+            $normalizedSlug = FriendlyUrlSlugNormalizer::normalize($row['slug']);
+
+            if ($normalizedSlug === $row['slug']) {
+                continue;
+            }
+
+            $this->sql(
+                'DELETE FROM friendly_urls WHERE domain_id = :domainId AND slug = :slug',
+                [
+                    'domainId' => $row['domain_id'],
+                    'slug' => $row['slug'],
+                ],
+            );
+
+            $this->sql(
+                'INSERT INTO friendly_urls (domain_id, slug, route_name, entity_id, main, redirect_to, redirect_code, last_modification)
+                 VALUES (:domainId, :slug, :routeName, :entityId, :main, :redirectTo, :redirectCode, :lastModification)
+                 ON CONFLICT DO NOTHING',
+                [
+                    'domainId' => $row['domain_id'],
+                    'slug' => $normalizedSlug,
+                    'routeName' => $row['route_name'],
+                    'entityId' => $row['entity_id'],
+                    'main' => $row['main'],
+                    'redirectTo' => $row['redirect_to'],
+                    'redirectCode' => $row['redirect_code'],
+                    'lastModification' => $row['last_modification'],
+                ],
+            );
+        }
+    }
+}

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1795,6 +1795,9 @@ msgstr "Ikona"
 msgid "If the country is not listed, you have to <a href=\"%countryCreateUrl%\" target=\"_blank\">create</a> it first. Or, in rare scenarios, your country code might not be <a href=\"%supportedCountriesUrl%\" target=\"_blank\">supported</a>."
 msgstr "Pokud země není uvedena, musíte ji nejprve <a href=\"%countryCreateUrl%\" target=\"_blank\">vytvořit</a>. Nebo ve vzácných případech váš kód země nemusí být <a href=\"%supportedCountriesUrl%\" target=\"_blank\">podporován</a>."
 
+msgid "If the slug contains non-ASCII characters (e.g. \"café\"), encode it as URL-encoded form (e.g. \"caf%C3%A9\"). You can use https://www.urlencoder.org/."
+msgstr "Pokud slug obsahuje jiné než ASCII znaky (např. \"café\"), zakódujte jej do URL-zakódované formy (např. \"caf%C3%A9\"). Můžete použít https://www.urlencoder.org/."
+
 msgid "If you allow negative stock, it is possible to order more items than are currently in stock."
 msgstr "Pokud povolíte nákup do mínusu, je možné objednat více položek, než je aktuálně na skladě."
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1795,6 +1795,9 @@ msgstr ""
 msgid "If the country is not listed, you have to <a href=\"%countryCreateUrl%\" target=\"_blank\">create</a> it first. Or, in rare scenarios, your country code might not be <a href=\"%supportedCountriesUrl%\" target=\"_blank\">supported</a>."
 msgstr ""
 
+msgid "If the slug contains non-ASCII characters (e.g. \"café\"), encode it as URL-encoded form (e.g. \"caf%C3%A9\"). You can use https://www.urlencoder.org/."
+msgstr ""
+
 msgid "If you allow negative stock, it is possible to order more items than are currently in stock."
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -1795,6 +1795,9 @@ msgstr "Ikona"
 msgid "If the country is not listed, you have to <a href=\"%countryCreateUrl%\" target=\"_blank\">create</a> it first. Or, in rare scenarios, your country code might not be <a href=\"%supportedCountriesUrl%\" target=\"_blank\">supported</a>."
 msgstr "Ak krajina nie je uvedená, musíte ju najskôr <a href=\"%countryCreateUrl%\" target=\"_blank\">vytvoriť</a>. Alebo vo zriedkavých scenároch váš kód krajiny nemusí byť <a href=\"%supportedCountriesUrl%\" target=\"_blank\">podporovaný</a>."
 
+msgid "If the slug contains non-ASCII characters (e.g. \"café\"), encode it as URL-encoded form (e.g. \"caf%C3%A9\"). You can use https://www.urlencoder.org/."
+msgstr "Ak slug obsahuje iné ako ASCII znaky (napr. \"café\"), zakódujte ho do URL-zakódovanej formy (napr. \"caf%C3%A9\"). Môžete použiť https://www.urlencoder.org/."
+
 msgid "If you allow negative stock, it is possible to order more items than are currently in stock."
 msgstr "Ak povolíte záporný stav skladu, je možné objednať viac položiek, ako je momentálne na sklade."
 

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -625,6 +625,9 @@ msgstr "Seo stránka se slugem {{ pageSlug }} již existuje"
 msgid "Slug can contain only letters, numbers, hyphens, underscores and slashes"
 msgstr "Slug může obsahovat pouze písmena, čísla, pomlčky, podtržítka a lomítka"
 
+msgid "Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/."
+msgstr "Slug obsahující jiné než ASCII znaky musí být URL-zakódován. Můžete použít https://www.urlencoder.org/."
+
 msgid "Status name cannot be longer than {{ limit }} characters"
 msgstr "Název stavu nesmí být delší než {{ limit }} znaků"
 

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -625,8 +625,8 @@ msgstr "Seo stránka se slugem {{ pageSlug }} již existuje"
 msgid "Slug can contain only letters, numbers, hyphens, underscores and slashes"
 msgstr "Slug může obsahovat pouze písmena, čísla, pomlčky, podtržítka a lomítka"
 
-msgid "Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/."
-msgstr "Slug obsahující jiné než ASCII znaky musí být URL-zakódován. Můžete použít https://www.urlencoder.org/."
+msgid "Slug containing non-ASCII characters must be URL-encoded. The encoded value of \"%enteredValue%\" is \"%normalizedValue%\"."
+msgstr "Slug obsahující jiné než ASCII znaky musí být URL-zakódován. Zakódovaná hodnota \"%enteredValue%\" je \"%normalizedValue%\"."
 
 msgid "Status name cannot be longer than {{ limit }} characters"
 msgstr "Název stavu nesmí být delší než {{ limit }} znaků"

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Slug can contain only letters, numbers, hyphens, underscores and slashes"
 msgstr ""
 
-msgid "Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/."
+msgid "Slug containing non-ASCII characters must be URL-encoded. The encoded value of \"%enteredValue%\" is \"%normalizedValue%\"."
 msgstr ""
 
 msgid "Status name cannot be longer than {{ limit }} characters"

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -625,6 +625,9 @@ msgstr ""
 msgid "Slug can contain only letters, numbers, hyphens, underscores and slashes"
 msgstr ""
 
+msgid "Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/."
+msgstr ""
+
 msgid "Status name cannot be longer than {{ limit }} characters"
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/validators.sk.po
+++ b/packages/framework/src/Resources/translations/validators.sk.po
@@ -625,6 +625,9 @@ msgstr "SEO stránka so slugom {{ pageSlug }} už existuje"
 msgid "Slug can contain only letters, numbers, hyphens, underscores and slashes"
 msgstr "Slug môže obsahovať len písmená, čísla, pomlčky, podčiarkovníky a lomítka"
 
+msgid "Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/."
+msgstr "Slug obsahujúci iné ako ASCII znaky musí byť URL-zakódovaný. Môžete použiť https://www.urlencoder.org/."
+
 msgid "Status name cannot be longer than {{ limit }} characters"
 msgstr "Názov stavu nemôže byť dlhší ako {{ limit }} znakov"
 

--- a/packages/framework/src/Resources/translations/validators.sk.po
+++ b/packages/framework/src/Resources/translations/validators.sk.po
@@ -625,8 +625,8 @@ msgstr "SEO stránka so slugom {{ pageSlug }} už existuje"
 msgid "Slug can contain only letters, numbers, hyphens, underscores and slashes"
 msgstr "Slug môže obsahovať len písmená, čísla, pomlčky, podčiarkovníky a lomítka"
 
-msgid "Slug containing non-ASCII characters must be URL-encoded. You can use https://www.urlencoder.org/."
-msgstr "Slug obsahujúci iné ako ASCII znaky musí byť URL-zakódovaný. Môžete použiť https://www.urlencoder.org/."
+msgid "Slug containing non-ASCII characters must be URL-encoded. The encoded value of \"%enteredValue%\" is \"%normalizedValue%\"."
+msgstr "Slug obsahujúci iné ako ASCII znaky musí byť URL-zakódovaný. Zakódovaná hodnota \"%enteredValue%\" je \"%normalizedValue%\"."
 
 msgid "Status name cannot be longer than {{ limit }} characters"
 msgstr "Názov stavu nemôže byť dlhší ako {{ limit }} znakov"

--- a/packages/framework/tests/Unit/Component/Constraints/UniqueSlugsOnDomainsValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/UniqueSlugsOnDomainsValidatorTest.php
@@ -102,12 +102,74 @@ class UniqueSlugsOnDomainsValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testValidateDuplicateEncodedAndDecodedSlugsOnSameDomain(): void
+    {
+        $values = [
+            [
+                UrlListData::FIELD_DOMAIN => 1,
+                UrlListData::FIELD_SLUG => 'new-%75rl/',
+            ],
+            [
+                UrlListData::FIELD_DOMAIN => 1,
+                UrlListData::FIELD_SLUG => 'new-url/',
+            ],
+        ];
+        $constraint = new UniqueSlugsOnDomains();
+        $constraint->messageDuplicate = 'myMessage';
+
+        $this->validator->validate($values, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ url }}', 'http://example.cz/new-url/')
+            ->assertRaised();
+    }
+
+    public function testValidateDuplicateSlugsWithDifferentEncodingCaseOnSameDomain(): void
+    {
+        $values = [
+            [
+                UrlListData::FIELD_DOMAIN => 1,
+                UrlListData::FIELD_SLUG => 'new-caf%C3%A9/',
+            ],
+            [
+                UrlListData::FIELD_DOMAIN => 1,
+                UrlListData::FIELD_SLUG => 'new-caf%c3%a9/',
+            ],
+        ];
+        $constraint = new UniqueSlugsOnDomains();
+        $constraint->messageDuplicate = 'myMessage';
+
+        $this->validator->validate($values, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ url }}', 'http://example.cz/new-caf%C3%A9/')
+            ->assertRaised();
+    }
+
     public function testValidateExistingSlug(): void
     {
         $values = [
             [
                 UrlListData::FIELD_DOMAIN => 1,
                 UrlListData::FIELD_SLUG => 'existing-url/',
+            ],
+        ];
+        $constraint = new UniqueSlugsOnDomains();
+        $constraint->message = 'myMessage';
+
+        $this->validator->validate($values, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ url }}', 'http://example.cz/existing-url/')
+            ->assertRaised();
+    }
+
+    public function testValidateExistingEncodedSlug(): void
+    {
+        $values = [
+            [
+                UrlListData::FIELD_DOMAIN => 1,
+                UrlListData::FIELD_SLUG => 'existing-%75rl/',
             ],
         ];
         $constraint = new UniqueSlugsOnDomains();

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrameworkBundle\Unit\Component\Router\FriendlyUrl;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -27,7 +28,7 @@ class FriendlyUrlFactoryTest extends TestCase
             'en' => 'en-name',
         ];
 
-        $friendlyUrlFactory = $this->getFriendlyUrlFactory();
+        $friendlyUrlFactory = $this->getFriendlyUrlFactoryMock();
         $friendlyUrlFactory->expects($this->atLeastOnce())->method('isRouteMultidomain')->willReturn(true);
 
         $friendlyUrls = $friendlyUrlFactory->createForAllDomains($routeName, $entityId, $namesByLocale);
@@ -57,13 +58,53 @@ class FriendlyUrlFactoryTest extends TestCase
 
         $this->expectException(FriendlyUrlIsNotMultidomainException::class);
 
-        $friendlyUrlFactory = $this->getFriendlyUrlFactory();
+        $friendlyUrlFactory = $this->getFriendlyUrlFactoryMock();
         $friendlyUrlFactory->expects($this->atLeastOnce())->method('isRouteMultidomain')->willReturn(false);
 
         $friendlyUrlFactory->createForAllDomains($routeName, $entityId, $namesByLocale);
     }
 
-    private function getFriendlyUrlFactory(): FriendlyUrlFactory|MockObject
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function slugNormalizationDataProvider(): array
+    {
+        return [
+            'normalizes percent-encoded utf-8 with lowercase hex' => ['caf%c3%a9', 'caf%C3%A9'],
+            'preserves plain ascii slug' => ['simple-slug', 'simple-slug'],
+            'encodes plain utf-8 characters' => ['café', 'caf%C3%A9'],
+        ];
+    }
+
+    #[DataProvider('slugNormalizationDataProvider')]
+    public function testCreateNormalizesSlug(string $slug, string $expectedSlug): void
+    {
+        $friendlyUrlFactory = $this->getFriendlyUrlFactory();
+        $friendlyUrl = $friendlyUrlFactory->create('front_product_detail', 1, 1, $slug);
+
+        $this->assertSame($expectedSlug, $friendlyUrl->getSlug());
+    }
+
+    private function getFriendlyUrlFactory(): FriendlyUrlFactory
+    {
+        $domain = $this->createDomain();
+        $domainRouterFactoryStub = $this->createStub(DomainRouterFactory::class);
+
+        return new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryStub);
+    }
+
+    private function getFriendlyUrlFactoryMock(): FriendlyUrlFactory|MockObject
+    {
+        $domain = $this->createDomain();
+        $domainRouterFactoryStub = $this->createStub(DomainRouterFactory::class);
+
+        return $this->getMockBuilder(FriendlyUrlFactory::class)
+            ->setConstructorArgs([$domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryStub])
+            ->onlyMethods(['isRouteMultidomain'])
+            ->getMock();
+    }
+
+    private function createDomain(): Domain
     {
         $domainConfigs = [
             DomainConfigHelper::getDomainConfig(),
@@ -75,20 +116,10 @@ class FriendlyUrlFactoryTest extends TestCase
         $settingStub = $this->createStub(Setting::class);
         $currentAdministratorStub = $this->createStub(CurrentAdministrator::class);
 
-        $domain = new Domain(
+        return new Domain(
             $domainConfigs,
             $settingStub,
             $currentAdministratorStub,
         );
-
-        $domainRouterFactoryStub = $this->createStub(DomainRouterFactory::class);
-
-        $friendlyUrlFactory = $this->getMockBuilder(FriendlyUrlFactory::class)
-            ->setConstructorArgs([$domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryStub])
-            ->onlyMethods(['isRouteMultidomain'])
-            ->getMock();
-
-
-        return $friendlyUrlFactory;
     }
 }

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlGeneratorTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlGeneratorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Router\FriendlyUrl;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlGenerator;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class FriendlyUrlGeneratorTest extends TestCase
+{
+    #[DataProvider('friendlyUrlSlugProvider')]
+    public function testGetGeneratedUrlDoesNotDoubleEncodeFriendlyUrlSlug(string $slug, string $expectedUrl): void
+    {
+        $friendlyUrlGenerator = $this->createFriendlyUrlGenerator();
+        $friendlyUrl = new FriendlyUrl('route_name', 1, 1, $slug);
+        $url = $friendlyUrlGenerator->getGeneratedUrl(
+            'route_name',
+            new Route('friendly-url'),
+            $friendlyUrl,
+            [],
+            UrlGeneratorInterface::ABSOLUTE_PATH,
+        );
+
+        $this->assertSame($expectedUrl, $url);
+    }
+
+    /**
+     * @return array<int, array{string, string}>
+     */
+    public static function friendlyUrlSlugProvider(): array
+    {
+        return [
+            ['10%', '/10%25'],
+            ['10%25', '/10%25'],
+            ['caf%C3%A9/', '/caf%C3%A9/'],
+            ['café/', '/caf%C3%A9/'],
+        ];
+    }
+
+    private function createFriendlyUrlGenerator(): FriendlyUrlGenerator
+    {
+        return new FriendlyUrlGenerator(
+            new RequestContext(),
+            $this->createStub(FriendlyUrlRepository::class),
+            $this->createStub(FriendlyUrlCacheKeyProvider::class),
+            $this->createStub(CacheInterface::class),
+        );
+    }
+}

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlSlugNormalizerTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlSlugNormalizerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Router\FriendlyUrl;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlSlugNormalizer;
+
+class FriendlyUrlSlugNormalizerTest extends TestCase
+{
+    public static function normalizationDataProvider(): array
+    {
+        return [
+            ['simple-slug/', 'simple-slug/'],
+            ['caf%C3%A9/', 'caf%C3%A9/'],
+            ['caf%c3%a9/', 'caf%C3%A9/'],
+            ['café/', 'caf%C3%A9/'],
+            ['folder/caf%C3%A9/', 'folder/caf%C3%A9/'],
+            ['10%', '10%25'],
+            ['new-%75rl/', 'new-url/'],
+            ['a%2Fb', 'a/b'],
+        ];
+    }
+
+    #[DataProvider('normalizationDataProvider')]
+    public function testNormalize(string $slug, string $expectedNormalizedSlug): void
+    {
+        $normalizedSlug = FriendlyUrlSlugNormalizer::normalize($slug);
+
+        self::assertSame($expectedNormalizedSlug, $normalizedSlug);
+    }
+}

--- a/packages/framework/tests/Unit/Form/FriendlyUrlTypeTest.php
+++ b/packages/framework/tests/Unit/Form/FriendlyUrlTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Form\FriendlyUrlType;
+
+class FriendlyUrlTypeTest extends TestCase
+{
+    public static function validSlugsProvider(): array
+    {
+        return [
+            ['new-url/'],
+            ['folder/new-url_123/'],
+            ['caf%C3%A9'],
+            ['folder/%C5%BElu%C5%A5ou%C4%8Dk%C3%BD-k%C5%AF%C5%88/'],
+        ];
+    }
+
+    public static function invalidSlugsProvider(): array
+    {
+        return [
+            ['café'],
+            ['folder/%'],
+            ['folder/%2'],
+            ['folder/%ZZ'],
+            ['folder/with space'],
+        ];
+    }
+
+    #[DataProvider('validSlugsProvider')]
+    public function testSlugRegexMatchesValidEncodedSlug(string $slug): void
+    {
+        self::assertMatchesRegularExpression(FriendlyUrlType::SLUG_REGEX, $slug);
+    }
+
+    #[DataProvider('invalidSlugsProvider')]
+    public function testSlugRegexDoesNotMatchInvalidOrNonEncodedSlug(string $slug): void
+    {
+        self::assertDoesNotMatchRegularExpression(FriendlyUrlType::SLUG_REGEX, $slug);
+    }
+}

--- a/packages/frontend-api/src/Model/FriendlyUrl/FriendlyUrlRepository.php
+++ b/packages/frontend-api/src/Model/FriendlyUrl/FriendlyUrlRepository.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository as FrameworkFriendlyUrlRepository;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlSlugNormalizer;
 
 class FriendlyUrlRepository
 {
@@ -27,7 +28,7 @@ class FriendlyUrlRepository
         $criteria = [
             'domainId' => $domainId,
             'routeName' => $routeName,
-            'slug' => $slug,
+            'slug' => FriendlyUrlSlugNormalizer::normalize($slug),
         ];
 
         return $this->getFriendlyUrlRepository()->findOneBy($criteria);

--- a/project-base/app/web/resolveFriendlyUrl.php
+++ b/project-base/app/web/resolveFriendlyUrl.php
@@ -48,6 +48,16 @@ function returnSlug(string $route, ?string $redirectTo, ?int $redirectCode = nul
     exit;
 }
 
+function normalizeSlug(string $slug): string
+{
+    $decodedSlug = rawurldecode($slug);
+    $decodedSlugSegments = explode('/', $decodedSlug);
+
+    $encodedSlugSegments = array_map(static fn (string $segment): string => rawurlencode($segment), $decodedSlugSegments);
+
+    return implode('/', $encodedSlugSegments);
+}
+
 if ($slug === null || $domainId === null) {
     writeToLog(sprintf('400 Bad Request because slug (%s) or domainId (%d) is null',
         $slug,
@@ -58,7 +68,7 @@ if ($slug === null || $domainId === null) {
     exit;
 }
 
-$slug = ltrim(trim($slug), '/');
+$slug = normalizeSlug(ltrim(trim($slug), '/'));
 
 try {
     $connection = new PDO(

--- a/upgrade-notes/backend_20260207_152404.md
+++ b/upgrade-notes/backend_20260207_152404.md
@@ -1,0 +1,4 @@
+#### ensure friendly url slug is always url-encoded ([#4445](https://github.com/shopsys/shopsys/pull/4445))
+
+- double-check `Shopsys\FrameworkBundle\Migrations\Version20260207120000` migration before running it on your production data
+- check your custom code - if you insert `slug` into `friendly_url` DB table (other than the entity-way), or if you search by `slug` column, be sure to always use `FriendlyUrlSlugNormalizer::normalize()` on the slug value


### PR DESCRIPTION
#### Description, the reason for the PR
When using URL-encoded slugs, the case-sensitive search might not work because, within the encoding, the case does not matter (e.g., both `caf%C3%A9` and `caf%c3%a9` are equivalent codes for `café`). 

To avoid the potential mismatched search, we now ensure the slug is always normalized and encoded in the database, and always encode (and normalize) the input slug before searching.

* normalization basically means we run `rawurlencode(rawurldecode())` on the given slug to ensure it is always encoded the same way

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-friendly-urls.odin.shopsys.cloud
  - https://cz.rv-friendly-urls.odin.shopsys.cloud
  - https://rv-friendly-urls.odin.shopsys.cloud/sk
<!-- Replace -->
