### PR TITLE
useAddOrderItemsToCart: cart skeleton now shows during repeat order redirect

### DIFF
--- a/project-base/storefront/utils/cart/useAddOrderItemsToCart.tsx
+++ b/project-base/storefront/utils/cart/useAddOrderItemsToCart.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { usePersistStore } from 'store/usePersistStore';
 import { useSessionStore } from 'store/useSessionStore';
+import { SkeletonEnum } from 'types/skeletons';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
 import { dispatchBroadcastChannel } from 'utils/useBroadcastChannel';
 
@@ -24,6 +25,7 @@ export const useAddOrderItemsToCart = () => {
     const [, addOrderItemsToCart] = useAddOrderItemsToCartMutation();
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
     const updatePortalContent = useSessionStore((store) => store.updatePortalContent);
+    const updatePageLoadingState = useSessionStore((store) => store.updatePageLoadingState);
 
     const handleAddingItemsToCart = async (input: TypeAddOrderItemsToCartInput) => {
         const addOrderItemsToCartResponse = await addOrderItemsToCart({ input });
@@ -41,6 +43,7 @@ export const useAddOrderItemsToCart = () => {
             const notAddedProducts = newCart.modifications.multipleAddedProductModifications.notAddedProducts;
             const addedAllProducts = notAddedProducts.length === 0;
             if (addedAllProducts) {
+                updatePageLoadingState({ isPageLoading: true, redirectPageType: SkeletonEnum.Cart });
                 router.push(cartUrl);
             } else {
                 updatePortalContent(

--- a/upgrade-notes/storefront_20260304_141759.md
+++ b/upgrade-notes/storefront_20260304_141759.md
@@ -1,0 +1,3 @@
+#### useAddOrderItemsToCart: cart skeleton now shows during repeat order redirect ([#4498](https://github.com/shopsys/shopsys/pull/4498))
+
+- see #project-base-diff


### PR DESCRIPTION
#### Description, the reason for the PR
Fix repeat order skeleton loader.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3782-repear-order-skeleton.odin.shopsys.cloud
  - https://cz.tc-ssp-3782-repear-order-skeleton.odin.shopsys.cloud
  - https://tc-ssp-3782-repear-order-skeleton.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773043041.748789 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3782-repear-order-skeleton.odin.shopsys.cloud
  - https://cz.tc-ssp-3782-repear-order-skeleton.odin.shopsys.cloud
  - https://tc-ssp-3782-repear-order-skeleton.odin.shopsys.cloud/sk
<!-- Replace -->
