### PR TITLE
phpstan: move particular file ignores from configs to inline suppressions

### DIFF
--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -5,12 +5,6 @@ parameters:
     ignoreErrors:
         # Don't forget to add these rules to phpstan.neon in monorepo
         -
-            message: '#Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$transport \(Shopsys\\FrameworkBundle\\Model\\Transport\\Transport\) does not accept null\.#'
-            path: %currentWorkingDirectory%/src/Model/Order/Order.php
-        -
-            message: '#Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$payment \(Shopsys\\FrameworkBundle\\Model\\Payment\\Payment\) does not accept null\.#'
-            path: %currentWorkingDirectory%/src/Model/Order/Order.php
-        -
             message: '#^Unsafe usage of new static\(\).#'
             path: %currentWorkingDirectory%/src/*
     excludePaths:

--- a/packages/framework/src/Command/YamlLintCommand.php
+++ b/packages/framework/src/Command/YamlLintCommand.php
@@ -114,6 +114,7 @@ EOF,
         });
 
         try {
+            // @phpstan-ignore argument.type (Symfony Yaml parser accepts this runtime bitmask combination)
             $this->getParser()->parse($content, Yaml::PARSE_CONSTANT | $flags);
         } catch (ParseException $e) {
             return ['file' => $file, 'line' => $e->getParsedLine(), 'valid' => false, 'message' => $e->getMessage()];

--- a/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
+++ b/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
@@ -57,7 +57,10 @@ trait FlashMessageTrait
 
     protected function renderStringTwigTemplate(string $template, array $parameters = []): string
     {
-        /** @var \Twig\Environment $twigEnvironment */
+        /**
+         * @var \Twig\Environment $twigEnvironment
+         * @phpstan-ignore symfonyContainer.privateService (Twig service is intentionally fetched from the container in this trait)
+         */
         $twigEnvironment = $this->container->get('twig');
         $twigTemplate = $twigEnvironment->createTemplate($template);
 

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
@@ -14,7 +14,10 @@ class RegisterExtendedEntitiesCompilerPass implements CompilerPassInterface
     #[Override]
     public function process(ContainerBuilder $container): void
     {
-        /** @var \Doctrine\ORM\Mapping\Driver\AttributeDriver $attributeReader */
+        /**
+         * @var \Doctrine\ORM\Mapping\Driver\AttributeDriver $attributeReader
+         * @phpstan-ignore symfonyContainer.privateService (Metadata driver service is intentionally fetched in compiler pass)
+         */
         $attributeReader = $container->get('doctrine.orm.default_metadata_driver');
 
         $entityExtensionMap = [];

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -613,10 +613,12 @@ class Order
     public function removeItem(OrderItem $item): void
     {
         if ($item->isTypeTransport()) {
+            // @phpstan-ignore assign.propertyType
             $this->transport = null;
         }
 
         if ($item->isTypePayment()) {
+            // @phpstan-ignore assign.propertyType
             $this->payment = null;
         }
         $this->items->removeElement($item);

--- a/packages/framework/src/Model/Security/AdministratorChecker.php
+++ b/packages/framework/src/Model/Security/AdministratorChecker.php
@@ -33,6 +33,7 @@ class AdministratorChecker extends InMemoryUserChecker
             throw new LoginWithDefaultPasswordException();
         }
 
+        // @phpstan-ignore arguments.count (Forward compatibility with Symfony 8 parent method signature)
         parent::checkPostAuth($user, $token);
     }
 }

--- a/packages/http-smoke-testing/src/HttpSmokeTestCase.php
+++ b/packages/http-smoke-testing/src/HttpSmokeTestCase.php
@@ -107,6 +107,7 @@ abstract class HttpSmokeTestCase extends KernelTestCase
 
     protected static function getRouterAdapter(): RouterAdapterInterface
     {
+        /** @phpstan-ignore symfonyContainer.serviceNotFound (Service is available in test environment) */
         $router = static::$kernel->getContainer()->get('test.service_container')->get(AdministrationRouter::class);
 
         return new SymfonyRouterAdapter($router);
@@ -122,7 +123,10 @@ abstract class HttpSmokeTestCase extends KernelTestCase
         $uri = static::getRouterAdapter()->generateUri($requestDataSet);
 
         $request = Request::create($uri);
-        /** @var \Symfony\Component\HttpFoundation\Session\SessionFactory $sessionFactory */
+        /**
+         * @var \Symfony\Component\HttpFoundation\Session\SessionFactory $sessionFactory
+         * @phpstan-ignore symfonyContainer.serviceNotFound (Service is available in test environment)
+         */
         $sessionFactory = static::$kernel->getContainer()->get('test.service_container')->get('session.factory');
         /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
         $requestStack = static::$kernel->getContainer()->get(RequestStack::class);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,23 +10,9 @@ parameters:
     ignoreErrors:
         # shopsys/framework - don't forget to add these rules to phpstan.neon in framework
         -
-            message: '#^Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$transport \(Shopsys\\FrameworkBundle\\Model\\Transport\\Transport\) does not accept null\.$#'
-            path: %currentWorkingDirectory%/packages/framework/src/Model/Order/Order.php
-        -
-            message: '#^Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$payment \(Shopsys\\FrameworkBundle\\Model\\Payment\\Payment\) does not accept null\.$#'
-            path: %currentWorkingDirectory%/packages/framework/src/Model/Order/Order.php
-        -
             message: '#^Unsafe usage of new static\(\).#'
             path: %currentWorkingDirectory%/packages/framework/*
         # shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base
-        -
-            # We need to have undefined variable for testing purposes
-            message: '#^Undefined variable: \$undefined$#'
-            path: %currentWorkingDirectory%/project-base/app/src/Controller/Test/ErrorHandlerController.php
-        -
-            # We need to have undefined variable for testing purposes
-            message: '#^Expression "\$undefined\[42\]" on a separate line does not do anything\.$#'
-            path: %currentWorkingDirectory%/project-base/app/src/Controller/Test/ErrorHandlerController.php
         -
             # Ignore annotations in generated code
             message: '#^PHPDoc tag @(param|return) has invalid value (.|\n)+ expected type at offset \d+$#'
@@ -42,15 +28,6 @@ parameters:
         -
             message: '#^Service "test.service_container" is not registered in the container.$#'
             path: %currentWorkingDirectory%/*/tests/*
-        -
-            message: '#^Service "doctrine.orm.default_metadata_driver" is private.$#'
-            path: %currentWorkingDirectory%/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
-        -
-            message: '#^Service "twig" is private.#'
-            path: %currentWorkingDirectory%/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
-        -
-            message: '#^Service "test.service_container" is not registered in the container.#'
-            path: %currentWorkingDirectory%/packages/http-smoke-testing/src/HttpSmokeTestCase.php
     excludePaths:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -51,14 +51,6 @@ parameters:
         -
             message: '#^Service "test.service_container" is not registered in the container.#'
             path: %currentWorkingDirectory%/packages/http-smoke-testing/src/HttpSmokeTestCase.php
-        -
-            # PHPStan inference issue with Yaml::parse flags in Symfony 7 - runtime behavior is correct
-            message: '#^Parameter \#2 \$flags of method Symfony\\Component\\Yaml\\Parser::parse\(\) expects#'
-            path: %currentWorkingDirectory%/packages/framework/src/Command/YamlLintCommand.php
-        -
-            # Symfony 7.4 forward compatibility - parent method will require 2 parameters in Symfony 8.0
-            message: '#^Method Symfony\\Component\\Security\\Core\\User\\InMemoryUserChecker::checkPostAuth\(\) invoked with 2 parameters, 1 required\.$#'
-            path: %currentWorkingDirectory%/packages/framework/src/Model/Security/AdministratorChecker.php
     excludePaths:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*

--- a/project-base/app/phpstan.neon
+++ b/project-base/app/phpstan.neon
@@ -7,14 +7,6 @@ parameters:
 
     ignoreErrors:
         -
-            # We need to have undefined variable for testing purposes
-            message: '#^Undefined variable: \$undefined$#'
-            path: %currentWorkingDirectory%/src/Controller/Test/ErrorHandlerController.php
-        -
-            # We need to have undefined variable for testing purposes
-            message: '#^Expression "\$undefined\[42\]" on a separate line does not do anything\.$#'
-            path: %currentWorkingDirectory%/src/Controller/Test/ErrorHandlerController.php
-        -
             # Ignore annotations in generated code
             message: '#^PHPDoc tag @(param|return) has invalid value (.|\n)+ expected type at offset \d+$#'
             path: %currentWorkingDirectory%/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php

--- a/project-base/app/src/Controller/Test/ErrorHandlerController.php
+++ b/project-base/app/src/Controller/Test/ErrorHandlerController.php
@@ -14,6 +14,7 @@ class ErrorHandlerController extends AbstractController
     #[Route(path: '/error-handler/notice')]
     public function noticeAction(): Response
     {
+        // @phpstan-ignore expr.resultUnused, variable.undefined (Undefined variable access is intentional for testing error handler behavior)
         $undefined[42];
 
         return new Response('');

--- a/upgrade-notes/backend_20260223_121125.md
+++ b/upgrade-notes/backend_20260223_121125.md
@@ -1,0 +1,3 @@
+#### phpstan: move particular file ignores from configs to inline suppressions ([#4466](https://github.com/shopsys/shopsys/pull/4466))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- We forgot to update the `packages/framework/phpstan.neon` in https://github.com/shopsys/shopsys/pull/4448
- It is better to have the inline suppressions where possible to avoid DRY in configuration (monorepo vs packages)

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-phpstan.odin.shopsys.cloud
  - https://cz.rv-fix-phpstan.odin.shopsys.cloud
  - https://rv-fix-phpstan.odin.shopsys.cloud/sk
<!-- Replace -->
