### PR TITLE
transport and payment selection is now disabled during in-flight mutations

### DIFF
--- a/project-base/storefront/components/Forms/Lib/LabelWrapper.tsx
+++ b/project-base/storefront/components/Forms/Lib/LabelWrapper.tsx
@@ -36,13 +36,13 @@ export const LabelWrapper: FC<LabelWrapperProps> = ({
                     inputType === 'text-input' &&
                         'pointer-events-none top-2 text-sm peer-placeholder-shown:top-1/2 peer-placeholder-shown:text-base peer-placeholder-shown:font-semibold peer-focus:top-2 peer-focus:text-sm peer-focus:font-normal',
                     (inputType === 'text-input' || inputType === 'selectbox' || inputType === 'textarea') &&
-                        'text-input-placeholder-default peer-hover:text-input-placeholder-hovered peer-focus:text-input-placeholder-active peer-disabled:text-input-placeholder-disabled absolute left-3 z-[2] block transform-none peer-placeholder-shown:-translate-y-1/2 peer-focus:translate-none motion-safe:transition-all',
+                        'text-input-placeholder-default peer-hover:text-input-placeholder-hovered peer-focus:text-input-placeholder-active peer-disabled:text-input-placeholder-disabled absolute left-3 z-2 block transform-none peer-placeholder-shown:-translate-y-1/2 peer-focus:translate-none motion-safe:transition-all',
                     (inputType === 'checkbox' || inputType === 'radio') && [
                         'group relative flex w-full cursor-pointer items-center gap-2 text-sm font-semibold',
                         checked
                             ? 'text-link-default hover:text-link-hovered'
                             : 'text-input-text-default hover:text-input-text-hovered',
-                        disabled && 'text-input-text-disabled hover:text-input-text-disabled cursor-no-drop opacity-60',
+                        disabled && 'text-input-text-disabled hover:text-input-text-disabled cursor-no-drop opacity-50',
                     ],
                     inputType === 'checkbox' && [
                         '[&>a]:text-link-default [&>a]:hover:text-link-hovered [&>a]:focus:text-link-hovered [&>a]:active:text-link-hovered',

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentContent.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentContent.tsx
@@ -21,7 +21,7 @@ export const TransportAndPaymentContent: FC = () => {
     const { transport, pickupPlace, payment } = useCurrentCart();
 
     const { changeTransportInCart, isChangingTransportInCart } = useChangeTransportInCart();
-    const { changePaymentInCart, isChangingPaymentInOrder } = useChangePaymentInCart();
+    const { changePaymentInCart, isChangingPaymentInCart } = useChangePaymentInCart();
     const [{ data: transportsData, fetching: areTransportsFetching }] = useTransportsQuery({
         variables: { cartUuid },
         requestPolicy: 'network-only',
@@ -35,7 +35,7 @@ export const TransportAndPaymentContent: FC = () => {
     const { goToPreviousStepFromTransportAndPaymentPage, goToNextStepFromTransportAndPaymentPage } =
         useTransportAndPaymentPageNavigation(validationMessages);
 
-    const isDisabled = hasValidationErrors(validationMessages) || isChangingTransportInCart || isChangingPaymentInOrder;
+    const isDisabled = hasValidationErrors(validationMessages) || isChangingTransportInCart || isChangingPaymentInCart;
 
     return (
         <OrderLayout
@@ -46,13 +46,13 @@ export const TransportAndPaymentContent: FC = () => {
 
             <OrderContentWrapper
                 activeStep={2}
-                isTransportOrPaymentLoading={isChangingTransportInCart || isChangingPaymentInOrder}
+                isTransportOrPaymentLoading={isChangingTransportInCart || isChangingPaymentInCart}
             >
                 {!!transportsData?.transports.length && (
                     <TransportAndPaymentSelect
                         changePaymentInCart={changePaymentInCart}
                         changeTransportInCart={changeTransportInCart}
-                        isTransportSelectionLoading={isChangingTransportInCart}
+                        isTransportSelectionLoading={isChangingTransportInCart || isChangingPaymentInCart}
                         lastOrderPickupPlace={lastOrderPickupPlace}
                         transports={transportsData.transports}
                     />
@@ -69,7 +69,7 @@ export const TransportAndPaymentContent: FC = () => {
                         step: t('Contact information'),
                     })}
                     shouldShowSpinnerOnNextStepButton={
-                        (isChangingTransportInCart || isChangingPaymentInOrder) && !!transport && !!payment
+                        (isChangingTransportInCart || isChangingPaymentInCart) && !!transport && !!payment
                     }
                 />
             </OrderContentWrapper>

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/PaymentSelectListItem.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/PaymentSelectListItem.tsx
@@ -12,10 +12,11 @@ type ChangePayment = ReturnType<typeof usePaymentChangeInSelect>['changePayment'
 type PaymentListItemProps = {
     payment: TypeSimplePaymentFragment;
     isActive?: boolean;
+    disabled?: boolean;
     changePayment: ChangePayment;
 };
 
-export const PaymentListItem: FC<PaymentListItemProps> = ({ payment, isActive = false, changePayment }) => {
+export const PaymentListItem: FC<PaymentListItemProps> = ({ payment, isActive = false, disabled, changePayment }) => {
     const { t } = useTranslation();
     const formatPrice = useFormatPrice();
 
@@ -35,6 +36,7 @@ export const PaymentListItem: FC<PaymentListItemProps> = ({ payment, isActive = 
             <Radiobutton
                 aria-label={ariaLabel}
                 checked={isActive}
+                disabled={disabled}
                 id={payment.uuid}
                 name="payment"
                 value={payment.uuid}

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
@@ -63,6 +63,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                                     <TransportListItem
                                         isActive
                                         changeTransport={changeTransport}
+                                        disabled={isTransportSelectionLoading}
                                         openPickupPlacePopup={() => openPickupPlacePopup(transport.uuid)}
                                         pickupPlace={pickupPlace}
                                         transport={transport}
@@ -82,6 +83,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                                         <TransportListItem
                                             key={transportItem.uuid}
                                             changeTransport={changeTransport}
+                                            disabled={isTransportSelectionLoading}
                                             pickupPlace={pickupPlace}
                                             transport={transportItem}
                                         />
@@ -96,6 +98,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                     {!!transport && transports.length > 1 && (
                         <AnimateCollapseDiv className="relative flex! flex-col" keyName="transport-reset">
                             <ResetButton
+                                disabled={isTransportSelectionLoading}
                                 text={t('Change transport type')}
                                 tid={TIDs.reset_transport_button}
                                 onClick={resetTransportAndPayment}
@@ -129,7 +132,12 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                                             disableAnimation={transport.payments.length === 1 ? true : false}
                                             keyName="payment-selected"
                                         >
-                                            <PaymentListItem isActive changePayment={changePayment} payment={payment} />
+                                            <PaymentListItem
+                                                isActive
+                                                changePayment={changePayment}
+                                                disabled={isTransportSelectionLoading}
+                                                payment={payment}
+                                            />
                                         </AnimateCollapseDiv>
                                     )}
                                 </AnimatePresence>
@@ -145,6 +153,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                                                 <PaymentListItem
                                                     key={paymentItem.uuid}
                                                     changePayment={changePayment}
+                                                    disabled={isTransportSelectionLoading}
                                                     payment={paymentItem}
                                                 />
                                             ))}
@@ -158,6 +167,7 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
                             {payment !== null && transport.payments.length > 1 && (
                                 <AnimateCollapseDiv className="relative flex! flex-col" keyName="payment-reset">
                                     <ResetButton
+                                        disabled={isTransportSelectionLoading}
                                         text={t('Change payment type')}
                                         tid={TIDs.reset_payment_button}
                                         onClick={resetPaymentAndGoPayBankSwift}
@@ -172,12 +182,13 @@ export const TransportAndPaymentSelect: FC<TransportAndPaymentSelectProps> = ({
     );
 };
 
-type ResetButtonProps = { text: string; onClick: () => void; tid: string };
+type ResetButtonProps = { text: string; onClick: () => void; tid: string; disabled?: boolean };
 
-const ResetButton: FC<ResetButtonProps> = ({ text, onClick, tid }) => (
+const ResetButton: FC<ResetButtonProps> = ({ text, onClick, tid, disabled }) => (
     <button
-        className="bg-background-more hover:bg-background-most flex w-full cursor-pointer items-center rounded-xl px-5 py-3 text-sm"
+        className="bg-background-more hover:bg-background-most flex w-full cursor-pointer items-center rounded-xl px-5 py-3 text-sm disabled:pointer-events-none disabled:opacity-50"
         data-tid={tid}
+        disabled={disabled}
         tabIndex={0}
         onClick={onClick}
     >

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelectItemLabel.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelectItemLabel.tsx
@@ -19,6 +19,7 @@ type TransportAndPaymentSelectItemLabelProps = {
     image?: TypeImageFragment | null;
     pickupPlaceDetail?: StoreOrPacketeryPoint;
     isActive?: boolean;
+    disabled?: boolean;
     showChangeButton?: boolean;
     openPickupPlacePopup?: () => void;
 };
@@ -31,6 +32,7 @@ export const TransportAndPaymentSelectItemLabel: FC<TransportAndPaymentSelectIte
     image,
     pickupPlaceDetail,
     isActive,
+    disabled,
     showChangeButton,
     openPickupPlacePopup,
 }) => {
@@ -113,7 +115,8 @@ export const TransportAndPaymentSelectItemLabel: FC<TransportAndPaymentSelectIte
                     {showChangeButton && pickupPlaceDetail && (
                         <button
                             aria-haspopup="dialog"
-                            className="text-link-default hover:text-link-hovered cursor-pointer text-left text-xs underline hover:no-underline"
+                            className="text-link-default hover:text-link-hovered cursor-pointer text-left text-xs underline hover:no-underline disabled:pointer-events-none disabled:opacity-50"
+                            disabled={disabled}
                             tabIndex={0}
                             onClick={openPickupPlacePopup}
                         >

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportSelectListItem.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportSelectListItem.tsx
@@ -16,6 +16,7 @@ type TransportListItemProps = {
         | (TypeTransportWithAvailablePaymentsFragment & TypeTransportStoresFragment)
         | TypeTransportWithAvailablePaymentsFragment;
     isActive?: boolean;
+    disabled?: boolean;
     changeTransport: ChangeTransport;
     pickupPlace: StoreOrPacketeryPoint | null;
     openPickupPlacePopup?: () => void;
@@ -24,6 +25,7 @@ type TransportListItemProps = {
 export const TransportListItem: FC<TransportListItemProps> = ({
     transport,
     isActive = false,
+    disabled,
     changeTransport,
     pickupPlace,
     openPickupPlacePopup,
@@ -47,6 +49,7 @@ export const TransportListItem: FC<TransportListItemProps> = ({
             <Radiobutton
                 aria-label={ariaLabel}
                 checked={isActive}
+                disabled={disabled}
                 id={transport.uuid}
                 name="transport"
                 value={transport.uuid}
@@ -54,6 +57,7 @@ export const TransportListItem: FC<TransportListItemProps> = ({
                     <TransportAndPaymentSelectItemLabel
                         daysUntilDelivery={transport.daysUntilDelivery}
                         description={transport.description}
+                        disabled={disabled}
                         image={transport.mainImage}
                         name={transport.name}
                         openPickupPlacePopup={() => openPickupPlacePopup?.()}

--- a/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
@@ -2,11 +2,11 @@ import {
     changeSelectionOfPaymentByName,
     changeSelectionOfTransportByName,
     chooseTransportPersonalCollectionAndStore,
+    waitForTransportAndPaymentToBeInteractive,
 } from './transportAndPaymentSupport';
 import { staticData, url } from 'fixtures/demodata';
 import { generateCreateOrderInput, generateCustomerRegistrationData } from 'fixtures/generators';
 import {
-    checkLoaderOverlayIsNotVisibleAfterTimePeriod,
     getSnapshotIndexingFunction,
     initializePersistStoreInLocalStorageToDefaultValues,
     SNAPSHOT_GROUP,
@@ -47,11 +47,11 @@ describe('Last Order Transport And Payment Select Tests', { retries: { runMode: 
         cy.visitAndWaitForStableAndInteractiveDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod(1000);
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfTransportByName(translations.transport.ppl);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod(1000);
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfPaymentByName(translations.payment.onDelivery);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod(1000);
+        waitForTransportAndPaymentToBeInteractive();
         cy.reloadAndWaitForStableAndInteractiveDOM();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after first change and refresh', {
             blackout: [
@@ -62,14 +62,14 @@ describe('Last Order Transport And Payment Select Tests', { retries: { runMode: 
         });
 
         changeSelectionOfTransportByName(translations.transport.ppl);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod(1000);
+        waitForTransportAndPaymentToBeInteractive();
         chooseTransportPersonalCollectionAndStore(
             staticData.transport.personalCollection.storePardubice.name,
             translations.transport.personalCollection,
         );
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod(1000);
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfPaymentByName(translations.payment.cash);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod(1000);
+        waitForTransportAndPaymentToBeInteractive();
         cy.reloadAndWaitForStableAndInteractiveDOM();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after second change and refresh', {
             blackout: [

--- a/project-base/storefront/cypress/e2e/transportAndPayment/paymentSelect.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/paymentSelect.cy.ts
@@ -3,12 +3,12 @@ import {
     changeSelectionOfTransportByName,
     removePaymentSelectionUsingButton,
     removeTransportSelectionUsingButton,
+    waitForTransportAndPaymentToBeInteractive,
 } from './transportAndPaymentSupport';
 import { goToNextOrderStep } from 'e2e/cart/cartSupport';
 import { staticData, url } from 'fixtures/demodata';
 import {
     checkCanGoToNextOrderStep,
-    checkLoaderOverlayIsNotVisibleAfterTimePeriod,
     checkUrl,
     getSnapshotIndexingFunction,
     initializePersistStoreInLocalStorageToDefaultValues,
@@ -32,7 +32,7 @@ describe('Payment Select Tests', () => {
 
     it('[Select Payment] should select payment on delivery', function () {
         changeSelectionOfPaymentByName(translations.payment.onDelivery);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         checkCanGoToNextOrderStep();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after payment selection', {
             blackout: [
@@ -48,11 +48,11 @@ describe('Payment Select Tests', () => {
 
     it('[Select And Change Payment] should select a payment, deselect it, and then change the payment option', function () {
         changeSelectionOfPaymentByName(translations.payment.onDelivery);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfPaymentByName(translations.payment.onDelivery);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfPaymentByName(translations.payment.creditCard);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         checkCanGoToNextOrderStep();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after changing payment selection', {
             blackout: [
@@ -68,7 +68,7 @@ describe('Payment Select Tests', () => {
 
     it('[Remove Payment Repeated Click] should remove payment using repeated clicks', function () {
         changeSelectionOfPaymentByName(translations.payment.creditCard);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -78,7 +78,7 @@ describe('Payment Select Tests', () => {
         });
 
         changeSelectionOfPaymentByName(translations.payment.creditCard);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after removing', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -90,7 +90,7 @@ describe('Payment Select Tests', () => {
 
     it('[Remove Payment Button Click] should remove payment using reset button', function () {
         changeSelectionOfPaymentByName(translations.payment.creditCard);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -100,7 +100,7 @@ describe('Payment Select Tests', () => {
         });
 
         removePaymentSelectionUsingButton();
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after removing', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -112,7 +112,7 @@ describe('Payment Select Tests', () => {
 
     it('[Remove & Select New T&P] should remove transport to remove payment as well, and then allow to select transport incompatible with previous payment', function () {
         changeSelectionOfPaymentByName(translations.payment.creditCard);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -122,7 +122,7 @@ describe('Payment Select Tests', () => {
         });
 
         removeTransportSelectionUsingButton();
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after removing transport', {
             blackout: [
                 { tid: TIDs.order_summary_cart_item_image },
@@ -132,7 +132,7 @@ describe('Payment Select Tests', () => {
         });
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(
             getSnapshotFullIndexAsString(),
             'after selecting transport incompatible with the previous payment',

--- a/project-base/storefront/cypress/e2e/transportAndPayment/transportAndPaymentSupport.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/transportAndPaymentSupport.ts
@@ -19,6 +19,24 @@ export const changeSelectionOfPaymentByName = (paymentName: string) => {
     cy.getByTID([TIDs.pages_order_payment, TIDs.pages_order_selectitem_label_name]).contains(paymentName).click('left');
 };
 
+const checkSectionHasEnabledRadios = (sectionTid: TIDs) => {
+    cy.getByTID([sectionTid], { timeout: 10000 }).find('input[type="radio"]').its('length').should('be.gte', 1);
+    cy.getByTID([sectionTid], { timeout: 10000 }).find('input[type="radio"]:enabled').its('length').should('be.gte', 1);
+};
+
+export const waitForTransportAndPaymentToBeInteractive = () => {
+    cy.getByTID([TIDs.loader_overlay], { timeout: 10000 }).should('not.exist');
+    checkSectionHasEnabledRadios(TIDs.pages_order_transport);
+
+    cy.get('body').then(($body) => {
+        const paymentSectionSelector = `[data-tid=${TIDs.pages_order_payment}]`;
+
+        if ($body.find(paymentSectionSelector).length > 0) {
+            checkSectionHasEnabledRadios(TIDs.pages_order_payment);
+        }
+    });
+};
+
 export const changeDayOfWeekInTransportsApiResponse = (dayOfWeek: number) => {
     cy.intercept('POST', '/graphql/TransportsFullQuery', (req) => {
         req.reply((response) => {

--- a/project-base/storefront/cypress/e2e/transportAndPayment/transportSelect.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/transportSelect.cy.ts
@@ -4,13 +4,13 @@ import {
     changeSelectionOfTransportByName,
     chooseTransportPersonalCollectionAndStore,
     removeTransportSelectionUsingButton,
+    waitForTransportAndPaymentToBeInteractive,
 } from './transportAndPaymentSupport';
 import { goToNextOrderStep } from 'e2e/cart/cartSupport';
 import { checkEmptyCartTextIsVisible, checkTransportSelectionIsNotVisible } from 'e2e/order/orderSupport';
 import { staticData, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
 import {
-    checkLoaderOverlayIsNotVisibleAfterTimePeriod,
     checkUrl,
     getSnapshotIndexingFunction,
     initializePersistStoreInLocalStorageToDefaultValues,
@@ -33,7 +33,7 @@ describe('Transport Select Tests', () => {
         cy.visitAndWaitForStableAndInteractiveDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -53,7 +53,7 @@ describe('Transport Select Tests', () => {
             staticData.transport.personalCollection.storeOstrava.name,
             translations.transport.personalCollection,
         );
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -68,11 +68,11 @@ describe('Transport Select Tests', () => {
         cy.visitAndWaitForStableAndInteractiveDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         changeSelectionOfTransportByName(translations.transport.ppl);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting, deselecting, and selecting again', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -87,7 +87,7 @@ describe('Transport Select Tests', () => {
         cy.visitAndWaitForStableAndInteractiveDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -97,7 +97,7 @@ describe('Transport Select Tests', () => {
         });
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after removing', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -112,7 +112,7 @@ describe('Transport Select Tests', () => {
         cy.visitAndWaitForStableAndInteractiveDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(translations.transport.czechPost);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after selecting', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -122,7 +122,7 @@ describe('Transport Select Tests', () => {
         });
 
         removeTransportSelectionUsingButton();
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'after removing', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },
@@ -180,7 +180,7 @@ describe('Transport Select Tests', () => {
 
         goToNextOrderStep();
         changeSelectionOfTransportByName(translations.transport.ppl);
-        checkLoaderOverlayIsNotVisibleAfterTimePeriod();
+        waitForTransportAndPaymentToBeInteractive();
         takeSnapshotAndCompare(getSnapshotFullIndexAsString(), 'transport and payment page with enough products', {
             blackout: [
                 { tid: TIDs.transport_and_payment_list_item_image },

--- a/project-base/storefront/utils/cart/useChangePaymentInCart.ts
+++ b/project-base/storefront/utils/cart/useChangePaymentInCart.ts
@@ -11,7 +11,7 @@ export type ChangePaymentInCart = (
 ) => Promise<TypeCartFragment | undefined | null>;
 
 export const useChangePaymentInCart = () => {
-    const [{ fetching: isChangingPaymentInOrder }, changePaymentInCartMutation] = useChangePaymentInCartMutation();
+    const [{ fetching: isChangingPaymentInCart }, changePaymentInCartMutation] = useChangePaymentInCartMutation();
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const { gtmCartInfo } = useGtmCartInfo();
     const { canSeePrices } = useAuthorization();
@@ -43,5 +43,5 @@ export const useChangePaymentInCart = () => {
         return changePaymentResult.data?.ChangePaymentInCart;
     };
 
-    return { changePaymentInCart, isChangingPaymentInOrder };
+    return { changePaymentInCart, isChangingPaymentInCart };
 };

--- a/upgrade-notes/storefront_20260225_132344.md
+++ b/upgrade-notes/storefront_20260225_132344.md
@@ -1,0 +1,5 @@
+#### Fix transport and payment race conditions ([#4480](https://github.com/shopsys/shopsys/pull/4480))
+
+- transport and payment radio buttons and reset buttons are now disabled while a transport or payment mutation is in flight
+- this prevents a race condition where selecting a new transport during an ongoing payment reset could result in an incompatible transport/payment combination error
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Prevents race condition when user changes transport while a previous transport or payment mutation hasn't completed yet.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3895-disabled-transport-and-payment.odin.shopsys.cloud
  - https://cz.tc-ssp-3895-disabled-transport-and-payment.odin.shopsys.cloud
  - https://tc-ssp-3895-disabled-transport-and-payment.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1772613863.310599 -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3895-disabled-transport-and-payment.odin.shopsys.cloud
  - https://cz.tc-ssp-3895-disabled-transport-and-payment.odin.shopsys.cloud
  - https://tc-ssp-3895-disabled-transport-and-payment.odin.shopsys.cloud/sk
<!-- Replace -->
