### PR TITLE
autocomplete search now shows "no results" message when LuigisBox returns no results

### DIFF
--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup.tsx
@@ -47,8 +47,8 @@ export const AutocompleteSearchPopup: FC<AutocompleteProps> = ({
     const isWithResults = !!(
         articlesSearch?.length ||
         brandSearch?.length ||
-        categoriesSearch?.totalCount ||
-        productsSearch?.totalCount
+        categoriesSearch?.edges?.length ||
+        productsSearch?.edges?.length
     );
 
     const showSearchResults = !showFavorites;

--- a/upgrade-notes/storefront_20260225_121823.md
+++ b/upgrade-notes/storefront_20260225_121823.md
@@ -1,0 +1,4 @@
+#### Empty Luigis box ([#4477](https://github.com/shopsys/shopsys/pull/4477))
+
+- LuigisBox sets totalCount to -1 for non-main types, which is truthy in JavaScript, causing the "no results" check to always evaluate as "has results"
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed info message when Luigis box returns -1.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3899-empty-luigis-box.odin.shopsys.cloud
  - https://cz.tc-ssp-3899-empty-luigis-box.odin.shopsys.cloud
  - https://tc-ssp-3899-empty-luigis-box.odin.shopsys.cloud/sk
<!-- Replace -->
