### PR TITLE
admin: Tom Select dropdown in modals now renders correctly

### DIFF
--- a/packages/administration/assets/src/js/initComponents.js
+++ b/packages/administration/assets/src/js/initComponents.js
@@ -9,7 +9,7 @@ function initSelect($container) {
         const settings = {
             allowEmptyOption: true,
             maxOptions: null,
-            dropdownParent: 'body',
+            dropdownParent: el.closest('.modal') ? null : 'body',
             plugins: {
                 dropdown_input: {},
                 no_backspace_delete: {},

--- a/upgrade-notes/backend_20260304_140254.md
+++ b/upgrade-notes/backend_20260304_140254.md
@@ -1,0 +1,3 @@
+#### Tom Select dropdown in modals now renders correctly ([#4497](https://github.com/shopsys/shopsys/pull/4497))
+
+- dropdown was appended to body, rendering behind the modal due to z-index and focus trap conflicts


### PR DESCRIPTION
#### Description, the reason for the PR
Fix select box in modal.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3831-fix-admin-select.odin.shopsys.cloud
  - https://cz.tc-ssp-3831-fix-admin-select.odin.shopsys.cloud
  - https://tc-ssp-3831-fix-admin-select.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773042057.941449 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3831-fix-admin-select.odin.shopsys.cloud
  - https://cz.tc-ssp-3831-fix-admin-select.odin.shopsys.cloud
  - https://tc-ssp-3831-fix-admin-select.odin.shopsys.cloud/sk
<!-- Replace -->
