### PR TITLE
reworked cron runner

### DIFF
--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -46,7 +46,7 @@ You can learn how to set up multiple cron instances in [Working with Multiple Cr
 ## Cron Limitations
 
 One cron run can only be run for a limited time by default to prevent high-memory usage of long-running jobs in PHP.
-In `app/config/cron.yaml` is set the default timeout to `240 seconds`:
+You can configure the behaviour of each instance in `app/config/cron.yaml`:
 
 ```yaml
 parameters:
@@ -54,6 +54,7 @@ parameters:
         default:
             run_every_min: 5
             timeout_iterated_cron_sec: 240
+            stop_on_failure: true
 ```
 
 That means, if the time needed to run all planned cron modules is higher than `240 seconds`, not all cron modules will be run in a current iteration.
@@ -62,6 +63,10 @@ but in some cases, the overall time of the "every 5 minutes" cron modules can be
 Then it's possible, some cron modules will never be run.
 
 It's crucial to monitor your crons and, if necessary, update their periodicity and timeout or split them into [multiple Cron Instances](#multiple-cron-instances).
+
+The `stop_on_failure` option controls whether the instance stops executing subsequent cron modules when one module fails.
+It defaults to `true`.
+Set it to `false` for instances whose modules are independent of each other so that a failure in one module does not prevent the remaining modules from running.
 
 !!! note
 

--- a/packages/administration/templates/content/default/cronListGrid.html.twig
+++ b/packages/administration/templates/content/default/cronListGrid.html.twig
@@ -1,5 +1,14 @@
 {% extends '@ShopsysAdministration/datagrid/grid.html.twig' %}
 
+{% block grid_multiple_drag_and_drop_title %}
+    {{ grid_title }}
+    {% if stopOnFailure %}
+        <span class="badge badge-sm bg-warning text-warning-fg ms-2">{{ 'Stops on first failure'|trans }}</span>
+    {% else %}
+        <span class="badge badge-sm bg-info text-info-fg ms-2">{{ 'Continues on failure'|trans }}</span>
+    {% endif %}
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No crons found.'|trans }}
 {% endblock %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -376,6 +376,9 @@ msgstr "Hlavička Content-Security-Policy"
 msgid "Content-Security-Policy header setting"
 msgstr "Nastavení hlavičky Content-Security-Policy"
 
+msgid "Continues on failure"
+msgstr "Pokračuje při chybě"
+
 msgid "Convert values associated with parameter"
 msgstr "Převeďte hodnoty spojené s parametrem"
 
@@ -1857,6 +1860,9 @@ msgstr "Speciální cena"
 
 msgid "Status"
 msgstr "Stav"
+
+msgid "Stops on first failure"
+msgstr "Zastaví se při první chybě"
 
 msgid "Store"
 msgstr "Prodejna"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -376,6 +376,9 @@ msgstr ""
 msgid "Content-Security-Policy header setting"
 msgstr ""
 
+msgid "Continues on failure"
+msgstr ""
+
 msgid "Convert values associated with parameter"
 msgstr ""
 
@@ -1856,6 +1859,9 @@ msgid "Special price"
 msgstr ""
 
 msgid "Status"
+msgstr ""
+
+msgid "Stops on first failure"
 msgstr ""
 
 msgid "Store"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -376,6 +376,9 @@ msgstr "Content-Security-Policy hlavička"
 msgid "Content-Security-Policy header setting"
 msgstr "Nastavenie Content-Security-Policy hlavičky"
 
+msgid "Continues on failure"
+msgstr "Pokračuje pri chybe"
+
 msgid "Convert values associated with parameter"
 msgstr "Preveďte hodnoty spojené s parametrem"
 
@@ -1857,6 +1860,9 @@ msgstr "Špeciálna cena"
 
 msgid "Status"
 msgstr "Stav"
+
+msgid "Stops on first failure"
+msgstr "Zastaví sa pri prvej chybe"
 
 msgid "Store"
 msgstr "Obchod"

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -46,25 +46,32 @@ class CronCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption(self::OPTION_LIST, null, InputOption::VALUE_NONE, 'List all Service commands')
-            ->addOption(self::OPTION_MODULE, null, InputOption::VALUE_OPTIONAL, 'Service ID')
+            ->addOption(
+                self::OPTION_LIST,
+                null,
+                InputOption::VALUE_NONE,
+                'List all Service commands',
+            )
+            ->addOption(
+                self::OPTION_MODULE,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Run only specific module (service ID)',
+            )
             ->addOption(
                 self::OPTION_INSTANCE_NAME,
                 null,
                 InputOption::VALUE_REQUIRED,
-                'specific cron instance identifier',
+                'Specific cron instance identifier',
             )
             ->addOption(
                 self::OPTION_RUN_ALL_SERIALLY,
                 null,
                 InputOption::VALUE_NONE,
-                'run all crons serially (this is not safe to run in production environment)',
+                'Run all cron jobs serially (this is not safe to run in production environment)',
             );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -145,13 +145,6 @@ class CronCommand extends Command
      */
     protected function getCronCommands(array $cronModuleConfigs, bool $includeInstance = false): array
     {
-        uasort(
-            $cronModuleConfigs,
-            function (CronModuleConfig $cronModuleConfigA, CronModuleConfig $cronModuleConfigB) {
-                return strcmp($cronModuleConfigA->getServiceId(), $cronModuleConfigB->getServiceId());
-            },
-        );
-
         $commands = [];
 
         foreach ($cronModuleConfigs as $cronModuleConfig) {

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -6,8 +6,8 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use DateTimeZone;
 use NinjaMutex\Lock\LockInterface;
+use NinjaMutex\Mutex;
 use Override;
-use Shopsys\FrameworkBundle\Command\Exception\CronCommandException;
 use Shopsys\FrameworkBundle\Command\Exception\CronIsLockedException;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
@@ -17,9 +17,11 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Process\Process;
 
 #[AsCommand(
     name: 'shopsys:cron',
@@ -78,6 +80,7 @@ class CronCommand extends Command
         $optionList = $input->getOption(self::OPTION_LIST);
         $optionInstanceName = $input->getOption(self::OPTION_INSTANCE_NAME);
         $optionRunAllSerially = $input->getOption(self::OPTION_RUN_ALL_SERIALLY);
+        $optionModule = $input->getOption(self::OPTION_MODULE);
 
         if ($optionList === true) {
             $this->listAllCronModulesSortedByServiceId($input, $output, $this->cronFacade);
@@ -92,9 +95,7 @@ class CronCommand extends Command
         }
 
         if ($optionRunAllSerially === true) {
-            foreach ($this->cronFacade->getAll() as $cronModuleConfig) {
-                $this->cronFacade->runModuleByServiceId($cronModuleConfig->getServiceId());
-            }
+            $this->runAllModulesSerially($output);
 
             return Command::SUCCESS;
         }
@@ -102,15 +103,26 @@ class CronCommand extends Command
         $instanceName = $optionInstanceName ?? $this->chooseInstance($input, $output);
 
         try {
-            $this->runCron($input, $this->cronFacade, $this->mutexFactory, $instanceName);
+            $mutex = $this->acquireInstanceMutex($instanceName);
         } catch (CronIsLockedException $e) {
             $output->writeln($e->getMessage());
 
             return Command::SUCCESS;
-        } catch (CronCommandException $e) {
-            $output->writeln($e->getMessage());
+        }
 
-            return Command::FAILURE;
+        try {
+            if ($optionModule !== null) {
+                $this->cronFacade->runSingleModule(
+                    $optionModule,
+                    $instanceName,
+                    $this->getProcessOutputCallback($output),
+                    $output->isDecorated(),
+                );
+            } else {
+                $this->runModulesInInstance($instanceName, $output);
+            }
+        } finally {
+            $mutex->releaseLock();
         }
 
         return Command::SUCCESS;
@@ -165,26 +177,9 @@ class CronCommand extends Command
         return $commands;
     }
 
-    protected function runCron(
-        InputInterface $input,
-        CronFacade $cronFacade,
-        MutexFactory $mutexFactory,
-        string $instanceName,
-    ): void {
-        $requestedModuleServiceId = $input->getOption(self::OPTION_MODULE);
-        $runAllModules = $requestedModuleServiceId === null;
-        $cronInstances = $this->parameterBag->get('cron_instances');
-        $instanceRunEveryMin = $cronInstances[$instanceName]['run_every_min'] ?? CronModuleConfig::RUN_EVERY_MIN_DEFAULT;
-
-        if ($instanceRunEveryMin < 0 || $instanceRunEveryMin > 30) {
-            $instanceRunEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT;
-        }
-
-        if ($runAllModules) {
-            $cronFacade->scheduleModulesByTime($this->dateTimeHelper->getCurrentRoundedTimeForIntervalAndTimezone($instanceRunEveryMin, $this->getCronTimeZone()));
-        }
-
-        $mutex = $mutexFactory->getPrefixedCronMutex($instanceName);
+    protected function acquireInstanceMutex(string $instanceName): Mutex
+    {
+        $mutex = $this->mutexFactory->getPrefixedCronMutex($instanceName);
 
         if (!$mutex->acquireLock(0)) {
             throw new CronIsLockedException(
@@ -192,12 +187,64 @@ class CronCommand extends Command
             );
         }
 
-        if ($runAllModules) {
-            $cronFacade->runScheduledModulesForInstance($instanceName);
-        } else {
-            $cronFacade->runModuleByServiceId($requestedModuleServiceId);
+        return $mutex;
+    }
+
+    protected function getInstanceRunEveryMin(string $instanceName): int
+    {
+        $cronInstances = $this->parameterBag->get('cron_instances');
+        $instanceRunEveryMin = $cronInstances[$instanceName]['run_every_min'] ?? CronModuleConfig::RUN_EVERY_MIN_DEFAULT;
+
+        if ($instanceRunEveryMin < 0 || $instanceRunEveryMin > 30) {
+            return CronModuleConfig::RUN_EVERY_MIN_DEFAULT;
         }
-        $mutex->releaseLock();
+
+        return $instanceRunEveryMin;
+    }
+
+    protected function runModulesInInstance(
+        string $instanceName,
+        OutputInterface $output,
+    ): void {
+        $instanceRunEveryMin = $this->getInstanceRunEveryMin($instanceName);
+
+        $this->cronFacade->scheduleModulesByTime(
+            $this->dateTimeHelper->getCurrentRoundedTimeForIntervalAndTimezone($instanceRunEveryMin, $this->getCronTimeZone()),
+        );
+
+        $this->cronFacade->runScheduledModulesForInstance(
+            $instanceName,
+            $this->getProcessOutputCallback($output),
+            $output->isDecorated(),
+        );
+    }
+
+    protected function runAllModulesSerially(OutputInterface $output): void
+    {
+        foreach ($this->cronFacade->getAll() as $cronModuleConfig) {
+            $this->cronFacade->runSingleModule(
+                $cronModuleConfig->getServiceId(),
+                $cronModuleConfig->getInstanceName(),
+                $this->getProcessOutputCallback($output),
+                $output->isDecorated(),
+            );
+        }
+    }
+
+    /**
+     * @return callable(string, string): void
+     */
+    protected function getProcessOutputCallback(OutputInterface $output): callable
+    {
+        return static function (string $type, string $buffer) use ($output): void {
+            if ($type === Process::ERR && $output instanceof ConsoleOutputInterface) {
+                $output->getErrorOutput()->write($buffer, false, OutputInterface::OUTPUT_RAW);
+
+                return;
+            }
+
+            $output->write($buffer, false, OutputInterface::OUTPUT_RAW);
+        };
     }
 
     protected function chooseInstance(InputInterface $input, OutputInterface $output): string

--- a/packages/framework/src/Command/CronModuleRunnerCommand.php
+++ b/packages/framework/src/Command/CronModuleRunnerCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleRunnerFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: self::COMMAND_NAME,
+    description: 'Runs a single cron module in isolated internal process.',
+    hidden: true,
+)]
+class CronModuleRunnerCommand extends Command
+{
+    public const string COMMAND_NAME = 'shopsys:cron:module-runner';
+
+    protected const string ARGUMENT_MODULE = 'module';
+    protected const string OPTION_INSTANCE_NAME = 'instance-name';
+    protected const string OPTION_RUN_ID = 'run-id';
+
+    public function __construct(
+        protected readonly CronModuleRunnerFacade $cronModuleRunnerFacade,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this->addArgument(self::ARGUMENT_MODULE, InputArgument::REQUIRED, 'Module to run (service ID).');
+        $this->addOption(self::OPTION_INSTANCE_NAME, null, InputOption::VALUE_REQUIRED, 'Cron instance name for log context.');
+        $this->addOption(self::OPTION_RUN_ID, null, InputOption::VALUE_REQUIRED, 'Cron run ID for log context.');
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $requestedModuleServiceId = $input->getArgument(self::ARGUMENT_MODULE);
+        $instanceName = $input->getOption(self::OPTION_INSTANCE_NAME);
+        $runId = $input->getOption(self::OPTION_RUN_ID);
+
+        $runStatus = $this->cronModuleRunnerFacade->runModuleByServiceIdInContext(
+            $requestedModuleServiceId,
+            is_string($instanceName) ? $instanceName : null,
+            is_string($runId) ? $runId : null,
+        );
+
+        return $runStatus === CronModuleExecutor::RUN_STATUS_ERROR ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/packages/framework/src/Component/Cron/Config/CronConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronConfig.php
@@ -37,7 +37,16 @@ class CronConfig
         $this->cronTimeResolver->validateTimeString($timeHours, 23, 1);
         $this->cronTimeResolver->validateTimeString($timeMinutes, 55, 1);
 
-        $cronModuleConfig = new CronModuleConfig($service, $serviceId, $timeHours, $timeMinutes, $readableName, $readableFrequency, $runEveryMin, $timeoutIteratedCronSec);
+        $cronModuleConfig = new CronModuleConfig(
+            $service,
+            $serviceId,
+            $timeHours,
+            $timeMinutes,
+            $readableName,
+            $readableFrequency,
+            $runEveryMin,
+            $timeoutIteratedCronSec,
+        );
         $cronModuleConfig->assignToInstance($instanceName);
 
         $this->cronModuleConfigs[] = $cronModuleConfig;

--- a/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
@@ -11,9 +11,9 @@ use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 
 class CronModuleConfig implements CronTimeInterface
 {
-    public const DEFAULT_INSTANCE_NAME = 'default';
-    public const RUN_EVERY_MIN_DEFAULT = 5;
-    public const TIMEOUT_ITERATED_CRON_SEC_DEFAULT = 240;
+    public const string DEFAULT_INSTANCE_NAME = 'default';
+    public const int RUN_EVERY_MIN_DEFAULT = 5;
+    public const int TIMEOUT_ITERATED_CRON_SEC_DEFAULT = 240;
 
     protected string $instanceName;
 

--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -8,8 +8,7 @@ use DateTimeInterface;
 use Monolog\Logger;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
-use Shopsys\FrameworkBundle\Component\Reflection\ReflectionHelper;
-use Throwable;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CronFacade
 {
@@ -17,7 +16,8 @@ class CronFacade
         protected readonly Logger $logger,
         protected readonly CronConfig $cronConfig,
         protected readonly CronModuleFacade $cronModuleFacade,
-        protected readonly CronModuleExecutor $cronModuleExecutor,
+        protected readonly ParameterBagInterface $parameterBag,
+        protected readonly CronModuleProcessRunner $cronModuleProcessRunner,
     ) {
     }
 
@@ -27,19 +27,32 @@ class CronFacade
         $this->cronModuleFacade->scheduleModules($cronModuleConfigsToSchedule);
     }
 
-    public function runScheduledModulesForInstance(string $instanceName): void
-    {
+    public function runScheduledModulesForInstance(
+        string $instanceName,
+        callable $processOutputCallback,
+        bool $isOutputDecorated,
+    ): void {
         $cronModuleConfigs = $this->cronConfig->getCronModuleConfigsForInstance($instanceName);
 
         $scheduledCronModuleConfigs = $this->cronModuleFacade->getOnlyScheduledCronModuleConfigs($cronModuleConfigs);
-        $this->runModules($scheduledCronModuleConfigs, $instanceName);
+
+        $this->runModules(
+            $scheduledCronModuleConfigs,
+            $instanceName,
+            $processOutputCallback,
+            $isOutputDecorated,
+        );
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig[] $cronModuleConfigs
      */
-    protected function runModules(array $cronModuleConfigs, string $instanceName): void
-    {
+    protected function runModules(
+        array $cronModuleConfigs,
+        string $instanceName,
+        callable $processOutputCallback,
+        bool $isOutputDecorated,
+    ): void {
         $unique = uniqid(more_entropy: true);
 
         $this->logger->pushProcessor(function ($record) use ($instanceName, $unique) {
@@ -52,79 +65,49 @@ class CronFacade
         $this->logger->info('Start of cron instance');
 
         try {
-            foreach ($cronModuleConfigs as $cronModuleConfig) {
-                $this->runSingleModule($cronModuleConfig);
+            $stopOnFailure = $this->shouldInstanceStopOnFailure($instanceName);
 
-                if ($this->cronModuleExecutor->canRun($cronModuleConfig) === false) {
+            foreach ($cronModuleConfigs as $cronModuleConfig) {
+                if ($this->cronModuleFacade->isModuleDisabled($cronModuleConfig)) {
+                    $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
+
+                    continue;
+                }
+
+                $result = $this->runSingleModule(
+                    $cronModuleConfig->getServiceId(),
+                    $instanceName,
+                    $processOutputCallback,
+                    $isOutputDecorated,
+                    $unique,
+                );
+
+                if ($result !== CronModuleProcessRunner::RESULT_SUCCESS && $stopOnFailure) {
+                    $this->logger->error('Stopping cron instance execution due to failure of a module');
+
                     break;
                 }
             }
-        } catch (Throwable $throwable) {
-            $this->logger->error('End of cron instance with error', [
-                'exception' => $throwable,
-            ]);
+        } finally {
+            $this->logger->info('End of cron instance');
             $this->logger->popProcessor();
-
-            return;
         }
-
-        $this->logger->info('End of cron instance');
-
-        $this->logger->popProcessor();
     }
 
-    public function runModuleByServiceId(string $serviceId): void
-    {
-        $cronModuleConfig = $this->cronConfig->getCronModuleConfigByServiceId($serviceId);
-
-        $this->runSingleModule($cronModuleConfig);
-    }
-
-    protected function runSingleModule(CronModuleConfig $cronModuleConfig): void
-    {
-        if ($this->cronModuleFacade->isModuleDisabled($cronModuleConfig) === true) {
-            return;
-        }
-
-        $shortServiceId = ReflectionHelper::getShortClassName($cronModuleConfig->getServiceId());
-        $this->logger->pushProcessor(function ($record) use ($shortServiceId) {
-            $record->extra['module'] = $shortServiceId;
-
-            return $record;
-        });
-
-        $this->logger->info('Cron module started');
-        $cronModuleService = $cronModuleConfig->getService();
-        $cronModuleService->setLogger($this->logger);
-        $this->cronModuleFacade->markCronAsStarted($cronModuleConfig);
-
-        try {
-            $status = $this->cronModuleExecutor->runModule(
-                $cronModuleService,
-                $this->cronModuleFacade->isModuleSuspended($cronModuleConfig),
-            );
-        } catch (Throwable $throwable) {
-            $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
-            $this->logger->error('Cron module ended with error', [
-                'exception' => $throwable,
-            ]);
-
-            throw $throwable;
-        }
-
-        $this->cronModuleFacade->markCronAsEnded($cronModuleConfig);
-
-        if ($status === CronModuleExecutor::RUN_STATUS_OK) {
-            $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
-        } elseif ($status === CronModuleExecutor::RUN_STATUS_SUSPENDED) {
-            $this->cronModuleFacade->suspendModule($cronModuleConfig);
-        }
-
-        $this->logger->info('Cron module ended', [
-            'status' => $status,
-        ]);
-
-        $this->logger->popProcessor();
+    public function runSingleModule(
+        string $serviceId,
+        string $instanceName,
+        callable $processOutputCallback,
+        bool $isOutputDecorated,
+        ?string $runId = null,
+    ): string {
+        return $this->cronModuleProcessRunner->runModule(
+            $serviceId,
+            $instanceName,
+            $processOutputCallback,
+            $isOutputDecorated,
+            $runId,
+        );
     }
 
     /**
@@ -148,8 +131,18 @@ class CronFacade
      */
     public function getInstanceNames(): array
     {
-        return array_unique(array_map(function (CronModuleConfig $config) {
-            return $config->getInstanceName();
-        }, $this->getAll()));
+        return array_unique(
+            array_map(
+                static fn (CronModuleConfig $config) => $config->getInstanceName(),
+                $this->getAll(),
+            ),
+        );
+    }
+
+    public function shouldInstanceStopOnFailure(string $instanceName): bool
+    {
+        $cronInstances = $this->parameterBag->get('cron_instances');
+
+        return $cronInstances[$instanceName]['stop_on_failure'] ?? true;
     }
 }

--- a/packages/framework/src/Component/Cron/CronModule.php
+++ b/packages/framework/src/Component/Cron/CronModule.php
@@ -11,9 +11,9 @@ use Symfony\Component\Clock\DatePoint;
 #[ORM\Entity]
 class CronModule
 {
-    public const CRON_STATUS_OK = 'ok';
-    public const CRON_STATUS_ERROR = 'error';
-    public const CRON_STATUS_RUNNING = 'running';
+    public const string CRON_STATUS_OK = 'ok';
+    public const string CRON_STATUS_ERROR = 'error';
+    public const string CRON_STATUS_RUNNING = 'running';
 
     /**
      * @var string

--- a/packages/framework/src/Component/Cron/CronModule.php
+++ b/packages/framework/src/Component/Cron/CronModule.php
@@ -113,6 +113,7 @@ class CronModule
 
     public function suspend(): void
     {
+        $this->scheduled = true;
         $this->suspended = true;
     }
 

--- a/packages/framework/src/Component/Cron/CronModuleExecutor.php
+++ b/packages/framework/src/Component/Cron/CronModuleExecutor.php
@@ -19,6 +19,7 @@ class CronModuleExecutor
     public const RUN_STATUS_OK = 'ok';
     public const RUN_STATUS_TIMEOUT = 'timeout';
     public const RUN_STATUS_SUSPENDED = 'suspended';
+    public const RUN_STATUS_ERROR = 'error';
 
     protected DateTimeImmutable $startedAt;
 

--- a/packages/framework/src/Component/Cron/CronModuleFacade.php
+++ b/packages/framework/src/Component/Cron/CronModuleFacade.php
@@ -106,7 +106,9 @@ class CronModuleFacade
     public function markCronAsFailed(CronModuleConfig $cronModuleConfig): void
     {
         $cronModule = $this->cronModuleRepository->getCronModuleByServiceId($cronModuleConfig->getServiceId());
-        $lastCronDuration = $this->clock->now()->getTimestamp() - $cronModule->getLastStartedAt()->getTimestamp();
+        $startedAt = $cronModule->getLastStartedAt() ?? $this->clock->now();
+        $finishedAt = $this->clock->now();
+        $lastCronDuration = max(0, $finishedAt->getTimestamp() - $startedAt->getTimestamp());
 
         /**
          * We want to avoid flushing the whole identity map (using EntityManager::flush())
@@ -130,7 +132,7 @@ class CronModuleFacade
             [
                 'errorStatus' => CronModule::CRON_STATUS_ERROR,
                 'serviceId' => $cronModuleConfig->getServiceId(),
-                'now' => $this->clock->now()->format('Y-m-d H:i:s'),
+                'now' => $finishedAt->format('Y-m-d H:i:s'),
                 'lastDuration' => $lastCronDuration,
             ],
         );
@@ -141,8 +143,8 @@ class CronModuleFacade
             [
                 'cronModuleId' => $cronModule->getServiceId(),
                 'status' => CronModule::CRON_STATUS_ERROR,
-                'startedAt' => $cronModule->getLastStartedAt()->format('Y-m-d H:i:s'),
-                'finishedAt' => $this->clock->now()->format('Y-m-d H:i:s'),
+                'startedAt' => $startedAt->format('Y-m-d H:i:s'),
+                'finishedAt' => $finishedAt->format('Y-m-d H:i:s'),
                 'duration' => $lastCronDuration,
             ],
         );

--- a/packages/framework/src/Component/Cron/CronModuleProcessRunner.php
+++ b/packages/framework/src/Component/Cron/CronModuleProcessRunner.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron;
+
+use Shopsys\FrameworkBundle\Command\CronModuleRunnerCommand;
+use Symfony\Component\Process\Process;
+
+class CronModuleProcessRunner
+{
+    public const string RESULT_SUCCESS = 'success';
+    public const string RESULT_FAILED = 'failed';
+
+    public function __construct(
+        protected readonly string $projectDir,
+    ) {
+    }
+
+    public function runModule(
+        string $serviceId,
+        string $instanceName,
+        callable $processOutputCallback,
+        bool $useAnsiOutput,
+        ?string $runId = null,
+    ): string {
+        $process = $this->createProcess(
+            $serviceId,
+            $instanceName,
+            $useAnsiOutput,
+            $runId,
+        );
+
+        $process->run($processOutputCallback);
+
+        return $process->isSuccessful() ? static::RESULT_SUCCESS : static::RESULT_FAILED;
+    }
+
+    protected function createProcess(
+        string $serviceId,
+        string $instanceName,
+        bool $useAnsiOutput,
+        ?string $runId = null,
+    ): Process {
+        $command = [
+            PHP_BINARY,
+            $this->projectDir . '/bin/console',
+            CronModuleRunnerCommand::COMMAND_NAME,
+            $serviceId,
+            '--instance-name=' . $instanceName,
+        ];
+
+        if ($runId !== null) {
+            $command[] = '--run-id=' . $runId;
+        }
+
+        $command[] = $useAnsiOutput ? '--ansi' : '--no-ansi';
+
+        return new Process(
+            $command,
+            $this->projectDir,
+            timeout: null,
+        );
+    }
+}

--- a/packages/framework/src/Component/Cron/CronModuleRunnerFacade.php
+++ b/packages/framework/src/Component/Cron/CronModuleRunnerFacade.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron;
+
+use Monolog\Logger;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Reflection\ReflectionHelper;
+use Throwable;
+
+class CronModuleRunnerFacade
+{
+    public function __construct(
+        protected readonly Logger $logger,
+        protected readonly CronConfig $cronConfig,
+        protected readonly CronModuleFacade $cronModuleFacade,
+        protected readonly CronModuleExecutor $cronModuleExecutor,
+    ) {
+    }
+
+    public function runModuleByServiceIdInContext(
+        string $serviceId,
+        ?string $instanceName = null,
+        ?string $runId = null,
+    ): string {
+        $this->logger->pushProcessor(static function ($record) use ($instanceName, $runId) {
+            if ($instanceName !== null) {
+                $record->extra['instance'] = $instanceName;
+            }
+
+            if ($runId !== null) {
+                $record->extra['runId'] = $runId;
+            }
+
+            return $record;
+        });
+
+        try {
+            $cronModuleConfig = $this->cronConfig->getCronModuleConfigByServiceId($serviceId);
+
+            return $this->runSingleModule($cronModuleConfig);
+        } finally {
+            $this->logger->popProcessor();
+        }
+    }
+
+    protected function runSingleModule(CronModuleConfig $cronModuleConfig): string
+    {
+        if ($this->cronModuleFacade->isModuleDisabled($cronModuleConfig) === true) {
+            $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
+
+            return CronModuleExecutor::RUN_STATUS_OK;
+        }
+
+        $shortServiceId = ReflectionHelper::getShortClassName($cronModuleConfig->getServiceId());
+        $this->logger->pushProcessor(function ($record) use ($shortServiceId) {
+            $record->extra['module'] = $shortServiceId;
+
+            return $record;
+        });
+
+        $this->logger->info('Cron module started');
+        $cronModuleService = $cronModuleConfig->getService();
+        $cronModuleService->setLogger($this->logger);
+        $this->cronModuleFacade->markCronAsStarted($cronModuleConfig);
+
+        try {
+            try {
+                $status = $this->cronModuleExecutor->runModule(
+                    $cronModuleService,
+                    $this->cronModuleFacade->isModuleSuspended($cronModuleConfig),
+                );
+            } catch (Throwable $throwable) {
+                $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
+                $this->logger->error('Cron module ended with error', [
+                    'exception' => $throwable,
+                ]);
+
+                return CronModuleExecutor::RUN_STATUS_ERROR;
+            }
+
+            $this->cronModuleFacade->markCronAsEnded($cronModuleConfig);
+
+            if ($status === CronModuleExecutor::RUN_STATUS_OK) {
+                $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
+            } elseif ($status === CronModuleExecutor::RUN_STATUS_SUSPENDED) {
+                $this->cronModuleFacade->suspendModule($cronModuleConfig);
+            }
+
+            $this->logger->info('Cron module ended', [
+                'status' => $status,
+            ]);
+        } finally {
+            $this->logger->popProcessor();
+        }
+
+
+        return $status;
+    }
+}

--- a/packages/framework/src/Component/Cron/MutexFactory.php
+++ b/packages/framework/src/Component/Cron/MutexFactory.php
@@ -9,7 +9,7 @@ use NinjaMutex\Mutex;
 
 class MutexFactory
 {
-    protected const MUTEX_CRON_NAME = 'cron';
+    protected const string MUTEX_CRON_NAME = 'cron';
 
     /**
      * @var \NinjaMutex\Mutex[]

--- a/packages/framework/src/Controller/Admin/DefaultController.php
+++ b/packages/framework/src/Controller/Admin/DefaultController.php
@@ -197,7 +197,12 @@ class DefaultController extends AdminBaseController
 
         $cronListGrid->setTitle(t('Cron overview (%instanceName%)', ['%instanceName%' => $instanceName]));
 
-        $cronListGrid->setTheme('@ShopsysAdministration/content/default/cronListGrid.html.twig');
+        $cronListGrid->setTheme(
+            '@ShopsysAdministration/content/default/cronListGrid.html.twig',
+            [
+                'stopOnFailure' => $this->cronFacade->shouldInstanceStopOnFailure($instanceName),
+            ],
+        );
 
         return $cronListGrid->createView();
     }

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
@@ -46,7 +46,7 @@ class RegisterCronModulesCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @param array<string, array{run_every_min: int|null, timeout_iterated_cron_sec: int|null}> $cronInstances
+     * @param array<string, array{run_every_min?: int|null, timeout_iterated_cron_sec?: int|null, stop_on_failure?: bool}> $cronInstances
      * @return array{run_every_min: int, timeout_iterated_cron_sec: int}
      */
     private function getInstanceConfig(array $cronInstances, string $instanceName): array

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -129,6 +129,14 @@ services:
         arguments:
             $logger: '@monolog.logger.cron'
 
+    Shopsys\FrameworkBundle\Component\Cron\CronModuleProcessRunner:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
+
+    Shopsys\FrameworkBundle\Component\Cron\CronModuleRunnerFacade:
+        arguments:
+            - '@monolog.logger.cron'
+
     Shopsys\FrameworkBundle\Component\CustomerUploadedFile\Config\CustomerUploadedFileConfig:
         arguments:
             - '%shopsys.customer_uploaded_file_config_filepath%'

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -6,66 +6,25 @@ namespace Tests\FrameworkBundle\Unit\Component\Cron;
 
 use Monolog\Logger;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopsys\FrameworkBundle\Component\Bytes\BytesHelper;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
-use Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleFacade;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleProcessRunner;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
-use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
-use Symfony\Component\Clock\Clock;
 use Symfony\Component\Clock\DatePoint;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CronFacadeTest extends TestCase
 {
-    public function testRunModuleByServiceId(): void
-    {
-        $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
-        $cronModuleServiceMock = $this->getMockBuilder(SimpleCronModuleInterface::class)->getMock();
-
-        $cronModuleServiceMock->expects($this->once())->method('run');
-
-        $serviceId = get_class($cronModuleServiceMock);
-
-        $cronConfig = $this->createCronConfigWithRegisteredServices([
-            $serviceId => $cronModuleServiceMock,
-        ]);
-        $this->createCronFacade($cronConfig, $cronModuleFacadeStub)->runModuleByServiceId($serviceId);
-    }
-
-    public function testRunIteratedModuleByServiceId(): void
-    {
-        $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
-        $cronModuleServiceMock = $this->getMockBuilder(IteratedCronModuleInterface::class)->getMock();
-
-        $iterations = 3;
-        $cronModuleServiceMock->expects($this->exactly($iterations))->method('iterate')->willReturnCallback(
-            function () use (&$iterations) {
-                $iterations--;
-
-                return $iterations > 0;
-            },
-        );
-
-        $serviceId = get_class($cronModuleServiceMock);
-
-        $cronConfig = $this->createCronConfigWithRegisteredServices([
-            $serviceId => $cronModuleServiceMock,
-        ]);
-        $this->createCronFacade($cronConfig, $cronModuleFacadeStub)->runModuleByServiceId($serviceId);
-    }
-
     public function testScheduleModulesByTime(): void
     {
         $validCronModuleServiceStub = $this->createStub(SimpleCronModuleInterface::class);
         $validServiceId = get_class($validCronModuleServiceStub);
         $invalidCronModuleServiceStub = $this->createStub(SimpleCronModuleInterface::class);
         $invalidServiceId = get_class($invalidCronModuleServiceStub);
-        $cronModuleFacadeMock = $this->mockCronModuleFacade();
 
         $cronTimeResolverStub = $this->createStub(CronTimeResolver::class);
         $cronTimeResolverStub->method('isValidAtTime')->willReturnCallback(
@@ -74,6 +33,7 @@ class CronFacadeTest extends TestCase
             },
         );
 
+        $cronModuleFacadeMock = $this->createMock(CronModuleFacade::class);
         $cronModuleFacadeMock->expects($this->atLeastOnce())
             ->method('scheduleModules')
             ->with(Assert::callback(function ($modules) use ($validServiceId) {
@@ -87,54 +47,61 @@ class CronFacadeTest extends TestCase
         $this->createCronFacade($cronConfig, $cronModuleFacadeMock)->scheduleModulesByTime(new DatePoint());
     }
 
-    public function testRunScheduledModules(): void
+    public function testRunSingleModuleDelegatesToProcessRunner(): void
     {
-        $scheduledCronModuleServiceMock = $this->getMockBuilder(SimpleCronModuleInterface::class)->getMock();
-        $scheduledServiceId = get_class($scheduledCronModuleServiceMock);
-        $unscheduledCronModuleServiceMock = $this->getMockBuilder(SimpleCronModuleInterface::class)->getMock();
-        $unscheduledServiceId = get_class($unscheduledCronModuleServiceMock);
         $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
+        $cronModuleProcessRunnerMock = $this->createMock(CronModuleProcessRunner::class);
 
-        $scheduledCronModuleServiceMock->expects($this->once())->method('run');
-        $unscheduledCronModuleServiceMock->expects($this->never())->method('run');
+        $cronModuleProcessRunnerMock->expects($this->once())
+            ->method('runModule')
+            ->with('service.id', 'default', $this->isCallable(), true, null)
+            ->willReturn(CronModuleProcessRunner::RESULT_SUCCESS);
+
+        $cronConfig = $this->createCronConfigWithRegisteredServices([]);
+
+        $result = $this->createCronFacade($cronConfig, $cronModuleFacadeStub, cronModuleProcessRunner: $cronModuleProcessRunnerMock)
+            ->runSingleModule('service.id', 'default', static function (): void {}, true);
+
+        $this->assertSame(CronModuleProcessRunner::RESULT_SUCCESS, $result);
+    }
+
+    public function testGetInstanceNamesReturnsUniqueNames(): void
+    {
+        $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
+        $cronModuleServiceStub = $this->createStub(SimpleCronModuleInterface::class);
+        $serviceId = get_class($cronModuleServiceStub);
 
         $cronConfig = $this->createCronConfigWithRegisteredServices([
-            $scheduledServiceId => $scheduledCronModuleServiceMock,
-            $unscheduledServiceId => $unscheduledCronModuleServiceMock,
+            $serviceId => $cronModuleServiceStub,
         ]);
-        $cronModuleFacadeStub
-            ->method('getOnlyScheduledCronModuleConfigs')
-            ->willReturnCallback(function () use ($scheduledServiceId, $scheduledCronModuleServiceMock) {
-                return [new CronModuleConfig($scheduledCronModuleServiceMock, $scheduledServiceId, '*', '*')];
-            });
 
-        $this->createCronFacade($cronConfig, $cronModuleFacadeStub)->runScheduledModulesForInstance(
-            CronModuleConfig::DEFAULT_INSTANCE_NAME,
-        );
+        $instanceNames = $this->createCronFacade($cronConfig, $cronModuleFacadeStub)->getInstanceNames();
+
+        $this->assertSame(['default'], $instanceNames);
     }
 
     private function createCronFacade(
         CronConfig $cronConfig,
         CronModuleFacade $cronModuleFacade,
+        ?ParameterBagInterface $parameterBag = null,
+        ?CronModuleProcessRunner $cronModuleProcessRunner = null,
     ): CronFacade {
-        $loggerStub = $this->createStub(Logger::class);
-        $bytesHelper = new BytesHelper();
+        $loggerMock = $this->createStub(Logger::class);
 
-        $cronModuleExecutor = new CronModuleExecutor($cronConfig, $loggerStub, $bytesHelper, Clock::get());
-
-        return new CronFacade($loggerStub, $cronConfig, $cronModuleFacade, $cronModuleExecutor);
-    }
-
-    private function mockCronModuleFacade(): CronModuleFacade|MockObject
-    {
-        return $this->createMock(CronModuleFacade::class);
+        return new CronFacade(
+            $loggerMock,
+            $cronConfig,
+            $cronModuleFacade,
+            $parameterBag ?? $this->createStub(ParameterBagInterface::class),
+            $cronModuleProcessRunner ?? $this->createStub(CronModuleProcessRunner::class),
+        );
     }
 
     private function createCronConfigWithRegisteredServices(
         array $servicesIndexedById,
         ?CronTimeResolver $cronTimeResolverMock = null,
     ): CronConfig {
-        $cronTimeResolver = $cronTimeResolverMock !== null ? $cronTimeResolverMock : new CronTimeResolver();
+        $cronTimeResolver = $cronTimeResolverMock ?? new CronTimeResolver();
         $cronConfig = new CronConfig($cronTimeResolver);
 
         foreach ($servicesIndexedById as $serviceId => $service) {

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -6,6 +6,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Cron;
 
 use Monolog\Logger;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
@@ -45,6 +46,61 @@ class CronFacadeTest extends TestCase
             $invalidServiceId => $invalidCronModuleServiceStub,
         ], $cronTimeResolverStub);
         $this->createCronFacade($cronConfig, $cronModuleFacadeMock)->scheduleModulesByTime(new DatePoint());
+    }
+
+    /**
+     * @return iterable<string, array{cronInstances: array<string, array<string, bool>>, expectedRunModuleCalls: int}>
+     */
+    public static function getStopOnFailureData(): iterable
+    {
+        yield 'stops after first failure when stop_on_failure is enabled' => [
+            'cronInstances' => [
+                CronModuleConfig::DEFAULT_INSTANCE_NAME => [
+                    'stop_on_failure' => true,
+                ],
+            ],
+            'expectedRunModuleCalls' => 1,
+        ];
+
+        yield 'continues after failure when stop_on_failure is disabled' => [
+            'cronInstances' => [
+                CronModuleConfig::DEFAULT_INSTANCE_NAME => [
+                    'stop_on_failure' => false,
+                ],
+            ],
+            'expectedRunModuleCalls' => 2,
+        ];
+
+        yield 'stops after first failure when instance is not configured (defaults to true)' => [
+            'cronInstances' => [],
+            'expectedRunModuleCalls' => 1,
+        ];
+    }
+
+    #[DataProvider('getStopOnFailureData')]
+    public function testRunScheduledModulesRespectsStopOnFailureConfiguration(
+        array $cronInstances,
+        int $expectedRunModuleCalls,
+    ): void {
+        $moduleStub = $this->createStub(SimpleCronModuleInterface::class);
+
+        $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
+        $cronModuleFacadeStub->method('getOnlyScheduledCronModuleConfigs')
+            ->willReturnArgument(0);
+        $cronModuleFacadeStub->method('isModuleDisabled')->willReturn(false);
+
+        $cronModuleProcessRunnerMock = $this->createMock(CronModuleProcessRunner::class);
+        $cronModuleProcessRunnerMock->expects($this->exactly($expectedRunModuleCalls))
+            ->method('runModule')
+            ->willReturn(CronModuleProcessRunner::RESULT_FAILED);
+
+        $parameterBagStub = $this->createStub(ParameterBagInterface::class);
+        $parameterBagStub->method('get')->willReturn($cronInstances);
+
+        $cronConfig = $this->createCronConfigWithRegisteredServices(['first' => $moduleStub, 'second' => $moduleStub]);
+
+        $this->createCronFacade($cronConfig, $cronModuleFacadeStub, $parameterBagStub, $cronModuleProcessRunnerMock)
+            ->runScheduledModulesForInstance(CronModuleConfig::DEFAULT_INSTANCE_NAME, static function (): void {}, false);
     }
 
     public function testRunSingleModuleDelegatesToProcessRunner(): void

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleRunnerFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleRunnerFacadeTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use Monolog\Logger;
+use Override;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleFacade;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleRunnerFacade;
+use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+
+class CronModuleRunnerFacadeTest extends TestCase
+{
+    private string $serviceId;
+
+    private CronConfig $cronConfig;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $cronModuleService = $this->createStub(SimpleCronModuleInterface::class);
+        $this->serviceId = get_class($cronModuleService);
+
+        $this->cronConfig = new CronConfig(new CronTimeResolver());
+        $this->cronConfig->registerCronModuleInstance(
+            $cronModuleService,
+            $this->serviceId,
+            '*',
+            '*',
+            CronModuleConfig::DEFAULT_INSTANCE_NAME,
+        );
+    }
+
+    public function testRunDisabledModuleReturnsOkAndUnschedulesIt(): void
+    {
+        $cronModuleFacadeMock = $this->createMock(CronModuleFacade::class);
+        $cronModuleFacadeMock->method('isModuleDisabled')->willReturn(true);
+        $cronModuleFacadeMock->expects($this->once())->method('unscheduleModule');
+        $cronModuleFacadeMock->expects($this->never())->method('markCronAsStarted');
+
+        $result = $this->createCronModuleRunnerFacade($cronModuleFacadeMock)
+            ->runModuleByServiceIdInContext($this->serviceId);
+
+        $this->assertSame(CronModuleExecutor::RUN_STATUS_OK, $result);
+    }
+
+    public function testRunModuleSuccessfullyReturnsOkAndUnschedulesIt(): void
+    {
+        $cronModuleFacadeMock = $this->createMock(CronModuleFacade::class);
+        $cronModuleFacadeMock->method('isModuleDisabled')->willReturn(false);
+        $cronModuleFacadeMock->method('isModuleSuspended')->willReturn(false);
+        $cronModuleFacadeMock->expects($this->once())->method('markCronAsStarted');
+        $cronModuleFacadeMock->expects($this->once())->method('markCronAsEnded');
+        $cronModuleFacadeMock->expects($this->once())->method('unscheduleModule');
+
+        $cronModuleExecutorStub = $this->createStub(CronModuleExecutor::class);
+        $cronModuleExecutorStub->method('runModule')->willReturn(CronModuleExecutor::RUN_STATUS_OK);
+
+        $result = $this->createCronModuleRunnerFacade($cronModuleFacadeMock, $cronModuleExecutorStub)
+            ->runModuleByServiceIdInContext($this->serviceId);
+
+        $this->assertSame(CronModuleExecutor::RUN_STATUS_OK, $result);
+    }
+
+    public function testRunModuleReturnsErrorAndMarksFailedOnException(): void
+    {
+        $cronModuleFacadeMock = $this->createMock(CronModuleFacade::class);
+        $cronModuleFacadeMock->method('isModuleDisabled')->willReturn(false);
+        $cronModuleFacadeMock->method('isModuleSuspended')->willReturn(false);
+        $cronModuleFacadeMock->expects($this->once())->method('markCronAsFailed');
+        $cronModuleFacadeMock->expects($this->never())->method('markCronAsEnded');
+        $cronModuleFacadeMock->expects($this->never())->method('unscheduleModule');
+
+        $cronModuleExecutorStub = $this->createStub(CronModuleExecutor::class);
+        $cronModuleExecutorStub->method('runModule')->willThrowException(new RuntimeException('Cron failed'));
+
+        $result = $this->createCronModuleRunnerFacade($cronModuleFacadeMock, $cronModuleExecutorStub)
+            ->runModuleByServiceIdInContext($this->serviceId);
+
+        $this->assertSame(CronModuleExecutor::RUN_STATUS_ERROR, $result);
+    }
+
+    public function testRunSuspendedModuleSuspendsItAgainWhenExecutorReturnsSuspended(): void
+    {
+        $cronModuleFacadeMock = $this->createMock(CronModuleFacade::class);
+        $cronModuleFacadeMock->method('isModuleDisabled')->willReturn(false);
+        $cronModuleFacadeMock->method('isModuleSuspended')->willReturn(true);
+        $cronModuleFacadeMock->expects($this->once())->method('markCronAsEnded');
+        $cronModuleFacadeMock->expects($this->once())->method('suspendModule');
+        $cronModuleFacadeMock->expects($this->never())->method('unscheduleModule');
+
+        $cronModuleExecutorStub = $this->createStub(CronModuleExecutor::class);
+        $cronModuleExecutorStub->method('runModule')->willReturn(CronModuleExecutor::RUN_STATUS_SUSPENDED);
+
+        $result = $this->createCronModuleRunnerFacade($cronModuleFacadeMock, $cronModuleExecutorStub)
+            ->runModuleByServiceIdInContext($this->serviceId);
+
+        $this->assertSame(CronModuleExecutor::RUN_STATUS_SUSPENDED, $result);
+    }
+
+    private function createCronModuleRunnerFacade(
+        CronModuleFacade $cronModuleFacade,
+        ?CronModuleExecutor $cronModuleExecutor = null,
+    ): CronModuleRunnerFacade {
+        return new CronModuleRunnerFacade(
+            $this->createStub(Logger::class),
+            $this->cronConfig,
+            $cronModuleFacade,
+            $cronModuleExecutor ?? $this->createStub(CronModuleExecutor::class),
+        );
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleFactory;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class CronModuleTest extends TestCase
+{
+    private CronModuleFactory $cronModuleFactory;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cronModuleFactory = new CronModuleFactory(new EntityNameResolver([]));
+    }
+
+    public function testSuspendSetsScheduledAndSuspendedFlags(): void
+    {
+        $cronModule = $this->cronModuleFactory->create('service.id');
+
+        $cronModule->suspend();
+
+        $this->assertTrue($cronModule->isSuspended());
+        $this->assertTrue($cronModule->isScheduled());
+    }
+
+    public function testUnscheduleResetsScheduledAndSuspendedFlags(): void
+    {
+        $cronModule = $this->cronModuleFactory->create('service.id');
+        $cronModule->suspend();
+
+        $cronModule->unschedule();
+
+        $this->assertFalse($cronModule->isSuspended());
+        $this->assertFalse($cronModule->isScheduled());
+    }
+}

--- a/project-base/app/config/cron.yaml
+++ b/project-base/app/config/cron.yaml
@@ -3,6 +3,13 @@ parameters:
         default:
             run_every_min: 5
             timeout_iterated_cron_sec: 240
+            stop_on_failure: true
+        service:
+            stop_on_failure: false
+        export:
+            stop_on_failure: false
+        gopay:
+            stop_on_failure: false
 
 services:
     _defaults:

--- a/upgrade-notes/backend_20260302_160353.md
+++ b/upgrade-notes/backend_20260302_160353.md
@@ -1,0 +1,32 @@
+#### reworked cron runner ([#4461](https://github.com/shopsys/shopsys/pull/4461))
+
+- `Shopsys\FrameworkBundle\Component\Cron\CronFacade::runModuleByServiceId()` was removed
+    - if you call this method directly, replace it with `CronFacade::runSingleModule()`:
+
+    ```diff
+    -$cronFacade->runModuleByServiceId($serviceId);
+    +$cronFacade->runSingleModule($serviceId, $instanceName, $processOutputCallback, $isOutputDecorated);
+    ```
+
+- `Shopsys\FrameworkBundle\Component\Cron\CronFacade::runScheduledModulesForInstance()` now requires two additional parameters `callable $processOutputCallback` and `bool $isOutputDecorated`:
+
+    ```diff
+    -$cronFacade->runScheduledModulesForInstance($instanceName);
+    +$cronFacade->runScheduledModulesForInstance($instanceName, $processOutputCallback, $isOutputDecorated);
+    ```
+
+- `Shopsys\FrameworkBundle\Command\CronCommand::runCron()` protected method was removed — if you extend `CronCommand` and override `runCron()`, migrate to the new methods `acquireInstanceMutex()` and `runModulesInInstance()`
+
+- new `stop_on_failure` configuration option added to cron instances in `cron.yaml` — the default when omitted is `true` (cron instance stops after the first module failure),
+  set it to `false` for instances whose modules are independent of each other and should not block subsequent modules from running:
+
+    ```diff
+     parameters:
+         cron_instances:
+             export:
+                 run_every_min: 5
+                 timeout_iterated_cron_sec: 240
+    +            stop_on_failure: false
+    ```
+
+- see #project-base-diff


### PR DESCRIPTION
#### Description, the reason for the PR

cron modules now run in isolated subprocesses

  - added CronModuleProcessRunner to spawn each module as a separate PHP process via shopsys:cron:internal-runner
  - added CronModuleRunnerFacade to handle in-process execution inside each subprocess
  - added CronInternalRunnerCommand (shopsys:cron:internal-runner, hidden) as the subprocess entry point
  - added stop_on_failure configuration option per cron instance
  - CronModule: suspend() now also sets $scheduled to true
  - CronModuleFacade: markCronAsFailed() now handles null $lastStartedAt safely

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
































----
:globe_with_meridians: Live Preview:
  - https://mg-cron.odin.shopsys.cloud
  - https://cz.mg-cron.odin.shopsys.cloud
  - https://mg-cron.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773053384.678899 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-cron.odin.shopsys.cloud
  - https://cz.mg-cron.odin.shopsys.cloud
  - https://mg-cron.odin.shopsys.cloud/sk
<!-- Replace -->
