### PR TITLE
added feed recovery for corrupted or nonexistent files during feed ge…

### DIFF
--- a/packages/framework/src/Model/Feed/FeedExport.php
+++ b/packages/framework/src/Model/Feed/FeedExport.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Feed;
 
 use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
+use Psr\Log\LoggerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\FrameworkBundle\DependencyInjection\ServicesResetter;
@@ -31,6 +33,7 @@ class FeedExport
         protected readonly string $feedFilepath,
         protected readonly string $feedLocalFilepath,
         protected readonly ServicesResetter $servicesResetter,
+        protected readonly LoggerInterface $logger,
         protected ?int $lastSeekId = null,
     ) {
     }
@@ -38,12 +41,57 @@ class FeedExport
     public function wakeUp(): void
     {
         if ($this->filesystem->has($this->getTemporaryFilepath())) {
-            $this->mountManager->move(
-                'main://' . $this->getTemporaryFilepath(),
-                'local://' . $this->transformStringHelper->removeDriveLetterFromPath($this->getTemporaryLocalFilepath()),
+            try {
+                $this->mountManager->move(
+                    'main://' . $this->getTemporaryFilepath(),
+                    'local://' . $this->transformStringHelper->removeDriveLetterFromPath($this->getTemporaryLocalFilepath()),
+                );
+
+                return;
+            } catch (FilesystemException $exception) {
+                $this->handleWakeUpFailure($exception);
+            }
+        }
+
+        $this->localFilesystem->touch($this->getTemporaryLocalFilepath());
+    }
+
+    protected function handleWakeUpFailure(FilesystemException $exception): void
+    {
+        $this->logger->error(
+            'Failed to download temporary feed file from storage, restarting feed generation from the beginning.',
+            [
+                'feedName' => $this->feed->getInfo()->getName(),
+                'domainId' => $this->domainConfig->getId(),
+                'temporaryFilepath' => $this->getTemporaryFilepath(),
+                'exception' => $exception,
+            ],
+        );
+
+        $this->tryDeleteRemoteTemporaryFile();
+        $this->tryDeleteLocalTemporaryFile();
+        $this->lastSeekId = null;
+    }
+
+    protected function tryDeleteRemoteTemporaryFile(): void
+    {
+        try {
+            $this->filesystem->delete($this->getTemporaryFilepath());
+        } catch (FilesystemException $deleteException) {
+            $this->logger->warning(
+                'Failed to delete stuck temporary feed file from remote storage. Manual cleanup may be required.',
+                [
+                    'temporaryFilepath' => $this->getTemporaryFilepath(),
+                    'exception' => $deleteException,
+                ],
             );
-        } else {
-            $this->localFilesystem->touch($this->getTemporaryLocalFilepath());
+        }
+    }
+
+    protected function tryDeleteLocalTemporaryFile(): void
+    {
+        if ($this->localFilesystem->exists($this->getTemporaryLocalFilepath())) {
+            $this->localFilesystem->remove($this->getTemporaryLocalFilepath());
         }
     }
 

--- a/packages/framework/src/Model/Feed/FeedExportFactory.php
+++ b/packages/framework/src/Model/Feed/FeedExportFactory.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Feed;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
+use Psr\Log\LoggerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\FrameworkBundle\DependencyInjection\ServicesResetter;
@@ -23,6 +24,7 @@ class FeedExportFactory
         protected readonly MountManager $mountManager,
         protected readonly ServicesResetter $servicesResetter,
         protected readonly TransformStringHelper $transformStringHelper,
+        protected readonly LoggerInterface $logger,
     ) {
     }
 
@@ -44,6 +46,7 @@ class FeedExportFactory
             $feedFilepath,
             $feedLocalFilepath,
             $this->servicesResetter,
+            $this->logger,
             $lastSeekId,
         );
     }


### PR DESCRIPTION
#### Description, the reason for the PR
We had problem on our servers that sometimes on S3 files could not be moved and that broke feed generation. This should fix such problem.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-uneditable-file-in-feed.odin.shopsys.cloud
  - https://cz.tl-fix-uneditable-file-in-feed.odin.shopsys.cloud
  - https://tl-fix-uneditable-file-in-feed.odin.shopsys.cloud/sk
<!-- Replace -->
