### PR TITLE
OrderGoPayStatusUpdateCronModule improvements 

### DIFF
--- a/packages/framework/src/Model/GoPay/Exception/GoPayStatusUpdateFailedException.php
+++ b/packages/framework/src/Model/GoPay/Exception/GoPayStatusUpdateFailedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\GoPay\Exception;
+
+use RuntimeException;
+
+class GoPayStatusUpdateFailedException extends RuntimeException
+{
+}

--- a/packages/framework/src/Model/GoPay/OrderGoPayStatusUpdateCronModule.php
+++ b/packages/framework/src/Model/GoPay/OrderGoPayStatusUpdateCronModule.php
@@ -9,6 +9,7 @@ use Monolog\Logger;
 use Override;
 use Psr\Clock\ClockInterface;
 use Shopsys\FrameworkBundle\Model\GoPay\Exception\GoPayPaymentDownloadException;
+use Shopsys\FrameworkBundle\Model\GoPay\Exception\GoPayStatusUpdateFailedException;
 use Shopsys\FrameworkBundle\Model\Order\Mail\OrderMailFacade;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
 use Shopsys\FrameworkBundle\Model\Payment\Service\PaymentServiceFacade;
@@ -33,6 +34,7 @@ class OrderGoPayStatusUpdateCronModule implements SimpleCronModuleInterface
     {
         $twentyOneDaysAgo = $this->clock->now()->modify('-21 days');
         $orders = $this->goPayFacade->getAllUnpaidGoPayOrders($twentyOneDaysAgo);
+        $failedOrderIds = [];
 
         $this->logger->info('Downloading status updates for orders.', [
             'ordersCount' => count($orders),
@@ -63,6 +65,7 @@ class OrderGoPayStatusUpdateCronModule implements SimpleCronModuleInterface
                 $this->logger->error($e->getMessage(), [
                     'exception' => $e,
                 ]);
+                $failedOrderIds[] = $orderId;
 
                 continue;
             }
@@ -87,10 +90,18 @@ class OrderGoPayStatusUpdateCronModule implements SimpleCronModuleInterface
             $this->logger->info('Sending order e-mail.', [
                 'orderId' => $orderId,
             ]);
+
             $this->orderMailFacade->sendEmail($order, $order->getStatus());
         }
 
         $this->em->flush();
+
+        if ($failedOrderIds !== []) {
+            throw new GoPayStatusUpdateFailedException(sprintf(
+                'GoPay status update failed for %d order(s).',
+                count($failedOrderIds),
+            ));
+        }
     }
 
     #[Override]

--- a/packages/framework/tests/Unit/Model/GoPay/OrderGoPayStatusUpdateCronModuleTest.php
+++ b/packages/framework/tests/Unit/Model/GoPay/OrderGoPayStatusUpdateCronModuleTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\GoPay;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use RuntimeException;
+use Shopsys\FrameworkBundle\Model\GoPay\Exception\GoPayPaymentDownloadException;
+use Shopsys\FrameworkBundle\Model\GoPay\GoPayFacade;
+use Shopsys\FrameworkBundle\Model\GoPay\OrderGoPayStatusUpdateCronModule;
+use Shopsys\FrameworkBundle\Model\Order\Mail\OrderMailFacade;
+use Shopsys\FrameworkBundle\Model\Order\Order;
+use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus;
+use Shopsys\FrameworkBundle\Model\Payment\Service\PaymentServiceFacade;
+use Symfony\Component\Clock\DatePoint;
+
+class OrderGoPayStatusUpdateCronModuleTest extends TestCase
+{
+    public function testRunThrowsWhenAnyOrderFailsAndStillProcessesSuccessfulOrder(): void
+    {
+        $failedOrder = $this->createOrderStub(1000);
+        $successfulOrderStatus = $this->createStub(OrderStatus::class);
+        $successfulOrder = $this->createOrderStub(1001, [false, true], $successfulOrderStatus);
+
+        $emMock = $this->createMock(EntityManagerInterface::class);
+        $emMock->expects($this->once())->method('flush');
+
+        $goPayFacadeStub = $this->createStub(GoPayFacade::class);
+        $goPayFacadeStub->method('getAllUnpaidGoPayOrders')
+            ->willReturn([$failedOrder, $successfulOrder]);
+
+        $paymentServiceFacadeMock = $this->createMock(PaymentServiceFacade::class);
+        $paymentServiceFacadeMock->expects($this->exactly(2))
+            ->method('updatePaymentTransactionsByOrder')
+            ->willReturnCallback(function (Order $order) use ($failedOrder, $successfulOrder) {
+                if ($order === $failedOrder) {
+                    throw new GoPayPaymentDownloadException(
+                        '/payments/payment-id',
+                        'GET',
+                        200,
+                        null,
+                        null,
+                    );
+                }
+
+                return $order === $successfulOrder;
+            });
+
+        $orderFacadeMock = $this->createMock(OrderFacade::class);
+        $orderFacadeMock->expects($this->once())
+            ->method('updatePaymentByLastPaymentTransaction')
+            ->with($successfulOrder);
+
+        $orderMailFacadeMock = $this->createMock(OrderMailFacade::class);
+        $orderMailFacadeMock->expects($this->once())
+            ->method('sendEmail')
+            ->with($successfulOrder, $successfulOrderStatus);
+
+        $clockStub = $this->createStub(ClockInterface::class);
+        $clockStub->method('now')->willReturn(new DatePoint('2026-01-01 00:00:00'));
+
+        $orderGoPayStatusUpdateCronModule = new OrderGoPayStatusUpdateCronModule(
+            $emMock,
+            $goPayFacadeStub,
+            $orderMailFacadeMock,
+            $paymentServiceFacadeMock,
+            $orderFacadeMock,
+            $clockStub,
+        );
+        $orderGoPayStatusUpdateCronModule->setLogger($this->createStub(Logger::class));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('GoPay status update failed for 1 order(s).');
+
+        $orderGoPayStatusUpdateCronModule->run();
+    }
+
+    /**
+     * @param array<int,bool> $isPaidReturns
+     */
+    private function createOrderStub(
+        int $orderId,
+        array $isPaidReturns = [false],
+        ?OrderStatus $orderStatus = null,
+    ): Order {
+        $orderStub = $this->getStubBuilder(Order::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getId',
+                'isDeleted',
+                'getGoPayTransactionStatusesIndexedByGoPayId',
+                'isPaid',
+                'getGoPayTransactions',
+                'getStatus',
+            ])
+            ->getStub();
+
+        $orderStub->method('getId')->willReturn($orderId);
+        $orderStub->method('isDeleted')->willReturn(false);
+        $orderStub->method('getGoPayTransactionStatusesIndexedByGoPayId')->willReturn([]);
+
+        if (count($isPaidReturns) === 1) {
+            $orderStub->method('isPaid')->willReturn($isPaidReturns[0]);
+        } else {
+            $orderStub->method('isPaid')->willReturnOnConsecutiveCalls(...$isPaidReturns);
+        }
+        $orderStub->method('getGoPayTransactions')->willReturn([]);
+        $orderStub->method('getStatus')->willReturn($orderStatus ?? $this->createStub(OrderStatus::class));
+
+        return $orderStub;
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

Updated `OrderGoPayStatusUpdateCronModule` to:
- keep processing successful orders even when some GoPay status downloads fail
- aggregate per-order GoPay download failures
- throw at the end of `run()` if any order failed, so module status is visible as `ERROR` in cron dashboard

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://mg-gopay-cron.odin.shopsys.cloud
  - https://cz.mg-gopay-cron.odin.shopsys.cloud
  - https://mg-gopay-cron.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773054428.913119 -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-gopay-cron.odin.shopsys.cloud
  - https://cz.mg-gopay-cron.odin.shopsys.cloud
  - https://mg-gopay-cron.odin.shopsys.cloud/sk
<!-- Replace -->
