### PR TITLE
fixed not proper login failed message in admin

### DIFF
--- a/packages/framework/src/Controller/Admin/LoginController.php
+++ b/packages/framework/src/Controller/Admin/LoginController.php
@@ -40,12 +40,12 @@ class LoginController extends AdminBaseController
 
         if ($lastAuthenticationError !== null) {
             $error = match (true) {
-                $lastAuthenticationError->getPrevious() instanceof LoginWithDefaultPasswordException => t(
+                $lastAuthenticationError instanceof LoginWithDefaultPasswordException => t(
                     'Oh, you just tried to log in using default credentials. We do not allow that on production'
                     . ' environment. If you are random hacker, please go somewhere else. If you are authorized user,'
                     . ' please use another account or contact developers and change password during deployment.',
                 ),
-                $lastAuthenticationError->getPrevious() instanceof TooManyLoginAttemptsAuthenticationException => t(
+                $lastAuthenticationError instanceof TooManyLoginAttemptsAuthenticationException => t(
                     'Too many login attempts. Please try again later.',
                 ),
                 default => t('Log in failed.'),


### PR DESCRIPTION
#### Description, the reason for the PR

On production, when user tries to log in with default credentials, or when tries to login with wrond password many times, the proper reason is now displayed on the login page. 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-login-error-msg.odin.shopsys.cloud
  - https://cz.mg-fix-login-error-msg.odin.shopsys.cloud
  - https://mg-fix-login-error-msg.odin.shopsys.cloud/sk
<!-- Replace -->
