### PR TITLE
transport validation errors from last order restore now show as info toast instead of errormol

### DIFF
--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/transportAndPaymentUtils.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/transportAndPaymentUtils.tsx
@@ -323,6 +323,7 @@ export const useLoadTransportAndPaymentFromLastOrder = (
             const newCart = await changeTransportInCart(
                 lastOrderData?.lastOrder?.transport.uuid ?? null,
                 lastOrderPickupPlace,
+                { suppressValidationErrors: true },
             );
             const successfullyChangedTransport = newCart?.transport?.uuid === lastOrderData?.lastOrder?.transport.uuid;
             const successfullyChangedPickupPlace =

--- a/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
@@ -80,3 +80,29 @@ describe('Last Order Transport And Payment Select Tests', { retries: { runMode: 
         });
     });
 });
+
+describe('Last Order Transport Overweight Tests', { retries: { runMode: 0 } }, () => {
+    beforeEach(() => {
+        initializePersistStoreInLocalStorageToDefaultValues();
+
+        const registrationInput = generateCustomerRegistrationData('commonCustomer');
+        cy.registerAsNewUser(registrationInput);
+        cy.addProductToCartForTest();
+        cy.preselectTransportForTest(staticData.transport.czechPost.uuid);
+        cy.preselectPaymentForTest(staticData.payment.onDelivery.uuid);
+        cy.createOrder(generateCreateOrderInput(registrationInput.email));
+        cy.addProductToCartForTest(staticData.products.helloKitty.uuid);
+        cy.addProductToCartForTest(staticData.products.philips32PFL4308.uuid);
+    });
+
+    it('[Last Order Overweight] should show no toast and keep Czech post unavailable when restored transport exceeds weight limit', function () {
+        cy.visitAndWaitForStableAndInteractiveDOM(url.order.transportAndPayment);
+
+        cy.getByTID([TIDs.toast_info]).should('not.exist');
+        cy.getByTID([TIDs.toast_error]).should('not.exist');
+        cy.getByTID([TIDs.pages_order_transport, TIDs.pages_order_selectitem_label_name]).should(
+            'not.contain',
+            translations.transport.czechPost,
+        );
+    });
+});

--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -24,6 +24,7 @@ type MutationErrorConfig = {
     errorType: FlashMessageKeys;
     gtmOrigin: GtmMessageOriginType;
     validationFields?: string[];
+    suppressValidationErrors?: boolean;
 };
 
 const MUTATION_ERROR_CONFIG: Partial<Record<string, MutationErrorConfig>> = {
@@ -163,6 +164,12 @@ const handleErrorMessagesForMutation = (error: CombinedError, t: Translate, oper
     }
 
     const { userError } = parsedErrors;
+
+    // Silently suppress validation errors (e.g. transport weight limit exceeded when restoring from last order)
+    const suppressErrors = operation.context.suppressValidationErrors ?? config.suppressValidationErrors;
+    if (userError?.validation && suppressErrors) {
+        return;
+    }
 
     // Handle validation errors for configured fields
     if (userError?.validation && config.validationFields) {

--- a/project-base/storefront/utils/cart/useChangeTransportInCart.ts
+++ b/project-base/storefront/utils/cart/useChangeTransportInCart.ts
@@ -9,6 +9,7 @@ import { useLatest } from 'utils/ui/useLatest';
 export type ChangeTransportInCart = (
     newTransportUuid: string | null,
     newPickupPlace: StoreOrPacketeryPoint | null,
+    options?: { suppressValidationErrors?: boolean },
 ) => Promise<TypeCartFragment | undefined | null>;
 
 export const useChangeTransportInCart = () => {
@@ -19,7 +20,7 @@ export const useChangeTransportInCart = () => {
 
     const gtmCart = useLatest(gtmCartInfo);
 
-    const changeTransportInCart: ChangeTransportInCart = async (newTransportUuid, newPickupPlace) => {
+    const changeTransportInCart: ChangeTransportInCart = async (newTransportUuid, newPickupPlace, options) => {
         const changeTransportResult = await changeTransportInCartMutation(
             {
                 input: {
@@ -28,7 +29,7 @@ export const useChangeTransportInCart = () => {
                     cartUuid,
                 },
             },
-            { additionalTypenames: ['dedup'] },
+            { additionalTypenames: ['dedup'], suppressValidationErrors: options?.suppressValidationErrors },
         );
 
         // EXTEND TRANSPORT MODIFICATIONS HERE

--- a/upgrade-notes/storefront_20260223_141614.md
+++ b/upgrade-notes/storefront_20260223_141614.md
@@ -1,0 +1,4 @@
+#### Improved order weight alert handling ([#4468](https://github.com/shopsys/shopsys/pull/4468))
+
+- transport validation errors from last order restore are now silently suppressed instead of shown as error toast
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fix info message after order weigh limit exceeded.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3884-transport-alert.odin.shopsys.cloud
  - https://cz.tc-ssp-3884-transport-alert.odin.shopsys.cloud
  - https://tc-ssp-3884-transport-alert.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772780429.192459 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3884-transport-alert.odin.shopsys.cloud
  - https://cz.tc-ssp-3884-transport-alert.odin.shopsys.cloud
  - https://tc-ssp-3884-transport-alert.odin.shopsys.cloud/sk
<!-- Replace -->
