### PR TITLE
CKeditor fixes

### DIFF
--- a/packages/administration/src/DependencyInjection/ShopsysAdministrationExtension.php
+++ b/packages/administration/src/DependencyInjection/ShopsysAdministrationExtension.php
@@ -16,6 +16,8 @@ use Symfony\Component\Finder\Finder;
 
 class ShopsysAdministrationExtension extends Extension implements PrependExtensionInterface
 {
+    protected const string CKEDITOR_PREVIEW_SANITIZER_NAME = 'shopsys.ckeditor_preview';
+
     /**
      * {@inheritdoc}
      */
@@ -55,6 +57,18 @@ class ShopsysAdministrationExtension extends Extension implements PrependExtensi
         $container->prependExtensionConfig('doctrine_migrations', [
             'migrations_paths' => [
                 'Shopsys\AdministrationBundle\Migrations' => __DIR__ . '/../Migrations',
+            ],
+        ]);
+
+        $container->prependExtensionConfig('framework', [
+            'html_sanitizer' => [
+                'sanitizers' => [
+                    static::CKEDITOR_PREVIEW_SANITIZER_NAME => [
+                        'allow_safe_elements' => true,
+                        'allow_relative_links' => true,
+                        'allow_relative_medias' => true,
+                    ],
+                ],
             ],
         ]);
 

--- a/packages/administration/templates/form/type/CKEditorType.html.twig
+++ b/packages/administration/templates/form/type/CKEditorType.html.twig
@@ -3,7 +3,7 @@
     <div class="js-cke-preview" id="{{ id }}-preview">
         <div class="card">
             <div class="card-body overflow-hidden cursor-pointer" style="min-height: 92px; max-height: 200px;">
-                {{ value|raw }}
+                {{ value|sanitize_html('shopsys.ckeditor_preview') }}
             </div>
             <div class="card-footer">
                 <div class="btn btn-primary btn-sm js-cke-preview-edit">{{ 'Edit'|trans }}</div>

--- a/project-base/app/tests/App/Functional/Twig/CkeditorPreviewHtmlSanitizerTest.php
+++ b/project-base/app/tests/App/Functional/Twig/CkeditorPreviewHtmlSanitizerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Twig;
+
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+use Tests\App\Test\FunctionalTestCase;
+
+final class CkeditorPreviewHtmlSanitizerTest extends FunctionalTestCase
+{
+    /**
+     * @inject html_sanitizer.sanitizer.shopsys.ckeditor_preview
+     */
+    private HtmlSanitizerInterface $ckeditorPreviewHtmlSanitizer;
+
+    public function testSanitizerPreservesRelativeMediaAndLinks(): void
+    {
+        $sanitizedContent = $this->ckeditorPreviewHtmlSanitizer->sanitize(
+            '<div><p>Hello <strong>world</strong><img alt="A4tech X710BK" src="/content/wysiwyg/test-image.jpg" /></p><a href="/product/test">link</a><script>alert(1)</script></div>',
+        );
+
+        $this->assertSame(
+            '<div><p>Hello <strong>world</strong><img alt="A4tech X710BK" src="/content/wysiwyg/test-image.jpg" /></p><a href="/product/test">link</a></div>',
+            $sanitizedContent,
+        );
+    }
+
+    public function testSanitizerNormalizesInvalidHtmlStructure(): void
+    {
+        $sanitizedContent = $this->ckeditorPreviewHtmlSanitizer->sanitize('<div><p>broken');
+
+        $this->assertSame('<div><p>broken</p></div>', $sanitizedContent);
+    }
+}

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -23,7 +23,7 @@ upstream storefront-upstream {
 server {
     listen 8081;
 
-    location ~ ^/(content(-test)?|build|public)/ {
+    location ~ ^/(content(-test)?|build|public|bundles)/ {
         proxy_set_header Host '127.0.0.1:8000';
         proxy_pass http://127.0.0.1:8080$request_uri;
     }

--- a/upgrade-notes/backend_20260316_115734.md
+++ b/upgrade-notes/backend_20260316_115734.md
@@ -1,0 +1,3 @@
+#### CKeditor fixes ([#4506](https://github.com/shopsys/shopsys/pull/4506))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- CKeditor was not loading properly when using local CDN
- malformed html was breaking the administration - it is now sanitized

#### Fixes issues
closes #2463

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://rv-fix-ckeditor.odin.shopsys.cloud
  - https://cz.rv-fix-ckeditor.odin.shopsys.cloud
  - https://rv-fix-ckeditor.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773828813.781239 -->