### PR TITLE
Packeta widget now filters pickup points based on the configured country per domain

### DIFF
--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/transportAndPaymentUtils.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/transportAndPaymentUtils.tsx
@@ -28,9 +28,11 @@ import { useCurrentCart } from 'utils/cart/useCurrentCart';
 import { getPublicConfigProperty } from 'utils/config/getNextConfig';
 import { hasValidationErrors } from 'utils/errors/hasValidationErrors';
 import { logException } from 'utils/errors/logException';
+import useTranslation from 'utils/i18n/useTranslationWrapper';
 import { isPacketeryTransport, mapPacketeryExtendedPoint, packeteryPick } from 'utils/packetery';
 import { StoreOrPacketeryPoint } from 'utils/packetery/types';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
+import { showErrorMessage } from 'utils/toasts/showErrorMessage';
 
 const PickupPlacePopup = dynamic(
     () => import('components/Blocks/Popup/PickupPlacePopup').then((component) => component.PickupPlacePopup),
@@ -68,7 +70,9 @@ export const useTransportChangeInSelect = (
     changeTransportHandler: ChangeTransportInCart,
     changePaymentHandler: ChangePaymentInCart,
 ) => {
-    const { defaultLocale } = useDomainConfig();
+    const { defaultLocale, packeteryCountry } = useDomainConfig();
+    const { t } = useTranslation();
+    const isPacketeryScriptLoadingRef = useRef(false);
     const [preSelectedPickupPlace, setPreSelectedPickupPlace] = useState(lastOrderPickupPlace);
     const clearPacketeryPickupPoint = usePersistStore((store) => store.clearPacketeryPickupPoint);
     const setPacketeryPickupPoint = usePersistStore((store) => store.setPacketeryPickupPoint);
@@ -126,24 +130,50 @@ export const useTransportChangeInSelect = (
     };
 
     const openPacketeryPopup = (newTransport: TypeTransportWithAvailablePaymentsFragment) => {
-        // packeteryApiKey is available from module scope
-
         if (!packeteryApiKey.length) {
             logException('Packeta API key was not set');
             return;
         }
 
-        packeteryPick(
-            packeteryApiKey,
-            (packeteryPoint) => {
-                if (packeteryPoint) {
-                    const mappedPacketeryPoint = mapPacketeryExtendedPoint(packeteryPoint);
-                    setPacketeryPickupPoint(mappedPacketeryPoint);
-                    changeTransportHandler(newTransport.uuid, mappedPacketeryPoint);
-                }
-            },
-            { language: defaultLocale },
-        );
+        const pickWithPacketery = () => {
+            packeteryPick(
+                packeteryApiKey,
+                (packeteryPoint) => {
+                    if (packeteryPoint) {
+                        const mappedPacketeryPoint = mapPacketeryExtendedPoint(packeteryPoint);
+                        setPacketeryPickupPoint(mappedPacketeryPoint);
+                        changeTransportHandler(newTransport.uuid, mappedPacketeryPoint);
+                    }
+                },
+                { language: defaultLocale, country: packeteryCountry },
+            );
+        };
+
+        if (window.Packeta?.Widget.pick !== undefined) {
+            pickWithPacketery();
+            return;
+        }
+
+        if (isPacketeryScriptLoadingRef.current) {
+            return;
+        }
+
+        isPacketeryScriptLoadingRef.current = true;
+        const script = document.createElement('script');
+        script.src = 'https://widget.packeta.com/v6/www/js/library.js';
+        script.async = true;
+        document.body.appendChild(script);
+
+        script.onload = () => {
+            isPacketeryScriptLoadingRef.current = false;
+            pickWithPacketery();
+        };
+
+        script.onerror = () => {
+            isPacketeryScriptLoadingRef.current = false;
+            showErrorMessage(t('Failed to load Packeta widget. Please try again later.'));
+            logException('Packetery script failed to load');
+        };
     };
 
     const openPersonalPickupPopup = (newTransport: TypeTransportWithAvailablePaymentsFragment) => {

--- a/project-base/storefront/next.config.js
+++ b/project-base/storefront/next.config.js
@@ -72,6 +72,7 @@ const nextConfig = {
                 },
                 gtmId: process.env.GTM_ID,
                 isLuigisBoxActive: (process.env.LUIGIS_BOX_ENABLED_DOMAIN_IDS ?? '').split(',').includes('1'),
+                packeteryCountry: 'cz',
                 type: 'B2C',
             },
             {
@@ -88,6 +89,7 @@ const nextConfig = {
                 },
                 gtmId: process.env.GTM_ID,
                 isLuigisBoxActive: (process.env.LUIGIS_BOX_ENABLED_DOMAIN_IDS ?? '').split(',').includes('2'),
+                packeteryCountry: 'cz',
                 type: 'B2B',
             },
             {
@@ -104,6 +106,7 @@ const nextConfig = {
                 },
                 gtmId: process.env.GTM_ID,
                 isLuigisBoxActive: (process.env.LUIGIS_BOX_ENABLED_DOMAIN_IDS ?? '').split(',').includes('2'),
+                packeteryCountry: 'sk',
                 type: 'B2B',
             },
         ],

--- a/project-base/storefront/pages/order/transport-and-payment.tsx
+++ b/project-base/storefront/pages/order/transport-and-payment.tsx
@@ -9,7 +9,6 @@ import { GtmPageType } from 'gtm/enums/GtmPageType';
 import { useGtmStaticPageViewEvent } from 'gtm/factories/useGtmStaticPageViewEvent';
 import { useGtmPageViewEvent } from 'gtm/utils/pageViewEvents/useGtmPageViewEvent';
 import { useGtmPaymentAndTransportPageViewEvent } from 'gtm/utils/pageViewEvents/useGtmPaymentAndTransportPageViewEvent';
-import Script from 'next/script';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps, ServerSidePropsType } from 'utils/serverSide/initServerSideProps';
 
@@ -20,8 +19,6 @@ const TransportAndPaymentPage: FC<ServerSidePropsType> = () => {
 
     return (
         <>
-            <Script src="https://widget.packeta.com/v6/www/js/library.js" strategy="afterInteractive" />
-
             <MetaRobots content="noindex" />
 
             <TransportAndPaymentContent />

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -205,6 +205,7 @@
     "Expand store info": "Rozbalit informace o prodejně",
     "Failed": "Chyba",
     "Failed to initialize payment gateway. Please try again.": "Nepodařilo se inicializovat platební bránu. Zkuste to prosím znovu.",
+    "Failed to load Packeta widget. Please try again later.": "Nepodařilo se načíst widget Packeta. Zkuste to prosím později.",
     "Failed to load payment gateway. Please try again.": "Nepodařilo se načíst platební bránu. Zkuste to prosím znovu.",
     "Faster checkout for purchases": "Rychlejší dokončení nákupu",
     "Files": "Soubory",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -191,6 +191,7 @@
     "Expand store info": "Expand store info",
     "Failed": "Failed",
     "Failed to initialize payment gateway. Please try again.": "Failed to initialize payment gateway. Please try again.",
+    "Failed to load Packeta widget. Please try again later.": "Failed to load Packeta widget. Please try again later.",
     "Failed to load payment gateway. Please try again.": "Failed to load payment gateway. Please try again.",
     "Faster checkout for purchases": "Faster checkout for purchases",
     "Files": "Files",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -205,6 +205,7 @@
     "Expand store info": "Rozbaliť informácie o obchode",
     "Failed": "Chyba",
     "Failed to initialize payment gateway. Please try again.": "Nepodarilo sa inicializovať platobnú bránu. Skúste to prosím znova.",
+    "Failed to load Packeta widget. Please try again later.": "Nepodarilo sa načítať widget Packeta. Skúste to prosím neskôr.",
     "Failed to load payment gateway. Please try again.": "Nepodarilo sa načítať platobnú bránu. Skúste to prosím znova.",
     "Faster checkout for purchases": "Rýchlejšie dokončenie nákupu",
     "Files": "Súbory",

--- a/project-base/storefront/types/globals.d.ts
+++ b/project-base/storefront/types/globals.d.ts
@@ -17,7 +17,7 @@ declare global {
     type SvgFC<P = object> = FC<P & SVGProps<SVGSVGElement>>;
 
     interface Window {
-        Packeta: {
+        Packeta?: {
             Viewport: {
                 element: null;
                 originalValue: null;

--- a/project-base/storefront/utils/config/getNextConfig.ts
+++ b/project-base/storefront/utils/config/getNextConfig.ts
@@ -22,6 +22,7 @@ interface NextConfigPublicRuntimeConfig {
         };
         gtmId?: string;
         isLuigisBoxActive: boolean;
+        packeteryCountry?: string;
         type: string;
     }>;
     cdnDomain?: string;

--- a/project-base/storefront/utils/domain/domainConfig.ts
+++ b/project-base/storefront/utils/domain/domainConfig.ts
@@ -20,6 +20,7 @@ export type DomainConfigType = {
     };
     gtmId?: string;
     isLuigisBoxActive: boolean;
+    packeteryCountry?: string;
     type: CustomerUserAreaEnum;
 };
 

--- a/project-base/storefront/utils/packetery/index.ts
+++ b/project-base/storefront/utils/packetery/index.ts
@@ -16,7 +16,8 @@ export const packeteryPick: PacketeryPickFunction = (apiKey, callback, opts, inE
         return;
     }
 
-    window.Packeta.Widget.pick(apiKey, callback, opts, inElement);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    window.Packeta?.Widget?.pick?.(apiKey, callback, opts, inElement);
 };
 
 export const mapPacketeryExtendedPoint = (packeteryExtendedPoint: PacketeryExtendedPoint): StoreOrPacketeryPoint => ({

--- a/upgrade-notes/storefront_20260225_111236.md
+++ b/upgrade-notes/storefront_20260225_111236.md
@@ -1,0 +1,7 @@
+#### Lazy-load Packeta widget and add country filtering ([#4476](https://github.com/shopsys/shopsys/pull/4476))
+
+- the Packeta widget script is no longer loaded globally via `<Script>` on the transport-and-payment page; it is now loaded on-demand when the user opens the Packeta pickup place popup
+- added `packeteryCountry` property to domain configuration (`DomainConfigType` in `domainConfig.ts`, `NextConfigPublicRuntimeConfig` in `getNextConfig.ts`, and `next.config.js`) to filter Packeta pickup points by country; supports multiple countries as a comma-separated string (e.g. `"cz,sk"`)
+- changed `Window.Packeta` type from required to optional in `globals.d.ts` (the widget script is no longer guaranteed to be loaded)
+- added error handling with a toast message when the Packeta script fails to load
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Lazy-load the Packeta widget script on-demand instead of globally, and add per-domain country filtering along with loading/error UX.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3898-packeta.odin.shopsys.cloud
  - https://cz.tc-ssp-3898-packeta.odin.shopsys.cloud
  - https://tc-ssp-3898-packeta.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772617652.020509 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3898-packeta.odin.shopsys.cloud
  - https://cz.tc-ssp-3898-packeta.odin.shopsys.cloud
  - https://tc-ssp-3898-packeta.odin.shopsys.cloud/sk
<!-- Replace -->
