### PR TITLE
Update to PHP 8.5

### DIFF
--- a/.cursor/rules/backend.mdc
+++ b/.cursor/rules/backend.mdc
@@ -8,7 +8,7 @@ description: Essential backend patterns and commands for PHP/Symfony
 ## Technology Stack
 
 - **Framework**: Symfony 6.4
-- **Language**: PHP 8.3
+- **Language**: PHP 8.5
 - **ORM**: Doctrine ORM
 - **GraphQL**: Overblog GraphQL Bundle
 - **Database**: PostgreSQL

--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "league/flysystem-google-cloud-storage": "^3.0",
         "league/iso3166": "^4.2.1",
-        "litipk/php-bignumbers": "^0.8.6",
+        "litipk/php-bignumbers": "^0.8.7",
         "nette/utils": "^4.0",
         "nikic/php-parser": "^5.1",
         "overblog/dataloader-bundle": "^1.1",
@@ -284,6 +284,12 @@
             }
         }
     },
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/bigcommerce/php-bignumbers"
+        }
+    ],
     "replace": {
         "shopsys/administration": "self.version",
         "shopsys/article-feed-luigis-box": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-amqp": "*",
         "ext-bcmath": "*",
         "ext-calendar": "*",
@@ -249,7 +249,7 @@
         "component-dir": "project-base/app/web/components",
         "sort-packages": true,
         "platform": {
-            "php": "8.3.2"
+            "php": "8.5.0"
         },
         "allow-plugins": {
             "cweagans/composer-patches": true,

--- a/composer.json
+++ b/composer.json
@@ -220,7 +220,7 @@
         "symfony/web-profiler-bundle": "^7.4",
         "symfony/yaml": "^7.4",
         "symplify/easy-coding-standard": "^13.0",
-        "shopsys/phpunit-injector": "^2.5.1"
+        "shopsys/phpunit-injector": "^2.7"
     },
     "conflict": {
         "symfony/symfony": "*",

--- a/docs/docker/docker-troubleshooting.md
+++ b/docs/docker/docker-troubleshooting.md
@@ -172,8 +172,8 @@ Docker images may fail to build during `docker compose up -d` due to invalid ref
 
 ```no-highlight
 Building php-fpm
-Step 1/41 : FROM php:8.3-fpm-bullseye as base
-ERROR: Service 'php-fpm' failed to build: Error parsing reference: "php:8.3-fpm-bullseye as base" is not a valid repository/tag: invalid reference format
+Step 1/41 : FROM php:8.5-fpm-alpine as base
+ERROR: Service 'php-fpm' failed to build: Error parsing reference: "php:8.5-fpm-alpine as base" is not a valid repository/tag: invalid reference format
 ```
 
 This is because you have a version of Docker that does not support [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).

--- a/docs/installation/application-requirements.md
+++ b/docs/installation/application-requirements.md
@@ -6,7 +6,7 @@ To be able to install, develop and run Shopsys Platform, the system should have 
 
 - [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [PostgreSQL 18](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
-- [PHP 8.3 or higher](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
+- [PHP 8.5 or higher](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 - [Composer](https://getcomposer.org/doc/00-intro.md#globally)
 - [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
 - [Redis](https://redis.io/topics/quickstart)
@@ -25,7 +25,7 @@ To be able to install, develop and run Shopsys Platform, the system should have 
         git config --system core.longpaths true
         ```
 - [PostgreSQL 18](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
-- [PHP 8.3 or higher](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
+- [PHP 8.5 or higher](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 - [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows)
 - [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
 - [Redis](https://github.com/MicrosoftArchive/redis/releases)

--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -12,7 +12,7 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 
 - [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [PHP](http://php.net/manual/en/install.unix.php)
-    - At least version **8.3 or higher**
+    - At least version **8.5 or higher**
 - [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 - [Docker](https://docs.docker.com/engine/installation/)
     - It's necessary to perform [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user), to be able to run docker commands as non-root user.

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -15,7 +15,7 @@ This solution uses [_Mutagen_](https://mutagen.io) (for relatively fast two-way 
 
 - [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [PHP](http://php.net/manual/en/install.macosx.php)
-    - At least version **8.3 or higher**
+    - At least version **8.5 or higher**
 - [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 - [Docker Desktop](https://docs.docker.com/engine/install/)
     - Enable Docker Compose V2 in General settings

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -154,10 +154,10 @@ _Note: You can also view the outgoing emails in the Symfony profiler._
 
 Yes, you can! Check [the quick guide](../automated-testing/running-acceptance-tests.md#how-to-watch-what-is-going-on-in-the-selenium-browser).
 
-## Why is there a faked PHP 8.3 platform in the Composer config?
+## Why is there a faked PHP 8.5 platform in the Composer config?
 
-As a general rule, packages and libraries that depend on PHP 8.3 will work as expected even on any higher 8.x version, but not vice versa.
-Maintainers of PHP are focusing on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration81.incompatible.php) introduced in PHP 8.3, in practice it doesn't cause issues).
+As a general rule, packages and libraries that depend on PHP 8.5 will work as expected even on any higher 8.x version, but not vice versa.
+Maintainers of PHP are focusing on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration81.incompatible.php) introduced in PHP 8.5, in practice it doesn't cause issues).
 
 Using [the `config.platform.php` option](https://getcomposer.org/doc/06-config.md#platform) in `composer.json` allows us to force Composer to install such dependencies, that work for all supported versions of PHP by Shopsys Platform.
 These dependencies are locked during each release of Shopsys Platform so users that install it can download exact versions of all libraries and tools that were tested and proved working.

--- a/docs/introduction/shopsys-framework-on-docker.md
+++ b/docs/introduction/shopsys-framework-on-docker.md
@@ -69,7 +69,7 @@ kind of recipe by which final image is cooked.
 Dockerfile example command:
 
 ```dockerfile
-FROM php:8.3-fpm-bullseye
+FROM php:8.5-fpm-alpine
 ```
 
 !!! note

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -177,7 +177,7 @@ To do so, remove the `config.platform.php` option from your `composer.json`:
          "preferred-install": "dist",
 -        "component-dir": "project-base/web/components",
 -        "platform": {
--            "php": "8.3"
+-            "php": "8.5"
 -        }
 +        "component-dir": "project-base/web/components"
      },
@@ -197,17 +197,17 @@ After all, your production server is the one that matters the most.
 First, run `php -v` on your server to find our the exact version, for example:
 
 ```no-highlight
-PHP 8.3.2 (cli)
+PHP 8.5.3 (cli)
 Copyright (c) The PHP Group
-Zend Engine v4.1.3, Copyright (c) Zend Technologies
-    with Zend OPcache v8.1.3, Copyright (c), by Zend Technologies
+Zend Engine v4.5.3, Copyright (c) Zend Technologies
+    with Zend OPcache v8.5.3, Copyright (c), by Zend Technologies
 ```
 
 Then change the version in your `docker/php-fpm/Dockerfile`:
 
 ```diff
-- FROM php:8.3-fpm-bullseye as base
-+ FROM php:8.3.2-fpm-bullseye as base
+- FROM php:8.5-fpm-alpine as base
++ FROM php:8.5.3-fpm-alpine as base
 ```
 
 After running `docker compose up -d --build` you'll have the application running on the same PHP.
@@ -216,8 +216,8 @@ Now you can modify the version in your `composer.json` as well so all packages w
 
 ```diff
          "platform": {
--            "php": "8.3"
-+            "php": "8.3.2"
+-            "php": "8.5"
++            "php": "8.5.3"
          }
 ```
 

--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -511,7 +511,7 @@ https://github.com/nodejs/docker-node/blob/main/LICENSE
 
 ### Php
 
-Image: `php:8.3-fpm-bullseye`  
+Image: `php:8.5-fpm-alpine`  
 License: The PHP License  
 http://php.net/license/
 

--- a/packages/administration/.github/workflows/run-checks-tests.yaml
+++ b/packages/administration/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/administration/composer.json
+++ b/packages/administration/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "knplabs/knp-menu-bundle": "^3.5",
-        "php": "^8.3",
+        "php": "^8.5",
         "shopsys/form-types-bundle": "19.0.x-dev",
         "shopsys/framework": "19.0.x-dev",
         "shopsys/migrations": "19.0.x-dev",

--- a/packages/administration/phpunit.xml
+++ b/packages/administration/phpunit.xml
@@ -25,5 +25,8 @@
             <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <ini name="error_reporting" value="24575"/>
+    </php>
     <source/>
 </phpunit>

--- a/packages/administration/src/Component/Crud/Helper/CrudTransformationHelper.php
+++ b/packages/administration/src/Component/Crud/Helper/CrudTransformationHelper.php
@@ -17,7 +17,10 @@ final class CrudTransformationHelper
      */
     public static function transformToRouteName(string $controllerName): string
     {
-        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', self::getCleanControllerName($controllerName)));
+        return $controllerName
+            |> self::getCleanControllerName(...)
+            |> (fn ($v) => preg_replace('/(?<!^)[A-Z]/', '_$0', $v))
+            |> strtolower(...);
     }
 
     public static function generateController(string $controllerClass, ActionType $pageType): string
@@ -34,7 +37,10 @@ final class CrudTransformationHelper
      */
     public static function transformToRouteUrl(string $controllerName): string
     {
-        return strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', self::getCleanControllerName($controllerName)));
+        return $controllerName
+            |> self::getCleanControllerName(...)
+            |> (fn ($v) => preg_replace('/(?<!^)[A-Z]/', '-$0', $v))
+            |> strtolower(...);
     }
 
     /**

--- a/packages/administration/src/Component/Security/AccessControl/RouteAccessControlData.php
+++ b/packages/administration/src/Component/Security/AccessControl/RouteAccessControlData.php
@@ -76,7 +76,7 @@ class RouteAccessControlData
         if (!class_exists($this->controllerClass)) {
             // Extract just the class name from the full path
             $parts = explode('\\', $this->controllerClass);
-            $shortControllerClass = end($parts);
+            $shortControllerClass = array_last($parts);
         } else {
             $shortControllerClass = (new ReflectionClass($this->controllerClass))->getShortName();
         }

--- a/packages/article-feed-luigis-box/.github/workflows/run-checks-tests.yaml
+++ b/packages/article-feed-luigis-box/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/article-feed-luigis-box/composer.json
+++ b/packages/article-feed-luigis-box/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/article-feed-luigis-box/phpunit.xml
+++ b/packages/article-feed-luigis-box/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/brand-feed-luigis-box/.github/workflows/run-checks-tests.yaml
+++ b/packages/brand-feed-luigis-box/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/brand-feed-luigis-box/composer.json
+++ b/packages/brand-feed-luigis-box/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/brand-feed-luigis-box/phpunit.xml
+++ b/packages/brand-feed-luigis-box/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/category-feed-luigis-box/.github/workflows/run-checks-tests.yaml
+++ b/packages/category-feed-luigis-box/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/category-feed-luigis-box/composer.json
+++ b/packages/category-feed-luigis-box/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/category-feed-luigis-box/phpunit.xml
+++ b/packages/category-feed-luigis-box/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/cli/.github/workflows/build-phar.yaml
+++ b/packages/cli/.github/workflows/build-phar.yaml
@@ -26,7 +26,7 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     tools: composer
                     extensions: json, yaml
 

--- a/packages/cli/composer.json
+++ b/packages/cli/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "commerceguys/intl": "^2.0",
         "symfony/config": "^7.4",
         "symfony/console": "^7.4",

--- a/packages/cli/src/Input/InteractiveInputCollector.php
+++ b/packages/cli/src/Input/InteractiveInputCollector.php
@@ -115,7 +115,7 @@ final class InteractiveInputCollector
             type: $io->choice(
                 'Domain type',
                 CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES,
-                CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES[array_key_first(CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES)],
+                array_first(CoreDomainConfigValidator::SUPPORTED_DOMAIN_TYPES),
             ),
             currencyCode: $io->ask(
                 'Currency code (e.g., EUR, CZK)',

--- a/packages/coding-standards/.github/workflows/run-checks-tests.yaml
+++ b/packages/coding-standards/.github/workflows/run-checks-tests.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php-versions: ['8.3']
+                php-versions: ['8.5']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-tokenizer": "*",
         "friendsofphp/php-cs-fixer": "^3.58.1",
         "nette/utils": "^4.0",

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -100,6 +100,7 @@ use Shopsys\CodingStandards\Sniffs\General\ForbiddenDumpSniff;
 use Shopsys\CodingStandards\Sniffs\General\ForbiddenExitSniff;
 use Shopsys\CodingStandards\Sniffs\General\ForbiddenSuperGlobalSniff;
 use Shopsys\CodingStandards\Sniffs\General\ObjectIsCreatedByFactorySniff;
+use Shopsys\CodingStandards\Sniffs\General\RequireOverrideAttributeOnPropertySniff;
 use Shopsys\CodingStandards\Sniffs\General\RequireOverrideAttributeSniff;
 use Shopsys\CodingStandards\Sniffs\General\ValidVariableNameSniff;
 use SlevomatCodingStandard\Sniffs\Arrays\TrailingArrayCommaSniff;
@@ -254,6 +255,7 @@ return ECSConfig::configure()
         DisallowEmptySniff::class,
         ParentCallSpacingSniff::class,
         UselessIfConditionWithReturnSniff::class,
+        RequireOverrideAttributeOnPropertySniff::class,
         RequireOverrideAttributeSniff::class,
         ParameterTypeHintSniff::class,
         ReturnTypeHintSniff::class,

--- a/packages/coding-standards/phpunit.xml
+++ b/packages/coding-standards/phpunit.xml
@@ -25,5 +25,8 @@
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/coding-standards/src/Sniffs/General/AbstractRequireOverrideAttributeSniff.php
+++ b/packages/coding-standards/src/Sniffs/General/AbstractRequireOverrideAttributeSniff.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Sniffs\General;
+
+use Override;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use ReflectionClass;
+use SlevomatCodingStandard\Helpers\NamespaceHelper;
+use SlevomatCodingStandard\Helpers\UseStatementHelper;
+
+use const T_ANON_CLASS;
+
+abstract class AbstractRequireOverrideAttributeSniff implements Sniff
+{
+    /**
+     * @return array<int|string>
+     */
+    #[Override]
+    public function register(): array
+    {
+        return [T_CLASS];
+    }
+
+    /**
+     * @param int $stackPtr
+     * @throws \ReflectionException
+     */
+    #[Override]
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_ANON_CLASS) {
+            return;
+        }
+
+        $classNamesToCheck = $this->getInterfaceNames($phpcsFile, $stackPtr);
+        $parentClassName = $this->getParentClassName($phpcsFile, $stackPtr);
+
+        if ($parentClassName !== null) {
+            $classNamesToCheck[] = $parentClassName;
+        }
+
+        foreach ($classNamesToCheck as $className) {
+            $this->processClassMembers($phpcsFile, $stackPtr, new ReflectionClass($className));
+        }
+    }
+
+    abstract protected function processClassMembers(
+        File $phpcsFile,
+        int $classPtr,
+        ReflectionClass $parentClass,
+    ): void;
+
+    protected function getParentClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+        $extendsPtr = $phpcsFile->findNext(T_EXTENDS, $stackPtr, $tokens[$stackPtr]['scope_opener']);
+
+        if ($extendsPtr === false) {
+            return null;
+        }
+
+        $parentClassPtr = $phpcsFile->findNext(T_STRING, $extendsPtr);
+
+        if ($parentClassPtr === false) {
+            return null;
+        }
+
+        $parentClassName = $tokens[$parentClassPtr]['content'];
+
+        return $this->resolveClassName($phpcsFile, $parentClassName, $parentClassPtr);
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getInterfaceNames(File $phpcsFile, int $stackPtr): array
+    {
+        $tokens = $phpcsFile->getTokens();
+        $interfaceNames = [];
+
+        $implementsPtr = $phpcsFile->findNext(T_IMPLEMENTS, $stackPtr, $tokens[$stackPtr]['scope_opener']);
+
+        if ($implementsPtr === false) {
+            return $interfaceNames;
+        }
+
+        $currentPtr = $implementsPtr;
+        $classOpenPtr = $tokens[$stackPtr]['scope_opener'];
+
+        while (($currentPtr = $phpcsFile->findNext(T_STRING, $currentPtr + 1, $classOpenPtr)) !== false) {
+            $interfaceName = $tokens[$currentPtr]['content'];
+            $resolvedName = $this->resolveClassName($phpcsFile, $interfaceName, $currentPtr);
+
+            if ($resolvedName !== null) {
+                $interfaceNames[] = $resolvedName;
+            }
+        }
+
+        return $interfaceNames;
+    }
+
+    protected function resolveClassName(File $phpcsFile, string $className, int $position): ?string
+    {
+        $allUseStatements = UseStatementHelper::getFileUseStatements($phpcsFile);
+
+        foreach ($allUseStatements as $useStatements) {
+            // PHP use statements are case-insensitive
+            $lowerClassName = strtolower($className);
+
+            if (isset($useStatements[$lowerClassName])) {
+                return $useStatements[$lowerClassName]->getFullyQualifiedTypeName();
+            }
+        }
+
+        $namespace = NamespaceHelper::findCurrentNamespaceName($phpcsFile, $position);
+
+        return $namespace ? $namespace . '\\' . $className : $className;
+    }
+
+    /**
+     * Adds the #[Override] attribute before the given token pointer and a `use Override;` statement if needed.
+     */
+    protected function applyOverrideAttributeFix(File $phpcsFile, int $searchFromPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $phpcsFile->fixer->beginChangeset();
+
+        $previousLinePtr = $phpcsFile->findPrevious(T_WHITESPACE, $searchFromPtr, null, false, PHP_EOL);
+
+        // Get indentation from the next line
+        $indent = '';
+
+        if ($previousLinePtr !== false && isset($tokens[$previousLinePtr + 1])) {
+            $nextToken = $tokens[$previousLinePtr + 1];
+
+            if ($nextToken['code'] === T_WHITESPACE) {
+                $indent = $nextToken['content'];
+            }
+        }
+
+        // Add the #[Override] attribute
+        $phpcsFile->fixer->addContentBefore($previousLinePtr + 1, $indent . '#[Override]' . PHP_EOL);
+
+        // Add use statement if needed
+        if (!$this->hasOverrideUseStatement($phpcsFile)) {
+            $this->addUseStatement($phpcsFile, 'Override');
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    protected function hasOverrideUseStatement(File $phpcsFile): bool
+    {
+        $allUseStatements = UseStatementHelper::getFileUseStatements($phpcsFile);
+
+        foreach ($allUseStatements as $useStatements) {
+            // Use statements are stored with lowercase keys
+            if (isset($useStatements['override'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function addUseStatement(File $phpcsFile, string $className): void
+    {
+        // First try to find existing use statements
+        $usePtr = $phpcsFile->findNext(T_USE, 0);
+
+        if ($usePtr !== false) {
+            // There are existing use statements, add before the first one
+            $previousLinePtr = $phpcsFile->findPrevious(T_WHITESPACE, $usePtr, null, false, PHP_EOL);
+            $phpcsFile->fixer->addContentBefore($previousLinePtr + 1, 'use ' . $className . ';' . PHP_EOL);
+
+            return;
+        }
+
+        // No existing use statements, find the namespace and add after it
+        $namespacePtr = $phpcsFile->findNext(T_NAMESPACE, 0);
+
+        if ($namespacePtr === false) {
+            return; // No namespace found, can't add use statement
+        }
+
+        // Find the semicolon after the namespace declaration
+        $semicolonPtr = $phpcsFile->findNext(T_SEMICOLON, $namespacePtr);
+
+        if ($semicolonPtr === false) {
+            return;
+        }
+
+        // Add the use statement after the namespace
+        $phpcsFile->fixer->addContentBefore($semicolonPtr + 1, PHP_EOL . PHP_EOL . 'use ' . $className . ';');
+    }
+}

--- a/packages/coding-standards/src/Sniffs/General/ForbiddenDumpSniff.php
+++ b/packages/coding-standards/src/Sniffs/General/ForbiddenDumpSniff.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\CodingStandards\Sniffs\General;
 
+use Override;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
 final class ForbiddenDumpSniff extends ForbiddenFunctionsSniff
@@ -17,6 +18,7 @@ final class ForbiddenDumpSniff extends ForbiddenFunctionsSniff
      * @var string[]|null[]
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      */
+    #[Override]
     public $forbiddenFunctions = [
         'd' => null,
         'dump' => null,

--- a/packages/coding-standards/src/Sniffs/General/ForbiddenExitSniff.php
+++ b/packages/coding-standards/src/Sniffs/General/ForbiddenExitSniff.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\CodingStandards\Sniffs\General;
 
+use Override;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
 final class ForbiddenExitSniff extends ForbiddenFunctionsSniff
@@ -17,6 +18,7 @@ final class ForbiddenExitSniff extends ForbiddenFunctionsSniff
      * @var string[]|null[]
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      */
+    #[Override]
     public $forbiddenFunctions = [
         'exit' => null,
     ];

--- a/packages/coding-standards/src/Sniffs/General/RequireOverrideAttributeOnPropertySniff.php
+++ b/packages/coding-standards/src/Sniffs/General/RequireOverrideAttributeOnPropertySniff.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Sniffs\General;
+
+use Override;
+use PHP_CodeSniffer\Files\File;
+use ReflectionClass;
+use SlevomatCodingStandard\Helpers\PropertyHelper;
+
+use const T_ANON_CLASS;
+
+class RequireOverrideAttributeOnPropertySniff extends AbstractRequireOverrideAttributeSniff
+{
+    #[Override]
+    protected function processClassMembers(
+        File $phpcsFile,
+        int $classPtr,
+        ReflectionClass $parentClass,
+    ): void {
+        $tokens = $phpcsFile->getTokens();
+        $classStartPtr = $tokens[$classPtr]['scope_opener'];
+        $classEndPtr = $tokens[$classPtr]['scope_closer'];
+
+        $variablePtr = $classStartPtr;
+
+        while (($variablePtr = $phpcsFile->findNext(T_VARIABLE, $variablePtr + 1, $classEndPtr)) !== false) {
+            if (!PropertyHelper::isProperty($phpcsFile, $variablePtr)) {
+                continue;
+            }
+
+            if (!$this->isDirectClassProperty($tokens, $variablePtr, $classPtr)) {
+                continue;
+            }
+
+            $propertyName = ltrim($tokens[$variablePtr]['content'], '$');
+
+            if (!$this->propertyExistsInParentClass($parentClass, $propertyName)) {
+                continue;
+            }
+
+            if ($this->hasOverrideAttribute($phpcsFile, $variablePtr)) {
+                continue;
+            }
+
+            $this->addOverrideAttributeError($phpcsFile, $variablePtr, $propertyName, $parentClass->getShortName());
+        }
+    }
+
+    /**
+     * Checks that the property belongs directly to the class being processed,
+     * not to a nested anonymous class.
+     *
+     * @param array<int, array<string, mixed>> $tokens
+     */
+    protected function isDirectClassProperty(array $tokens, int $variablePtr, int $classPtr): bool
+    {
+        $conditions = $tokens[$variablePtr]['conditions'];
+
+        foreach (array_reverse($conditions, true) as $condPtr => $condType) {
+            if (in_array($condType, [T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], true)) {
+                return $condPtr === $classPtr;
+            }
+        }
+
+        return false;
+    }
+
+    protected function propertyExistsInParentClass(ReflectionClass $parentClass, string $propertyName): bool
+    {
+        if ($parentClass->hasProperty($propertyName)) {
+            $property = $parentClass->getProperty($propertyName);
+
+            return !$property->isPrivate();
+        }
+
+        if ($parentClass->isInterface()) {
+            foreach ($parentClass->getInterfaces() as $parentInterface) {
+                if ($this->propertyExistsInParentClass($parentInterface, $propertyName)) {
+                    return true;
+                }
+            }
+        }
+
+        $parentOfParent = $parentClass->getParentClass();
+
+        if ($parentOfParent !== false) {
+            return $this->propertyExistsInParentClass($parentOfParent, $propertyName);
+        }
+
+        return false;
+    }
+
+    protected function hasOverrideAttribute(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prevBoundary = $phpcsFile->findPrevious(
+            [T_SEMICOLON, T_OPEN_CURLY_BRACKET, T_CLOSE_CURLY_BRACKET],
+            $stackPtr - 1,
+        );
+
+        $searchStart = ($prevBoundary !== false) ? $prevBoundary + 1 : 0;
+
+        $attributePtr = $searchStart;
+
+        while (($attributePtr = $phpcsFile->findNext(T_ATTRIBUTE, $attributePtr, $stackPtr)) !== false) {
+            $attributeEnd = $phpcsFile->findNext(T_ATTRIBUTE_END, $attributePtr);
+
+            if ($attributeEnd === false) {
+                $attributePtr++;
+
+                continue;
+            }
+
+            for ($i = $attributePtr; $i <= $attributeEnd; $i++) {
+                if ($tokens[$i]['code'] === T_STRING && $tokens[$i]['content'] === 'Override') {
+                    return true;
+                }
+            }
+
+            $attributePtr = $attributeEnd + 1;
+        }
+
+        return false;
+    }
+
+    protected function addOverrideAttributeError(
+        File $phpcsFile,
+        int $stackPtr,
+        string $propertyName,
+        string $parentClassName,
+    ): void {
+        $error = "Property \${$propertyName} overrides {$parentClassName}::\${$propertyName} but is missing #[Override] attribute.";
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'MissingOverride');
+
+        if (!$fix) {
+            return;
+        }
+
+        $this->applyOverrideAttributeFix($phpcsFile, $stackPtr);
+    }
+}

--- a/packages/coding-standards/src/Sniffs/General/RequireOverrideAttributeSniff.php
+++ b/packages/coding-standards/src/Sniffs/General/RequireOverrideAttributeSniff.php
@@ -6,51 +6,13 @@ namespace Shopsys\CodingStandards\Sniffs\General;
 
 use Override;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Sniffs\Sniff;
 use ReflectionClass;
 use SlevomatCodingStandard\Helpers\FunctionHelper;
-use SlevomatCodingStandard\Helpers\NamespaceHelper;
-use SlevomatCodingStandard\Helpers\UseStatementHelper;
 
-use const T_ANON_CLASS;
-
-class RequireOverrideAttributeSniff implements Sniff
+class RequireOverrideAttributeSniff extends AbstractRequireOverrideAttributeSniff
 {
-    /**
-     * @return array<int|string>
-     */
     #[Override]
-    public function register(): array
-    {
-        return [T_CLASS];
-    }
-
-    /**
-     * @param int $stackPtr
-     * @throws \ReflectionException
-     */
-    #[Override]
-    public function process(File $phpcsFile, $stackPtr): void
-    {
-        $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] === T_ANON_CLASS) {
-            return;
-        }
-
-        $classNamesToCheck = $this->getInterfaceNames($phpcsFile, $stackPtr);
-        $parentClassName = $this->getParentClassName($phpcsFile, $stackPtr);
-
-        if ($parentClassName !== null) {
-            $classNamesToCheck[] = $parentClassName;
-        }
-
-        foreach ($classNamesToCheck as $className) {
-            $this->processClassMethods($phpcsFile, $stackPtr, new ReflectionClass($className));
-        }
-    }
-
-    private function processClassMethods(
+    protected function processClassMembers(
         File $phpcsFile,
         int $classPtr,
         ReflectionClass $parentClass,
@@ -84,82 +46,15 @@ class RequireOverrideAttributeSniff implements Sniff
         }
     }
 
-    private function getParentClassName(File $phpcsFile, int $stackPtr): ?string
-    {
-        $tokens = $phpcsFile->getTokens();
-        $extendsPtr = $phpcsFile->findNext(T_EXTENDS, $stackPtr, $tokens[$stackPtr]['scope_opener']);
-
-        if ($extendsPtr === false) {
-            return null;
-        }
-
-        $parentClassPtr = $phpcsFile->findNext(T_STRING, $extendsPtr);
-
-        if ($parentClassPtr === false) {
-            return null;
-        }
-
-        $parentClassName = $tokens[$parentClassPtr]['content'];
-
-        return $this->resolveClassName($phpcsFile, $parentClassName, $parentClassPtr);
-    }
-
-    /**
-     * @return array<string>
-     */
-    private function getInterfaceNames(File $phpcsFile, int $stackPtr): array
-    {
-        $tokens = $phpcsFile->getTokens();
-        $interfaceNames = [];
-
-        $implementsPtr = $phpcsFile->findNext(T_IMPLEMENTS, $stackPtr, $tokens[$stackPtr]['scope_opener']);
-
-        if ($implementsPtr === false) {
-            return $interfaceNames;
-        }
-
-        $currentPtr = $implementsPtr;
-        $classOpenPtr = $tokens[$stackPtr]['scope_opener'];
-
-        while (($currentPtr = $phpcsFile->findNext(T_STRING, $currentPtr + 1, $classOpenPtr)) !== false) {
-            $interfaceName = $tokens[$currentPtr]['content'];
-            $resolvedName = $this->resolveClassName($phpcsFile, $interfaceName, $currentPtr);
-
-            if ($resolvedName !== null) {
-                $interfaceNames[] = $resolvedName;
-            }
-        }
-
-        return $interfaceNames;
-    }
-
-    private function resolveClassName(File $phpcsFile, string $className, int $position): ?string
-    {
-        $allUseStatements = UseStatementHelper::getFileUseStatements($phpcsFile);
-
-        foreach ($allUseStatements as $useStatements) {
-            // PHP use statements are case-insensitive
-            $lowerClassName = strtolower($className);
-
-            if (isset($useStatements[$lowerClassName])) {
-                return $useStatements[$lowerClassName]->getFullyQualifiedTypeName();
-            }
-        }
-
-        $namespace = NamespaceHelper::findCurrentNamespaceName($phpcsFile, $position);
-
-        return $namespace ? $namespace . '\\' . $className : $className;
-    }
-
     /**
      * Checks magic methods like __construct, __destruct, __call, etc.
      */
-    private function isMagicMethod(string $methodName): bool
+    protected function isMagicMethod(string $methodName): bool
     {
         return str_starts_with($methodName, '__');
     }
 
-    private function methodExistsInParentClass(ReflectionClass $parentClass, string $methodName): bool
+    protected function methodExistsInParentClass(ReflectionClass $parentClass, string $methodName): bool
     {
         if ($parentClass->hasMethod($methodName)) {
             return true;
@@ -183,7 +78,7 @@ class RequireOverrideAttributeSniff implements Sniff
         return false;
     }
 
-    private function hasOverrideAttribute(File $phpcsFile, int $stackPtr): bool
+    protected function hasOverrideAttribute(File $phpcsFile, int $stackPtr): bool
     {
         $tokens = $phpcsFile->getTokens();
         $attributePtr = $phpcsFile->findPrevious(T_ATTRIBUTE, $stackPtr - 1);
@@ -214,7 +109,7 @@ class RequireOverrideAttributeSniff implements Sniff
         return false;
     }
 
-    private function addOverrideAttributeError(
+    protected function addOverrideAttributeError(
         File $phpcsFile,
         int $stackPtr,
         string $methodName,
@@ -227,77 +122,7 @@ class RequireOverrideAttributeSniff implements Sniff
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
-        $phpcsFile->fixer->beginChangeset();
-
-        // Find the line before the method
         $methodNamePtr = $phpcsFile->findNext(T_STRING, $stackPtr);
-        $previousLinePtr = $phpcsFile->findPrevious(T_WHITESPACE, $methodNamePtr, null, false, PHP_EOL);
-
-        // Get indentation from the next line
-        $indent = '';
-
-        if ($previousLinePtr !== false && isset($tokens[$previousLinePtr + 1])) {
-            $nextToken = $tokens[$previousLinePtr + 1];
-
-            if ($nextToken['code'] === T_WHITESPACE) {
-                $indent = $nextToken['content'];
-            }
-        }
-
-        // Add the #[Override] attribute
-        $phpcsFile->fixer->addContentBefore($previousLinePtr + 1, $indent . '#[Override]' . PHP_EOL);
-
-        // Add use statement if needed
-        if (!$this->hasOverrideUseStatement($phpcsFile)) {
-            $this->addUseStatement($phpcsFile, 'Override');
-        }
-
-        $phpcsFile->fixer->endChangeset();
-    }
-
-    private function hasOverrideUseStatement(File $phpcsFile): bool
-    {
-        $allUseStatements = UseStatementHelper::getFileUseStatements($phpcsFile);
-
-        foreach ($allUseStatements as $useStatements) {
-            // Use statements are stored with lowercase keys
-            if (isset($useStatements['override'])) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function addUseStatement(File $phpcsFile, string $className): void
-    {
-        // First try to find existing use statements
-        $usePtr = $phpcsFile->findNext(T_USE, 0);
-
-        if ($usePtr !== false) {
-            // There are existing use statements, add before the first one
-            $previousLinePtr = $phpcsFile->findPrevious(T_WHITESPACE, $usePtr, null, false, PHP_EOL);
-            $phpcsFile->fixer->addContentBefore($previousLinePtr + 1, 'use ' . $className . ';' . PHP_EOL);
-
-            return;
-        }
-
-        // No existing use statements, find the namespace and add after it
-        $namespacePtr = $phpcsFile->findNext(T_NAMESPACE, 0);
-
-        if ($namespacePtr === false) {
-            return; // No namespace found, can't add use statement
-        }
-
-        // Find the semicolon after the namespace declaration
-        $semicolonPtr = $phpcsFile->findNext(T_SEMICOLON, $namespacePtr);
-
-        if ($semicolonPtr === false) {
-            return;
-        }
-
-        // Add the use statement after the namespace
-        $phpcsFile->fixer->addContentBefore($semicolonPtr + 1, PHP_EOL . PHP_EOL . 'use ' . $className . ';');
+        $this->applyOverrideAttributeFix($phpcsFile, $methodNamePtr);
     }
 }

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Base/PropertyInterface.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Base/PropertyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base;
+
+interface PropertyInterface
+{
+    public string $label { get; }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Base/PropertyParentClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Base/PropertyParentClass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base;
+
+class PropertyParentClass
+{
+    protected string $name = '';
+
+    protected int $value = 0;
+
+    private string $secret = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Correct/AlreadyHasOverride.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Correct/AlreadyHasOverride.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Override;
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class AlreadyHasOverride extends PropertyParentClass
+{
+    #[Override]
+    protected string $name = 'overridden';
+
+    #[Override]
+    protected int $value = 42;
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Correct/NoOverrideNeeded.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Correct/NoOverrideNeeded.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class NoOverrideNeeded extends PropertyParentClass
+{
+    protected string $uniqueProperty = '';
+
+    private string $anotherUniqueProperty = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Correct/PrivateParentProperty.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Correct/PrivateParentProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class PrivateParentProperty extends PropertyParentClass
+{
+    private string $secret = 'my secret';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Fixed/ClassWithInterface.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Fixed/ClassWithInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Override;
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyInterface;
+
+class ClassWithInterface implements PropertyInterface
+{
+    #[Override]
+    public string $label = '';
+
+    public string $uniqueProperty = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Fixed/CombinedParentsClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Fixed/CombinedParentsClass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Override;
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyInterface;
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class CombinedParentsClass extends PropertyParentClass implements PropertyInterface
+{
+    #[Override]
+    protected string $name = 'overridden';
+
+    #[Override]
+    public string $label = '';
+
+    public string $uniqueProperty = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Fixed/SimpleWithParentClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Fixed/SimpleWithParentClass.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Override;
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class SimpleWithParentClass extends PropertyParentClass
+{
+    #[Override]
+    protected string $name = 'overridden';
+
+    #[Override]
+    protected int $value = 42;
+
+    private string $uniqueProperty = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/RequireOverrideAttributeOnPropertySniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/RequireOverrideAttributeOnPropertySniffTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Shopsys\CodingStandards\Sniffs\General\RequireOverrideAttributeOnPropertySniff;
+use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
+
+final class RequireOverrideAttributeOnPropertySniffTest extends AbstractSniffTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getSniffClassName(): string
+    {
+        return RequireOverrideAttributeOnPropertySniff::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getFixableFiles(): iterable
+    {
+        yield [__DIR__ . '/Fixed/SimpleWithParentClass.php', __DIR__ . '/Wrong/SimpleWithParentClass.php'];
+
+        yield [__DIR__ . '/Fixed/ClassWithInterface.php', __DIR__ . '/Wrong/ClassWithInterface.php'];
+
+        yield [__DIR__ . '/Fixed/CombinedParentsClass.php', __DIR__ . '/Wrong/CombinedParentsClass.php'];
+
+        yield [__DIR__ . '/Correct/NoOverrideNeeded.php'];
+
+        yield [__DIR__ . '/Correct/AlreadyHasOverride.php'];
+
+        yield [__DIR__ . '/Correct/PrivateParentProperty.php'];
+    }
+
+    #[DataProvider('getFixableFiles')]
+    public function testFixableFiles(string $fixedFileName, ?string $inputFileName = null): void
+    {
+        $this->runFixableFilesTest($fixedFileName, $inputFileName);
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Wrong/ClassWithInterface.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Wrong/ClassWithInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyInterface;
+
+class ClassWithInterface implements PropertyInterface
+{
+    public string $label = '';
+
+    public string $uniqueProperty = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Wrong/CombinedParentsClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Wrong/CombinedParentsClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyInterface;
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class CombinedParentsClass extends PropertyParentClass implements PropertyInterface
+{
+    protected string $name = 'overridden';
+
+    public string $label = '';
+
+    public string $uniqueProperty = '';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Wrong/SimpleWithParentClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/RequireOverrideAttributeOnPropertySniff/Wrong/SimpleWithParentClass.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff;
+
+use Tests\CodingStandards\Unit\Sniffs\RequireOverrideAttributeOnPropertySniff\Base\PropertyParentClass;
+
+class SimpleWithParentClass extends PropertyParentClass
+{
+    protected string $name = 'overridden';
+
+    protected int $value = 42;
+
+    private string $uniqueProperty = '';
+}

--- a/packages/form-types-bundle/.github/workflows/run-checks-tests.yaml
+++ b/packages/form-types-bundle/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/form-types-bundle/composer.json
+++ b/packages/form-types-bundle/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/form": "^7.4",

--- a/packages/framework/.github/workflows/run-checks-tests.yaml
+++ b/packages/framework/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl-74.2, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-amqp": "*",
         "ext-bcmath": "*",
         "ext-calendar": "*",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -68,7 +68,7 @@
         "knplabs/knp-menu-bundle": "^3.5",
         "league/csv": "^9.6",
         "league/flysystem": "^3.11",
-        "litipk/php-bignumbers": "^0.8.6",
+        "litipk/php-bignumbers": "^0.8.7",
         "league/iso3166": "^4.2.1",
         "nette/utils": "^4.0",
         "nikic/php-parser": "^5.1",
@@ -143,6 +143,12 @@
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"
     },
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/bigcommerce/php-bignumbers"
+        }
+    ],
     "config": {
         "allow-plugins": {
             "symfony/flex": true,

--- a/packages/framework/phpunit.xml
+++ b/packages/framework/phpunit.xml
@@ -25,5 +25,8 @@
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -208,7 +208,7 @@ class CronCommand extends Command
             CronModuleConfig::DEFAULT_INSTANCE_NAME,
             $instanceNames,
             true,
-        ) ? CronModuleConfig::DEFAULT_INSTANCE_NAME : reset(
+        ) ? CronModuleConfig::DEFAULT_INSTANCE_NAME : array_first(
             $instanceNames,
         );
 

--- a/packages/framework/src/Command/TranslationReplaceSourceCommand.php
+++ b/packages/framework/src/Command/TranslationReplaceSourceCommand.php
@@ -156,8 +156,7 @@ class TranslationReplaceSourceCommand extends Command
                 $continues = isset($item['translated']) ? 'translated' : 'ids';
 
                 if (is_array($item[$continues])) {
-                    end($item[$continues]);
-                    $item[$continues][key($item[$continues])] .= substr($line, 1, -1);
+                    $item[$continues][array_key_last($item[$continues])] .= substr($line, 1, -1);
                 } else {
                     $item[$continues] .= substr($line, 1, -1);
                 }
@@ -203,8 +202,7 @@ class TranslationReplaceSourceCommand extends Command
                 // PO are by definition indexed so sort by index.
                 ksort($plurals);
                 // Make sure every index is filled.
-                end($plurals);
-                $count = key($plurals);
+                $count = array_key_last($plurals);
                 // Fill missing spots with '-'.
                 $empties = array_fill(0, $count + 1, '-');
                 $plurals += $empties;

--- a/packages/framework/src/Component/Console/DomainChoiceHandler.php
+++ b/packages/framework/src/Component/Console/DomainChoiceHandler.php
@@ -23,7 +23,7 @@ class DomainChoiceHandler
             throw new NoDomainSetException();
         }
 
-        $firstDomainConfig = reset($domainConfigs);
+        $firstDomainConfig = array_first($domainConfigs);
 
         if (count($domainConfigs) === 1) {
             return $firstDomainConfig;

--- a/packages/framework/src/Component/DataFixture/DomainsForDataFixtureProvider.php
+++ b/packages/framework/src/Component/DataFixture/DomainsForDataFixtureProvider.php
@@ -63,7 +63,7 @@ class DomainsForDataFixtureProvider
     {
         $allowedDomains = $this->getAllowedDemoDataDomains();
 
-        return reset($allowedDomains);
+        return array_first($allowedDomains);
     }
 
     public function isDomainIdAllowed(int $domainId): bool

--- a/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
+++ b/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
@@ -65,7 +65,7 @@ class QueryBuilderExtender
             throw new InvalidCountOfAliasesException($rootAliases);
         }
 
-        return reset($rootAliases);
+        return array_first($rootAliases);
     }
 
     /**

--- a/packages/framework/src/Component/Domain/AdminDomainTabsFacade.php
+++ b/packages/framework/src/Component/Domain/AdminDomainTabsFacade.php
@@ -42,7 +42,7 @@ class AdminDomainTabsFacade
             return $this->domain->getDomainConfigById($domainId);
         } catch (InvalidDomainIdException|SessionNotFoundException) {
             $allowedDomainIds = $this->domain->getAdminEnabledDomainIds();
-            $firstAllowedDomainId = reset($allowedDomainIds);
+            $firstAllowedDomainId = array_first($allowedDomainIds);
 
             $this->setSelectedDomainId($firstAllowedDomainId);
 

--- a/packages/framework/src/Component/Elasticsearch/IndexDefinition.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexDefinition.php
@@ -52,7 +52,9 @@ class IndexDefinition
 
     protected function getDocumentDefinitionVersion(): string
     {
-        return md5(serialize($this->getDefinition()));
+        return $this->getDefinition()
+            |> serialize(...)
+            |> md5(...);
     }
 
     public function getVersionedIndexName(): string

--- a/packages/framework/src/Component/Elasticsearch/IndexFacade.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexFacade.php
@@ -227,7 +227,10 @@ class IndexFacade
                     $this->indexRepository->bulkUpdate($indexAlias, $currentBatchData);
                 }
 
-                $idsToDelete = array_values(array_diff($idsToExport, array_keys($currentBatchData)));
+                $idsToDelete = $currentBatchData
+                    |> array_keys(...)
+                    |> (fn ($v) => array_diff($idsToExport, $v))
+                    |> array_values(...);
 
                 if (count($idsToDelete) > 0) {
                     $this->indexRepository->deleteIds($indexAlias, $idsToDelete);

--- a/packages/framework/src/Component/Elasticsearch/IndexFacade.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexFacade.php
@@ -165,7 +165,7 @@ class IndexFacade
             $this->exportIds($index, $indexDefinition, $changedIdsBatch);
 
             $progressBar->advance(count($changedIdsBatch));
-            $lastProcessedId = end($changedIdsBatch);
+            $lastProcessedId = array_last($changedIdsBatch);
         }
 
         $progressBar->finish();

--- a/packages/framework/src/Component/EntityExtension/EntityNameResolver.php
+++ b/packages/framework/src/Component/EntityExtension/EntityNameResolver.php
@@ -64,7 +64,6 @@ class EntityNameResolver
         $reflection = new ReflectionObject($object);
 
         foreach ($reflection->getProperties() as $property) {
-            $property->setAccessible(true);
             $value = $property->getValue($object);
             $resolvedValue = $this->resolveIn($value);
             $property->setValue($object, $resolvedValue);

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -499,7 +499,9 @@ class Grid
 
     protected function loadRows(): void
     {
-        if (array_key_exists($this->orderSourceColumnName, $this->columnsById)
+        if (
+            $this->orderSourceColumnName !== null
+            && array_key_exists($this->orderSourceColumnName, $this->columnsById)
             && $this->columnsById[$this->orderSourceColumnName]->isSortable()
         ) {
             $orderSourceColumnName = $this->columnsById[$this->orderSourceColumnName]->getOrderSourceColumnName();

--- a/packages/framework/src/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/packages/framework/src/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -61,7 +61,7 @@ class FileProfilerStorage extends BaseFileProfilerStorage
                 $profile->getParentToken(),
                 $profile->getStatusCode(),
                 $profile->getVirtualType(),
-            ]);
+            ], ',', '"', '\\');
             fclose($file);
         }
 

--- a/packages/framework/src/Component/Image/Image.php
+++ b/packages/framework/src/Component/Image/Image.php
@@ -33,12 +33,14 @@ class Image extends AbstractTranslatableEntity implements EntityFileUploadInterf
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Component\Image\ImageTranslation>
      */
     #[Prezent\Translations(targetEntity: ImageTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Component/Image/ImageTranslation.php
+++ b/packages/framework/src/Component/Image/ImageTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Image;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class ImageTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Component\Image\Image
      */
     #[Prezent\Translatable(targetEntity: Image::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Component/Money/Money.php
+++ b/packages/framework/src/Component/Money/Money.php
@@ -30,6 +30,20 @@ class Money implements JsonSerializable
      */
     public static function createFromFloat(float $float, int $scale): static
     {
+        if (is_nan($float)) {
+            throw new InvalidNumericArgumentException(
+                'NAN',
+                new InvalidArgumentException('NAN and INF values are not supported'),
+            );
+        }
+
+        if (is_infinite($float)) {
+            throw new InvalidNumericArgumentException(
+                $float > 0 ? 'INF' : '-INF',
+                new InvalidArgumentException('NAN and INF values are not supported'),
+            );
+        }
+
         // Using Decimal::fromString as the Decimal::fromFloat has issues with specified scale
         // See https://github.com/Litipk/php-bignumbers/pull/67 for details
         $decimal = static::createDecimal((string)$float, $scale);

--- a/packages/framework/src/Component/Phing/PhingDownloader.php
+++ b/packages/framework/src/Component/Phing/PhingDownloader.php
@@ -84,9 +84,9 @@ class PhingDownloader
         return $this->getVersionFromString($phingLatestVersionString);
     }
 
-    protected function getVersionFromString(string $string): ?Version
+    protected function getVersionFromString(?string $string): ?Version
     {
-        if (preg_match(self::SEMVER_REGEX, $string, $matches) === 1) {
+        if ($string !== null && preg_match(self::SEMVER_REGEX, $string, $matches) === 1) {
             return new Version($matches[0]);
         }
 

--- a/packages/framework/src/Component/String/TransformStringHelper.php
+++ b/packages/framework/src/Component/String/TransformStringHelper.php
@@ -88,7 +88,9 @@ class TransformStringHelper
         $transliteratorToLatin = Transliterator::create('Any-Latin');
         $transliteratorToAscii = Transliterator::create('Latin-ASCII');
 
-        return $transliteratorToAscii->transliterate($transliteratorToLatin->transliterate($string));
+        return $string
+            |> $transliteratorToLatin->transliterate(...)
+            |> $transliteratorToAscii->transliterate(...);
     }
 
     /**
@@ -113,7 +115,12 @@ class TransformStringHelper
             return null;
         }
 
-        return trim(preg_replace('/\s\s+/', ' ', strip_tags(str_replace('<', ' <', html_entity_decode($htmlText)))));
+        return $htmlText
+            |> html_entity_decode(...)
+            |> (fn ($v) => str_replace('<', ' <', $v))
+            |> strip_tags(...)
+            |> (fn ($v) => preg_replace('/\s\s+/', ' ', $v))
+            |> trim(...);
     }
 
     public function removeStringFromStart(string $string, string $stringToRemove): string

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -121,7 +121,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
 
     protected function extractMessage(MethodCall $methodCall): void
     {
-        $firstArgumentWithMessage = reset($methodCall->args);
+        $firstArgumentWithMessage = array_first($methodCall->args);
 
         if (!($firstArgumentWithMessage->value instanceof String_)) {
             return;

--- a/packages/framework/src/Component/Translation/TwigFileExtractor.php
+++ b/packages/framework/src/Component/Translation/TwigFileExtractor.php
@@ -28,7 +28,6 @@ class TwigFileExtractor implements FileVisitorInterface
     {
         $reflectionObject = new ReflectionObject($this->originalTwigFileExtractor);
         $traverserReflectionProperty = $reflectionObject->getProperty('traverser');
-        $traverserReflectionProperty->setAccessible(true);
         /** @var \Twig\NodeTraverser $traverser */
         $traverser = $traverserReflectionProperty->getValue($this->originalTwigFileExtractor);
         $traverser->addVisitor(new CustomTransFiltersVisitor());

--- a/packages/framework/src/Component/UploadedFile/UploadedFileFacade.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileFacade.php
@@ -302,7 +302,7 @@ class UploadedFileFacade extends AbstractUploadedFileFacade
         string $type,
         UploadedFileData $uploadedFileData,
     ): int {
-        $temporaryFilename = end($uploadedFileData->uploadedFiles) ?: null;
+        $temporaryFilename = array_last($uploadedFileData->uploadedFiles);
         $hasPickerSelection = count($uploadedFileData->relations) > 0;
         $orderedFiles = $uploadedFileData->orderedFiles;
 
@@ -312,7 +312,7 @@ class UploadedFileFacade extends AbstractUploadedFileFacade
         }
 
         if (count($orderedFiles) > 0 && ($temporaryFilename || $hasPickerSelection)) {
-            $this->deleteRelationsByEntityAndUploadedFiles($entity, [reset($orderedFiles)], $type);
+            $this->deleteRelationsByEntityAndUploadedFiles($entity, [array_first($orderedFiles)], $type);
         }
 
         if ($temporaryFilename && !$hasPickerSelection) {
@@ -321,8 +321,8 @@ class UploadedFileFacade extends AbstractUploadedFileFacade
                 $entityName,
                 $type,
                 $temporaryFilename,
-                end($uploadedFileData->uploadedFilenames) ?: '',
-                end($uploadedFileData->names) ?: [],
+                array_last($uploadedFileData->uploadedFilenames) ?: '',
+                array_last($uploadedFileData->names) ?: [],
             );
 
             return 1;

--- a/packages/framework/src/Component/UploadedFile/UploadedFileTranslation.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\UploadedFile;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class UploadedFileTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile
      */
     #[Prezent\Translatable(targetEntity: UploadedFile::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -401,7 +401,7 @@ class CustomerController extends AdminBaseController
         }
 
         $customerUsers = $this->customerFacade->getCustomerUsers($customer);
-        $firstCustomerUser = reset($customerUsers);
+        $firstCustomerUser = array_first($customerUsers);
 
         return $this->generateUrl('admin_customer_edit', ['id' => $firstCustomerUser->getId()]);
     }
@@ -415,7 +415,7 @@ class CustomerController extends AdminBaseController
         }
 
         $customerUsers = $this->customerFacade->getCustomerUsers($customer);
-        $firstCustomerUser = reset($customerUsers);
+        $firstCustomerUser = array_first($customerUsers);
 
         return t('Back to customer {{ name }}', ['{{ name }}' => $firstCustomerUser->getFullName()]);
     }

--- a/packages/framework/src/Controller/Admin/DeliveryAddressController.php
+++ b/packages/framework/src/Controller/Admin/DeliveryAddressController.php
@@ -68,7 +68,7 @@ class DeliveryAddressController extends AdminBaseController
             }
 
             $customerUsers = $this->customerFacade->getCustomerUsers($customer);
-            $firstCustomerUser = reset($customerUsers);
+            $firstCustomerUser = array_first($customerUsers);
 
             return $this->redirectToRoute('admin_customer_edit', ['id' => $firstCustomerUser->getId()]);
         }
@@ -119,7 +119,7 @@ class DeliveryAddressController extends AdminBaseController
             }
 
             $customerUsers = $this->customerFacade->getCustomerUsers($customer);
-            $firstCustomerUser = reset($customerUsers);
+            $firstCustomerUser = array_first($customerUsers);
 
             return $this->redirectToRoute('admin_customer_edit', ['id' => $firstCustomerUser->getId()]);
         }
@@ -179,7 +179,7 @@ class DeliveryAddressController extends AdminBaseController
         }
 
         $customerUsers = $this->customerFacade->getCustomerUsers($customer);
-        $firstCustomerUser = reset($customerUsers);
+        $firstCustomerUser = array_first($customerUsers);
 
         return $this->generateUrl('admin_customer_edit', ['id' => $firstCustomerUser->getId()]);
     }
@@ -193,7 +193,7 @@ class DeliveryAddressController extends AdminBaseController
         }
 
         $customerUsers = $this->customerFacade->getCustomerUsers($customer);
-        $firstCustomerUser = reset($customerUsers);
+        $firstCustomerUser = array_first($customerUsers);
 
         return t('Back to customer {{ name }}', ['{{ name }}' => $firstCustomerUser->getCustomerUserFullName()]);
     }

--- a/packages/framework/src/Controller/Admin/DomainController.php
+++ b/packages/framework/src/Controller/Admin/DomainController.php
@@ -98,7 +98,7 @@ class DomainController extends AdminBaseController
                 $files = $iconData !== null ? $iconData->uploadedFiles : [];
 
                 if (count($files) !== 0) {
-                    $iconName = reset($files);
+                    $iconName = array_first($files);
 
                     $this->domainFacade->editIcon($id, $iconName);
 

--- a/packages/framework/src/Controller/Admin/NewsletterController.php
+++ b/packages/framework/src/Controller/Admin/NewsletterController.php
@@ -116,7 +116,7 @@ class NewsletterController extends AdminBaseController
             $email = $emailData['email'];
             $createdAt = $emailData['createdAt'];
             $fields = [$email, $createdAt];
-            $output->fputcsv($fields, ';');
+            $output->fputcsv($fields, ';', '"', '\\');
         }
     }
 }

--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -331,7 +331,9 @@ class ProductController extends AdminBaseController
         $products = $this->productFacade->findAllByCatnums($catnums);
 
         foreach ($products as $product) {
-            $response[$product->getCatnum()] = $product->getName();
+            if ($product->getCatnum() !== null) {
+                $response[$product->getCatnum()] = $product->getName();
+            }
         }
 
         return new JsonResponse($response);

--- a/packages/framework/src/Controller/Admin/SearchAdminController.php
+++ b/packages/framework/src/Controller/Admin/SearchAdminController.php
@@ -60,7 +60,10 @@ class SearchAdminController extends AdminBaseController
 
     protected function convertStringWithDiacritics(string $string): string
     {
-        return strtolower(preg_replace('~[\p{M}-]+~u', '', Normalizer::normalize($string, Normalizer::FORM_D)));
+        return $string
+            |> (fn ($v) => Normalizer::normalize($v, Normalizer::FORM_D))
+            |> (fn ($v) => preg_replace('~[\p{M}-]+~u', '', $v))
+            |> strtolower(...);
     }
 
     protected function buildPathByItem(ItemInterface $item): array

--- a/packages/framework/src/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -34,7 +34,9 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
                 $validators[$attributes[0]['alias']] = new Reference($id);
             }
 
-            $validators[$definition->getClass()] = new Reference($id);
+            if ($definition->getClass() !== null) {
+                $validators[$definition->getClass()] = new Reference($id);
+            }
             $validators[$id] = new Reference($id);
         }
 

--- a/packages/framework/src/Migrations/Version20241106123834.php
+++ b/packages/framework/src/Migrations/Version20241106123834.php
@@ -20,9 +20,9 @@ class Version20241106123834 extends AbstractMigration implements DomainAwareInte
     public function up(Schema $schema): void
     {
         $allowedAdminLocales = $this->administratorLocalizationFacade->getAllowedAdminLocales();
-        $defaultLocale = reset($allowedAdminLocales);
+        $defaultLocale = array_first($allowedAdminLocales);
 
-        if ($defaultLocale === false) {
+        if ($defaultLocale === null) {
             throw new AdminLocaleNotFoundException();
         }
 

--- a/packages/framework/src/Migrations/Version20241112100245.php
+++ b/packages/framework/src/Migrations/Version20241112100245.php
@@ -30,7 +30,7 @@ class Version20241112100245 extends AbstractMigration implements DomainAwareInte
         $rootBlogCategories = $this->sql('SELECT id FROM blog_categories WHERE parent_id IS NULL AND level = 0')->fetchAllAssociative();
 
         if (count($rootBlogCategories) === 1) {
-            $blogCategoryId = reset($rootBlogCategories)['id'];
+            $blogCategoryId = array_first($rootBlogCategories)['id'];
             $translation = $this->sql('SELECT 1 FROM blog_category_translations WHERE translatable_id = ?', [$blogCategoryId])->fetchOne();
 
             if ($translation === false) {

--- a/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
@@ -63,9 +63,9 @@ class AdministratorLocalizationFacade
     public function getDefaultAdminLocale(): string
     {
         $allowedAdminLocales = $this->allowedAdminLocales;
-        $defaultAdminLocale = reset($allowedAdminLocales);
+        $defaultAdminLocale = array_first($allowedAdminLocales);
 
-        if ($defaultAdminLocale === false) {
+        if ($defaultAdminLocale === null) {
             throw new AdminLocaleNotFoundException();
         }
 

--- a/packages/framework/src/Model/Blog/Article/BlogArticle.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticle.php
@@ -27,6 +27,7 @@ class BlogArticle extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -39,6 +40,7 @@ class BlogArticle extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleTranslation>
      */
     #[Prezent\Translations(targetEntity: BlogArticleTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Blog/Article/BlogArticleTranslation.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Blog\Article;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -13,6 +14,7 @@ use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 class BlogArticleTranslation extends AbstractTranslation
 {
     #[Prezent\Translatable(targetEntity: BlogArticle::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Blog/Category/BlogCategory.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategory.php
@@ -29,12 +29,14 @@ class BlogCategory extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryTranslation>
      */
     #[Prezent\Translations(targetEntity: BlogCategoryTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryTranslation.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Blog\Category;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -13,6 +14,7 @@ use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 class BlogCategoryTranslation extends AbstractTranslation
 {
     #[Prezent\Translatable(targetEntity: BlogCategory::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Category/Category.php
+++ b/packages/framework/src/Model/Category/Category.php
@@ -32,6 +32,7 @@ class Category extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -44,6 +45,7 @@ class Category extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Category\CategoryTranslation>
      */
     #[Prezent\Translations(targetEntity: CategoryTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Category/CategoryTranslation.php
+++ b/packages/framework/src/Model/Category/CategoryTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Category;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class CategoryTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Category\Category
      */
     #[Prezent\Translatable(targetEntity: Category::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
@@ -276,7 +276,7 @@ class ReadyCategorySeoMixFacade
                 $text = $parameterFilterData['minimalValue'];
                 $parameterValueId = $this->parameterFacade->getParameterValueByValueTextNumericValueAndLocale((string)$text, (string)$text, $currentLocale);
             } else {
-                $parameterUuid = reset($parameterFilterData['values']);
+                $parameterUuid = array_first($parameterFilterData['values']);
 
                 if (array_key_exists($parameterUuid, $parameterValueIdsByUuids) === false) {
                     throw new ParameterValueNotFoundException(sprintf(

--- a/packages/framework/src/Model/Complaint/Status/ComplaintStatus.php
+++ b/packages/framework/src/Model/Complaint/Status/ComplaintStatus.php
@@ -24,12 +24,14 @@ class ComplaintStatus extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusTranslation>
      */
     #[Prezent\Translations(targetEntity: ComplaintStatusTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Complaint/Status/ComplaintStatusTranslation.php
+++ b/packages/framework/src/Model/Complaint/Status/ComplaintStatusTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Complaint\Status;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class ComplaintStatusTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatus
      */
     #[Prezent\Translatable(targetEntity: ComplaintStatus::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Country/Country.php
+++ b/packages/framework/src/Model/Country/Country.php
@@ -25,6 +25,7 @@ class Country extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -39,6 +40,7 @@ class Country extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Country\CountryTranslation>
      */
     #[Prezent\Translations(targetEntity: CountryTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Country/CountryTranslation.php
+++ b/packages/framework/src/Model/Country/CountryTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Country;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class CountryTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Country\Country
      */
     #[Prezent\Translatable(targetEntity: Country::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Customer/User/CustomerUserDataFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserDataFactory.php
@@ -50,7 +50,7 @@ class CustomerUserDataFactory
     {
         $customerUserData = $this->createForCustomer($customer);
         $customerUsers = $this->customerRepository->getCustomerUsers($customer);
-        $customerUser = reset($customerUsers);
+        $customerUser = array_first($customerUsers);
         $customerUserData->pricingGroup = $customerUser->getPricingGroup();
         $customerUserData->domainId = $customerUser->getDomainId();
 

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroup.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroup.php
@@ -21,12 +21,14 @@ class CustomerUserRoleGroup extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroupTranslation>
      */
     #[Prezent\Translations(targetEntity: CustomerUserRoleGroupTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupTranslation.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Customer\User\Role;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class CustomerUserRoleGroupTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroup
      */
     #[Prezent\Translatable(targetEntity: CustomerUserRoleGroup::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/GoPay/GoPayOrderStatus.php
+++ b/packages/framework/src/Model/GoPay/GoPayOrderStatus.php
@@ -24,6 +24,10 @@ class GoPayOrderStatus
     {
         $goPaySubStatusesToTranslate = self::getGoPaySubStatusesToTranslate();
 
+        if ($goPaySubStatus === null) {
+            return null;
+        }
+
         return $goPaySubStatusesToTranslate[$goPaySubStatus] ?? null;
     }
 

--- a/packages/framework/src/Model/LanguageConstant/LanguageConstant.php
+++ b/packages/framework/src/Model/LanguageConstant/LanguageConstant.php
@@ -26,6 +26,7 @@ class LanguageConstant extends AbstractTranslatableEntity
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -44,6 +45,7 @@ class LanguageConstant extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantTranslation>
      */
     #[Prezent\Translations(targetEntity: LanguageConstantTranslation::class)]
+    #[Override]
     protected $translations;
 
     public function __construct(LanguageConstantData $languageConstantData)

--- a/packages/framework/src/Model/LanguageConstant/LanguageConstantTranslation.php
+++ b/packages/framework/src/Model/LanguageConstant/LanguageConstantTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\LanguageConstant;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class LanguageConstantTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstant
      */
     #[Prezent\Translatable(targetEntity: LanguageConstant::class)]
+    #[Override]
     protected $translatable;
 
     #[ORM\Column(type: 'text')]

--- a/packages/framework/src/Model/Order/Mail/OrderMail.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMail.php
@@ -329,7 +329,7 @@ class OrderMail implements MessageFactoryInterface
             return null;
         }
 
-        $orderRoundingItem = reset($orderRoundingItems);
+        $orderRoundingItem = array_first($orderRoundingItems);
 
         return $this->twig->render('@ShopsysFramework/Mail/Order/roundingInfo.html.twig', [
             'order' => $order,

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -883,7 +883,7 @@ class Order
             throw new OrderItemNotFoundException('Order item `transport` not found.');
         }
 
-        return reset($transports);
+        return array_first($transports);
     }
 
     public function getPaymentItem(): OrderItem
@@ -894,7 +894,7 @@ class Order
             throw new OrderItemNotFoundException('Order item `payment` not found.');
         }
 
-        return reset($payments);
+        return array_first($payments);
     }
 
     /**

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -344,7 +344,7 @@ class OrderFacade
                 $order->isFreeTransportAndPaymentApplied(),
             );
         } else {
-            $paymentPrice = reset($previousPaymentItems)->getPrice();
+            $paymentPrice = array_first($previousPaymentItems)->getPrice();
         }
 
         $orderPaymentData = $this->orderItemDataFactory->create(OrderItemTypeEnum::TYPE_PAYMENT);

--- a/packages/framework/src/Model/Order/Status/OrderStatus.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatus.php
@@ -25,12 +25,14 @@ class OrderStatus extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTranslation>
      */
     #[Prezent\Translations(targetEntity: OrderStatusTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Order/Status/OrderStatusTranslation.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatusTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Order\Status;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class OrderStatusTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus
      */
     #[Prezent\Translatable(targetEntity: OrderStatus::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -36,12 +36,14 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Payment\PaymentTranslation>
      */
     #[Prezent\Translations(targetEntity: PaymentTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Payment/PaymentTranslation.php
+++ b/packages/framework/src/Model/Payment/PaymentTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class PaymentTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Payment\Payment
      */
     #[Prezent\Translatable(targetEntity: Payment::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/PriceList/PriceListFacade.php
+++ b/packages/framework/src/Model/PriceList/PriceListFacade.php
@@ -319,7 +319,7 @@ class PriceListFacade
 
     protected function getFileContent(UploadedFileData $uploadedFileData): string
     {
-        $path = $this->fileUpload->getTemporaryFilepathForMountManager(reset($uploadedFileData->uploadedFiles));
+        $path = $this->fileUpload->getTemporaryFilepathForMountManager(array_first($uploadedFileData->uploadedFiles));
 
         return $this->mountManager->read('main://' . $path);
     }

--- a/packages/framework/src/Model/Product/Brand/Brand.php
+++ b/packages/framework/src/Model/Product/Brand/Brand.php
@@ -27,6 +27,7 @@ class Brand extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -45,6 +46,7 @@ class Brand extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Brand\BrandTranslation>
      */
     #[Prezent\Translations(targetEntity: BrandTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Product/Brand/BrandTranslation.php
+++ b/packages/framework/src/Model/Product/Brand/BrandTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class BrandTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand
      */
     #[Prezent\Translatable(targetEntity: Brand::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Product/Filter/PriceRangeRepository.php
+++ b/packages/framework/src/Model/Product/Filter/PriceRangeRepository.php
@@ -80,7 +80,7 @@ class PriceRangeRepository
             ->select('MIN(pmip.inputPrice) AS minimalPrice, MAX(pmip.inputPrice) AS maximalPrice');
 
         $priceRangeData = $queryBuilder->getQuery()->execute();
-        $priceRangeDataRow = reset($priceRangeData);
+        $priceRangeDataRow = array_first($priceRangeData);
 
         return new PriceRange(
             Money::create($priceRangeDataRow['minimalPrice'] ?? 0),

--- a/packages/framework/src/Model/Product/Flag/Flag.php
+++ b/packages/framework/src/Model/Product/Flag/Flag.php
@@ -25,6 +25,7 @@ class Flag extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -37,6 +38,7 @@ class Flag extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation>
      */
     #[Prezent\Translations(targetEntity: FlagTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Product/Flag/FlagTranslation.php
+++ b/packages/framework/src/Model/Product/Flag/FlagTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class FlagTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\Flag
      */
     #[Prezent\Translatable(targetEntity: Flag::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Product/GiftPlan/GiftCartFacade.php
+++ b/packages/framework/src/Model/Product/GiftPlan/GiftCartFacade.php
@@ -39,7 +39,7 @@ class GiftCartFacade
             $giftQuantity = $giftCartItemSetup->getQuantity();
 
             $giftCartItems = array_filter($cart->getProductGiftCartItems(), fn (CartItem $cartItem) => $cartItem->getProduct()->getId() === $giftProduct->getId());
-            $giftCartItem = reset($giftCartItems);
+            $giftCartItem = array_first($giftCartItems);
 
             if ($giftCartItem) {
                 $giftCartItem->changeQuantity($giftQuantity);

--- a/packages/framework/src/Model/Product/Parameter/Parameter.php
+++ b/packages/framework/src/Model/Product/Parameter/Parameter.php
@@ -34,6 +34,7 @@ class Parameter extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
@@ -46,6 +47,7 @@ class Parameter extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterTranslation>
      */
     #[Prezent\Translations(targetEntity: ParameterTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
@@ -141,7 +141,11 @@ class ParameterFacade
             $parameter = $this->getById((int)$parameterId);
             $parameterValue = $this->parameterRepository->getParameterValueById((int)$parameterValueId);
 
-            $parameterValueNamesIndexedByParameterNames[$parameter->getName()] = $parameterValue->getText();
+            $parameterName = $parameter->getName();
+
+            if ($parameterName !== null) {
+                $parameterValueNamesIndexedByParameterNames[$parameterName] = $parameterValue->getText();
+            }
         }
 
         return $parameterValueNamesIndexedByParameterNames;

--- a/packages/framework/src/Model/Product/Parameter/ParameterGroup.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGroup.php
@@ -27,12 +27,14 @@ class ParameterGroup extends AbstractTranslatableEntity implements OrderableEnti
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupTranslation>
      */
     #[Prezent\Translations(targetEntity: ParameterGroupTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Product/Parameter/ParameterGroupTranslation.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGroupTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class ParameterGroupTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroup
      */
     #[Prezent\Translatable(targetEntity: ParameterGroup::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Product/Parameter/ParameterTranslation.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class ParameterTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter
      */
     #[Prezent\Translatable(targetEntity: Parameter::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueFileResolver.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueFileResolver.php
@@ -37,7 +37,7 @@ class ParameterValueFileResolver
                 continue;
             }
 
-            $firstFile = reset($parameterValueFiles);
+            $firstFile = array_first($parameterValueFiles);
             $resolvedFileData = $this->uploadedFileDataExtractor->extractUploadedFileData($firstFile, $domainConfig);
 
             $parameterValuesData[$key]['parameter_value_icon_anchor_text'] = $resolvedFileData['anchorText'];

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -46,12 +46,14 @@ class Product extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\ProductTranslation>
      */
     #[Prezent\Translations(targetEntity: ProductTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Product/ProductTranslation.php
+++ b/packages/framework/src/Model/Product/ProductTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class ProductTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Product\Product
      */
     #[Prezent\Translatable(targetEntity: Product::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Product/Unit/Unit.php
+++ b/packages/framework/src/Model/Product/Unit/Unit.php
@@ -23,12 +23,14 @@ class Unit extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Unit\UnitTranslation>
      */
     #[Prezent\Translations(targetEntity: UnitTranslation::class)]
+    #[Override]
     protected $translations;
 
     public function __construct(UnitData $unitData)

--- a/packages/framework/src/Model/Product/Unit/UnitTranslation.php
+++ b/packages/framework/src/Model/Product/Unit/UnitTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Unit;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class UnitTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit
      */
     #[Prezent\Translatable(targetEntity: Unit::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/src/Model/Seo/Page/SeoPageRepository.php
+++ b/packages/framework/src/Model/Seo/Page/SeoPageRepository.php
@@ -75,6 +75,6 @@ class SeoPageRepository
             ->getQuery()
             ->getResult();
 
-        return count($seoPage) === 0 ? null : reset($seoPage);
+        return array_first($seoPage);
     }
 }

--- a/packages/framework/src/Model/Stock/ProductStockFacade.php
+++ b/packages/framework/src/Model/Stock/ProductStockFacade.php
@@ -79,7 +79,7 @@ class ProductStockFacade
 
         foreach ($stocksIndexedById as $stockId => $stock) {
             $filteredProductStockDataItem = array_filter($productStockDataItems, fn ($productStockDataItem) => $productStockDataItem->stockId === $stockId);
-            $productStockData = reset($filteredProductStockDataItem);
+            $productStockData = array_first($filteredProductStockDataItem);
 
             $productStock = $productStocksIndexedByStockId[$stockId] ?? $this->createProductStock($product, $stock);
             $productStock->edit($productStockData);

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -36,12 +36,14 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Transport\TransportTranslation>
      */
     #[Prezent\Translations(targetEntity: TransportTranslation::class)]
+    #[Override]
     protected $translations;
 
     /**

--- a/packages/framework/src/Model/Transport/TransportTranslation.php
+++ b/packages/framework/src/Model/Transport/TransportTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Transport;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -17,6 +18,7 @@ class TransportTranslation extends AbstractTranslation
      * @var \Shopsys\FrameworkBundle\Model\Transport\Transport
      */
     #[Prezent\Translatable(targetEntity: Transport::class)]
+    #[Override]
     protected $translatable;
 
     /**

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass3.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass3.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
 
+use Override;
+
 class ChildClass3 extends BaseClass3
 {
     /**
      * @var \App\Model\Category\CategoryFacade
      */
+    #[Override]
     public $categoryFacade;
 }

--- a/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -30,7 +30,7 @@ class QueryBuilderExtenderTest extends TestCase
         $queryBuilderExtender->addOrExtendJoin($queryBuilder, BaseProduct::class, 'p', '1 = 1');
 
         $joinDqlPart = $queryBuilder->getDQLPart('join');
-        $this->assertCount(1, reset($joinDqlPart));
+        $this->assertCount(1, array_first($joinDqlPart));
     }
 
     #[DataProvider('extendJoinWithExtendedEntityProvider')]

--- a/packages/framework/tests/Unit/Component/Translation/ConstraintMessageExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConstraintMessageExtractorTest.php
@@ -66,7 +66,7 @@ class ConstraintMessageExtractorTest extends TestCase
         $extractor = new ConstraintMessageExtractor($phpParserNodeHelper);
 
         $parserFactory = new ParserFactory();
-        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.3'));
+        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.5'));
         $ast = $parser->parse(file_get_contents($file->getPathname()));
 
         $catalogue = new MessageCatalogue();

--- a/packages/framework/tests/Unit/Component/Translation/ConstraintMessagePropertyExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConstraintMessagePropertyExtractorTest.php
@@ -70,7 +70,7 @@ class ConstraintMessagePropertyExtractorTest extends TestCase
         $extractor = new ConstraintMessagePropertyExtractor(new PhpParserNodeHelper());
 
         $parserFactory = new ParserFactory();
-        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.3'));
+        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.5'));
         $ast = $parser->parse(file_get_contents($file->getPathname()));
 
         $catalogue = new MessageCatalogue();

--- a/packages/framework/tests/Unit/Component/Translation/ConstraintViolationExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConstraintViolationExtractorTest.php
@@ -46,7 +46,7 @@ class ConstraintViolationExtractorTest extends TestCase
         $extractor = new ConstraintViolationExtractor();
 
         $parserFactory = new ParserFactory();
-        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.3'));
+        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.5'));
         $ast = $parser->parse(file_get_contents($file->getPathname()));
 
         $catalogue = new MessageCatalogue();

--- a/packages/framework/tests/Unit/Component/Translation/PhpFileExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/PhpFileExtractorTest.php
@@ -87,7 +87,7 @@ class PhpFileExtractorTest extends TestCase
         $extractor = $this->getExtractor();
 
         $parserFactory = new ParserFactory();
-        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.3'));
+        $parser = $parserFactory->createForVersion(PhpVersion::fromString('8.5'));
         $ast = $parser->parse(file_get_contents($file->getPathname()));
 
         $catalogue = new MessageCatalogue();

--- a/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
@@ -158,7 +158,6 @@ class CountryFormTypeTest extends TypeTestCase
         /* Entity returned by mock have to have Id properly set */
         $reflection = new ReflectionClass($country);
         $property = $reflection->getProperty('id');
-        $property->setAccessible(true);
         $property->setValue($country, 1);
 
         $this->countryFacade = $this->createStub(CountryFacade::class);

--- a/packages/framework/tests/Unit/Model/Blog/Article/Elasticsearch/FilterQueryTest.php
+++ b/packages/framework/tests/Unit/Model/Blog/Article/Elasticsearch/FilterQueryTest.php
@@ -170,7 +170,6 @@ class FilterQueryTest extends TestCase
         $blogCategory = new BlogCategory($blogCategoryData);
         $reflection = new ReflectionClass($blogCategory);
         $property = $reflection->getProperty('id');
-        $property->setAccessible(true);
         $property->setValue($blogCategory, 1);
 
         return $blogCategory;

--- a/packages/framework/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php
@@ -34,7 +34,7 @@ class CustomerUserUpdateDataFactoryTest extends TestCase
         $customer = $customerUser->getCustomer();
 
         $deliveryAddresses = $customer->getDeliveryAddresses();
-        $deliveryAddress = reset($deliveryAddresses);
+        $deliveryAddress = array_first($deliveryAddresses);
 
         $orderData = TestOrderProvider::getTestOrderData();
         $order = new Order(

--- a/packages/frontend-api/.github/workflows/run-checks-tests.yaml
+++ b/packages/frontend-api/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "elasticsearch/elasticsearch": "^7.6.1",
         "hybridauth/hybridauth": "^3.11",
         "lcobucci/jwt": "^5.4",

--- a/packages/frontend-api/phpunit.xml
+++ b/packages/frontend-api/phpunit.xml
@@ -25,5 +25,8 @@
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/frontend-api/src/Component/Files/FilesBatchLoader.php
+++ b/packages/frontend-api/src/Component/Files/FilesBatchLoader.php
@@ -98,8 +98,8 @@ class FilesBatchLoader
 
         foreach ($filesBatchLoadData as $fileBatchLoadData) {
             $entityFiles = $filesIndexedByEntityId[$fileBatchLoadData->getEntityId()] ?? [];
-            $firstFile = reset($entityFiles);
-            $files[$fileBatchLoadData->getId()] = $firstFile !== false ? $this->getResolvedFile($firstFile) : null;
+            $firstFile = array_first($entityFiles);
+            $files[$fileBatchLoadData->getId()] = $firstFile !== null ? $this->getResolvedFile($firstFile) : null;
         }
 
         return $files;

--- a/packages/frontend-api/src/Component/GqlContext/GqlContextInitializer.php
+++ b/packages/frontend-api/src/Component/GqlContext/GqlContextInitializer.php
@@ -28,7 +28,7 @@ class GqlContextInitializer implements EventSubscriberInterface
 
     public function initializeContext(ExecutorArgumentsEvent $event): void
     {
-        $flattened = new RecursiveIteratorIterator(new RecursiveArrayIterator($event->getVariableValue() ?? []));
+        $flattened = new RecursiveIteratorIterator(new RecursiveArrayIterator((array)($event->getVariableValue() ?? []), RecursiveArrayIterator::CHILD_ARRAYS_ONLY));
 
         $event->getContextValue()['args'] = iterator_to_array($flattened, true);
     }

--- a/packages/frontend-api/src/Model/Order/OrderItemApiFacade.php
+++ b/packages/frontend-api/src/Model/Order/OrderItemApiFacade.php
@@ -236,7 +236,7 @@ class OrderItemApiFacade
         if (count($orX) > 1) {
             $queryBuilder->andWhere($queryBuilder->expr()->orX(...$orX));
         } elseif (count($orX) > 0) {
-            $queryBuilder->andWhere(reset($orX));
+            $queryBuilder->andWhere(array_first($orX));
         }
     }
 

--- a/packages/frontend-api/src/Model/Resolver/OpeningHours/OpeningHoursResolverMap.php
+++ b/packages/frontend-api/src/Model/Resolver/OpeningHours/OpeningHoursResolverMap.php
@@ -24,19 +24,19 @@ class OpeningHoursResolverMap extends ResolverMap
             'OpeningHours' => [
                 'status' => function (array $openingHours): string {
                     /** @var \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours $openingHour */
-                    $openingHour = reset($openingHours);
+                    $openingHour = array_first($openingHours);
 
                     return $this->storeOpeningHoursApiProvider->getStatus($openingHour->getStore());
                 },
                 'dayOfWeek' => function (array $openingHours): int {
                     /** @var \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours $openingHour */
-                    $openingHour = reset($openingHours);
+                    $openingHour = array_first($openingHours);
 
                     return $this->dateTimeHelper->getCurrentDayOfWeek($openingHour->getStore()->getDomainId());
                 },
                 'openingHoursOfDays' => function (array $openingHours): array {
                     /** @var \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours $openingHour */
-                    $openingHour = reset($openingHours);
+                    $openingHour = array_first($openingHours);
 
                     return $this->storeOpeningHoursApiProvider->getFollowingWeekOpeningHours($openingHour->getStore());
                 },

--- a/packages/google-cloud-bundle/.github/workflows/run-checks-tests.yaml
+++ b/packages/google-cloud-bundle/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/google-cloud-bundle/composer.json
+++ b/packages/google-cloud-bundle/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "google/cloud-storage": "^1.10",
         "league/flysystem-google-cloud-storage": "^3.0",
         "shopsys/form-types-bundle": "19.0.x-dev",

--- a/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
+++ b/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php-versions: ['8.3']
+                php-versions: ['8.5']
                 composer-preferred-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "phpunit/phpunit": "^12.5",
         "symfony/framework-bundle": "^7.4",
         "symfony/http-foundation": "^7.4",

--- a/packages/http-smoke-testing/phpunit.xml
+++ b/packages/http-smoke-testing/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
+++ b/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
@@ -48,7 +48,7 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
     private function extractAttributesForController(string $controller): array
     {
         try {
-            $reflectionMethod = new ReflectionMethod($controller);
+            $reflectionMethod = ReflectionMethod::createFromMethodName($controller);
         } catch (ReflectionException $e) {
             return [];
         }

--- a/packages/luigis-box/.github/workflows/run-checks-tests.yaml
+++ b/packages/luigis-box/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/luigis-box/composer.json
+++ b/packages/luigis-box/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "shopsys/form-types-bundle": "19.0.x-dev",
         "shopsys/framework": "19.0.x-dev",
         "shopsys/frontend-api": "19.0.x-dev",

--- a/packages/luigis-box/phpunit.xml
+++ b/packages/luigis-box/phpunit.xml
@@ -25,5 +25,8 @@
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
+++ b/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
@@ -106,7 +106,7 @@ class LuigisBoxClient
         }
 
         if ($endpoint === LuigisBoxEndpointEnum::RECOMMENDATIONS) {
-            $data = reset($data);
+            $data = array_first($data);
         }
 
         return $this->getResultsIndexedByItemType($data, $endpoint, array_keys($limitsByType));
@@ -297,7 +297,7 @@ class LuigisBoxClient
             return TypeInLuigisBoxEnum::PRODUCT;
         }
 
-        return reset($types);
+        return array_first($types);
     }
 
     /**

--- a/packages/luigis-box/src/Model/Batch/LuigisBoxBatchLoader.php
+++ b/packages/luigis-box/src/Model/Batch/LuigisBoxBatchLoader.php
@@ -133,7 +133,7 @@ class LuigisBoxBatchLoader
     {
         $categoryArray = $this->categoryFacade->getVisibleCategoriesByIds([$luigisBoxResult->getIds()], $this->domain->getCurrentDomainConfig());
 
-        return reset($categoryArray);
+        return array_first($categoryArray);
     }
 
     protected function mapArticleData(LuigisBoxResult $luigisBoxResult): array
@@ -179,7 +179,7 @@ class LuigisBoxBatchLoader
         }
 
         if ($this->mainBatchLoadData === null) {
-            $this->mainBatchLoadData = reset($luigisBoxBatchLoadData);
+            $this->mainBatchLoadData = array_first($luigisBoxBatchLoadData);
         }
 
         return $this->mainBatchLoadData;

--- a/packages/maker/.github/workflows/run-checks-tests.yaml
+++ b/packages/maker/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/maker/composer.json
+++ b/packages/maker/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "doctrine/collections": "^1.5",
         "doctrine/data-fixtures": "^1.3",
         "doctrine/dbal": "^3.8.5",

--- a/packages/maker/src/EntityConfig/EntityConfig.php
+++ b/packages/maker/src/EntityConfig/EntityConfig.php
@@ -88,7 +88,7 @@ class EntityConfig
             return null;
         }
 
-        return reset($domainPropertiesOnly);
+        return array_first($domainPropertiesOnly);
     }
 
     /**

--- a/packages/maker/src/Utils/EntityChoiceHelper.php
+++ b/packages/maker/src/Utils/EntityChoiceHelper.php
@@ -84,6 +84,10 @@ class EntityChoiceHelper
      */
     protected function filterOutShopsysEntitiesThatHaveExtensionInProjectBase(array $allEntityNames): array
     {
-        return array_values(array_diff_key($allEntityNames, array_flip(array_keys($this->entityExtensionMap))));
+        return $this->entityExtensionMap
+            |> array_keys(...)
+            |> array_flip(...)
+            |> (fn ($v) => array_diff_key($allEntityNames, $v))
+            |> array_values(...);
     }
 }

--- a/packages/maker/src/Utils/NamingHelper.php
+++ b/packages/maker/src/Utils/NamingHelper.php
@@ -10,7 +10,10 @@ final class NamingHelper
 {
     public static function convertEntityNameToTableName(string $entityName): string
     {
-        return Str::asSnakeCase(Str::singularCamelCaseToPluralCamelCase(Str::getShortClassName($entityName)));
+        return $entityName
+            |> Str::getShortClassName(...)
+            |> Str::singularCamelCaseToPluralCamelCase(...)
+            |> Str::asSnakeCase(...);
     }
 
     public static function getJoinTableName(string $entityName, string $relatedEntityName): string

--- a/packages/migrations/.github/workflows/run-checks-tests.yaml
+++ b/packages/migrations/.github/workflows/run-checks-tests.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php-versions: ['8.3']
+                php-versions: ['8.5']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "doctrine/dbal": "^3.8.5",
         "doctrine/doctrine-migrations-bundle": "^3.7.0",
         "doctrine/migrations": "^3.4.1",

--- a/packages/migrations/phpunit.xml
+++ b/packages/migrations/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -120,7 +120,7 @@ class GenerateMigrationCommand extends Command
             return new MigrationsLocation($migrationDirectoriesIndexedByNamespace[$chosenNamespace], $chosenNamespace);
         }
 
-        $firstNamespace = reset($availableNamespaces);
+        $firstNamespace = array_first($availableNamespaces);
 
         return new MigrationsLocation($migrationDirectoriesIndexedByNamespace[$firstNamespace], $firstNamespace);
     }

--- a/packages/migrations/tests/Unit/Component/Doctrine/Migrations/AbstractMigrationTest.php
+++ b/packages/migrations/tests/Unit/Component/Doctrine/Migrations/AbstractMigrationTest.php
@@ -17,8 +17,6 @@ class AbstractMigrationTest extends TestCase
 
         $reflectionClass = new ReflectionClass(AbstractMigration::class);
         $addSqlMethod = $reflectionClass->getMethod('addSql');
-        $addSqlMethod->setAccessible(true);
-
         $this->expectException(MethodIsNotAllowedException::class);
 
         $addSqlMethod->invokeArgs($abstractMigrationStub, ['']);

--- a/packages/php-image/Dockerfile
+++ b/packages/php-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG LINUX_DISTRIBUTION=alpine
 ARG project_root='/'
 ARG NODE_MAJOR=24
-ARG PHP_VERSION=8.3
+ARG PHP_VERSION=8.5
 
 # Node and Composer are already installed in the node_builder and composer_builder stages
 FROM composer:latest AS composer_builder
@@ -25,7 +25,6 @@ FROM php:${PHP_VERSION}-fpm-${LINUX_DISTRIBUTION} AS base
 #  bcmath - Arbitrary precision mathematics
 #  gd - Image processing for gd extension
 #  intl - Internationalization for intl extension
-#  opcache - Opcode cache for performance
 #  pdo_pgsql - PostgreSQL driver for PDO
 #  pgsql - PostgreSQL driver
 #  zip - Zip archive handling for zip extension
@@ -68,7 +67,6 @@ RUN apk add --no-cache --virtual .build-deps \
         calendar \
         gd \
         intl \
-        opcache \
         pdo_pgsql \
         pgsql \
         zip && \

--- a/packages/php-image/README.md
+++ b/packages/php-image/README.md
@@ -1,7 +1,7 @@
 ## Shopsys PHP Image
 
 Shopsys PHP Image is an optimized docker image for running Shopsys Platform in production and development environments.
-It is based on `php:8.3-fpm-bullseye` image and contains all necessary extensions and tools for running Shopsys Platform.
+It is based on `php:8.5-fpm-alpine` image and contains all necessary extensions and tools for running Shopsys Platform.
 
 This repository is maintained by [shopsys/shopsys] monorepo, information about changes is in its `CHANGELOG` file.
 

--- a/packages/plugin-interface/.github/workflows/run-checks-tests.yaml
+++ b/packages/plugin-interface/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/plugin-interface/composer.json
+++ b/packages/plugin-interface/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "symfony/monolog-bridge": "^7.4"
     }
 }

--- a/packages/product-feed-google/.github/workflows/run-checks-tests.yaml
+++ b/packages/product-feed-google/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/product-feed-google/phpunit.xml
+++ b/packages/product-feed-google/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/product-feed-heureka-delivery/.github/workflows/run-checks-tests.yaml
+++ b/packages/product-feed-heureka-delivery/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "doctrine/orm": "^2.20.9",
         "shopsys/form-types-bundle": "19.0.x-dev",
         "shopsys/framework": "19.0.x-dev",

--- a/packages/product-feed-heureka-delivery/phpunit.xml
+++ b/packages/product-feed-heureka-delivery/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/product-feed-heureka/.github/workflows/run-checks-tests.yaml
+++ b/packages/product-feed-heureka/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-pdo": "*",

--- a/packages/product-feed-heureka/phpunit.xml
+++ b/packages/product-feed-heureka/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/product-feed-luigis-box/.github/workflows/run-checks-tests.yaml
+++ b/packages/product-feed-luigis-box/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/product-feed-luigis-box/composer.json
+++ b/packages/product-feed-luigis-box/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/product-feed-luigis-box/phpunit.xml
+++ b/packages/product-feed-luigis-box/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/product-feed-mergado/.github/workflows/run-checks-tests.yaml
+++ b/packages/product-feed-mergado/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/product-feed-mergado/composer.json
+++ b/packages/product-feed-mergado/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/product-feed-mergado/phpunit.xml
+++ b/packages/product-feed-mergado/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/product-feed-zbozi/.github/workflows/run-checks-tests.yaml
+++ b/packages/product-feed-zbozi/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^3.8.5",

--- a/packages/product-feed-zbozi/phpunit.xml
+++ b/packages/product-feed-zbozi/phpunit.xml
@@ -19,5 +19,8 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
 >
+  <php>
+    <ini name="error_reporting" value="24575"/>
+  </php>
   <source/>
 </phpunit>

--- a/packages/s3-bridge/.github/workflows/run-checks-tests.yaml
+++ b/packages/s3-bridge/.github/workflows/run-checks-tests.yaml
@@ -18,7 +18,7 @@ jobs:
             -   name: Install PHP, extensions and tools
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.3'
+                    php-version: '8.5'
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies

--- a/packages/s3-bridge/composer.json
+++ b/packages/s3-bridge/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "aws/aws-sdk-php": "^3.220.0",
         "league/flysystem": "^3.11",
         "league/flysystem-aws-s3-v3": "^3.12.2",

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -135,7 +135,7 @@
         "symfony/debug-bundle": "^7.4",
         "symfony/var-dumper": "^7.4",
         "symfony/web-profiler-bundle": "^7.4",
-        "shopsys/phpunit-injector": "^2.6.0"
+        "shopsys/phpunit-injector": "^2.7"
     },
     "conflict": {
         "symfony/symfony": "*",

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "ext-amqp": "*",
         "ext-bcmath": "*",
         "ext-ctype": "*",
@@ -175,7 +175,7 @@
         "component-dir": "web/components",
         "sort-packages": true,
         "platform": {
-            "php": "8.3.2"
+            "php": "8.5.0"
         },
         "allow-plugins": {
             "cweagans/composer-patches": true,

--- a/project-base/app/phpunit.xml
+++ b/project-base/app/phpunit.xml
@@ -25,6 +25,7 @@
     <env name="APP_ENV" value="test"/>
     <env name="APP_DEBUG" value="false"/>
     <ini name="memory_limit" value="4G"/>
+    <ini name="error_reporting" value="24575"/>
   </php>
   <testsuites>
     <testsuite name="Unit">

--- a/project-base/app/sniffer/FrontendApiNamespaceSniffer.php
+++ b/project-base/app/sniffer/FrontendApiNamespaceSniffer.php
@@ -166,8 +166,8 @@ class FrontendApiNamespaceSniffer implements Sniff
         $namespacePartsIndexedByPosition = $this->getNamespacePartsIndexedByPosition($file, $position);
 
 
-        $namespacePart = reset($namespacePartsIndexedByPosition);
-        while ($namespacePart !== false) {
+        $namespacePart = array_first($namespacePartsIndexedByPosition);
+        while ($namespacePart !== null) {
             if ($namespacePart === $checkedNamespacePart) {
                 $previousNamespacePart = prev($namespacePartsIndexedByPosition);
                 if ($previousNamespacePart !== self::FRONTEND_API_NAMESPACE_PART) {

--- a/project-base/app/src/DataFixtures/Demo/ComplaintDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ComplaintDataFixture.php
@@ -54,7 +54,7 @@ class ComplaintDataFixture extends AbstractReferenceFixture implements Dependent
         /** @var \App\Model\Order\Order $order2 */
         $order2 = $this->getReference(OrderDataFixture::ORDER_PREFIX . 2);
         $orderItems2 = $order2->getProductItems();
-        $complaintItem2 = $this->complaintHelper->createComplaintItemData(reset($orderItems2), 'Broken!', 1, [$uploadedFile4]);
+        $complaintItem2 = $this->complaintHelper->createComplaintItemData(array_first($orderItems2), 'Broken!', 1, [$uploadedFile4]);
         $complaint2 = $this->complaintHelper->createComplaint(
             $customerUser1,
             $order2,

--- a/project-base/app/src/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Performance/ProductDataFixture.php
@@ -77,7 +77,7 @@ class ProductDataFixture
 
             if ($productTemplate === false) {
                 $this->createVariants($variantCatnumsByMainVariantCatnum);
-                $productTemplate = reset($this->productTemplates);
+                $productTemplate = array_first($this->productTemplates);
             }
             $productData = $this->productDataFactory->createFromProduct($productTemplate);
             $productData->files = $this->uploadedFileDataFactory->create();

--- a/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -139,7 +139,10 @@ class ProductExportRepository extends BaseProductExportRepository
                 $variantCatnums[] = $variant->getCatnum();
             }
 
-            return trim(implode(' ', array_unique($variantCatnums)));
+            return $variantCatnums
+                |> array_unique(...)
+                |> (fn ($v) => implode(' ', $v))
+                |> trim(...);
         }
 
         return $product->getCatnum();
@@ -156,7 +159,10 @@ class ProductExportRepository extends BaseProductExportRepository
                 $variantEans[] = $variant->getEan() ?? '';
             }
 
-            return trim(implode(' ', array_unique($variantEans)));
+            return $variantEans
+                |> array_unique(...)
+                |> (fn ($v) => implode(' ', $v))
+                |> trim(...);
         }
 
         return $product->getEan() ?? '';
@@ -173,7 +179,10 @@ class ProductExportRepository extends BaseProductExportRepository
                 $variantEans[] = $variant->getPartno() ?? '';
             }
 
-            return trim(implode(' ', array_unique($variantEans)));
+            return $variantEans
+                |> array_unique(...)
+                |> (fn ($v) => implode(' ', $v))
+                |> trim(...);
         }
 
         return $product->getPartno() ?? '';

--- a/project-base/app/src/Model/Product/Product.php
+++ b/project-base/app/src/Model/Product/Product.php
@@ -58,6 +58,7 @@ class Product extends BaseProduct
      * @var string
      */
     #[ORM\Column(type: 'string', length: 100, unique: true, nullable: false)]
+    #[Override]
     protected $catnum;
 
     /**

--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -166,7 +166,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $logs = $this->entityLogRepository->getEntityLogsFromLastLogCollection($entityName, $entityId);
 
         /** @var \Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLog $log */
-        $log = reset($logs);
+        $log = array_first($logs);
 
         $this->assertSame(EntityLogActionEnum::UPDATE, $log->getAction());
         $this->assertSame($orderFromDb->getId(), $log->getEntityId());
@@ -198,11 +198,11 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $logs = $this->entityLogRepository->getEntityLogsFromLastLogCollection($entityName, $entityId);
         $orderLogs = array_filter($logs, fn (EntityLog $log) => $log->getEntityName() === 'Order');
         /** @var \Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLog $orderLog */
-        $orderLog = reset($orderLogs);
+        $orderLog = array_first($orderLogs);
 
         $orderItemLogs = array_filter($logs, fn (EntityLog $log) => $log->getEntityName() === 'OrderItem');
         /** @var \Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLog $orderItemLog */
-        $orderItemLog = reset($orderItemLogs);
+        $orderItemLog = array_first($orderItemLogs);
 
         $this->assertSame(EntityLogActionEnum::CREATE, $orderItemLog->getAction());
         $this->assertSame($productTicketName, $orderItemLog->getEntityIdentifier());
@@ -255,7 +255,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
 
         $this->assertCount(2, $logs);
         $logs = array_filter($logs, fn (EntityLog $log) => $log->getEntityName() === 'OrderItem');
-        $changeSet = reset($logs)->getChangeSet();
+        $changeSet = array_first($logs)->getChangeSet();
 
         $this->assertArrayHasKey('name', $changeSet);
 

--- a/project-base/app/tests/App/Functional/EntityExtension/EntityExtensionTest.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/EntityExtensionTest.php
@@ -225,12 +225,12 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
         $foundOneToManyBidirectionalEntities = $foundProduct->getOneToManyBidirectionalEntities();
         $this->assertCount(1, $foundOneToManyBidirectionalEntities);
-        $foundOneToManyBidirectionalEntity = reset($foundOneToManyBidirectionalEntities);
+        $foundOneToManyBidirectionalEntity = array_first($foundOneToManyBidirectionalEntities);
         $this->assertSame('one-to-many bidirectional', $foundOneToManyBidirectionalEntity->getName());
 
         $foundOneToManyUnidirectionalWithJoinTableEntities = $foundProduct->getOneToManyUnidirectionalWithJoinTableEntities();
         $this->assertCount(1, $foundOneToManyUnidirectionalWithJoinTableEntities);
-        $foundOneToManyUnidirectionalWithJoinTableEntity = reset($foundOneToManyUnidirectionalWithJoinTableEntities);
+        $foundOneToManyUnidirectionalWithJoinTableEntity = array_first($foundOneToManyUnidirectionalWithJoinTableEntities);
         $this->assertSame(
             'one-to-many unidirectional with join table',
             $foundOneToManyUnidirectionalWithJoinTableEntity->getName(),
@@ -238,7 +238,7 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
         $foundOneToManySelfReferencingEntities = $foundProduct->getOneToManySelfReferencingEntities();
         $this->assertCount(1, $foundOneToManySelfReferencingEntities);
-        $foundOneToManySelfReferencingEntity = reset($foundOneToManySelfReferencingEntities);
+        $foundOneToManySelfReferencingEntity = array_first($foundOneToManySelfReferencingEntities);
         $this->assertInstanceOf(ExtendedProduct::class, $foundOneToManySelfReferencingEntity);
         $this->assertSame(
             self::ONE_TO_MANY_SELF_REFERENCING_PRODUCT_ID,
@@ -251,19 +251,19 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
         $foundManyToManyUnidirectionalEntities = $foundProduct->getManyToManyUnidirectionalEntities();
         $this->assertCount(1, $foundManyToManyUnidirectionalEntities);
-        $foundManyToManyUnidirectionalEntity = reset($foundManyToManyUnidirectionalEntities);
+        $foundManyToManyUnidirectionalEntity = array_first($foundManyToManyUnidirectionalEntities);
         $this->assertInstanceOf(UnidirectionalEntity::class, $foundManyToManyUnidirectionalEntity);
         $this->assertSame('many-to-many unidirectional', $foundManyToManyUnidirectionalEntity->getName());
 
         $foundManyToManyBidirectionalEntities = $foundProduct->getManyToManyBidirectionalEntities();
         $this->assertCount(1, $foundManyToManyBidirectionalEntities);
-        $foundManyToManyBidirectionalEntity = reset($foundManyToManyBidirectionalEntities);
+        $foundManyToManyBidirectionalEntity = array_first($foundManyToManyBidirectionalEntities);
         $this->assertInstanceOf(ProductManyToManyBidirectionalEntity::class, $foundManyToManyBidirectionalEntity);
         $this->assertSame('many-to-many bidirectional', $foundManyToManyBidirectionalEntity->getName());
 
         $foundManyToManySelfReferencingEntities = $foundProduct->getManyToManySelfReferencingEntities();
         $this->assertCount(1, $foundManyToManySelfReferencingEntities);
-        $foundManyToManySelfReferencingEntity = reset($foundManyToManySelfReferencingEntities);
+        $foundManyToManySelfReferencingEntity = array_first($foundManyToManySelfReferencingEntities);
         $this->assertInstanceOf(ExtendedProduct::class, $foundManyToManySelfReferencingEntity);
         $this->assertSame(
             self::MANY_TO_MANY_SELF_REFERENCING_PRODUCT_ID,
@@ -271,7 +271,7 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
         );
         $foundManyToManySelfReferencingInverseEntities = $foundManyToManySelfReferencingEntity->getManyToManySelfReferencingInverseEntities();
         $this->assertCount(1, $foundManyToManySelfReferencingInverseEntities);
-        $foundManyToManySelfReferencingInverseEntity = reset($foundManyToManySelfReferencingInverseEntities);
+        $foundManyToManySelfReferencingInverseEntity = array_first($foundManyToManySelfReferencingInverseEntities);
         $this->assertInstanceOf(ExtendedProduct::class, $foundManyToManySelfReferencingInverseEntity);
         $this->assertSame($foundProduct, $foundManyToManySelfReferencingInverseEntity);
     }
@@ -357,12 +357,12 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
         $foundOneToManyBidirectionalEntities = $foundCategory->getOneToManyBidirectionalEntities();
         $this->assertCount(1, $foundOneToManyBidirectionalEntities);
-        $foundOneToManyBidirectionalEntity = reset($foundOneToManyBidirectionalEntities);
+        $foundOneToManyBidirectionalEntity = array_first($foundOneToManyBidirectionalEntities);
         $this->assertSame('one-to-many bidirectional', $foundOneToManyBidirectionalEntity->getName());
 
         $foundOneToManyUnidirectionalWithJoinTableEntities = $foundCategory->getOneToManyUnidirectionalWithJoinTableEntities();
         $this->assertCount(1, $foundOneToManyUnidirectionalWithJoinTableEntities);
-        $foundOneToManyUnidirectionalWithJoinTableEntity = reset($foundOneToManyUnidirectionalWithJoinTableEntities);
+        $foundOneToManyUnidirectionalWithJoinTableEntity = array_first($foundOneToManyUnidirectionalWithJoinTableEntities);
         $this->assertSame(
             'one-to-many unidirectional with join table',
             $foundOneToManyUnidirectionalWithJoinTableEntity->getName(),
@@ -370,7 +370,7 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
         $foundOneToManySelfReferencingEntities = $foundCategory->getOneToManySelfReferencingEntities();
         $this->assertCount(1, $foundOneToManySelfReferencingEntities);
-        $foundOneToManySelfReferencingEntity = reset($foundOneToManySelfReferencingEntities);
+        $foundOneToManySelfReferencingEntity = array_first($foundOneToManySelfReferencingEntities);
         $this->assertInstanceOf(ExtendedCategory::class, $foundOneToManySelfReferencingEntity);
         $this->assertSame(
             self::ONE_TO_MANY_SELF_REFERENCING_CATEGORY_ID,
@@ -383,19 +383,19 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
         $foundManyToManyUnidirectionalEntities = $foundCategory->getManyToManyUnidirectionalEntities();
         $this->assertCount(1, $foundManyToManyUnidirectionalEntities);
-        $foundManyToManyUnidirectionalEntity = reset($foundManyToManyUnidirectionalEntities);
+        $foundManyToManyUnidirectionalEntity = array_first($foundManyToManyUnidirectionalEntities);
         $this->assertInstanceOf(UnidirectionalEntity::class, $foundManyToManyUnidirectionalEntity);
         $this->assertSame('many-to-many unidirectional', $foundManyToManyUnidirectionalEntity->getName());
 
         $foundManyToManyBidirectionalEntities = $foundCategory->getManyToManyBidirectionalEntities();
         $this->assertCount(1, $foundManyToManyBidirectionalEntities);
-        $foundManyToManyBidirectionalEntity = reset($foundManyToManyBidirectionalEntities);
+        $foundManyToManyBidirectionalEntity = array_first($foundManyToManyBidirectionalEntities);
         $this->assertInstanceOf(CategoryManyToManyBidirectionalEntity::class, $foundManyToManyBidirectionalEntity);
         $this->assertSame('many-to-many bidirectional', $foundManyToManyBidirectionalEntity->getName());
 
         $foundManyToManySelfReferencingEntities = $foundCategory->getManyToManySelfReferencingEntities();
         $this->assertCount(1, $foundManyToManySelfReferencingEntities);
-        $foundManyToManySelfReferencingEntity = reset($foundManyToManySelfReferencingEntities);
+        $foundManyToManySelfReferencingEntity = array_first($foundManyToManySelfReferencingEntities);
         $this->assertInstanceOf(ExtendedCategory::class, $foundManyToManySelfReferencingEntity);
         $this->assertSame(
             self::MANY_TO_MANY_SELF_REFERENCING_CATEGORY_ID,
@@ -403,7 +403,7 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
         );
         $foundManyToManySelfReferencingInverseEntities = $foundManyToManySelfReferencingEntity->getManyToManySelfReferencingInverseEntities();
         $this->assertCount(1, $foundManyToManySelfReferencingInverseEntities);
-        $foundManyToManySelfReferencingInverseEntity = reset($foundManyToManySelfReferencingInverseEntities);
+        $foundManyToManySelfReferencingInverseEntity = array_first($foundManyToManySelfReferencingInverseEntities);
         $this->assertInstanceOf(ExtendedCategory::class, $foundManyToManySelfReferencingInverseEntity);
         $this->assertSame($foundCategory, $foundManyToManySelfReferencingInverseEntity);
     }

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/Category/Category.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/Category/Category.php
@@ -26,6 +26,7 @@ class Category extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     #[ORM\Column(type: 'guid', unique: true)]
@@ -35,6 +36,7 @@ class Category extends AbstractTranslatableEntity
      * @var \Doctrine\Common\Collections\Collection<int, \Tests\App\Functional\EntityExtension\Model\Category\CategoryTranslation>
      */
     #[Prezent\Translations(targetEntity: CategoryTranslation::class)]
+    #[Override]
     protected $translations;
 
     #[Gedmo\TreeParent]

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/Category/CategoryTranslation.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/Category/CategoryTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\App\Functional\EntityExtension\Model\Category;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class CategoryTranslation extends AbstractTranslation
      * @var \Tests\App\Functional\EntityExtension\Model\Category\Category
      */
     #[Prezent\Translatable(targetEntity: Category::class)]
+    #[Override]
     protected $translatable;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/ExtendedDummyEntity.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/ExtendedDummyEntity.php
@@ -6,6 +6,7 @@ namespace Tests\App\Functional\EntityExtension\Model;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
 
 #[ORM\Entity]
@@ -19,5 +20,6 @@ class ExtendedDummyEntity extends DummyEntity
     #[ORM\ManyToMany(targetEntity: Flag::class)]
     #[ORM\JoinTable(name: 'dummy_flags')]
     #[ORM\OrderBy(['id' => 'DESC'])]
+    #[Override]
     protected Collection $flags;
 }

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/Product/Product.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/Product/Product.php
@@ -28,12 +28,14 @@ class Product extends AbstractTranslatableEntity
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Override]
     protected $id;
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int, \Tests\App\Functional\EntityExtension\Model\Product\ProductTranslation>
      */
     #[Prezent\Translations(targetEntity: ProductTranslation::class)]
+    #[Override]
     protected $translations;
 
     #[ORM\Column(type: 'string', length: 100, nullable: true)]

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/Product/ProductTranslation.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/Product/ProductTranslation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\App\Functional\EntityExtension\Model\Product;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
 
@@ -16,6 +17,7 @@ class ProductTranslation extends AbstractTranslation
      * @var \Tests\App\Functional\EntityExtension\Model\Product\Product
      */
     #[Prezent\Translatable(targetEntity: Product::class)]
+    #[Override]
     protected $translatable;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]

--- a/project-base/app/tests/App/Functional/Model/Product/Elasticsearch/ProductExportRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Elasticsearch/ProductExportRepositoryTest.php
@@ -19,7 +19,7 @@ class ProductExportRepositoryTest extends TransactionFunctionalTestCase
         $data = $this->repository->getProductsData($this->domain->getId(), $this->domain->getLocale(), 0, 10);
         $this->assertCount(10, $data);
 
-        $structure = array_keys(reset($data));
+        $structure = array_keys(array_first($data));
         sort($structure);
 
         $expectedStructure = $this->getExpectedStructureForRepository();

--- a/project-base/app/tests/App/Performance/JmeterCsvReporter.php
+++ b/project-base/app/tests/App/Performance/JmeterCsvReporter.php
@@ -19,7 +19,7 @@ class JmeterCsvReporter
             'success',
             'URL',
             'Variables',
-        ]);
+        ], ',', '"', '\\');
     }
 
     /**
@@ -42,6 +42,6 @@ class JmeterCsvReporter
             $isSuccessful ? 'true' : 'false',
             '/' . $relativeUrl,
             $queryCount,
-        ]);
+        ], ',', '"', '\\');
     }
 }

--- a/project-base/app/tests/App/Test/Codeception/AcceptanceTester.php
+++ b/project-base/app/tests/App/Test/Codeception/AcceptanceTester.php
@@ -39,7 +39,7 @@ class AcceptanceTester extends Actor implements ActorInterface
 
         $closure = Closure::fromCallable(function (RemoteWebDriver $webdriver): void {
             $handles = $webdriver->getWindowHandles();
-            $lastWindow = end($handles);
+            $lastWindow = array_last($handles);
             $this->switchToWindow($lastWindow);
         });
 

--- a/project-base/app/tests/App/Unit/Tests/Performance/Page/PerformanceResultsCsvExporterTest.php
+++ b/project-base/app/tests/App/Unit/Tests/Performance/Page/PerformanceResultsCsvExporterTest.php
@@ -96,10 +96,10 @@ class PerformanceResultsCsvExporterTest extends TestCase
 
         // seek to $rowIndex
         for ($i = 0; $i < $lineIndex; $i++) {
-            fgetcsv($handle);
+            fgetcsv($handle, null, ',', '"', '\\');
         }
 
-        return fgetcsv($handle);
+        return fgetcsv($handle, null, ',', '"', '\\');
     }
 
     private function createPerformanceResultsCsvExporter(): PerformanceResultsCsvExporter

--- a/project-base/app/tests/FrontendApiBundle/Functional/CategorySeo/CategorySeoTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/CategorySeo/CategorySeoTest.php
@@ -327,7 +327,7 @@ class CategorySeoTest extends GraphQlTestCase
             },
         );
 
-        $colorFilterValues = reset($colorFilter)['values'];
+        $colorFilterValues = array_first($colorFilter)['values'];
         $black = t('black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale());
 
         $blackColorFilter = array_filter(
@@ -337,6 +337,6 @@ class CategorySeoTest extends GraphQlTestCase
             },
         );
 
-        $this->assertTrue(reset($blackColorFilter)['isSelected']);
+        $this->assertTrue(array_first($blackColorFilter)['isSelected']);
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/DeliveryAddressIsNotDuplicatedTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/DeliveryAddressIsNotDuplicatedTest.php
@@ -40,7 +40,7 @@ class DeliveryAddressIsNotDuplicatedTest extends GraphQlWithLoginTestCase
         $this->getResponseContentForGql(__DIR__ . '/../_graphql/mutation/CreateOrderMutation.graphql', $orderVariables);
 
         $deliveryAddresses = $this->getCustomersDeliveryAddresses();
-        $lastDeliveryAddressUuid = end($deliveryAddresses)['uuid'];
+        $lastDeliveryAddressUuid = array_last($deliveryAddresses)['uuid'];
 
         $this->assertCount(2, $deliveryAddresses);
 
@@ -55,7 +55,7 @@ class DeliveryAddressIsNotDuplicatedTest extends GraphQlWithLoginTestCase
         $deliveryAddresses = $this->getCustomersDeliveryAddresses();
 
         $this->assertCount(2, $deliveryAddresses);
-        $this->assertEquals($lastDeliveryAddressUuid, end($deliveryAddresses)['uuid']);
+        $this->assertEquals($lastDeliveryAddressUuid, array_last($deliveryAddresses)['uuid']);
     }
 
     private function initializeCart(): void

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductTest.php
@@ -511,6 +511,6 @@ class ProductTest extends GraphQlTestCase
         $redColorParameterValue = $this->getReference(ParameterColorValueDataFixture::PARAMETER_VALUE_RED_REFERENCE_PREFIX . $locale, ParameterValue::class);
         $allFilesArray = $this->getFilesByEntity($redColorParameterValue);
 
-        return reset($allFilesArray);
+        return array_first($allFilesArray);
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringOptionsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringOptionsTest.php
@@ -769,6 +769,6 @@ class ProductsFilteringOptionsTest extends GraphQlTestCase
         $redColorParameterValue = $this->getReference(ParameterColorValueDataFixture::PARAMETER_VALUE_RED_REFERENCE_PREFIX . $this->firstDomainLocale, ParameterValue::class);
         $allFilesArray = $this->getFilesByEntity($redColorParameterValue);
 
-        return reset($allFilesArray);
+        return array_first($allFilesArray);
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserOwnerTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserOwnerTest.php
@@ -290,7 +290,7 @@ class CustomerUserOwnerTest extends GraphQlB2bDomainWithLoginTestCase
     {
         $anotherUserOrder = $this->getReferenceForDomain(CompanyOrderDataFixture::COMPANY_ORDER_PREFIX . 3, $this->domain->getId(), Order::class);
         $orderItems = $anotherUserOrder->getItems();
-        $orderItem = reset($orderItems);
+        $orderItem = array_first($orderItems);
         $response = $this->getResponseContentForGql(
             __DIR__ . '/../../Functional/Complaint/graphql/CreateComplaintMutation.graphql',
             [

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserSelfManageTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserSelfManageTest.php
@@ -171,7 +171,7 @@ class CustomerUserSelfManageTest extends GraphQlB2bDomainWithLoginTestCase
     private function getCreateComplaintResponse(Order $order): array
     {
         $orderItems = $order->getItems();
-        $orderItem = reset($orderItems);
+        $orderItem = array_first($orderItems);
 
         return $this->getResponseContentForGql(
             __DIR__ . '/../../Functional/Complaint/graphql/CreateComplaintMutation.graphql',

--- a/project-base/app/web/imageResizer.php
+++ b/project-base/app/web/imageResizer.php
@@ -64,9 +64,15 @@ if ($CDN_DOMAIN === '' || $CDN_API_KEY === null || $CDN_API_SALT === null) {
 
     $extension = getExtension($IMAGE_URL);
 
-    $encodedUrl = rtrim(strtr(base64_encode($IMAGE_URL), '+/', '-_'), '=');
+    $encodedUrl = $IMAGE_URL
+        |> base64_encode(...)
+        |> (fn($v) => strtr($v, '+/', '-_'))
+        |> (fn($v) => rtrim($v, '='));
     $path = "/{$resize}/{$width}/{$height}/{$gravity}/{$enlarge}/{$encodedUrl}.{$extension}";
-    $signature = rtrim(strtr(base64_encode(hash_hmac('sha256', $saltBin . "/" . $ttl . "/" . $path, $keyBin, true)), '+/', '-_'), '=');
+    $signature = hash_hmac('sha256', $saltBin . "/" . $ttl . "/" . $path, $keyBin, true)
+        |> base64_encode(...)
+        |> (fn($v) => strtr($v, '+/', '-_'))
+        |> (fn($v) => rtrim($v, '='));
 
     $imageUrl = sprintf("%s/zoh4eiLi/IMG/%d/%s%s", $CDN_DOMAIN, $ttl, $signature, $path);
 }

--- a/project-base/app/web/imageResizer.php
+++ b/project-base/app/web/imageResizer.php
@@ -96,8 +96,6 @@ function getImageFromUrl(string $url): void
     $image = curl_exec($ch);
     $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
     $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-
     if ($statusCode !== 200 || !$image) {
         render404();
         exit;

--- a/project-base/app/web/imageResizer.php
+++ b/project-base/app/web/imageResizer.php
@@ -152,7 +152,7 @@ function findExactOrClosestLargerOrLargestImageSize(int $requestedImageSize, arr
         }
     }
 
-    return end($allowedImageSizes);
+    return array_last($allowedImageSizes);
 }
 
 function render404(): void

--- a/project-base/gatling/makeSummary.php
+++ b/project-base/gatling/makeSummary.php
@@ -148,7 +148,10 @@ class Summary
 }
 
 $summaryPath = '/gatlingResults/' . getenv('SUMMARY_DIR');
-$simulationDirs = explode("\n", str_replace("\r", '', file_get_contents($summaryPath . '/results.log')));
+$simulationDirs = $summaryPath . '/results.log'
+    |> file_get_contents(...)
+    |> (fn($v) => str_replace("\r", '', $v))
+    |> (fn($v) => explode("\n", $v));
 $simulationDirs = array_filter($simulationDirs);
 
 ob_start(function ($content) use ($summaryPath) {
@@ -159,10 +162,10 @@ ob_start(function ($content) use ($summaryPath) {
 
 $summary = new Summary();
 foreach ($simulationDirs as $simulationDir) {
-    $lines = explode(
-        "\n",
-        str_replace("\r", '', file_get_contents('/gatlingResults/' . $simulationDir . '/simulation.log'))
-    );
+    $lines = '/gatlingResults/' . $simulationDir . '/simulation.log'
+        |> file_get_contents(...)
+        |> (fn($v) => str_replace("\r", '', $v))
+        |> (fn($v) => explode("\n", $v));
 
     foreach ($lines as $line) {
         $data = explode("\t", $line);

--- a/project-base/gatling/makeSummary.php
+++ b/project-base/gatling/makeSummary.php
@@ -48,14 +48,14 @@ class PageStats
     {
         $this->checkFrozen();
 
-        return reset($this->requestsTimes);
+        return array_first($this->requestsTimes);
     }
 
     public function getMaxRequestTime(): int
     {
         $this->checkFrozen();
 
-        return end($this->requestsTimes);
+        return array_last($this->requestsTimes);
     }
 
     public function getAvgRequestTime(): int

--- a/project-base/scripts/install-docker-wsl-debian.sh
+++ b/project-base/scripts/install-docker-wsl-debian.sh
@@ -25,13 +25,13 @@ printf "${GREEN}Installing docker compose${NC}\n"
 sudo curl -L "https://github.com/docker/compose/releases/download/2.29.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
-printf "${GREEN}Installing PHP 8.3${NC}\n"
+printf "${GREEN}Installing PHP 8.5${NC}\n"
 
 wget https://packages.sury.org/php/apt.gpg
 sudo apt-key add apt.gpg
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/php7.list
 sudo apt update
-sudo apt install -y php8.3
+sudo apt install -y php8.5
 
 printf "${GREEN}Installing Composer${NC}\n"
 

--- a/upgrade-notes/backend_20260223_225326.md
+++ b/upgrade-notes/backend_20260223_225326.md
@@ -1,0 +1,4 @@
+#### PHP 8.5 compatibility ([#4470](https://github.com/shopsys/shopsys/pull/4470))
+
+- see #project-base-diff to update your project
+- for reference, see [PHP 8.4 migration guide](https://www.php.net/manual/en/migration84.php) and [PHP 8.5 migration guide](https://www.php.net/manual/en/migration85.php)

--- a/utils/license-acknowledgements-generator/template.md
+++ b/utils/license-acknowledgements-generator/template.md
@@ -75,7 +75,7 @@ License: MIT
 https://github.com/nodejs/docker-node/blob/main/LICENSE
 
 ### Php
-Image: `php:8.3-fpm-bullseye`  
+Image: `php:8.5-fpm-alpine`  
 License: The PHP License  
 http://php.net/license/
 


### PR DESCRIPTION
#### Description, the reason for the PR
- Pipe operator adoption — Many internal method implementations now use PHP 8.5 |> operator, so your project needs PHP 8.5+
- #[\Override] on properties
- litipk/php-bignumbers switched to bigcommerce/php-bignumbers fork
- PHPUnit E_DEPRECATED suppression to prevent vendor deprecation notices

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://tl-php-8-5.odin.shopsys.cloud
  - https://cz.tl-php-8-5.odin.shopsys.cloud
  - https://tl-php-8-5.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772029225.654169 -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-php-8-5.odin.shopsys.cloud
  - https://cz.tl-php-8-5.odin.shopsys.cloud
  - https://tl-php-8-5.odin.shopsys.cloud/sk
<!-- Replace -->
