### PR TITLE
fix ckeditor links

### DIFF
--- a/packages/framework/assets/js/admin/components/CKEditorLinkVariableProtocol.js
+++ b/packages/framework/assets/js/admin/components/CKEditorLinkVariableProtocol.js
@@ -1,0 +1,56 @@
+// When the CKEditor link dialog URL contains a template variable (e.g. {order_detail_url}),
+// automatically switch the protocol dropdown to <other> so it doesn't get prefixed with http://
+import Register from '../../common/utils/Register';
+
+function initCKEditorLinkVariableProtocol() {
+    if (typeof CKEDITOR === 'undefined') {
+        return;
+    }
+
+    if (CKEDITOR._linkProtocolFixRegistered) {
+        return;
+    }
+    CKEDITOR._linkProtocolFixRegistered = true;
+
+    function switchProtocolIfNeeded(dialog) {
+        var urlField = dialog.getContentElement('info', 'url');
+        var protocolField = dialog.getContentElement('info', 'protocol');
+        var url;
+        if (urlField && protocolField) {
+            url = urlField.getValue();
+            if (url && url.indexOf('{') !== -1 && protocolField.getValue() !== '') {
+                protocolField.setValue('');
+            }
+        }
+    }
+
+    CKEDITOR.on('dialogDefinition', ev => {
+        if (ev.data.name !== 'link') {
+            return;
+        }
+
+        var originalOnShow = ev.data.definition.onShow;
+        ev.data.definition.onShow = function () {
+            var urlField;
+            var inputEl;
+
+            if (originalOnShow) {
+                originalOnShow.call(this);
+            }
+
+            switchProtocolIfNeeded(this);
+
+            urlField = this.getContentElement('info', 'url');
+            if (urlField && !urlField._protocolFixPatched) {
+                urlField._protocolFixPatched = true;
+
+                inputEl = urlField.getInputElement().$;
+                inputEl.addEventListener('keyup', () => {
+                    switchProtocolIfNeeded(this);
+                });
+            }
+        };
+    });
+}
+
+new Register().registerCallback(initCKEditorLinkVariableProtocol, 'CKEditorLinkVariableProtocol');

--- a/packages/framework/assets/js/admin/components/CKEditorPreview.js
+++ b/packages/framework/assets/js/admin/components/CKEditorPreview.js
@@ -4,6 +4,10 @@ export default class CKEditorPreview {
     constructor($ckEditorPreview) {
         const $editButton = $ckEditorPreview.children('.js-cke-preview-edit');
 
+        $ckEditorPreview.on('click', 'a', e => {
+            e.preventDefault();
+        });
+
         $ckEditorPreview.click(() => {
             $ckEditorPreview.hide();
             $editButton.hide();

--- a/packages/framework/assets/js/admin/components/index.js
+++ b/packages/framework/assets/js/admin/components/index.js
@@ -5,6 +5,7 @@ import './AjaxConfirm';
 import './Article';
 import './CategoryTreeForm';
 import './CategoryTreeSorting';
+import './CKEditorLinkVariableProtocol';
 import './CKEditorPreview';
 import './choiceControl';
 import './Complaint';


### PR DESCRIPTION
#### Description, the reason for the PR
Links in CKEditor preview cards no longer navigate away from the admin page when clicked. The CKEditor link dialog now automatically switches the protocol to <other> when the URL contains template variables like {order_detail_url}, preventing broken links caused by an http:// prefix.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3855-ckeditor.odin.shopsys.cloud
  - https://cz.tc-ssp-3855-ckeditor.odin.shopsys.cloud
  - https://tc-ssp-3855-ckeditor.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773215525.948049 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3855-ckeditor.odin.shopsys.cloud
  - https://cz.tc-ssp-3855-ckeditor.odin.shopsys.cloud
  - https://tc-ssp-3855-ckeditor.odin.shopsys.cloud/sk
<!-- Replace -->
