### PR TITLE
add missing symfony security-core security-http composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,6 +178,8 @@
         "symfony/rate-limiter": "^7.4",
         "symfony/runtime": "^7.4",
         "symfony/security-bundle": "^7.4",
+        "symfony/security-core": "^7.4",
+        "symfony/security-http": "^7.4",
         "symfony/serializer": "^7.4",
         "symfony/service-contracts": "^3.5",
         "symfony/stopwatch": "^7.4",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -107,6 +107,8 @@
         "symfony/property-info": "^7.4",
         "symfony/rate-limiter": "^7.4",
         "symfony/security-bundle": "^7.4",
+        "symfony/security-core": "^7.4",
+        "symfony/security-http": "^7.4",
         "symfony/serializer": "^7.4",
         "symfony/service-contracts": "^3.5",
         "symfony/ux-icons": "^2.22",

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -42,6 +42,8 @@
         "symfony/http-foundation": "^7.4",
         "symfony/http-kernel": "^7.4",
         "symfony/clock": "^7.4",
+        "symfony/security-core": "^7.4",
+        "symfony/security-http": "^7.4",
         "symfony/routing": "^7.4",
         "webonyx/graphql-php": "^15.29.1"
     },


### PR DESCRIPTION
#### Description, the reason for the PR
- classes from the packages are used directly in e.g. `CustomerLoginHandler` or `TokenAuthenticator`
- so far, we have required `symfony/security-bundle` only, but that does not guarantee the `security-core` and `security-http` packages to be installed in `^7.4` version as `^8.0` is also allowed
- when `8.0` version of these packages is installed, it breaks our code as we are not ready for that
  - see https://github.com/shopsys/frontend-api/actions/runs/22663956697/job/65690873843
  - see https://github.com/shopsys/framework/actions/runs/22709717219/job/65848787532
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-packages.odin.shopsys.cloud
  - https://cz.rv-fix-packages.odin.shopsys.cloud
  - https://rv-fix-packages.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773050513.324919 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-packages.odin.shopsys.cloud
  - https://cz.rv-fix-packages.odin.shopsys.cloud
  - https://rv-fix-packages.odin.shopsys.cloud/sk
<!-- Replace -->
