### PR TITLE
admin: fixed product quick search

### DIFF
--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -161,7 +161,7 @@ class ProductController extends AdminBaseController
 
         // Cannot call $form->handleRequest() because the GET forms are not handled in POST request.
         // See: https://github.com/symfony/symfony/issues/12244
-        $quickSearchForm->submit($request->query->get($quickSearchForm->getName()));
+        $quickSearchForm->submit($request->query->all($quickSearchForm->getName()));
 
         $massActionForm = $this->createForm(ProductMassActionFormType::class);
         $massActionForm->handleRequest($request);


### PR DESCRIPTION
#### Description, the reason for the PR

In #4409 there was an oversight of how product quick search is handled, and submitting the quick search form throws an error.
This is fixed now.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-fix-product-search.odin.shopsys.cloud
  - https://cz.mg-fix-product-search.odin.shopsys.cloud
  - https://mg-fix-product-search.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1770836979.876609 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-product-search.odin.shopsys.cloud
  - https://cz.mg-fix-product-search.odin.shopsys.cloud
  - https://mg-fix-product-search.odin.shopsys.cloud/sk
<!-- Replace -->
