### PR TITLE
FE API: rollback mutation & discard async messages on error

### DIFF
--- a/.agents/skills/test-writing/SKILL.md
+++ b/.agents/skills/test-writing/SKILL.md
@@ -2,13 +2,21 @@
 name: test-writing
 description: >
   This skill MUST be used when the user asks to write tests, add tests, create test cases,
-  test a specific class or method, or when working on any *Test.php file in this Shopsys
-  application. Applies codebase-specific best practices across unit, functional, GraphQL API,
-  smoke, and acceptance test layers.
+  run/execute/re-run/debug tests, test a specific class or method, or when working on any
+  *Test.php file in this Shopsys application. Applies codebase-specific best practices across
+  unit, functional, GraphQL API, smoke, and acceptance test layers.
 version: 1.0.0
 ---
 
 # Shopsys Test Writing Guide
+
+## Trigger Scope
+
+Use this skill whenever the request is about tests in this repository, including:
+- writing or modifying tests
+- running or re-running tests
+- debugging failing tests
+- selecting the right command/suite/configuration for a test run
 
 ## 1. Layer Selection — Pick the Right Base Class First
 

--- a/docs/automated-testing/introduction-to-automated-testing.md
+++ b/docs/automated-testing/introduction-to-automated-testing.md
@@ -1,7 +1,7 @@
 # Introduction to Automated Testing
 
 Testing is a crucial part of the development and maintenance of reliable software.  
-For this reason, Shopsys Platform comes with 5 types of automated tests:
+For this reason, Shopsys Platform comes with 6 types of automated tests:
 
 - [Unit tests](#unit-tests)
 - [Functional tests](#functional-tests)
@@ -91,8 +91,8 @@ See test class `\Tests\FrameworkBundle\Unit\Model\Cart\CartTest` in the `shopsys
 Notice that test method names describe the tested scenario. Also, notice that each test case focuses just on one specific class behavior.
 When a test fails, it provides detailed feedback to the developer.
 
-You can create similar unit tests anywhere in your directory `tests/Unit/`.
-If they are named with the prefix `Test` and are extending `\PHPUnit\Framework\TestCase`, they will be executed during the [`tests` Phing target](../introduction/console-commands-for-application-management-phing-targets.md#tests).
+You can create similar unit tests in directories registered in `phpunit.xml` (for example `tests/App/Unit/` and `tests/*Bundle/Unit/`).
+If they are named with the suffix `Test` (for example `*Test.php`) and are extending `\PHPUnit\Framework\TestCase`, they will be executed during the [`tests` Phing target](../introduction/console-commands-for-application-management-phing-targets.md#tests).
 
 ### Functional tests
 
@@ -131,7 +131,22 @@ Use `FunctionalTestCase` if you are sure that you won't commit anything to the d
 ### Application tests
 
 When you need to check your direct response from the application by accessing it directly via URL, application tests are the way to go.
-`ApplicationTestCase` is used, for example, in our frontend API testing `GraphlQlTestCase`
+`ApplicationTestCase` is used, for example, in our frontend API testing `GraphQlTestCase`.
+
+#### Isolated client in application tests
+
+`ApplicationTestCase` keeps one client instance with disabled kernel reboot during a test.
+This is useful for speed, but all requests in the test share the same kernel service instances.
+
+If your scenario needs request-level transaction semantics (commit/rollback) or must avoid state leakage between requests, create a dedicated client using `createNewClient()` (or helper wrappers such as `withIsolatedClient()` in GraphQL tests).
+
+Use isolated client when:
+
+- you verify behavior implemented in `kernel.request` / `kernel.response` listeners or subscribers
+- you need a fresh container state for a specific request flow
+- you intentionally run a scenario outside the default per-test transaction wrapper
+
+Note that isolated client has its own kernel/container and DB connection, so it does not see uncommitted changes from another client transaction.
 
 #### Advantages:
 

--- a/ecs.php
+++ b/ecs.php
@@ -187,6 +187,7 @@ return ECSConfig::configure()
                 __DIR__ . '/packages/framework/tests/Unit/Model/Payment/IndependentPaymentVisibilityCalculationTest.php',
                 __DIR__ . '/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php',
                 __DIR__ . '/packages/frontend-api/src/Model/Resolver/Customer/User/CustomerUserResolverMap.php',
+                __DIR__ . '/packages/frontend-api/tests/Unit/Component/HttpFoundation/GraphqlOperationTypeResolverTest.php',
                 __DIR__ . '/packages/maker/src/EntityConfig/EntityFieldsConfigurator.php',
                 __DIR__ . '/packages/migrations/tests/Unit/Component/Doctrine/Migrations/MigrationsLockComparatorTest.php',
                 __DIR__ . '/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php',

--- a/packages/framework/src/Component/Context/ContextResolver.php
+++ b/packages/framework/src/Component/Context/ContextResolver.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Component\Context;
 
 use InvalidArgumentException;
 use Override;
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Webmozart\Assert\Assert;
 
 final class ContextResolver implements ContextResolverInterface
@@ -23,8 +24,10 @@ final class ContextResolver implements ContextResolverInterface
     /**
      * @param iterable<\Shopsys\FrameworkBundle\Component\Context\AbstractContext> $contexts
      */
-    public function __construct(iterable $contexts = [])
-    {
+    public function __construct(
+        iterable $contexts,
+        private readonly string $environment,
+    ) {
         foreach ($contexts as $context) {
             $this->addContext($context);
         }
@@ -126,9 +129,11 @@ final class ContextResolver implements ContextResolverInterface
 
     private function buildMatchingResults(): void
     {
-        if ($this->contextMatchingResults !== []) {
+        if ($this->contextMatchingResults !== [] && !$this->isTestEnvironment()) {
             return;
         }
+
+        $this->contextMatchingResults = [];
 
         foreach ($this->contexts as $context) {
             if (isset($this->contextMatchingResults[$context->getIdentifier()])) {
@@ -137,6 +142,11 @@ final class ContextResolver implements ContextResolverInterface
 
             $this->contextMatchingResults[$context->getIdentifier()] = $this->contextMatches($context);
         }
+    }
+
+    private function isTestEnvironment(): bool
+    {
+        return $this->environment === EnvironmentType::TEST;
     }
 
     /**

--- a/packages/framework/src/Component/HttpFoundation/SilencedExceptionEvent.php
+++ b/packages/framework/src/Component/HttpFoundation/SilencedExceptionEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SilencedExceptionEvent extends Event
+{
+}

--- a/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
+++ b/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
@@ -14,8 +14,6 @@ class TransactionalMasterRequestListener
 {
     protected bool $inTransaction = false;
 
-    protected static bool $isManuallyRollbacked = false;
-
     /**
      * @param \Traversable<int, \Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestConditionProviderInterface> $transactionalMasterRequestConditionProviders
      */
@@ -23,11 +21,6 @@ class TransactionalMasterRequestListener
         protected readonly Traversable $transactionalMasterRequestConditionProviders,
         protected readonly EntityManagerInterface $em,
     ) {
-    }
-
-    public static function setTransactionManuallyRollbacked(): void
-    {
-        static::$isManuallyRollbacked = true;
     }
 
     public function onKernelRequest(RequestEvent $event): void
@@ -40,18 +33,32 @@ class TransactionalMasterRequestListener
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if ($this->inTransaction && !static::$isManuallyRollbacked) {
-            $this->em->commit();
-            $this->inTransaction = false;
+        if (!$this->inTransaction) {
+            return;
         }
+
+        $this->em->commit();
+        $this->inTransaction = false;
     }
 
     public function onKernelException(ExceptionEvent $event): void
     {
-        if ($this->inTransaction) {
-            $this->em->rollback();
-            $this->inTransaction = false;
+        $this->rollbackTransaction();
+    }
+
+    public function onSilencedException(SilencedExceptionEvent $event): void
+    {
+        $this->rollbackTransaction();
+    }
+
+    protected function rollbackTransaction(): void
+    {
+        if (!$this->inTransaction) {
+            return;
         }
+
+        $this->em->rollback();
+        $this->inTransaction = false;
     }
 
     protected function shouldBeginTransaction(RequestEvent $event): bool

--- a/packages/framework/src/Component/Messenger/DelayedEnvelope/DispatchCollectedEnvelopesSubscriber.php
+++ b/packages/framework/src/Component/Messenger/DelayedEnvelope/DispatchCollectedEnvelopesSubscriber.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope;
 
 use Override;
 use Psr\Log\LoggerInterface;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -63,6 +64,7 @@ class DispatchCollectedEnvelopesSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::EXCEPTION => 'resetCollectedMessageEnvelopes',
+            SilencedExceptionEvent::class => 'resetCollectedMessageEnvelopes',
             KernelEvents::RESPONSE => ['handleCollectedMessageEnvelopes', -10],
             ConsoleEvents::TERMINATE => ['handleCollectedMessageEnvelopes', -10],
             WorkerMessageHandledEvent::class => ['handleCollectedMessageEnvelopes', 10],

--- a/packages/framework/src/Controller/Admin/CategorySeoController.php
+++ b/packages/framework/src/Controller/Admin/CategorySeoController.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanCreate;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
@@ -35,6 +36,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[ForRole(AdminRoleConstant::ROLE_CATEGORY_SEO)]
 class CategorySeoController extends AdminBaseController
@@ -50,6 +52,7 @@ class CategorySeoController extends AdminBaseController
         protected readonly ReadyCategorySeoMixGridFactory $readyCategorySeoMixGridFactory,
         protected readonly Domain $domain,
         protected readonly SelectedCategorySeoMixCombinationFactory $selectedCategorySeoMixCombinationFactory,
+        protected readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -251,8 +254,10 @@ class CategorySeoController extends AdminBaseController
 
                 return $this->redirect($newCombinationsUrl);
             } catch (ReadyCategorySeoMixUrlsContainBadDomainUrlException) {
+                $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
                 $this->addErrorFlash(t('Fill URL only for selected domain'));
             } catch (ReadyCategorySeoMixUrlsDoNotContainUrlForCorrectDomainException) {
+                $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
                 $this->addErrorFlash(t('Fill URL also for selected domain'));
             }
         }

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrameworkBundle\Model\CategorySeo;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestListener;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\UrlListData;
 use Shopsys\FrameworkBundle\Model\CategorySeo\Exception\ReadyCategorySeoMixNotFoundException;
@@ -40,8 +39,6 @@ class ReadyCategorySeoMixFacade
     ): ReadyCategorySeoMix {
         $readyCategorySeoMix = $this->findBySelectedCategorySeoMixCombination($selectedCategorySeoMixCombination);
 
-        $this->em->beginTransaction();
-
         if ($readyCategorySeoMix === null) {
             $readyCategorySeoMix = $this->readyCategorySeoMixFactory->create($readyCategorySeoMixData);
             $this->em->persist($readyCategorySeoMix);
@@ -59,16 +56,7 @@ class ReadyCategorySeoMixFacade
 
         $this->saveReadyCategoryMixFriendlyUrls($readyCategorySeoMix, $urlListData);
 
-        try {
-            $this->validateReadyCategoryMixFriendlyUrls($readyCategorySeoMix);
-        } catch (ReadyCategorySeoMixUrlsContainBadDomainUrlException | ReadyCategorySeoMixUrlsDoNotContainUrlForCorrectDomainException $e) {
-            TransactionalMasterRequestListener::setTransactionManuallyRollbacked();
-            $this->em->rollback();
-
-            throw $e;
-        }
-
-        $this->em->commit();
+        $this->validateReadyCategoryMixFriendlyUrls($readyCategorySeoMix);
 
         return $readyCategorySeoMix;
     }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -312,6 +312,7 @@ services:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
+            - { name: kernel.event_listener, event: Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent, method: onSilencedException }
 
     Shopsys\FrameworkBundle\Component\HttpFoundation\VaryResponseByXRequestedWithHeaderListener:
         tags:

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -110,7 +110,9 @@ services:
             - { name: data_collector, id: shopsys_framework_core, template: '@ShopsysFramework/Components/Collector/shopsysFramework.html.twig', priority: -300 }
 
     Shopsys\FrameworkBundle\Component\Context\ContextResolver:
-        arguments: [!tagged_iterator shopsys.context]
+        arguments:
+            $contexts: !tagged_iterator shopsys.context
+            $environment: '%kernel.environment%'
 
     Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface:
         alias: Shopsys\FrameworkBundle\Component\Context\ContextResolver

--- a/packages/framework/tests/Unit/Component/Context/ContextResolverTest.php
+++ b/packages/framework/tests/Unit/Component/Context/ContextResolverTest.php
@@ -6,16 +6,18 @@ namespace Tests\FrameworkBundle\Unit\Component\Context;
 
 use InvalidArgumentException;
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Context\AbstractContext;
 use Shopsys\FrameworkBundle\Component\Context\ContextResolver;
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 
 class ContextResolverTest extends TestCase
 {
     public function testConstructorAddsContexts(): void
     {
         $context = new TestContextA(shouldMatch: true);
-        $resolver = new ContextResolver([$context]);
+        $resolver = $this->createContextResolver([$context]);
 
         // Test that context was registered correctly by checking if it matches
         $this->assertTrue($resolver->isCurrentContext(TestContextA::class));
@@ -29,7 +31,7 @@ class ContextResolverTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Context with identifier "' . TestContextA::class . '" is already registered');
 
-        new ContextResolver([$context1, $context2]);
+        $this->createContextResolver([$context1, $context2]);
     }
 
     public function testContextMatching(): void
@@ -38,7 +40,7 @@ class ContextResolverTest extends TestCase
         $context2 = new TestContextB(shouldMatch: true);
         $context3 = new TestContextC(shouldMatch: true);
 
-        $resolver = new ContextResolver([$context1, $context2, $context3]);
+        $resolver = $this->createContextResolver([$context1, $context2, $context3]);
 
         $this->assertFalse($resolver->isCurrentContext(TestContextA::class));
         $this->assertTrue($resolver->isCurrentContext(TestContextB::class));
@@ -51,7 +53,7 @@ class ContextResolverTest extends TestCase
         $requiredContext = new TestContextB(shouldMatch: true);
         $independentContext = new TestContextC(shouldMatch: true);
 
-        $resolver = new ContextResolver([$contextWithDependency, $requiredContext, $independentContext]);
+        $resolver = $this->createContextResolver([$contextWithDependency, $requiredContext, $independentContext]);
 
         $this->assertTrue($resolver->isCurrentContext(TestContextA::class));
         $this->assertTrue($resolver->isCurrentContext(TestContextB::class));
@@ -63,14 +65,17 @@ class ContextResolverTest extends TestCase
         $nonMatchingRequiredContext = new TestContextB(shouldMatch: false);
         $contextWithDependency = new TestContextA(shouldMatch: true, requiredContexts: [TestContextB::class]);
 
-        $resolver = new ContextResolver([$nonMatchingRequiredContext, $contextWithDependency]);
+        $resolver = $this->createContextResolver([$nonMatchingRequiredContext, $contextWithDependency]);
 
         $this->assertFalse($resolver->isCurrentContext(TestContextA::class));
         $this->assertFalse($resolver->isCurrentContext(TestContextB::class));
     }
 
-    public function testContextMatchingResultsAreCached(): void
-    {
+    #[DataProvider('contextMatchingCacheBehaviorDataProvider')]
+    public function testContextMatchingCacheBehavior(
+        string $environment,
+        int $expectedMatchesCallCount,
+    ): void {
         $matchesCallCount = 0;
 
         $context = new class($matchesCallCount) extends AbstractContext {
@@ -92,13 +97,29 @@ class ContextResolverTest extends TestCase
             }
         };
 
-        $resolver = new ContextResolver([$context]);
+        $resolver = $this->createContextResolver([$context], $environment);
 
         $contextClass = $context::class;
         $resolver->isCurrentContext($contextClass);
         $resolver->isCurrentContext($contextClass);
 
-        $this->assertSame(1, $matchesCallCount, 'matches() should only be called once due to caching');
+        $this->assertSame($expectedMatchesCallCount, $matchesCallCount);
+    }
+
+    /**
+     * @return iterable<string, array{environment: string, expectedMatchesCallCount: int}>
+     */
+    public static function contextMatchingCacheBehaviorDataProvider(): iterable
+    {
+        yield 'context matching results are cached in non-test environment' => [
+            'environment' => EnvironmentType::DEVELOPMENT,
+            'expectedMatchesCallCount' => 1,
+        ];
+
+        yield 'context matching results are not cached in test environment' => [
+            'environment' => EnvironmentType::TEST,
+            'expectedMatchesCallCount' => 2,
+        ];
     }
 
     public function testComplexDependencyChain(): void
@@ -107,7 +128,7 @@ class ContextResolverTest extends TestCase
         $middleContext = new TestContextB(shouldMatch: true, requiredContexts: [TestContextC::class]);
         $leafContext = new TestContextA(shouldMatch: true, requiredContexts: [TestContextB::class]);
 
-        $resolver = new ContextResolver([$rootContext, $middleContext, $leafContext]);
+        $resolver = $this->createContextResolver([$rootContext, $middleContext, $leafContext]);
 
         $this->assertTrue($resolver->isCurrentContext(TestContextC::class));
         $this->assertTrue($resolver->isCurrentContext(TestContextB::class));
@@ -122,7 +143,7 @@ class ContextResolverTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Circular dependency detected: ' . TestContextA::class . ' → ' . TestContextB::class . ' → ' . TestContextA::class);
 
-        new ContextResolver([$contextA, $contextB]);
+        $this->createContextResolver([$contextA, $contextB]);
     }
 
     public function testComplexCircularDependencyDetection(): void
@@ -134,7 +155,7 @@ class ContextResolverTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Circular dependency detected: ' . TestContextA::class . ' → ' . TestContextB::class . ' → ' . TestContextC::class . ' → ' . TestContextA::class);
 
-        new ContextResolver([$contextA, $contextB, $contextC]);
+        $this->createContextResolver([$contextA, $contextB, $contextC]);
     }
 
     public function testCircularDependencyInMiddleOfChain(): void
@@ -146,6 +167,16 @@ class ContextResolverTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Circular dependency detected: ' . TestContextB::class . ' → ' . TestContextC::class . ' → ' . TestContextB::class);
 
-        new ContextResolver([$contextA, $contextB, $contextC]);
+        $this->createContextResolver([$contextA, $contextB, $contextC]);
+    }
+
+    /**
+     * @param iterable<\Shopsys\FrameworkBundle\Component\Context\AbstractContext> $contexts
+     */
+    private function createContextResolver(
+        iterable $contexts,
+        string $environment = EnvironmentType::PRODUCTION,
+    ): ContextResolver {
+        return new ContextResolver($contexts, $environment);
     }
 }

--- a/packages/framework/tests/Unit/Component/HttpFoundation/TransactionalMasterRequestListenerTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/TransactionalMasterRequestListenerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\HttpFoundation;
+
+use ArrayIterator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestConditionProviderInterface;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Traversable;
+
+class TransactionalMasterRequestListenerTest extends TestCase
+{
+    public function testBeginsAndCommitsTransactionOnSuccessfulRequest(): void
+    {
+        $entityManagerMock = $this->createMock(EntityManagerInterface::class);
+        $entityManagerMock->expects($this->once())
+            ->method('beginTransaction');
+        $entityManagerMock->expects($this->once())
+            ->method('commit');
+        $entityManagerMock->expects($this->never())
+            ->method('rollback');
+
+        $listener = new TransactionalMasterRequestListener(
+            $this->createTransactionalMasterRequestConditionProviders(),
+            $entityManagerMock,
+        );
+
+        $listener->onKernelRequest($this->createMainRequestEvent());
+        $listener->onKernelResponse($this->createMainResponseEvent());
+    }
+
+    public function testSilencedExceptionRollbackDoesNotLeakToFollowingRequest(): void
+    {
+        $entityManagerMock = $this->createMock(EntityManagerInterface::class);
+        $entityManagerMock->expects($this->exactly(2))
+            ->method('beginTransaction');
+        $entityManagerMock->expects($this->once())
+            ->method('commit');
+        $entityManagerMock->expects($this->once())
+            ->method('rollback');
+
+        $listener = new TransactionalMasterRequestListener(
+            $this->createTransactionalMasterRequestConditionProviders(),
+            $entityManagerMock,
+        );
+
+        $listener->onKernelRequest($this->createMainRequestEvent());
+        $listener->onSilencedException(new SilencedExceptionEvent());
+
+        $listener->onKernelRequest($this->createMainRequestEvent());
+        $listener->onKernelResponse($this->createMainResponseEvent());
+    }
+
+    public function testExceptionRollbackDoesNotLeakToFollowingRequest(): void
+    {
+        $entityManagerMock = $this->createMock(EntityManagerInterface::class);
+        $entityManagerMock->expects($this->exactly(2))
+            ->method('beginTransaction');
+        $entityManagerMock->expects($this->once())
+            ->method('commit');
+        $entityManagerMock->expects($this->once())
+            ->method('rollback');
+
+        $listener = new TransactionalMasterRequestListener(
+            $this->createTransactionalMasterRequestConditionProviders(),
+            $entityManagerMock,
+        );
+
+        $listener->onKernelRequest($this->createMainRequestEvent());
+        $listener->onKernelException($this->createMainExceptionEvent());
+
+        $listener->onKernelRequest($this->createMainRequestEvent());
+        $listener->onKernelResponse($this->createMainResponseEvent());
+    }
+
+    /**
+     * @return \Traversable<int, \Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestConditionProviderInterface>
+     */
+    private function createTransactionalMasterRequestConditionProviders(): Traversable
+    {
+        /** @var \PHPUnit\Framework\MockObject\Stub&\Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestConditionProviderInterface $conditionProviderStub */
+        $conditionProviderStub = $this->createStub(TransactionalMasterRequestConditionProviderInterface::class);
+        $conditionProviderStub->method('shouldBeginTransaction')
+            ->willReturn(true);
+
+        return new ArrayIterator([$conditionProviderStub]);
+    }
+
+    private function createMainRequestEvent(): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+
+    private function createMainResponseEvent(): ResponseEvent
+    {
+        return new ResponseEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response(),
+        );
+    }
+
+    private function createMainExceptionEvent(): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            new RuntimeException(),
+        );
+    }
+}

--- a/packages/frontend-api/src/Component/HttpFoundation/GraphqlMutationErrorRollbackSubscriber.php
+++ b/packages/frontend-api/src/Component/HttpFoundation/GraphqlMutationErrorRollbackSubscriber.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\HttpFoundation;
+
+use Overblog\GraphQLBundle\Event\Events;
+use Overblog\GraphQLBundle\Event\ExecutorResultEvent;
+use Override;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class GraphqlMutationErrorRollbackSubscriber implements EventSubscriberInterface
+{
+    protected const string MUTATION_OPERATION = 'mutation';
+
+    protected bool $shouldRollbackTransaction = false;
+
+    public function __construct(
+        protected readonly GraphqlOperationTypeResolver $graphqlOperationTypeResolver,
+        protected readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    /**
+     * @return array<string, string|array<int, array{0: string, 1?: int}>>
+     */
+    #[Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::POST_EXECUTOR => [
+                ['onPostExecutor'],
+            ],
+            KernelEvents::RESPONSE => [
+                ['onKernelResponse', 10],
+            ],
+        ];
+    }
+
+    public function onPostExecutor(ExecutorResultEvent $event): void
+    {
+        if (count($event->getResult()->errors) === 0) {
+            return;
+        }
+
+        $operationType = $this->graphqlOperationTypeResolver->resolveOperationTypeFromPayload([
+            'query' => $event->getExecutorArguments()->getRequestString(),
+            'operationName' => $event->getExecutorArguments()->getOperationName(),
+        ]);
+
+        if ($operationType !== static::MUTATION_OPERATION) {
+            return;
+        }
+
+        $this->shouldRollbackTransaction = true;
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest() || !$this->shouldRollbackTransaction) {
+            return;
+        }
+
+        $this->shouldRollbackTransaction = false;
+        $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
+    }
+}

--- a/packages/frontend-api/src/Component/HttpFoundation/GraphqlOperationTypeResolver.php
+++ b/packages/frontend-api/src/Component/HttpFoundation/GraphqlOperationTypeResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\HttpFoundation;
+
+use GraphQL\Error\SyntaxError;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\Parser;
+
+class GraphqlOperationTypeResolver
+{
+    protected const string QUERY = 'query';
+
+    protected const string OPERATION_NAME = 'operationName';
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function resolveOperationTypeFromPayload(array $payload): ?string
+    {
+        $query = $payload[static::QUERY] ?? null;
+
+        if (!is_string($query)) {
+            return null;
+        }
+
+        $operationName = $payload[static::OPERATION_NAME] ?? null;
+
+        if (!is_string($operationName)) {
+            $operationName = null;
+        }
+
+        return $this->resolveOperationType($query, $operationName);
+    }
+
+    protected function resolveOperationType(string $query, ?string $operationName): ?string
+    {
+        try {
+            $parsedQuery = Parser::parse($query);
+        } catch (SyntaxError) {
+            return null;
+        }
+
+        $operationType = null;
+
+        foreach ($parsedQuery->definitions as $definition) {
+            if (!$definition instanceof OperationDefinitionNode) {
+                continue;
+            }
+
+            if ($operationName !== null) {
+                if ($definition->name === null || $definition->name->value !== $operationName) {
+                    continue;
+                }
+
+                return $definition->operation;
+            }
+
+            if ($operationType !== null) {
+                return null;
+            }
+
+            $operationType = $definition->operation;
+        }
+
+        return $operationType;
+    }
+}

--- a/packages/frontend-api/src/Component/HttpFoundation/TransactionalMasterRequestConditionProvider.php
+++ b/packages/frontend-api/src/Component/HttpFoundation/TransactionalMasterRequestConditionProvider.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Component\HttpFoundation;
 
-use GraphQL\Error\SyntaxError;
-use GraphQL\Language\AST\OperationDefinitionNode;
-use GraphQL\Language\Parser;
 use Override;
 use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
 use Shopsys\FrameworkBundle\Component\Context\FrontendApiContext;
@@ -20,6 +17,7 @@ class TransactionalMasterRequestConditionProvider implements TransactionalMaster
 
     public function __construct(
         protected readonly ContextResolverInterface $contextResolver,
+        protected readonly GraphqlOperationTypeResolver $graphqlOperationTypeResolver,
     ) {
     }
 
@@ -47,24 +45,8 @@ class TransactionalMasterRequestConditionProvider implements TransactionalMaster
             throw new InvalidArgumentUserError('Request content is not a valid JSON.');
         }
 
-        if (!array_key_exists(static::QUERY_TYPE, $source)) {
-            return false;
-        }
+        $operationType = $this->graphqlOperationTypeResolver->resolveOperationTypeFromPayload($source);
 
-        $queryString = $source[static::QUERY_TYPE];
-
-        try {
-            $parsed = Parser::parse($queryString);
-
-            foreach ($parsed->definitions as $definition) {
-                if ($definition instanceof OperationDefinitionNode) {
-                    return $definition->operation === static::QUERY_TYPE;
-                }
-            }
-        } catch (SyntaxError) {
-            return false;
-        }
-
-        return false;
+        return $operationType === static::QUERY_TYPE;
     }
 }

--- a/packages/frontend-api/src/Component/Messenger/GraphqlErrorResetDelayedEnvelopesSubscriber.php
+++ b/packages/frontend-api/src/Component/Messenger/GraphqlErrorResetDelayedEnvelopesSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\Messenger;
+
+use Overblog\GraphQLBundle\Event\Events;
+use Overblog\GraphQLBundle\Event\ExecutorResultEvent;
+use Override;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class GraphqlErrorResetDelayedEnvelopesSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        protected readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    /**
+     * @return array<string, string|array<int, array{0: string, 1?: int}>>
+     */
+    #[Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::POST_EXECUTOR => [
+                ['onPostExecutor'],
+            ],
+        ];
+    }
+
+    public function onPostExecutor(ExecutorResultEvent $event): void
+    {
+        if (count($event->getResult()->errors) === 0) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
+    }
+}

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -24,6 +24,8 @@ services:
 
     Shopsys\FrontendApiBundle\Component\GqlContext\GqlContextInitializer: ~
 
+    Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlOperationTypeResolver: ~
+
     Shopsys\FrontendApiBundle\Controller\Admin\CustomerUserController:
         tags: [ 'controller.service_arguments' ]
 

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -24,6 +24,8 @@ services:
 
     Shopsys\FrontendApiBundle\Component\GqlContext\GqlContextInitializer: ~
 
+    Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlMutationErrorRollbackSubscriber: ~
+
     Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlOperationTypeResolver: ~
 
     Shopsys\FrontendApiBundle\Controller\Admin\CustomerUserController:

--- a/packages/frontend-api/tests/Unit/Component/HttpFoundation/GraphqlOperationTypeResolverTest.php
+++ b/packages/frontend-api/tests/Unit/Component/HttpFoundation/GraphqlOperationTypeResolverTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Unit\Component\HttpFoundation;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlOperationTypeResolver;
+
+class GraphqlOperationTypeResolverTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('resolveOperationTypeFromPayloadDataProvider')]
+    public function testResolveOperationTypeFromPayload(array $payload, ?string $expectedOperationType): void
+    {
+        $graphqlOperationTypeResolver = new GraphqlOperationTypeResolver();
+
+        $actualOperationType = $graphqlOperationTypeResolver->resolveOperationTypeFromPayload($payload);
+
+        $this->assertSame($expectedOperationType, $actualOperationType);
+    }
+
+    /**
+     * @return iterable<string, array{payload: array<string, mixed>, expectedOperationType: string|null}>
+     */
+    public static function resolveOperationTypeFromPayloadDataProvider(): iterable
+    {
+        yield 'single query operation' => [
+            'payload' => [
+                'query' => <<<'GRAPHQL'
+                    query {
+                        products(first: 1) {
+                            edges {
+                                node {
+                                    uuid
+                                }
+                            }
+                        }
+                    }
+                    GRAPHQL,
+            ],
+            'expectedOperationType' => 'query',
+        ];
+
+        yield 'single mutation operation' => [
+            'payload' => [
+                'query' => <<<'GRAPHQL'
+                    mutation {
+                        RemoveProductList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+                    GRAPHQL,
+            ],
+            'expectedOperationType' => 'mutation',
+        ];
+
+        yield 'multiple operations with operationName' => [
+            'payload' => [
+                'query' => <<<'GRAPHQL'
+                    query ProductListQuery {
+                        productList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+
+                    mutation RemoveProductListMutation {
+                        RemoveProductList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+                    GRAPHQL,
+                'operationName' => 'RemoveProductListMutation',
+            ],
+            'expectedOperationType' => 'mutation',
+        ];
+
+        yield 'multiple operations without operationName is ambiguous' => [
+            'payload' => [
+                'query' => <<<'GRAPHQL'
+                    query ProductListQuery {
+                        productList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+
+                    mutation RemoveProductListMutation {
+                        RemoveProductList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+                    GRAPHQL,
+            ],
+            'expectedOperationType' => null,
+        ];
+
+        yield 'operationName not matching any operation' => [
+            'payload' => [
+                'query' => <<<'GRAPHQL'
+                    query ProductListQuery {
+                        productList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+                    GRAPHQL,
+                'operationName' => 'UnknownOperation',
+            ],
+            'expectedOperationType' => null,
+        ];
+
+        yield 'non-string operationName is ignored' => [
+            'payload' => [
+                'query' => <<<'GRAPHQL'
+                    mutation RemoveProductListMutation {
+                        RemoveProductList(input: {type: WISHLIST}) {
+                            uuid
+                        }
+                    }
+                    GRAPHQL,
+                'operationName' => 123,
+            ],
+            'expectedOperationType' => 'mutation',
+        ];
+
+        yield 'invalid query syntax' => [
+            'payload' => [
+                'query' => 'query {',
+            ],
+            'expectedOperationType' => null,
+        ];
+
+        yield 'missing query key in payload' => [
+            'payload' => [
+                'operationName' => 'ProductListQuery',
+            ],
+            'expectedOperationType' => null,
+        ];
+
+        yield 'non-string query in payload' => [
+            'payload' => [
+                'query' => ['query ProductListQuery { productList(input: {type: WISHLIST}) { uuid } }'],
+            ],
+            'expectedOperationType' => null,
+        ];
+    }
+}

--- a/project-base/app/config/packages/test/messenger.yaml
+++ b/project-base/app/config/packages/test/messenger.yaml
@@ -1,0 +1,7 @@
+framework:
+    messenger:
+        routing:
+            Tests\App\Test\Messenger\DummyMessage: dummy_transport
+        transports:
+            dummy_transport:
+                dsn: 'in-memory://'

--- a/project-base/app/tests/App/Test/Messenger/DummyMessage.php
+++ b/project-base/app/tests/App/Test/Messenger/DummyMessage.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Test\Messenger;
+
+final class DummyMessage
+{
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/CartTotalItemsPriceTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/CartTotalItemsPriceTest.php
@@ -47,53 +47,25 @@ class CartTotalItemsPriceTest extends GraphQlTestCase
     private function addPaymentCardToCart(string $cartUuid): void
     {
         $paymentCard = $this->getReference(PaymentDataFixture::PAYMENT_CARD, Payment::class);
-        $changePaymentInCartMutation = '
-            mutation {
-                ChangePaymentInCart(input:{
-                    cartUuid: "' . $cartUuid . '"
-                    paymentUuid: "' . $paymentCard->getUuid() . '"
-                }) {
-                    uuid
-                }
-            }
-        ';
-
-        $this->getResponseContentForQuery($changePaymentInCartMutation);
+        $this->getResponseContentForGql(__DIR__ . '/../_graphql/mutation/ChangePaymentInCartMutation.graphql', [
+            'cartUuid' => $cartUuid,
+            'paymentUuid' => $paymentCard->getUuid(),
+        ]);
     }
 
     private function addTransportPplToCart(string $cartUuid): void
     {
         $transportPpl = $this->getReference(TransportDataFixture::TRANSPORT_PPL, Transport::class);
-        $changeTransportInCartMutation = '
-            mutation {
-                ChangeTransportInCart(input:{
-                    cartUuid: "' . $cartUuid . '"
-                    paymentUuid: "' . $transportPpl->getUuid() . '"
-                }) {
-                    uuid
-                }
-            }
-        ';
-
-        $this->getResponseContentForQuery($changeTransportInCartMutation);
+        $this->getResponseContentForGql(__DIR__ . '/../_graphql/mutation/ChangeTransportInCartMutation.graphql', [
+            'cartUuid' => $cartUuid,
+            'transportUuid' => $transportPpl->getUuid(),
+        ]);
     }
 
     private function getCartResponse(string $cartUuid): array
     {
-        $getCartQuery = '
-            query {
-                cart(cartInput:{
-                    cartUuid: "' . $cartUuid . '"
-                }) {
-                    totalItemsPrice {
-                        priceWithVat
-                        priceWithoutVat
-                        vatAmount
-                    }
-                }
-            }
-        ';
-
-        return $this->getResponseContentForQuery($getCartQuery);
+        return $this->getResponseContentForGql(__DIR__ . '/graphql/CartWithDiscountBreakdown.graphql', [
+            'cartUuid' => $cartUuid,
+        ]);
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/GraphqlMutationTransactionRollbackTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/GraphqlMutationTransactionRollbackTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\HttpFoundation;
+
+use App\DataFixtures\Demo\ProductDataFixture;
+use App\Model\Product\Product;
+use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class GraphqlMutationTransactionRollbackTest extends GraphQlTestCase
+{
+    public function testMutationWithGraphqlErrorRollsBackPreviousWrite(): void
+    {
+        $this->runWithIsolatedProductList([$this, 'doTestMutationWithGraphqlErrorRollsBackPreviousWrite']);
+    }
+
+    public function testSuccessfulMutationCommitsChanges(): void
+    {
+        $this->runWithIsolatedProductList([$this, 'doTestSuccessfulMutationCommitsChanges']);
+    }
+
+    public function testQueryErrorDoesNotAffectFollowingMutationCommit(): void
+    {
+        $this->runWithIsolatedProductList([$this, 'doTestQueryErrorDoesNotAffectFollowingMutationCommit']);
+    }
+
+    private function doTestMutationWithGraphqlErrorRollsBackPreviousWrite(string $productListUuid): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/graphql/AddProductToListAndFailMutation.graphql',
+            [
+                'productUuid' => $this->getProductUuid(69),
+                'notExistingProductUuid' => Uuid::uuid4()->toString(),
+                'productListUuid' => $productListUuid,
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+
+        $this->assertUserError($response, 'product-not-found');
+        $this->assertSame([69], array_column($response['data']['AddProductToList']['products'], 'id'));
+        $this->assertNull($this->findProductListByUuid($productListUuid));
+    }
+
+    private function doTestSuccessfulMutationCommitsChanges(string $productListUuid): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../Product/ProductList/graphql/AddProductToListMutation.graphql',
+            [
+                'productUuid' => $this->getProductUuid(69),
+                'productListUuid' => $productListUuid,
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+        $this->getResponseDataForGraphQlType($response, 'AddProductToList');
+
+        $productList = $this->findProductListByUuid($productListUuid);
+
+        $this->assertNotNull($productList);
+        $this->assertSame([69], array_column($productList['products'], 'id'));
+    }
+
+    private function doTestQueryErrorDoesNotAffectFollowingMutationCommit(string $productListUuid): void
+    {
+        $queryResponse = $this->getResponseContentForGql(
+            __DIR__ . '/graphql/InvalidProductListQuery.graphql',
+            [
+                'type' => ProductListTypeEnum::WISHLIST,
+                'productListUuid' => $productListUuid,
+            ],
+        );
+        $this->assertResponseContainsArrayOfErrors($queryResponse);
+
+        $mutationResponse = $this->getResponseContentForGql(
+            __DIR__ . '/../Product/ProductList/graphql/AddProductToListMutation.graphql',
+            [
+                'productUuid' => $this->getProductUuid(69),
+                'productListUuid' => $productListUuid,
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+        $this->getResponseDataForGraphQlType($mutationResponse, 'AddProductToList');
+
+        $productList = $this->findProductListByUuid($productListUuid);
+
+        $this->assertNotNull($productList);
+        $this->assertSame([69], array_column($productList['products'], 'id'));
+    }
+
+    /**
+     * @param callable(string): void $scenario
+     */
+    private function runWithIsolatedProductList(callable $scenario): void
+    {
+        $productListUuid = Uuid::uuid4()->toString();
+
+        $this->withIsolatedClient(
+            fn () => $scenario($productListUuid),
+            fn () => $this->removeProductListIfExists($productListUuid),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function findProductListByUuid(string $productListUuid): ?array
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../Product/ProductList/graphql/ProductListQuery.graphql',
+            [
+                'uuid' => $productListUuid,
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+
+        return $response['data']['productList'];
+    }
+
+    protected function removeProductListIfExists(string $productListUuid): void
+    {
+        if ($this->findProductListByUuid($productListUuid) === null) {
+            return;
+        }
+
+        $this->getResponseContentForGql(
+            __DIR__ . '/../Product/ProductList/graphql/RemoveProductListMutation.graphql',
+            [
+                'productListUuid' => $productListUuid,
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+    }
+
+    protected function getProductUuid(int $productId): string
+    {
+        $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productId, Product::class);
+
+        return $product->getUuid();
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/graphql/AddProductToListAndFailMutation.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/graphql/AddProductToListAndFailMutation.graphql
@@ -1,0 +1,12 @@
+mutation AddProductToListAndFailMutation($productUuid: Uuid!, $notExistingProductUuid: Uuid!, $productListUuid: Uuid!, $type: ProductListTypeEnum!) {
+    AddProductToList(input: {productUuid: $productUuid, productListInput: {type: $type, uuid: $productListUuid}}) {
+        uuid
+        type
+        products {
+            id
+        }
+    }
+    RemoveProductFromList(input: {productUuid: $notExistingProductUuid, productListInput: {type: $type, uuid: $productListUuid}}) {
+        uuid
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/graphql/InvalidProductListQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/graphql/InvalidProductListQuery.graphql
@@ -1,0 +1,6 @@
+query InvalidProductListQuery($type: ProductListTypeEnum!, $productListUuid: Uuid!) {
+    productList(input: {type: $type, uuid: $productListUuid}) {
+        uuid
+        nonExistingField
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/Messenger/GraphqlDelayedMessagesResetTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Messenger/GraphqlDelayedMessagesResetTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Messenger;
+
+use App\DataFixtures\Demo\ProductDataFixture;
+use App\Model\Product\Product;
+use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Tests\App\Test\Messenger\DummyMessage;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class GraphqlDelayedMessagesResetTest extends GraphQlTestCase
+{
+    /**
+     * @inject
+     */
+    private MessageBusInterface $messageBus;
+
+    /**
+     * @inject messenger.transport.dummy_transport
+     */
+    private InMemoryTransport $inMemoryTransport;
+
+    public function testDelayedMessagesAreDispatchedOnSuccessfulGraphqlQuery(): void
+    {
+        $dummyTransport = $this->prepareDummyTransportWithDelayedMessage();
+
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../Product/ProductList/graphql/ProductListQuery.graphql',
+            [
+                'uuid' => Uuid::uuid4()->toString(),
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+
+        $this->assertArrayNotHasKey('errors', $response);
+        $this->assertCount(1, $dummyTransport->getSent());
+    }
+
+    public function testDelayedMessagesAreResetOnGraphqlQueryError(): void
+    {
+        $dummyTransport = $this->prepareDummyTransportWithDelayedMessage();
+
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../Order/graphql/GetOrderQuery.graphql',
+            [
+                'urlHash' => 'non-existent-order-hash',
+            ],
+        );
+
+        $this->assertResponseContainsArrayOfErrors($response);
+        $this->assertCount(0, $dummyTransport->getSent());
+    }
+
+    public function testDelayedMessagesAreResetOnGraphqlMutationError(): void
+    {
+        $dummyTransport = $this->prepareDummyTransportWithDelayedMessage();
+
+        $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . 69, Product::class);
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../HttpFoundation/graphql/AddProductToListAndFailMutation.graphql',
+            [
+                'productUuid' => $product->getUuid(),
+                'notExistingProductUuid' => Uuid::uuid4()->toString(),
+                'productListUuid' => Uuid::uuid4()->toString(),
+                'type' => ProductListTypeEnum::WISHLIST,
+            ],
+        );
+
+        $this->assertResponseContainsArrayOfErrors($response);
+        $this->assertCount(0, $dummyTransport->getSent());
+    }
+
+    private function prepareDummyTransportWithDelayedMessage(): InMemoryTransport
+    {
+        $this->inMemoryTransport->reset();
+
+        $this->messageBus->dispatch(new DummyMessage());
+        $this->assertCount(0, $this->inMemoryTransport->getSent());
+
+        return $this->inMemoryTransport;
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/app/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -90,6 +90,34 @@ abstract class GraphQlTestCase extends ApplicationTestCase
         $this->assertEquals($expected, Json::decode($result, true), $result);
     }
 
+    /**
+     * @template TReturn
+     * @param callable(): TReturn $callback
+     * @param callable(): void|null $finallyCallback
+     * @return TReturn
+     */
+    protected function withIsolatedClient(callable $callback, ?callable $finallyCallback = null): mixed
+    {
+        $originalClient = self::$client;
+        $isolatedClient = $this->createNewClient();
+        self::$client = $isolatedClient;
+
+        try {
+            return $callback();
+        } finally {
+            if ($finallyCallback !== null) {
+                $finallyCallback();
+            }
+
+            if ($isolatedClient !== $originalClient) {
+                $isolatedClient->enableReboot();
+                $isolatedClient->getKernel()->shutdown();
+            }
+
+            self::$client = $originalClient;
+        }
+    }
+
     protected function getResponseContentForQuery(string $query, array $variables = []): array
     {
         $content = $this->getResponseForQuery($query, $variables)->getContent();

--- a/upgrade-notes/backend_20260225_140730.md
+++ b/upgrade-notes/backend_20260225_140730.md
@@ -1,0 +1,5 @@
+#### FE API: rollback mutation & discard async messages on error ([#4479](https://github.com/shopsys/shopsys/pull/4479))
+
+- `Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestListener::setTransactionManuallyRollbacked()` was removed
+    - if you need to enforce transaction rollback in your code, you can dispatch `Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent` instead
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

GQL requests always return 200 OK (the errors are handled internally), so the error handlers listening on kernel errors are not called. This PR addresses that problem, so that DB transactions are rolled back when an error occurs during GQL mutation. Moreover, RabbitMQ messages are now discarded on an error within GQL request.

#### Fixes issues
closes #2515
closes #2375 

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















----
:globe_with_meridians: Live Preview:
  - https://rv-mutation-rollback.odin.shopsys.cloud
  - https://cz.rv-mutation-rollback.odin.shopsys.cloud
  - https://rv-mutation-rollback.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772446566.468769 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-mutation-rollback.odin.shopsys.cloud
  - https://cz.rv-mutation-rollback.odin.shopsys.cloud
  - https://rv-mutation-rollback.odin.shopsys.cloud/sk
<!-- Replace -->
