### PR TITLE
phpstan: keep symfony private-service ignores in monorepo config only

### DIFF
--- a/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
+++ b/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
@@ -57,10 +57,7 @@ trait FlashMessageTrait
 
     protected function renderStringTwigTemplate(string $template, array $parameters = []): string
     {
-        /**
-         * @var \Twig\Environment $twigEnvironment
-         * @phpstan-ignore symfonyContainer.privateService (Twig service is intentionally fetched from the container in this trait)
-         */
+        /** @var \Twig\Environment $twigEnvironment */
         $twigEnvironment = $this->container->get('twig');
         $twigTemplate = $twigEnvironment->createTemplate($template);
 

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
@@ -14,10 +14,7 @@ class RegisterExtendedEntitiesCompilerPass implements CompilerPassInterface
     #[Override]
     public function process(ContainerBuilder $container): void
     {
-        /**
-         * @var \Doctrine\ORM\Mapping\Driver\AttributeDriver $attributeReader
-         * @phpstan-ignore symfonyContainer.privateService (Metadata driver service is intentionally fetched in compiler pass)
-         */
+        /** @var \Doctrine\ORM\Mapping\Driver\AttributeDriver $attributeReader */
         $attributeReader = $container->get('doctrine.orm.default_metadata_driver');
 
         $entityExtensionMap = [];

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterImageEntitiesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterImageEntitiesCompilerPass.php
@@ -20,10 +20,7 @@ class RegisterImageEntitiesCompilerPass implements CompilerPassInterface
     #[Override]
     public function process(ContainerBuilder $container): void
     {
-        /**
-         * @var \Doctrine\ORM\Mapping\Driver\AttributeDriver $attributeReader
-         * @phpstan-ignore symfonyContainer.privateService (Metadata driver service is intentionally fetched in compiler pass)
-         */
+        /** @var \Doctrine\ORM\Mapping\Driver\AttributeDriver $attributeReader */
         $attributeReader = $container->get('doctrine.orm.default_metadata_driver');
         $allClasses = $attributeReader->getAllClassNames();
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,16 @@ parameters:
         constantHassers: false
 
     ignoreErrors:
+        # Monorepo-only: these are reported only when Symfony container metadata from project-base is available.
+        -
+            identifier: symfonyContainer.privateService
+            path: %currentWorkingDirectory%/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
+        -
+            identifier: symfonyContainer.privateService
+            path: %currentWorkingDirectory%/packages/framework/src/DependencyInjection/Compiler/RegisterImageEntitiesCompilerPass.php
+        -
+            identifier: symfonyContainer.privateService
+            path: %currentWorkingDirectory%/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
         # shopsys/framework - don't forget to add these rules to phpstan.neon in framework
         -
             message: '#^Unsafe usage of new static\(\).#'


### PR DESCRIPTION
#### Description, the reason for the PR
This is a fix of fix introduced in #4466 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-php-stan-better.odin.shopsys.cloud
  - https://cz.rv-fix-php-stan-better.odin.shopsys.cloud
  - https://rv-fix-php-stan-better.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772018503.788119 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-php-stan-better.odin.shopsys.cloud
  - https://cz.rv-fix-php-stan-better.odin.shopsys.cloud
  - https://rv-fix-php-stan-better.odin.shopsys.cloud/sk
<!-- Replace -->
