### PR TITLE
project-base: fix composer patches paths

### DIFF
--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -194,8 +194,8 @@
         "public-dir": "web",
         "patches": {
             "overblog/graphql-bundle": {
-                "Remove kernel.reset tag from Executor to prevent schema clearing": "project-base/app/patch/overblog-executor-reset.patch",
-                "Use customerValidators translation domain in InputValidator": "project-base/app/patch/overblog-validator.patch"
+                "Remove kernel.reset tag from Executor to prevent schema clearing": "patch/overblog-executor-reset.patch",
+                "Use customerValidators translation domain in InputValidator": "patch/overblog-validator.patch"
             }
         },
         "symfony": {

--- a/upgrade-notes/backend_20260205_213240.md
+++ b/upgrade-notes/backend_20260205_213240.md
@@ -20,3 +20,4 @@ The notes below cover Shopsys-specific changes:
     - for full details, see [PHPUnit 12 release announcement](https://phpunit.de/announcements/phpunit-12.html) and [PHPUnit 12.5 test doubles documentation](https://docs.phpunit.de/en/12.5/test-doubles.html)
 - `phpunit.xml` now includes stricter settings for notices (`failOnNotice`, `failOnPhpunitNotice`, `displayDetailsOnTestsThatTriggerNotices`, `displayDetailsOnPhpunitNotices`) and deprecations (`failOnDeprecation`, `failOnPhpunitDeprecation`, `displayDetailsOnTestsThatTriggerDeprecations`, `displayDetailsOnPhpunitDeprecations`)
 - see #project-base-diff to update your project
+- see also #project-base-diff of [#4464](https://github.com/shopsys/shopsys/pull/4464) with additional fix

--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndCommitLockFilesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndCommitLockFilesReleaseWorker.php
@@ -16,7 +16,7 @@ final class CreateAndCommitLockFilesReleaseWorker extends AbstractShopsysRelease
         Version $version,
         string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME,
     ): string {
-        return 'Create or update and commit composer.lock, symfony.lock, package-lock.json, and migrations-lock.yml and [Manually] push it';
+        return 'Create or update and commit composer.lock, symfony.lock, package-lock.json, patches.lock.json, and migrations-lock.yml and [Manually] push it';
     }
 
     #[Override]
@@ -38,16 +38,18 @@ final class CreateAndCommitLockFilesReleaseWorker extends AbstractShopsysRelease
         $this->processRunner->run(sprintf('cd %s/project-base/app && composer update && npm install', $tempDirectory));
         $this->processRunner->run(sprintf('cd %s/project-base/app && php phing db-rebuild', $tempDirectory));
 
-        $this->symfonyStyle->note('Committing changes in composer.lock, symfony.lock, package-lock.json, and migrations-lock.yml');
+        $this->symfonyStyle->note('Committing changes in composer.lock, symfony.lock, package-lock.json, patches.lock.json, and migrations-lock.yml');
         $this->processRunner->run(sprintf('cp %s/project-base/app/composer.lock %s/project-base/app/composer.lock', $tempDirectory, $currentDir));
         $this->processRunner->run(sprintf('cp %s/project-base/app/symfony.lock %s/project-base/app/symfony.lock', $tempDirectory, $currentDir));
         $this->processRunner->run(sprintf('cp %s/project-base/app/package-lock.json %s/project-base/app/package-lock.json', $tempDirectory, $currentDir));
         $this->processRunner->run(sprintf('cp %s/project-base/app/migrations-lock.yml %s/project-base/app/migrations-lock.yml', $tempDirectory, $currentDir));
+        $this->processRunner->run(sprintf('cp %s/project-base/app/patches.lock.json %s/project-base/app/patches.lock.json', $tempDirectory, $currentDir));
 
         $this->processRunner->run('git add -f project-base/app/composer.lock');
         $this->processRunner->run('git add project-base/app/symfony.lock');
         $this->processRunner->run('git add -f project-base/app/package-lock.json');
         $this->processRunner->run('git add -f project-base/app/migrations-lock.yml');
+        $this->processRunner->run('git add -f project-base/app/patches.lock.json');
 
         $message = sprintf('locked versions of dependencies for %s release', $version->getVersionString());
         $this->commit($message);
@@ -59,7 +61,7 @@ final class CreateAndCommitLockFilesReleaseWorker extends AbstractShopsysRelease
 
         $this->symfonyStyle->confirm(
             sprintf(
-                'confirm that composer.lock, symfony.lock, package-lock.json, and migrations-lock.yml are pushed to "%s" branch',
+                'confirm that composer.lock, symfony.lock, package-lock.json, patches.lock.json, and migrations-lock.yml are pushed to "%s" branch',
                 $this->currentBranchName,
             ),
         );


### PR DESCRIPTION
#### Description, the reason for the PR
The paths were misconfigured within https://github.com/shopsys/shopsys/pull/4448
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-project-base-patches.odin.shopsys.cloud
  - https://cz.rv-fix-project-base-patches.odin.shopsys.cloud
  - https://rv-fix-project-base-patches.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1771585044.776359 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-project-base-patches.odin.shopsys.cloud
  - https://cz.rv-fix-project-base-patches.odin.shopsys.cloud
  - https://rv-fix-project-base-patches.odin.shopsys.cloud/sk
<!-- Replace -->
