### PR TITLE
design: Tom-Select dropdown now renders above the fixed bottom bar

### DIFF
--- a/packages/administration/assets/src/styles/tom-select.scss
+++ b/packages/administration/assets/src/styles/tom-select.scss
@@ -1,3 +1,7 @@
 .ts-hidden-accessible {
     left: 0 !important;
 }
+
+.ts-dropdown {
+    z-index: 1020 !important;
+}


### PR DESCRIPTION
#### Description, the reason for the PR
Fix select box z-index.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3886-country-select-list.odin.shopsys.cloud
  - https://cz.tc-ssp-3886-country-select-list.odin.shopsys.cloud
  - https://tc-ssp-3886-country-select-list.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772611978.974059 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3886-country-select-list.odin.shopsys.cloud
  - https://cz.tc-ssp-3886-country-select-list.odin.shopsys.cloud
  - https://tc-ssp-3886-country-select-list.odin.shopsys.cloud/sk
<!-- Replace -->
