### PR TITLE
order relations that can influence order item price calculations are now stored during order creation

### DIFF
--- a/.agents/skills/review-server-logs/SKILL.md
+++ b/.agents/skills/review-server-logs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: review-server-logs
+description: Connects to the Odin review server via SSH and searches Docker container logs for errors, exceptions, and 5xx responses on a given review branch.
+tools: Bash
+user_invocable: true
+---
+
+You are a log analysis specialist. Your job is to connect to the Odin review server and find relevant errors in the Docker container logs for a specified review branch.
+
+## Connection Details
+
+- **Host**: odin.shopsys.cloud
+- **Port**: 4010
+- **User**: The user's last name (lowercase). Ask the user if you don't know their name — check memory first.
+- **Switch user**: After SSH, commands must run as `github-runner` via `sudo su - github-runner -c '...'`
+- **Base path**: `/home/github-runner/actions-runner/_work/shopsys/shopsys/`
+
+## Branch Directory Convention
+
+The review branch directory name is derived from the git branch name:
+- Replace `/` with `-`
+- Lowercase
+- Example: `TL/freeze-order-prices-before-setting-change` → `tl-freeze-order-prices-before-setting-change`
+
+## Steps
+
+1. **Determine the branch**: Ask the user which branch to check, or use the current git branch if not specified.
+
+2. **Verify the deployment exists**: List the base path to confirm the branch directory exists.
+
+3. **Check containers are running**:
+   ```
+   ssh <user>@odin.shopsys.cloud -p 4010 "sudo su - github-runner -c 'cd <base_path>/<branch-dir> && export BRANCH_NAME_ESCAPED=<branch-dir> && docker compose ps 2>/dev/null'" 2>&1 | grep -v 'level=warning'
+   ```
+
+4. **Search php-fpm logs for errors** (exclude known noise):
+   ```
+   ssh <user>@odin.shopsys.cloud -p 4010 "sudo su - github-runner -c 'cd <base_path>/<branch-dir> && export BRANCH_NAME_ESCAPED=<branch-dir> && docker compose logs php-fpm 2>/dev/null'" 2>&1 | grep -v 'level=warning' | grep -v 'GoPay\|GoPayStatus\|cron_modules_pkey\|InvalidToken\|Packetery\|PacketeryCron' | grep -i -E '"level":400|"level":500|CRITICAL|ERROR'
+   ```
+
+5. **Search nginx/webserver logs for 5xx responses**:
+   ```
+   ssh <user>@odin.shopsys.cloud -p 4010 "sudo su - github-runner -c 'cd <base_path>/<branch-dir> && export BRANCH_NAME_ESCAPED=<branch-dir> && docker compose logs webserver 2>/dev/null'" 2>&1 | grep -v 'level=warning' | grep -E '" 5[0-9][0-9] '
+   ```
+
+6. **If errors are found**, get surrounding context by filtering logs around the error timestamp to understand the full request flow.
+
+## Important Notes
+
+- Always set `BRANCH_NAME_ESCAPED` env var before running `docker compose` commands — otherwise you'll get warnings and potentially wrong container names.
+- Filter out `level=warning` from stderr (Docker Compose env var warnings).
+- Known noise to exclude: GoPay cron errors (no real credentials on review), Packetery cron errors, `cron_modules_pkey` duplicate key violations (startup race conditions), `InvalidTokenUserMessageException` (expired tokens).
+- Container logs are lost on redeployment. If logs are empty or the relevant timeframe is missing, inform the user.
+- Use `--since` flag to narrow down time ranges when needed (e.g., `docker compose logs php-fpm --since 24h`).
+- Set appropriate timeouts (60s) for SSH commands as log retrieval can be slow.
+
+## Output
+
+Present findings clearly:
+1. List all errors found with timestamps
+2. For each error, show the full error message/stack trace
+3. Cross-reference with nginx access logs to identify the exact request that caused it
+4. Provide your analysis of the root cause

--- a/.agents/skills/upgrade-notes-analyzer/SKILL.md
+++ b/.agents/skills/upgrade-notes-analyzer/SKILL.md
@@ -139,7 +139,9 @@ Analyzes PR diffs to identify breaking changes, feature movements, and scope.
 **Style:**
 - Action verbs: "use", "replace", "update"
 - Always use FQCN
-- Focus on WHAT to do, not WHY
+- Focus on WHAT to do, not WHY — do not explain reasons behind changes, only describe what changed and what action to take
+- If a method/class was renamed (same purpose, new name), say "was renamed to", NOT "was removed, use X instead"
+- When listing alternatives, use "or" not semicolons (e.g., "use X instead or use Y to populate all at once")
 - Key test: "Will code break without manual changes?" → YES = include
 
 **Code example formatting:**

--- a/packages/administration/templates/content/currency/listGrid.html.twig
+++ b/packages/administration/templates/content/currency/listGrid.html.twig
@@ -12,6 +12,14 @@
     {% endif %}
 {% endblock %}
 
+{% block grid_value_cell_edit_id_code %}
+    {% if row is not null and row.c.id in currencyIdsUsedInOrders %}
+        {{ form_widget(form.code, { rawSymbolAfterInput: info_icon('Code can\'t be modified because it is used for pairing with existing orders.'|trans) }) }}
+    {% else %}
+        {{ form_widget(form.code) }}
+    {% endif %}
+{% endblock %}
+
 {% block grid_value_cell_edit_id_exchangeRate %}
     {% set info_message = null %}
 

--- a/packages/administration/templates/content/order/listGrid.html.twig
+++ b/packages/administration/templates/content/order/listGrid.html.twig
@@ -33,7 +33,7 @@
 {% endblock %}
 
 {% block grid_value_cell_id_total_price %}
-    {{ value|priceWithCurrency(row.order.currency) }}
+    {{ value|priceWithCurrencyByOrder(row.order) }}
 {% endblock %}
 
 {% block grid_value_cell_id_created_at %}

--- a/packages/administration/templates/content/order/preview.html.twig
+++ b/packages/administration/templates/content/order/preview.html.twig
@@ -23,14 +23,14 @@
                         {{ item.name }}
                     </td>
                     <td class="text-end">{{ item.quantity }} {{ item.unitName }}</td>
-                    <td class="text-end">{{ item.totalPriceWithVat|priceWithCurrency(order.currency) }}</td>
+                    <td class="text-end">{{ item.totalPriceWithVat|priceWithCurrencyByOrder(order) }}</td>
                 </tr>
             {% endfor %}
         </tbody>
         <tfoot>
             <tr>
                 <td colspan="2" class="text-end"><strong>{{ 'Total including VAT'|trans }}</strong></td>
-                <td class="text-end"><strong>{{ order.totalPriceWithVat|priceWithCurrency(order.currency) }}</strong></td>
+                <td class="text-end"><strong>{{ order.totalPriceWithVat|priceWithCurrencyByOrder(order) }}</strong></td>
             </tr>
         </tfoot>
     </table>

--- a/packages/administration/templates/form/content/OrderItemsType.html.twig
+++ b/packages/administration/templates/form/content/OrderItemsType.html.twig
@@ -32,14 +32,10 @@
                            data-prototype="{{ orderItemMacro.orderItem(form.itemsWithoutTransportAndPayment.vars.prototype, null, null, inputPriceType)|escape }}"
                            data-order-product-add-url="{{ url('admin_order_addproduct', { orderId: order.id }) }}"
                     >
-                        {% for productItem in order.productItems %}
-                            {{ orderItemMacro.orderItem(form.itemsWithoutTransportAndPayment[productItem.id], productItem.id, productItem, inputPriceType) }}
-                        {% endfor %}
-
                         {% for orderItemId, orderItemForm in form.itemsWithoutTransportAndPayment %}
-                            {% if not orderItemForm.rendered %}
-                                {{ orderItemMacro.orderItem(orderItemForm, orderItemId, null, inputPriceType) }}
-                            {% endif %}
+                            {% set itemData = orderItemForm.vars.data %}
+                            {% set productItemData = (itemData is not null and itemData.type in ['product', 'productGift']) ? itemData : null %}
+                            {{ orderItemMacro.orderItem(orderItemForm, orderItemId, productItemData, inputPriceType) }}
                         {% endfor %}
 
                         {{ orderItemMacro.orderTransport(form.orderTransport, transportPricesWithVatByTransportId, transportVatPercentsByTransportId, inputPriceType) }}

--- a/packages/administration/templates/form/content/OrderItemsType.html.twig
+++ b/packages/administration/templates/form/content/OrderItemsType.html.twig
@@ -16,11 +16,11 @@
                             <th>{{ 'Catalog number'|trans }}</th>
                             <th class="text-end">{{ 'Amount'|trans }}</th>
                             <th class="text-end">{{ 'Unit'|trans }}</th>
-                            <th class="text-wrap text-end">{{ 'Unit price excluding VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+                            <th class="text-wrap text-end">{{ 'Unit price excluding VAT'|trans }} ({{ currencySymbolByCode(order.currencyCode) }})</th>
                             <th class="text-wrap text-end">{{ 'VAT rate (%)'|trans }}</th>
-                            <th class="text-wrap text-end">{{ 'Unit price including VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
-                            <th class="text-wrap text-end">{{ 'Total excluding VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
-                            <th class="text-wrap text-end">{{ 'Total including VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+                            <th class="text-wrap text-end">{{ 'Unit price including VAT'|trans }} ({{ currencySymbolByCode(order.currencyCode) }})</th>
+                            <th class="text-wrap text-end">{{ 'Total excluding VAT'|trans }} ({{ currencySymbolByCode(order.currencyCode) }})</th>
+                            <th class="text-wrap text-end">{{ 'Total including VAT'|trans }} ({{ currencySymbolByCode(order.currencyCode) }})</th>
                             <th class="text-wrap text-center">
                                 {{ 'Set prices manually'|trans }}
                                 {{ info_icon('All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically.'|trans) }}
@@ -51,10 +51,10 @@
                                 <strong>{{ 'Total'|trans }}</strong>
                             </td>
                             <td class="text-end">
-                                <strong>{{ order.totalPriceWithoutVat|priceWithCurrency(order.currency) }}</strong>
+                                <strong>{{ order.totalPriceWithoutVat|priceWithCurrencyByOrder(order) }}</strong>
                             </td>
                             <td class="text-end">
-                                <strong>{{ order.totalPriceWithVat|priceWithCurrency(order.currency) }}</strong>
+                                <strong>{{ order.totalPriceWithVat|priceWithCurrencyByOrder(order) }}</strong>
                             </td>
                             <td></td>
                             <td></td>

--- a/packages/administration/templates/form/content/PaymentTransactionsType.html.twig
+++ b/packages/administration/templates/form/content/PaymentTransactionsType.html.twig
@@ -40,11 +40,11 @@
             {% endif %}
         </td>
         <td class="text-end">
-            {{ paymentTransaction.paidAmount|priceWithCurrency(order.currency) }}
+            {{ paymentTransaction.paidAmount|priceWithCurrencyByOrder(order) }}
         </td>
         <td class="text-end">
             <span class="js-refunded-amount">
-            {{ paymentTransaction.refundedAmount|priceWithCurrency(order.currency) }}
+            {{ paymentTransaction.refundedAmount|priceWithCurrencyByOrder(order) }}
                 {% if paymentTransaction.refundable %}
                     <span class="js-refunded-amount-edit cursor-pointer" title="edit">{{ ux_icon('pencil') }}</span>
                 {% endif %}
@@ -55,12 +55,12 @@
             </span>
         </td>
         <td class="text-end">
-            {{ paymentTransaction.refundableAmount|priceWithCurrency(order.currency) }}
+            {{ paymentTransaction.refundableAmount|priceWithCurrencyByOrder(order) }}
         </td>
         <td>
             {% if paymentTransaction.refundable %}
                 <div style="width: 150px">
-                    {{ form_widget(paymentTransactionForm.refundAmount, {symbolAfterInput: currencySymbolByCurrencyId(order.currency.id), attr: { class: 'text-end'}}) }}
+                    {{ form_widget(paymentTransactionForm.refundAmount, {symbolAfterInput: currencySymbolByCode(order.currencyCode), attr: { class: 'text-end'}}) }}
                     {{ form_errors(paymentTransactionForm.refundAmount, {errors_attr: { inline: true }}) }}
                 </div>
             {% else %}

--- a/packages/administration/templates/form/content/customer/orderListType.html.twig
+++ b/packages/administration/templates/form/content/customer/orderListType.html.twig
@@ -57,7 +57,7 @@
                                         {{ order.deliveryStreet }}<br />
                                         {{ order.deliveryCity }}, {{ order.deliveryPostcode }}
                                     </td>
-                                    <td>{{ order.totalPriceWithVat|priceWithCurrency(order.currency) }}</td>
+                                    <td>{{ order.totalPriceWithVat|priceWithCurrencyByOrder(order) }}</td>
                                     <td>{{ order.status.name }}</td>
                                 </tr>
                             {% endfor %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -313,6 +313,9 @@ msgstr "Svátky a interní dny"
 msgid "Closing modules"
 msgstr "Zapínací moduly"
 
+msgid "Code can't be modified because it is used for pairing with existing orders."
+msgstr "Kód nemůže být upraven, protože je spárovaný s existujícím objednávkami."
+
 msgid "Color parameter values"
 msgstr "Hodnota parametru typu barva"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -313,6 +313,9 @@ msgstr ""
 msgid "Closing modules"
 msgstr ""
 
+msgid "Code can't be modified because it is used for pairing with existing orders."
+msgstr ""
+
 msgid "Color parameter values"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -313,6 +313,9 @@ msgstr "Zatvorené dni"
 msgid "Closing modules"
 msgstr "Zatvárací moduly"
 
+msgid "Code can't be modified because it is used for pairing with existing orders."
+msgstr "Kód nemôže byť upravený, pretože je spárovaný s existujúcim objednávkami."
+
 msgid "Color parameter values"
 msgstr "Hodnoty farebných parametrov"
 

--- a/packages/framework/src/Component/CurrencyFormatter/CurrencyFormatterFactory.php
+++ b/packages/framework/src/Component/CurrencyFormatter/CurrencyFormatterFactory.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrameworkBundle\Component\CurrencyFormatter;
 use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
 use CommerceGuys\Intl\Formatter\CurrencyFormatter;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 class CurrencyFormatterFactory
 {
@@ -19,15 +18,17 @@ class CurrencyFormatterFactory
     ) {
     }
 
-    public function createByLocaleAndCurrency(string $locale, Currency $currency): CurrencyFormatter
-    {
+    public function createByLocaleAndMinFractionDigits(
+        string $locale,
+        int $minFractionDigits,
+    ): CurrencyFormatter {
         return new CurrencyFormatter(
             $this->numberFormatRepository,
             $this->intlCurrencyRepository,
             [
                 'locale' => $locale,
                 'style' => 'standard',
-                'minimum_fraction_digits' => $currency->getMinFractionDigits(),
+                'minimum_fraction_digits' => $minFractionDigits,
                 'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
             ],
         );

--- a/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionType.php
+++ b/packages/framework/src/Form/Admin/PaymentTransaction/PaymentTransactionType.php
@@ -87,7 +87,7 @@ final class PaymentTransactionType extends AbstractType
         if ($order === null) {
             return;
         }
-        $formattedRefundableAmount = $this->priceExtension->priceWithCurrencyFilter($originalPaymentTransaction->getRefundableAmount(), $order->getCurrency());
+        $formattedRefundableAmount = $this->priceExtension->priceWithCurrencyByOrderFilter($originalPaymentTransaction->getRefundableAmount(), $order);
         $context->buildViolation(t('You can refund only %refundableAmount%.', ['%refundableAmount%' => $formattedRefundableAmount]))
             ->atPath('refundAmount')
             ->addViolation();

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -48,6 +48,7 @@ final class CurrencyFormType extends AbstractType
             ])
             ->add('code', TextType::class, [
                 'required' => true,
+                'disabled' => $options['is_used_in_orders'],
                 'constraints' => [
                     new Constraints\NotBlank(message: 'Please enter currency code'),
                     new Constraints\Choice(
@@ -100,6 +101,8 @@ final class CurrencyFormType extends AbstractType
         $resolver
             ->setRequired('is_default_currency')
             ->setAllowedTypes('is_default_currency', 'bool')
+            ->setRequired('is_used_in_orders')
+            ->setAllowedTypes('is_used_in_orders', 'bool')
             ->setDefaults([
                 'data_class' => CurrencyData::class,
                 'attr' => ['novalidate' => 'novalidate'],

--- a/packages/framework/src/Form/OrderItemsType.php
+++ b/packages/framework/src/Form/OrderItemsType.php
@@ -83,9 +83,10 @@ final class OrderItemsType extends AbstractType
         $view->vars['transportVatPercentsByTransportId'] = $this->transportFacade->getTransportVatPercentsByDomainIdIndexedByTransportId(
             $order->getDomainId(),
         );
-        $view->vars['paymentPricesWithVatByPaymentId'] = $this->paymentFacade->getPaymentPricesWithVatByCurrencyAndDomainIdIndexedByPaymentId(
-            $order->getCurrency(),
+        $view->vars['paymentPricesWithVatByPaymentId'] = $this->paymentFacade->getPaymentPricesWithVatByDomainIdIndexedByPaymentId(
             $order->getDomainId(),
+            $order->getCurrencyRoundingType(),
+            $order->getCurrencyRoundingPlacesPriceWithoutVat(),
         );
         $view->vars['paymentVatPercentsByPaymentId'] = $this->paymentFacade->getPaymentVatPercentsByDomainIdIndexedByPaymentId(
             $order->getDomainId(),

--- a/packages/framework/src/Migrations/Version20260310120000.php
+++ b/packages/framework/src/Migrations/Version20260310120000.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20260310120000 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE orders ADD currency_code VARCHAR(3) NOT NULL DEFAULT \'\'');
+        $this->sql('ALTER TABLE orders ADD currency_rounding_type VARCHAR(15) NOT NULL DEFAULT \'\'');
+        $this->sql('ALTER TABLE orders ADD currency_rounding_places_price_without_vat INT NOT NULL DEFAULT 2');
+        $this->sql('ALTER TABLE orders ADD currency_min_fraction_digits INT NOT NULL DEFAULT 2');
+        $this->sql('ALTER TABLE orders ADD payment_czk_rounding BOOLEAN NOT NULL DEFAULT FALSE');
+
+        $this->sql('
+            UPDATE orders o
+            SET
+                currency_code = c.code,
+                currency_rounding_type = c.rounding_type,
+                currency_rounding_places_price_without_vat = c.rounding_places_price_without_vat,
+                currency_min_fraction_digits = c.min_fraction_digits,
+                payment_czk_rounding = COALESCE(
+                    (SELECT p.czk_rounding
+                     FROM order_items oi
+                     JOIN payments p ON p.id = oi.payment_id
+                     WHERE oi.order_id = o.id AND oi.type = \'payment\'
+                     LIMIT 1),
+                    FALSE
+                )
+            FROM currencies c
+            WHERE c.id = o.currency_id
+        ');
+
+        $this->sql('ALTER TABLE orders ALTER COLUMN currency_code DROP DEFAULT');
+        $this->sql('ALTER TABLE orders ALTER COLUMN currency_rounding_type DROP DEFAULT');
+        $this->sql('ALTER TABLE orders ALTER COLUMN currency_rounding_places_price_without_vat DROP DEFAULT');
+        $this->sql('ALTER TABLE orders ALTER COLUMN currency_min_fraction_digits DROP DEFAULT');
+        $this->sql('ALTER TABLE orders ALTER COLUMN payment_czk_rounding DROP DEFAULT');
+
+        $this->sql('ALTER TABLE orders DROP CONSTRAINT IF EXISTS fk_e52ffdee38248176');
+        $this->sql('DROP INDEX IF EXISTS idx_e52ffdee38248176');
+        $this->sql('ALTER TABLE orders DROP COLUMN currency_id');
+
+        $this->sql('ALTER TABLE currencies ADD CONSTRAINT UNIQ_37C4469377153098 UNIQUE (code)');
+        $this->sql('CREATE INDEX idx_orders_currency_code ON orders (currency_code)');
+        $this->sql('ALTER TABLE orders ADD CONSTRAINT fk_orders_currency_code FOREIGN KEY (currency_code) REFERENCES currencies (code)');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/GoPay/GoPayOrderMapper.php
+++ b/packages/framework/src/Model/GoPay/GoPayOrderMapper.php
@@ -34,7 +34,7 @@ class GoPayOrderMapper
                 'contact' => $this->createContactData($order),
             ],
             'amount' => $this->formatPriceForGoPay($order->getTotalPriceWithVat()),
-            'currency' => $order->getCurrency()->getCode(),
+            'currency' => $order->getCurrencyCode(),
             'order_number' => $order->getNumber(),
             'order_description' => t('Order number') . ' ' . $order->getNumber(),
             'items' => $goPayPaymentItemsData,

--- a/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
@@ -82,6 +82,7 @@ class OrderItemDataFactory
                 $calculatedPriceWithoutVat = $this->orderItemPriceCalculation->calculatePriceWithoutVatForInputPriceWithVat(
                     $orderItemData,
                     $orderItem->getOrder()->getDomainId(),
+                    $orderItem->getOrder()->getCurrencyRoundingPlacesPriceWithoutVat(),
                 );
 
                 if (!$orderItemData->unitPriceWithoutVat->equals($calculatedPriceWithoutVat)) {
@@ -96,7 +97,7 @@ class OrderItemDataFactory
                 $calculatedPriceWithVat = $this->orderItemPriceCalculation->calculatePriceWithVatForInputPriceWithoutVat(
                     $orderItemData,
                     $orderItem->getOrder()->getDomainId(),
-                    $orderItem->getOrder()->getCurrency(),
+                    $orderItem->getOrder()->getCurrencyRoundingType(),
                 );
 
                 if (!$orderItemData->unitPriceWithVat->equals($calculatedPriceWithVat)) {

--- a/packages/framework/src/Model/Order/Item/OrderItemPriceCalculation.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemPriceCalculation.php
@@ -6,8 +6,6 @@ namespace Shopsys\FrameworkBundle\Model\Order\Item;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\OrderItemHasNoIdException;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation;
@@ -25,17 +23,19 @@ class OrderItemPriceCalculation
         protected readonly VatDataFactory $vatDataFactory,
         protected readonly PricingSetting $pricingSetting,
         protected readonly Rounding $rounding,
-        protected readonly CurrencyFacade $currencyFacade,
     ) {
     }
 
-    public function calculatePriceWithoutVatForInputPriceWithVat(OrderItemData $orderItemData, int $domainId): Money
-    {
+    public function calculatePriceWithoutVatForInputPriceWithVat(
+        OrderItemData $orderItemData,
+        int $domainId,
+        int $roundingPlaces,
+    ): Money {
         $vatData = $this->vatDataFactory->create();
         $vatData->name = 'orderItemVat';
         $vatData->percent = $orderItemData->vatPercent;
         $vat = $this->vatFactory->create($vatData, $domainId);
-        $vatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($orderItemData->unitPriceWithVat, $vat, $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId));
+        $vatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($orderItemData->unitPriceWithVat, $vat, $roundingPlaces);
 
         return $orderItemData->unitPriceWithVat->subtract($vatAmount);
     }
@@ -43,14 +43,14 @@ class OrderItemPriceCalculation
     public function calculatePriceWithVatForInputPriceWithoutVat(
         OrderItemData $orderItemData,
         int $domainId,
-        Currency $currency,
+        string $currencyRoundingType,
     ): Money {
         $vatData = $this->vatDataFactory->create();
         $vatData->name = 'orderItemVat';
         $vatData->percent = $orderItemData->vatPercent;
         $vat = $this->vatFactory->create($vatData, $domainId);
 
-        return $this->rounding->roundPriceWithVatByCurrency($this->priceCalculation->applyVatPercent($orderItemData->unitPriceWithoutVat, $vat), $currency);
+        return $this->rounding->roundPriceWithVat($this->priceCalculation->applyVatPercent($orderItemData->unitPriceWithoutVat, $vat), $currencyRoundingType);
     }
 
     public function calculateTotalPrice(OrderItem $orderItem): PriceInterface
@@ -62,13 +62,15 @@ class OrderItemPriceCalculation
         $vatData = $this->vatDataFactory->create();
         $vatData->name = 'orderItemVat';
         $vatData->percent = $orderItem->getVatPercent();
-        $vat = $this->vatFactory->create($vatData, $orderItem->getOrder()->getDomainId());
-        $currency = $orderItem->getOrder()->getCurrency();
+        $order = $orderItem->getOrder();
+        $vat = $this->vatFactory->create($vatData, $order->getDomainId());
+        $roundingType = $order->getCurrencyRoundingType();
+        $roundingPlaces = $order->getCurrencyRoundingPlacesPriceWithoutVat();
 
         switch ($this->pricingSetting->getInputPriceType()) {
             case PricingSetting::PRICE_TYPE_WITH_VAT:
                 $totalPriceWithVat = $orderItem->getUnitPriceWithVat()->multiply($orderItem->getQuantity());
-                $totalVatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($totalPriceWithVat, $vat, $currency);
+                $totalVatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($totalPriceWithVat, $vat, $roundingPlaces);
                 $totalPriceWithoutVat = $totalPriceWithVat->subtract($totalVatAmount);
 
                 return new Price($totalPriceWithoutVat, $totalPriceWithVat);
@@ -76,12 +78,12 @@ class OrderItemPriceCalculation
             case PricingSetting::PRICE_TYPE_WITHOUT_VAT:
                 $totalPriceWithoutVat = $this->rounding->roundPriceWithoutVat(
                     $orderItem->getUnitPriceWithoutVat()->multiply($orderItem->getQuantity()),
-                    $currency,
+                    $roundingPlaces,
                 );
 
-                $totalPriceWithVat = $this->rounding->roundPriceWithVatByCurrency(
+                $totalPriceWithVat = $this->rounding->roundPriceWithVat(
                     $orderItem->getUnitPriceWithVat()->multiply($orderItem->getQuantity()),
-                    $currency,
+                    $roundingType,
                 );
 
                 return new Price($totalPriceWithoutVat, $totalPriceWithVat);

--- a/packages/framework/src/Model/Order/Mail/OrderMail.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMail.php
@@ -164,9 +164,9 @@ class OrderMail implements MessageFactoryInterface
 
     protected function getFormattedPriceWithVat(Order $order): string
     {
-        $price = $this->priceExtension->priceTextWithCurrencyByCurrencyIdAndLocaleFilter(
+        $price = $this->priceExtension->priceTextWithCurrencyByOrderAndLocaleFilter(
             $order->getTotalPriceWithVat(),
-            $order->getCurrency()->getId(),
+            $order,
             $this->getDomainLocaleByOrder($order),
         );
 
@@ -175,9 +175,9 @@ class OrderMail implements MessageFactoryInterface
 
     protected function getFormattedPriceWithoutVat(Order $order): string
     {
-        $price = $this->priceExtension->priceTextWithCurrencyByCurrencyIdAndLocaleFilter(
+        $price = $this->priceExtension->priceTextWithCurrencyByOrderAndLocaleFilter(
             $order->getTotalPriceWithoutVat(),
-            $order->getCurrency()->getId(),
+            $order,
             $this->getDomainLocaleByOrder($order),
         );
 

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -23,7 +23,6 @@ use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTypeEnum;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentTypeEnum;
 use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransaction;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
@@ -278,13 +277,6 @@ class Order
     protected $urlHash;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency
-     */
-    #[ORM\JoinColumn(nullable: false)]
-    #[ORM\ManyToOne(targetEntity: Currency::class)]
-    protected $currency;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null
      */
     #[ORM\JoinColumn(nullable: true, name: 'administrator_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
@@ -360,6 +352,36 @@ class Order
     #[ORM\Column(type: 'boolean')]
     protected $freeTransportAndPaymentApplied;
 
+    /**
+     * @var string
+     */
+    #[ORM\Column(type: 'string', length: 3)]
+    protected $currencyCode;
+
+    /**
+     * @var string
+     */
+    #[ORM\Column(type: 'string', length: 15)]
+    protected $currencyRoundingType;
+
+    /**
+     * @var int
+     */
+    #[ORM\Column(type: 'integer')]
+    protected $currencyRoundingPlacesPriceWithoutVat;
+
+    /**
+     * @var int
+     */
+    #[ORM\Column(type: 'integer')]
+    protected $currencyMinFractionDigits;
+
+    /**
+     * @var bool
+     */
+    #[ORM\Column(type: 'boolean')]
+    protected $paymentCzkRounding;
+
     public function __construct(
         OrderData $orderData,
         string $orderNumber,
@@ -378,7 +400,6 @@ class Order
         $this->createdAt = $orderData->createdAt;
         $this->domainId = $orderData->domainId;
         $this->urlHash = $urlHash;
-        $this->currency = $orderData->currency;
         $this->createdAsAdministrator = $orderData->createdAsAdministrator;
         $this->createdAsAdministratorName = $orderData->createdAsAdministratorName;
         $this->origin = $orderData->origin;
@@ -388,6 +409,12 @@ class Order
         $this->paymentTransactions = new ArrayCollection();
         $this->goPayBankSwift = $orderData->goPayBankSwift;
         $this->pickupPlaceIdentifier = $orderData->pickupPlaceIdentifier;
+
+        $this->currencyCode = $orderData->currencyCode;
+        $this->currencyRoundingType = $orderData->currencyRoundingType;
+        $this->currencyRoundingPlacesPriceWithoutVat = $orderData->currencyRoundingPlacesPriceWithoutVat;
+        $this->currencyMinFractionDigits = $orderData->currencyMinFractionDigits;
+        $this->paymentCzkRounding = $orderData->paymentCzkRounding;
     }
 
     /**
@@ -554,6 +581,7 @@ class Order
     protected function editOrderPayment(OrderData $orderData): void
     {
         $orderPaymentData = $orderData->orderPayment;
+        $this->paymentCzkRounding = $orderPaymentData->payment->isCzkRounding();
         $this->getPaymentItem()->edit($orderPaymentData);
     }
 
@@ -688,11 +716,43 @@ class Order
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency
+     * @return string
      */
-    public function getCurrency()
+    public function getCurrencyCode()
     {
-        return $this->currency;
+        return $this->currencyCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrencyRoundingType()
+    {
+        return $this->currencyRoundingType;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrencyRoundingPlacesPriceWithoutVat()
+    {
+        return $this->currencyRoundingPlacesPriceWithoutVat;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrencyMinFractionDigits()
+    {
+        return $this->currencyMinFractionDigits;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaymentCzkRounding()
+    {
+        return $this->paymentCzkRounding;
     }
 
     public function setTotalPrices(PriceInterface $orderTotalPrice, PriceInterface $productsTotalPrice): void

--- a/packages/framework/src/Model/Order/OrderData.php
+++ b/packages/framework/src/Model/Order/OrderData.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 
@@ -155,9 +156,29 @@ class OrderData
     public $domainId;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency|null
+     * @var string|null
      */
-    public $currency;
+    public $currencyCode;
+
+    /**
+     * @var string|null
+     */
+    public $currencyRoundingType;
+
+    /**
+     * @var int|null
+     */
+    public $currencyRoundingPlacesPriceWithoutVat;
+
+    /**
+     * @var int|null
+     */
+    public $currencyMinFractionDigits;
+
+    /**
+     * @var bool|null
+     */
+    public $paymentCzkRounding;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null
@@ -391,5 +412,13 @@ class OrderData
     public function getPromoCodeDiscountPrice(): PriceInterface
     {
         return $this->getTotalPriceForItemTypes([OrderItemTypeEnum::TYPE_DISCOUNT])->inverse();
+    }
+
+    public function fillCurrencyFieldsFromCurrency(Currency $currency): void
+    {
+        $this->currencyCode = $currency->getCode();
+        $this->currencyRoundingType = $currency->getRoundingType();
+        $this->currencyRoundingPlacesPriceWithoutVat = $currency->getRoundingPlacesPriceWithoutVat();
+        $this->currencyMinFractionDigits = $currency->getMinFractionDigits();
     }
 }

--- a/packages/framework/src/Model/Order/OrderDataFactory.php
+++ b/packages/framework/src/Model/Order/OrderDataFactory.php
@@ -63,41 +63,20 @@ class OrderDataFactory
         $orderData->city = $order->getCity();
         $orderData->postcode = $order->getPostcode();
         $orderData->country = $order->getCountry();
-        $orderData->deliveryAddressSameAsBillingAddress = $order->isDeliveryAddressSameAsBillingAddress();
-
-        if (!$order->isDeliveryAddressSameAsBillingAddress()) {
-            $orderData->deliveryFirstName = $order->getDeliveryFirstName();
-            $orderData->deliveryLastName = $order->getDeliveryLastName();
-            $orderData->deliveryCompanyName = $order->getDeliveryCompanyName();
-            $orderData->deliveryTelephone = $order->getDeliveryTelephone();
-            $orderData->deliveryStreet = $order->getDeliveryStreet();
-            $orderData->deliveryCity = $order->getDeliveryCity();
-            $orderData->deliveryPostcode = $order->getDeliveryPostcode();
-            $orderData->deliveryCountry = $order->getDeliveryCountry();
-        }
+        $this->fillDeliveryAddressFromOrder($orderData, $order);
         $orderData->note = $order->getNote();
 
-        foreach ($order->getItemsSortedWithRelatedItems() as $orderItem) {
-            if (array_key_exists($orderItem->getId(), $orderData->items)) {
-                continue;
-            }
-
-            $orderItemData = $this->orderItemDataFactory->createFromOrderItem($orderItem);
-
-            foreach ($orderItem->getRelatedItems() as $relatedItem) {
-                $relatedOrderItemData = $this->orderItemDataFactory->createFromOrderItem($relatedItem);
-                $orderData->items[$relatedItem->getId()] = $relatedOrderItemData;
-                $orderItemData->relatedOrderItemsData[] = $relatedOrderItemData;
-            }
-
-            $orderData->items[$orderItem->getId()] = $orderItemData;
-        }
+        $this->fillItemsFromOrder($orderData, $order);
 
         $orderData->createdAt = $order->getCreatedAt();
         $orderData->deliveredAt = $order->getDeliveredAt();
 
         $orderData->domainId = $order->getDomainId();
-        $orderData->currency = $order->getCurrency();
+        $orderData->currencyCode = $order->getCurrencyCode();
+        $orderData->currencyRoundingType = $order->getCurrencyRoundingType();
+        $orderData->currencyRoundingPlacesPriceWithoutVat = $order->getCurrencyRoundingPlacesPriceWithoutVat();
+        $orderData->currencyMinFractionDigits = $order->getCurrencyMinFractionDigits();
+        $orderData->paymentCzkRounding = $order->isPaymentCzkRounding();
         $orderData->createdAsAdministrator = $order->getCreatedAsAdministrator();
         $orderData->createdAsAdministratorName = $order->getCreatedAsAdministratorName();
         $orderData->orderTransport = $this->orderItemDataFactory->createFromOrderItem($order->getTransportItem());
@@ -118,6 +97,43 @@ class OrderDataFactory
 
         if ($withdrawalRequest !== null) {
             $orderData->withdrawalRequestData = $this->withdrawalRequestDataFactory->createFromWithdrawalRequest($withdrawalRequest);
+        }
+    }
+
+    protected function fillDeliveryAddressFromOrder(OrderData $orderData, Order $order): void
+    {
+        $orderData->deliveryAddressSameAsBillingAddress = $order->isDeliveryAddressSameAsBillingAddress();
+
+        if ($order->isDeliveryAddressSameAsBillingAddress()) {
+            return;
+        }
+
+        $orderData->deliveryFirstName = $order->getDeliveryFirstName();
+        $orderData->deliveryLastName = $order->getDeliveryLastName();
+        $orderData->deliveryCompanyName = $order->getDeliveryCompanyName();
+        $orderData->deliveryTelephone = $order->getDeliveryTelephone();
+        $orderData->deliveryStreet = $order->getDeliveryStreet();
+        $orderData->deliveryCity = $order->getDeliveryCity();
+        $orderData->deliveryPostcode = $order->getDeliveryPostcode();
+        $orderData->deliveryCountry = $order->getDeliveryCountry();
+    }
+
+    protected function fillItemsFromOrder(OrderData $orderData, Order $order): void
+    {
+        foreach ($order->getItemsSortedWithRelatedItems() as $orderItem) {
+            if (array_key_exists($orderItem->getId(), $orderData->items)) {
+                continue;
+            }
+
+            $orderItemData = $this->orderItemDataFactory->createFromOrderItem($orderItem);
+
+            foreach ($orderItem->getRelatedItems() as $relatedItem) {
+                $relatedOrderItemData = $this->orderItemDataFactory->createFromOrderItem($relatedItem);
+                $orderData->items[$relatedItem->getId()] = $relatedOrderItemData;
+                $orderItemData->relatedOrderItemsData[] = $relatedOrderItemData;
+            }
+
+            $orderData->items[$orderItem->getId()] = $orderItemData;
         }
     }
 

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -37,7 +37,6 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Payment\Service\PaymentServiceFacade;
 use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionDataFactory;
 use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionFacade;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
@@ -107,8 +106,8 @@ class OrderFacade
     {
         $order = $this->orderRepository->getById($orderId);
 
-        $this->calculateOrderItemDataPrices($orderData->orderTransport, $order->getDomainId(), $orderData->currency);
-        $this->calculateOrderItemDataPrices($orderData->orderPayment, $order->getDomainId(), $orderData->currency);
+        $this->calculateOrderItemDataPrices($orderData->orderTransport, $order->getDomainId(), $order->getCurrencyRoundingType(), $order->getCurrencyRoundingPlacesPriceWithoutVat());
+        $this->calculateOrderItemDataPrices($orderData->orderPayment, $order->getDomainId(), $order->getCurrencyRoundingType(), $order->getCurrencyRoundingPlacesPriceWithoutVat());
         $this->refreshOrderItemsWithoutTransportAndPayment($order, $orderData);
         $this->updateTransportAndPaymentNamesInOrderData($orderData, $order);
 
@@ -245,7 +244,7 @@ class OrderFacade
         foreach ($order->getItemsWithoutTransportAndPayment() as $orderItem) {
             if (array_key_exists($orderItem->getId(), $orderItemsWithoutTransportAndPaymentData)) {
                 $orderItemData = $orderItemsWithoutTransportAndPaymentData[$orderItem->getId()];
-                $this->calculateOrderItemDataPrices($orderItemData, $order->getDomainId(), $orderData->currency);
+                $this->calculateOrderItemDataPrices($orderItemData, $order->getDomainId(), $order->getCurrencyRoundingType(), $order->getCurrencyRoundingPlacesPriceWithoutVat());
                 $orderItem->edit($orderItemData);
             } else {
                 $order->removeItem($orderItem);
@@ -253,7 +252,7 @@ class OrderFacade
         }
 
         foreach ($orderData->getNewItemsWithoutTransportAndPayment() as $newOrderItemData) {
-            $this->calculateOrderItemDataPrices($newOrderItemData, $order->getDomainId(), $orderData->currency);
+            $this->calculateOrderItemDataPrices($newOrderItemData, $order->getDomainId(), $order->getCurrencyRoundingType(), $order->getCurrencyRoundingPlacesPriceWithoutVat());
 
             $newOrderItem = $this->orderItemFactory->createProduct(
                 $newOrderItemData,
@@ -274,7 +273,8 @@ class OrderFacade
     protected function calculateOrderItemDataPrices(
         OrderItemData $orderItemData,
         int $domainId,
-        Currency $currency,
+        string $currencyRoundingType,
+        int $roundingPlaces,
     ): void {
         if ($orderItemData->usePriceCalculation) {
             switch ($this->pricingSetting->getInputPriceType()) {
@@ -282,6 +282,7 @@ class OrderFacade
                     $orderItemData->unitPriceWithoutVat = $this->orderItemPriceCalculation->calculatePriceWithoutVatForInputPriceWithVat(
                         $orderItemData,
                         $domainId,
+                        $roundingPlaces,
                     );
 
                     break;
@@ -289,7 +290,7 @@ class OrderFacade
                     $orderItemData->unitPriceWithVat = $this->orderItemPriceCalculation->calculatePriceWithVatForInputPriceWithoutVat(
                         $orderItemData,
                         $domainId,
-                        $currency,
+                        $currencyRoundingType,
                     );
 
                     break;
@@ -338,10 +339,11 @@ class OrderFacade
         if ($updatePaymentPrice || count($previousPaymentItems) === 0) {
             $paymentPrice = $this->paymentPriceCalculation->calculatePrice(
                 $payment,
-                $order->getCurrency(),
                 $order->getTotalProductsPrice(),
                 $order->getDomainId(),
                 $order->isFreeTransportAndPaymentApplied(),
+                $order->getCurrencyRoundingType(),
+                $order->getCurrencyRoundingPlacesPriceWithoutVat(),
             );
         } else {
             $paymentPrice = array_first($previousPaymentItems)->getPrice();
@@ -357,6 +359,7 @@ class OrderFacade
 
         $orderData = $this->orderDataFactory->createFromOrder($order);
         $orderData->orderPayment = $orderPaymentData;
+        $orderData->paymentCzkRounding = $payment->isCzkRounding();
         $this->edit($order->getId(), $orderData);
     }
 

--- a/packages/framework/src/Model/Order/OrderPriceCalculation.php
+++ b/packages/framework/src/Model/Order/OrderPriceCalculation.php
@@ -6,7 +6,6 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
-use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
@@ -48,20 +47,21 @@ class OrderPriceCalculation
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
     public function calculateOrderRoundingPrice(
-        Payment $payment,
-        Currency $currency,
+        bool $paymentCzkRounding,
+        string $currencyCode,
+        string $currencyRoundingType,
         PriceInterface $orderTotalPrice,
     ): ?PriceInterface {
-        if (!$payment->isCzkRounding() || $currency->getCode() !== Currency::CODE_CZK) {
+        if (!$paymentCzkRounding || $currencyCode !== Currency::CODE_CZK) {
             return null;
         }
 
         $priceWithVat = $orderTotalPrice->getPriceWithVat();
         $roundedPriceWithVat = $priceWithVat->round(0);
 
-        $roundingPrice = $this->rounding->roundPriceWithVatByCurrency(
+        $roundingPrice = $this->rounding->roundPriceWithVat(
             $roundedPriceWithVat->subtract($priceWithVat),
-            $currency,
+            $currencyRoundingType,
         );
 
         if ($roundingPrice->isZero()) {

--- a/packages/framework/src/Model/Order/OrderRepository.php
+++ b/packages/framework/src/Model/Order/OrderRepository.php
@@ -161,11 +161,10 @@ class OrderRepository
     public function getCustomerUserOrderList(CustomerUser $customerUser): array
     {
         return $this->createOrderQueryBuilder()
-            ->select('o, oi, os, ost, c')
+            ->select('o, oi, os, ost')
             ->join('o.items', 'oi')
             ->join('o.status', 'os')
             ->join('os.translations', 'ost')
-            ->join('o.currency', 'c')
             ->andWhere('o.customerUser = :customerUser')
             ->orderBy('o.createdAt', 'DESC')
             ->setParameter('customerUser', $customerUser)
@@ -178,10 +177,9 @@ class OrderRepository
     public function getLastCustomerOrdersByLimit(Customer $customer, int $limit, string $locale): array
     {
         return $this->createOrderQueryBuilder()
-            ->select('o, os, ost, c')
+            ->select('o, os, ost')
             ->join('o.status', 'os')
             ->join('os.translations', 'ost', Join::WITH, 'ost.locale = :locale')
-            ->join('o.currency', 'c')
             ->andWhere('o.customer = :customer')
             ->orderBy('o.createdAt', 'DESC')
             ->setParameter('customer', $customer)
@@ -252,20 +250,19 @@ class OrderRepository
         return $this->em->createQueryBuilder()
             ->select('c')
             ->from(Currency::class, 'c')
-            ->join(Order::class, 'o', Join::WITH, 'o.currency = c.id')
-            ->groupBy('c')
+            ->join(Order::class, 'o', Join::WITH, 'o.currencyCode = c.code')
+            ->groupBy('c.id')
             ->getQuery()->execute();
     }
 
     protected function getOrderListQueryBuilder(): QueryBuilder
     {
         return $this->em->createQueryBuilder()
-            ->select('o, oi, os, ost, c')
+            ->select('o, oi, os, ost')
             ->from(Order::class, 'o')
             ->join('o.items', 'oi')
             ->join('o.status', 'os')
             ->join('os.translations', 'ost')
-            ->join('o.currency', 'c')
             ->leftJoin('o.customerUser', 'cu');
     }
 

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddleware.php
@@ -43,10 +43,11 @@ class AddPaymentMiddleware implements OrderProcessorMiddlewareInterface
 
         $paymentPrice = $this->paymentPriceCalculation->calculatePrice(
             $payment,
-            $currency,
             $orderProcessingData->orderData->getProductsTotalPriceAfterAppliedDiscounts(),
             $domainId,
             $orderProcessingData->orderData->freeTransportAndPaymentApplied,
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         $orderItemData = $this->createPaymentItemData($paymentPrice, $payment, $orderProcessingData->getDomainConfig());
@@ -56,6 +57,7 @@ class AddPaymentMiddleware implements OrderProcessorMiddlewareInterface
         $orderData->addTotalPrice($paymentPrice, OrderItemTypeEnum::TYPE_PAYMENT);
 
         $orderData->orderPayment = $orderItemData;
+        $orderData->paymentCzkRounding = $payment->isCzkRounding();
         $orderData->goPayBankSwift = $orderProcessingData->orderInput->findAdditionalData(static::ADDITIONAL_DATA_GOPAY_BANK_SWIFT);
 
         $orderData->addItem($orderItemData);

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
@@ -42,7 +42,12 @@ class AddRoundingMiddleware implements OrderProcessorMiddlewareInterface
 
         $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($orderProcessingData->getDomainId());
 
-        $roundingPrice = $this->orderPriceCalculation->calculateOrderRoundingPrice($payment, $currency, $orderData->totalPrice);
+        $roundingPrice = $this->orderPriceCalculation->calculateOrderRoundingPrice(
+            $payment->isCzkRounding(),
+            $currency->getCode(),
+            $currency->getRoundingType(),
+            $orderData->totalPrice,
+        );
 
         if ($roundingPrice !== null && !$roundingPrice->isZero()) {
             $orderData->addItem($this->createRoundingItemData($roundingPrice, $orderProcessingData->getDomainConfig()));

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyNominalPromoCodeMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyNominalPromoCodeMiddleware.php
@@ -93,11 +93,12 @@ class ApplyNominalPromoCodeMiddleware extends AbstractPromoCodeMiddleware
 
         $discountValue = Money::create($promoCodeLimit->getDiscount());
 
+        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $discountPrice = $this->discountCalculation->calculateNominalDiscount(
             $discountValue,
             $totalApplicableProductsPrice,
             (float)$defaultVat->getPercent(),
-            $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         $discountOrderItemData = $this->orderItemDataFactory->create(OrderItemTypeEnum::TYPE_DISCOUNT);

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyPercentagePromoCodeMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyPercentagePromoCodeMiddleware.php
@@ -88,11 +88,13 @@ class ApplyPercentagePromoCodeMiddleware extends AbstractPromoCodeMiddleware
         $locale = $domainConfig->getLocale();
         $domainId = $domainConfig->getId();
 
+        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $discountPrice = $this->discountCalculation->calculatePercentageDiscountRoundedByCurrency(
             $this->getItemTotalPriceWithAppliedPromotions($productItem),
             (float)$productItem->vatPercent,
             (float)$promoCodeLimit->getDiscount(),
-            $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId),
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         if ($discountPrice === null) {

--- a/packages/framework/src/Model/Order/PromoCode/DiscountCalculation.php
+++ b/packages/framework/src/Model/Order/PromoCode/DiscountCalculation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Order\PromoCode;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
@@ -28,13 +27,14 @@ class DiscountCalculation
         PriceInterface $totalItemPrice,
         float $vatPercent,
         float $discountPercent,
-        Currency $currency,
+        string $roundingType,
+        int $roundingPlaces,
     ): ?PriceInterface {
         $multiplier = (string)($discountPercent / 100);
 
-        $priceWithVat = $this->rounding->roundPriceWithVatByCurrency(
+        $priceWithVat = $this->rounding->roundPriceWithVat(
             $totalItemPrice->getPriceWithVat()->multiply($multiplier),
-            $currency,
+            $roundingType,
         );
 
         if ($priceWithVat->isZero()) {
@@ -42,17 +42,17 @@ class DiscountCalculation
         }
 
         if ($this->pricingSetting->getInputPriceType() === PricingSetting::PRICE_TYPE_WITH_VAT) {
-            $priceVatAmount = $this->priceCalculation->getVatAmountByPriceWithVatForVatPercent($priceWithVat, $vatPercent, $currency);
+            $priceVatAmount = $this->priceCalculation->getVatAmountByPriceWithVatForVatPercent($priceWithVat, $vatPercent, $roundingPlaces);
             $priceWithoutVat = $priceWithVat->subtract($priceVatAmount);
         } else {
             $priceWithoutVat = $this->rounding->roundPriceWithoutVat(
                 $totalItemPrice->getPriceWithoutVat()->multiply($multiplier),
-                $currency,
+                $roundingPlaces,
             );
 
-            $priceWithVat = $this->rounding->roundPriceWithVatByCurrency(
+            $priceWithVat = $this->rounding->roundPriceWithVat(
                 $this->priceCalculation->applyVatByPercent($priceWithoutVat, $vatPercent),
-                $currency,
+                $roundingType,
             );
         }
 
@@ -63,14 +63,14 @@ class DiscountCalculation
         Money $discount,
         PriceInterface $totalPrice,
         float $vatPercent,
-        Currency $currency,
+        int $roundingPlaces,
     ): PriceInterface {
         if ($this->pricingSetting->getInputPriceType() === PricingSetting::PRICE_TYPE_WITH_VAT) {
             if ($discount->isGreaterThan($totalPrice->getPriceWithVat())) {
                 return $totalPrice;
             }
 
-            $priceVatAmount = $this->priceCalculation->getVatAmountByPriceWithVatForVatPercent($discount, $vatPercent, $currency);
+            $priceVatAmount = $this->priceCalculation->getVatAmountByPriceWithVatForVatPercent($discount, $vatPercent, $roundingPlaces);
             $priceWithoutVat = $discount->subtract($priceVatAmount);
 
             return new Price($priceWithoutVat, $discount);

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -10,7 +10,6 @@ use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Model\GoPay\PaymentMethod\GoPayPaymentMethod;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentNotFoundException;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
@@ -132,15 +131,16 @@ class PaymentFacade
     /**
      * @return \Shopsys\FrameworkBundle\Component\Money\Money[]
      */
-    public function getPaymentPricesWithVatByCurrencyAndDomainIdIndexedByPaymentId(
-        Currency $currency,
+    public function getPaymentPricesWithVatByDomainIdIndexedByPaymentId(
         int $domainId,
+        string $roundingType,
+        int $roundingPlaces,
     ): array {
         $paymentPricesWithVatByPaymentId = [];
         $payments = $this->getAllIncludingDeleted();
 
         foreach ($payments as $payment) {
-            $paymentPrice = $this->paymentPriceCalculation->calculateIndependentPrice($payment, $currency, $domainId);
+            $paymentPrice = $this->paymentPriceCalculation->calculateIndependentPrice($payment, $domainId, $roundingType, $roundingPlaces);
             $paymentPricesWithVatByPaymentId[$payment->getId()] = $paymentPrice->getPriceWithVat();
         }
 
@@ -184,8 +184,9 @@ class PaymentFacade
             $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
             $prices[$domainId] = $this->paymentPriceCalculation->calculateIndependentPrice(
                 $payment,
-                $currency,
                 $domainId,
+                $currency->getRoundingType(),
+                $currency->getRoundingPlacesPriceWithoutVat(),
             );
         }
 
@@ -210,8 +211,9 @@ class PaymentFacade
 
             $prices[$domainId] = $this->paymentPriceCalculation->calculateIndependentPrice(
                 $payment,
-                $currency,
                 $domainId,
+                $currency->getRoundingType(),
+                $currency->getRoundingPlacesPriceWithoutVat(),
             );
         }
 

--- a/packages/framework/src/Model/Payment/PaymentInstructionFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentInstructionFacade.php
@@ -79,7 +79,7 @@ class PaymentInstructionFacade
                 $payment,
                 $order->getNumber(),
                 (float)$order->getTotalPrice()->getPriceWithVat()->getAmount(),
-                $order->getCurrency(),
+                $order->getCurrencyCode(),
                 $order->getDomainId(),
             );
 
@@ -135,14 +135,14 @@ class PaymentInstructionFacade
         Payment $payment,
         string $variableSymbol,
         float $amount,
-        Currency $currency,
+        string $currencyCode,
         int $domainId,
     ): string {
         return SpaydHelper::createSpayd(
             $payment->getIban($domainId),
             $amount,
-            $currency->getCode(),
-            $currency->getCode() === Currency::CODE_CZK ? null : $payment->getBicSwift($domainId),  // BIC required for non-CZK
+            $currencyCode,
+            $currencyCode === Currency::CODE_CZK ? null : $payment->getBicSwift($domainId),  // BIC required for non-CZK
             $variableSymbol,
         );
     }

--- a/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
@@ -22,25 +21,31 @@ class PaymentPriceCalculation
 
     public function calculatePrice(
         Payment $payment,
-        Currency $currency,
         PriceInterface $productsPrice,
         int $domainId,
         bool $forceFreePayment,
+        string $roundingType,
+        int $roundingPlaces,
     ): PriceInterface {
         if ($this->freeTransportAndPaymentFacade->isFree($productsPrice, $domainId, $forceFreePayment)) {
             return Price::zero();
         }
 
-        return $this->calculateIndependentPrice($payment, $currency, $domainId);
+        return $this->calculateIndependentPrice($payment, $domainId, $roundingType, $roundingPlaces);
     }
 
-    public function calculateIndependentPrice(Payment $payment, Currency $currency, int $domainId): PriceInterface
-    {
+    public function calculateIndependentPrice(
+        Payment $payment,
+        int $domainId,
+        string $roundingType,
+        int $roundingPlaces,
+    ): PriceInterface {
         return $this->basePriceCalculation->calculateRoundedBasePrice(
             $payment->getPrice($domainId)->getPrice(),
             $this->pricingSetting->getInputPriceType(),
             $payment->getPaymentDomain($domainId)->getVat(),
-            $currency,
+            $roundingType,
+            $roundingPlaces,
         );
     }
 }

--- a/packages/framework/src/Model/Pricing/BasePriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/BasePriceCalculation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 
@@ -21,20 +20,21 @@ class BasePriceCalculation
         Money $inputPrice,
         int $inputPriceType,
         Vat $vat,
-        Currency $currency,
+        string $roundingType,
+        int $roundingPlaces,
     ): PriceInterface {
         switch ($inputPriceType) {
             case PricingSetting::PRICE_TYPE_WITH_VAT:
-                $basePriceWithVat = $this->rounding->roundPriceWithVatByCurrency($inputPrice, $currency);
-                $vatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($basePriceWithVat, $vat, $currency);
-                $basePriceWithoutVat = $this->rounding->roundPriceWithoutVat($basePriceWithVat->subtract($vatAmount), $currency);
+                $basePriceWithVat = $this->rounding->roundPriceWithVat($inputPrice, $roundingType);
+                $vatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($basePriceWithVat, $vat, $roundingPlaces);
+                $basePriceWithoutVat = $this->rounding->roundPriceWithoutVat($basePriceWithVat->subtract($vatAmount), $roundingPlaces);
 
                 return new Price($basePriceWithoutVat, $basePriceWithVat);
 
             case PricingSetting::PRICE_TYPE_WITHOUT_VAT:
-                $basePriceWithoutVat = $this->rounding->roundPriceWithoutVat($inputPrice, $currency);
+                $basePriceWithoutVat = $this->rounding->roundPriceWithoutVat($inputPrice, $roundingPlaces);
                 $basePriceWithVat = $this->priceCalculation->applyVatPercent($basePriceWithoutVat, $vat);
-                $basePriceWithVat = $this->rounding->roundPriceWithVatByCurrency($basePriceWithVat, $currency);
+                $basePriceWithVat = $this->rounding->roundPriceWithVat($basePriceWithVat, $roundingType);
 
                 return new Price($basePriceWithoutVat, $basePriceWithVat);
 

--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -42,7 +42,7 @@ class Currency
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string', length: 3)]
+    #[ORM\Column(type: 'string', length: 3, unique: true)]
     protected $code;
 
     /**

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
@@ -44,11 +44,17 @@ class CurrencyGridFactory implements GridFactoryInterface
         $grid->addDeleteActionColumn('admin_currency_deleteconfirm', ['id' => 'c.id'])
             ->setAjaxConfirm();
 
+        $currencyIdsUsedInOrders = array_map(
+            fn ($currency) => $currency->getId(),
+            $this->currencyFacade->getCurrenciesUsedInOrders(),
+        );
+
         $grid->setTheme(
             '@ShopsysAdministration/content/currency/listGrid.html.twig',
             [
                 'defaultCurrency' => $this->currencyFacade->getDefaultCurrency(),
                 'notAllowedToDeleteCurrencyIds' => $this->currencyFacade->getNotAllowedToDeleteCurrencyIds(),
+                'currencyIdsUsedInOrders' => $currencyIdsUsedInOrders,
             ],
         );
 

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyInlineEdit.php
@@ -58,6 +58,7 @@ class CurrencyInlineEdit extends AbstractGridInlineEdit
 
         return $this->formFactory->create(CurrencyFormType::class, $currencyData, [
             'is_default_currency' => $this->isDefaultCurrencyId($rowId),
+            'is_used_in_orders' => $this->isCurrencyUsedInOrders($rowId),
         ]);
     }
 
@@ -72,6 +73,20 @@ class CurrencyInlineEdit extends AbstractGridInlineEdit
         }
 
         return false;
+    }
+
+    protected function isCurrencyUsedInOrders(?int $currencyId): bool
+    {
+        if ($currencyId === null) {
+            return false;
+        }
+
+        $currencyIdsUsedInOrders = array_map(
+            fn ($currency) => $currency->getId(),
+            $this->currencyFacade->getCurrenciesUsedInOrders(),
+        );
+
+        return in_array($currencyId, $currencyIdsUsedInOrders, true);
     }
 
     #[Override]

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
@@ -51,10 +51,12 @@ class InputPriceRecalculator
 
         $this->batchProcessQuery($query, function (Payment $payment) use ($toInputPriceType): void {
             foreach ($payment->getPrices() as $paymentInputPrice) {
+                $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($paymentInputPrice->getDomainId());
                 $paymentPrice = $this->paymentPriceCalculation->calculateIndependentPrice(
                     $payment,
-                    $this->currencyFacade->getDomainDefaultCurrencyByDomainId($paymentInputPrice->getDomainId()),
                     $paymentInputPrice->getDomainId(),
+                    $currency->getRoundingType(),
+                    $currency->getRoundingPlacesPriceWithoutVat(),
                 );
 
                 $newInputPrice = $this->inputPriceCalculation->getInputPrice(

--- a/packages/framework/src/Model/Pricing/PriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/PriceCalculation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 
 class PriceCalculation
@@ -16,25 +15,28 @@ class PriceCalculation
     {
     }
 
-    public function getVatAmountByPriceWithVat(Money $priceWithVat, Vat $vat, Currency $currency): Money
-    {
+    public function getVatAmountByPriceWithVat(
+        Money $priceWithVat,
+        Vat $vat,
+        int $roundingPlaces,
+    ): Money {
         $divisor = (string)(1 + (float)$vat->getPercent() / 100);
 
         $priceWithoutVat = $priceWithVat->divide($divisor, static::PRICE_CALCULATION_MAX_SCALE);
 
-        return $this->rounding->roundVatAmount($priceWithVat->subtract($priceWithoutVat), $currency);
+        return $this->rounding->roundVatAmount($priceWithVat->subtract($priceWithoutVat), $roundingPlaces);
     }
 
     public function getVatAmountByPriceWithVatForVatPercent(
         Money $priceWithVat,
         float $vatPercent,
-        Currency $currency,
+        int $roundingPlaces,
     ): Money {
         $divisor = (string)(1 + $vatPercent / 100);
 
         $priceWithoutVat = $priceWithVat->divide($divisor, static::PRICE_CALCULATION_MAX_SCALE);
 
-        return $this->rounding->roundVatAmount($priceWithVat->subtract($priceWithoutVat), $currency);
+        return $this->rounding->roundVatAmount($priceWithVat->subtract($priceWithoutVat), $roundingPlaces);
     }
 
     public function applyVatPercent(Money $priceWithoutVat, Vat $vat): Money

--- a/packages/framework/src/Model/Pricing/PriceConverter.php
+++ b/packages/framework/src/Model/Pricing/PriceConverter.php
@@ -26,7 +26,7 @@ class PriceConverter
         $domainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $price = $this->convertPriceToPriceInDomainDefaultCurrency($price, $priceCurrency, $domainDefaultCurrency);
 
-        return $this->rounding->roundPriceWithoutVat($price, $domainDefaultCurrency);
+        return $this->rounding->roundPriceWithoutVat($price, $domainDefaultCurrency->getRoundingPlacesPriceWithoutVat());
     }
 
     public function convertPriceWithVatToDomainDefaultCurrencyPrice(
@@ -37,7 +37,7 @@ class PriceConverter
         $domainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $price = $this->convertPriceToPriceInDomainDefaultCurrency($price, $priceCurrency, $domainDefaultCurrency);
 
-        return $this->rounding->roundPriceWithVatByCurrency($price, $domainDefaultCurrency);
+        return $this->rounding->roundPriceWithVat($price, $domainDefaultCurrency->getRoundingType());
     }
 
     protected function convertPriceToPriceInDomainDefaultCurrency(

--- a/packages/framework/src/Model/Pricing/Rounding.php
+++ b/packages/framework/src/Model/Pricing/Rounding.php
@@ -10,10 +10,8 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\Exception\InvalidCurrencyRoun
 
 class Rounding
 {
-    public function roundPriceWithVatByCurrency(Money $priceWithVat, Currency $currency): Money
+    public function roundPriceWithVat(Money $priceWithVat, string $roundingType): Money
     {
-        $roundingType = $currency->getRoundingType();
-
         switch ($roundingType) {
             case Currency::ROUNDING_TYPE_HUNDREDTHS:
                 return $priceWithVat->round(2);
@@ -29,13 +27,13 @@ class Rounding
         }
     }
 
-    public function roundPriceWithoutVat(Money $priceWithoutVat, Currency $currency): Money
+    public function roundPriceWithoutVat(Money $priceWithoutVat, int $roundingPlaces): Money
     {
-        return $priceWithoutVat->round($currency->getRoundingPlacesPriceWithoutVat());
+        return $priceWithoutVat->round($roundingPlaces);
     }
 
-    public function roundVatAmount(Money $vatAmount, Currency $currency): Money
+    public function roundVatAmount(Money $vatAmount, int $roundingPlaces): Money
     {
-        return $vatAmount->round($currency->getRoundingPlacesPriceWithoutVat());
+        return $vatAmount->round($roundingPlaces);
     }
 }

--- a/packages/framework/src/Model/Pricing/SpecialPrice/SpecialPriceFactory.php
+++ b/packages/framework/src/Model/Pricing/SpecialPrice/SpecialPriceFactory.php
@@ -36,11 +36,13 @@ class SpecialPriceFactory
         string $priceListName,
         int $productId,
     ): SpecialPrice {
+        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $price = $this->basePriceCalculation->calculateRoundedBasePrice(
             $specialPriceAmount,
             $this->pricingSetting->getInputPriceType(),
             $vat,
-            $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId),
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         return $this->create(

--- a/packages/framework/src/Model/Product/GiftPlan/GiftPlanSettingFacade.php
+++ b/packages/framework/src/Model/Product/GiftPlan/GiftPlanSettingFacade.php
@@ -54,7 +54,8 @@ class GiftPlanSettingFacade
             $inputPrice,
             $this->pricingSetting->getInputPriceType(),
             $vat,
-            $defaultCurrency,
+            $defaultCurrency->getRoundingType(),
+            $defaultCurrency->getRoundingPlacesPriceWithoutVat(),
         );
     }
 

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCalculation.php
@@ -92,7 +92,8 @@ class ProductPriceCalculation
             $inputPrice,
             $this->pricingSetting->getInputPriceType(),
             $product->getVatForDomain($domainId),
-            $defaultCurrency,
+            $defaultCurrency->getRoundingType(),
+            $defaultCurrency->getRoundingPlacesPriceWithoutVat(),
         );
 
         return new ProductPrice($basePrice, $pricingGroup, false);

--- a/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
@@ -88,7 +88,7 @@ class QuantifiedProductPriceCalculation
         Vat $vat,
         Currency $currency,
     ): Money {
-        return $this->priceCalculation->getVatAmountByPriceWithVat($totalPriceWithVat, $vat, $currency);
+        return $this->priceCalculation->getVatAmountByPriceWithVat($totalPriceWithVat, $vat, $currency->getRoundingPlacesPriceWithoutVat());
     }
 
     /**

--- a/packages/framework/src/Model/Statistics/StatisticsRepository.php
+++ b/packages/framework/src/Model/Statistics/StatisticsRepository.php
@@ -129,7 +129,7 @@ class StatisticsRepository
         $query = $this->em->createNativeQuery(
             'SELECT SUM(o.total_price_with_vat * c.exchange_rate) AS total_price
             FROM orders o
-            JOIN currencies c ON o.currency_id = c.id
+            JOIN currencies c ON c.code = o.currency_code
             JOIN order_statuses os ON o.status_id = os.id AND os.type != :canceled
             WHERE o.created_at BETWEEN :start_date AND :end_date AND o.deleted = FALSE',
             $resultSetMapping,

--- a/packages/framework/src/Model/Transport/TransportPriceCalculation.php
+++ b/packages/framework/src/Model/Transport/TransportPriceCalculation.php
@@ -50,7 +50,8 @@ class TransportPriceCalculation
             $transportPrice->getPrice(),
             $this->pricingSetting->getInputPriceType(),
             $vat,
-            $defaultCurrencyForDomain,
+            $defaultCurrencyForDomain->getRoundingType(),
+            $defaultCurrencyForDomain->getRoundingPlacesPriceWithoutVat(),
         );
     }
 }

--- a/packages/framework/src/Resources/views/Front/Content/Payment/qrCode.html.twig
+++ b/packages/framework/src/Resources/views/Front/Content/Payment/qrCode.html.twig
@@ -6,7 +6,7 @@
         <img src="{{ qrCodeImageSrc }}" alt="{% trans into locale %}QR code{% endtrans %}" class="qr-code" />
     </p>
     <p>
-        {% trans into locale %}Total price{% endtrans %}: {{ totalPrice.priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, locale)|hidePrice(order.customerUser) }}
+        {% trans into locale %}Total price{% endtrans %}: {{ totalPrice.priceWithVat|priceTextWithCurrencyByOrderAndLocale(order, locale)|hidePrice(order.customerUser) }}
     </p>
     <p>{% trans into locale %}Account number{% endtrans %}: {{ accountNumber }}</p>
     <p>{% trans into locale %}Variable symbol{% endtrans %}: {{ orderNumber }}</p>

--- a/packages/framework/src/Resources/views/Front/Content/PersonalData/orders.xml.twig
+++ b/packages/framework/src/Resources/views/Front/Content/PersonalData/orders.xml.twig
@@ -87,8 +87,8 @@
                         {% if not item.unitPriceWithVat.isZero %}
                             <item_unit_price_with_vat>{{ item.unitPriceWithVat|moneyFormat|hidePrice(customerUser) }}</item_unit_price_with_vat>
                         {% endif %}
-                        {% if order.currency.code %}
-                            <item_currency_code><![CDATA[{{ order.currency.code }}]]></item_currency_code>
+                        {% if order.currencyCode %}
+                            <item_currency_code><![CDATA[{{ order.currencyCode }}]]></item_currency_code>
                         {% endif %}
                     </item>
                 {% endfor %}

--- a/packages/framework/src/Resources/views/Mail/Order/paymentInfo.html.twig
+++ b/packages/framework/src/Resources/views/Mail/Order/paymentInfo.html.twig
@@ -24,7 +24,7 @@
                             <strong style="white-space: nowrap; padding-left: 10px;">
                         {% endif %}
 
-                        {{ orderPaymentTotalPrice.priceWithoutVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}
+                        {{ orderPaymentTotalPrice.priceWithoutVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}
                         {% if displayBoth %}
                             {{ 'ex VAT'|trans }}&nbsp;
                         {% endif %}
@@ -41,7 +41,7 @@
 
                 {% if displayWithVat %}
                     <strong style="white-space: nowrap; padding-left: 10px;">
-                        {{ orderPaymentTotalPrice.priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}
+                        {{ orderPaymentTotalPrice.priceWithVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}
                         {% if displayBoth and not isZeroPrice %}
                             {{ 'inc VAT'|trans }}&nbsp;
                         {% endif %}

--- a/packages/framework/src/Resources/views/Mail/Order/products.html.twig
+++ b/packages/framework/src/Resources/views/Mail/Order/products.html.twig
@@ -63,7 +63,7 @@
                                                                 {% if displayBoth %}
                                                                     {% trans into orderLocale %}ex VAT{% endtrans %}
                                                                 {% endif %}
-                                                                <span style="white-space: nowrap;">{{ orderItem.unitPriceWithoutVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}</span><br>
+                                                                <span style="white-space: nowrap;">{{ orderItem.unitPriceWithoutVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}</span><br>
                                                             {% endif %}
                                                         {% endif %}
 
@@ -72,7 +72,7 @@
                                                             {% if displayBoth %}
                                                                 {% trans into orderLocale %}inc VAT{% endtrans %}
                                                             {% endif %}
-                                                            <span style="white-space: nowrap;">{{ orderItem.unitPriceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}</span><br>
+                                                            <span style="white-space: nowrap;">{{ orderItem.unitPriceWithVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}</span><br>
                                                         {% endif %}
 
                                                         {% trans into orderLocale %}Catalog number{% endtrans %}: <span style="white-space: nowrap;">{{ orderItem.catnum }}</span><br>
@@ -85,7 +85,7 @@
                                                                 <strong style="white-space: nowrap; padding-left: 10px;">
                                                             {% endif %}
 
-                                                            {{ orderItemTotalPricesById[orderItem.id].priceWithoutVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}
+                                                            {{ orderItemTotalPricesById[orderItem.id].priceWithoutVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}
                                                             {% if displayBoth %}
                                                                 {{ 'ex VAT'|trans }}
                                                             {% endif %}
@@ -102,7 +102,7 @@
 
                                                     {% if displayWithVat %}
                                                         <strong style="white-space: nowrap; padding-left: 10px;">
-                                                            {{ orderItemTotalPricesById[orderItem.id].priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}
+                                                            {{ orderItemTotalPricesById[orderItem.id].priceWithVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}
                                                             {% if displayBoth and not isZeroTotalPrice %}
                                                                 {{ 'inc VAT'|trans }}&nbsp;
                                                             {% endif %}

--- a/packages/framework/src/Resources/views/Mail/Order/roundingInfo.html.twig
+++ b/packages/framework/src/Resources/views/Mail/Order/roundingInfo.html.twig
@@ -1,4 +1,4 @@
 {% trans_default_domain 'customerMessages' %}
 <p style="text-align: right; margin: 0;">
-    {{ orderRoundingItem.name }}: <strong>{{ orderRoundingTotalPrice.priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}</strong>
+    {{ orderRoundingItem.name }}: <strong>{{ orderRoundingTotalPrice.priceWithVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}</strong>
 </p>

--- a/packages/framework/src/Resources/views/Mail/Order/transportInfo.html.twig
+++ b/packages/framework/src/Resources/views/Mail/Order/transportInfo.html.twig
@@ -24,7 +24,7 @@
                             <strong style="white-space: nowrap; padding-left: 10px;">
                         {% endif %}
 
-                        {{ orderTransportTotalPrice.priceWithoutVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}
+                        {{ orderTransportTotalPrice.priceWithoutVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}
                         {% if displayBoth %}
                             {{ 'ex VAT'|trans }}&nbsp;
                         {% endif %}
@@ -41,7 +41,7 @@
 
                 {% if displayWithVat %}
                     <strong style="white-space: nowrap; padding-left: 10px;">
-                        {{ orderTransportTotalPrice.priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale)|hidePrice(order.customerUser) }}
+                        {{ orderTransportTotalPrice.priceWithVat|priceTextWithCurrencyByOrderAndLocale(order, orderLocale)|hidePrice(order.customerUser) }}
                         {% if displayBoth and not isZeroPrice %}
                             {{ 'inc VAT'|trans }}&nbsp;
                         {% endif %}

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Twig\Extension\AbstractExtension;
@@ -72,6 +73,16 @@ class PriceExtension extends AbstractExtension
                 'priceFromDecimalStringWithCurrencyAdmin',
                 $this->priceFromDecimalStringWithCurrencyAdmin(...),
             ),
+            new TwigFilter(
+                'priceWithCurrencyByOrder',
+                $this->priceWithCurrencyByOrderFilter(...),
+                ['is_safe' => ['html']],
+            ),
+            new TwigFilter(
+                'priceTextWithCurrencyByOrderAndLocale',
+                $this->priceTextWithCurrencyByOrderAndLocaleFilter(...),
+                ['is_safe' => ['html']],
+            ),
         ];
     }
 
@@ -97,6 +108,11 @@ class PriceExtension extends AbstractExtension
             new TwigFunction(
                 'currencyCode',
                 $this->getCurrencyCodeByDomainId(...),
+            ),
+            new TwigFunction(
+                'currencySymbolByCode',
+                $this->getCurrencySymbolByCode(...),
+                ['is_safe' => ['html']],
             ),
         ];
     }
@@ -156,17 +172,37 @@ class PriceExtension extends AbstractExtension
         return $this->formatCurrency($price, $currency);
     }
 
+    public function priceWithCurrencyByOrderFilter(Money $price, Order $order): string
+    {
+        return $this->formatCurrencyByFrozenValues($price, $order->getCurrencyCode(), $order->getCurrencyMinFractionDigits());
+    }
+
+    public function priceTextWithCurrencyByOrderAndLocaleFilter(Money $price, Order $order, string $locale): string
+    {
+        if ($price->isZero()) {
+            return t('Free', [], Translator::CUSTOMER_TRANSLATION_DOMAIN, $locale);
+        }
+
+        return $this->formatCurrencyByFrozenValues($price, $order->getCurrencyCode(), $order->getCurrencyMinFractionDigits(), $locale);
+    }
+
     protected function formatCurrency(Money $price, Currency $currency, ?string $locale = null): string
     {
+        return $this->formatCurrencyByFrozenValues($price, $currency->getCode(), $currency->getMinFractionDigits(), $locale);
+    }
+
+    protected function formatCurrencyByFrozenValues(
+        Money $price,
+        string $currencyCode,
+        int $minFractionDigits,
+        ?string $locale = null,
+    ): string {
         if ($locale === null) {
             $locale = $this->localization->getRequestLocale();
         }
 
-        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($locale, $currency);
-        $intlCurrency = $this->intlCurrencyRepository->get(
-            $currency->getCode(),
-            $locale,
-        );
+        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndMinFractionDigits($locale, $minFractionDigits);
+        $intlCurrency = $this->intlCurrencyRepository->get($currencyCode, $locale);
 
         return $currencyFormatter->format($price->getAmount(), $intlCurrency->getCurrencyCode());
     }
@@ -227,6 +263,14 @@ class PriceExtension extends AbstractExtension
     {
         $currency = $this->currencyFacade->getById($currencyId);
         $intlCurrency = $this->intlCurrencyRepository->get($currency->getCode(), $locale);
+
+        return $intlCurrency->getSymbol();
+    }
+
+    public function getCurrencySymbolByCode(string $currencyCode): string
+    {
+        $locale = $this->localization->getRequestLocale();
+        $intlCurrency = $this->intlCurrencyRepository->get($currencyCode, $locale);
 
         return $intlCurrency->getSymbol();
     }

--- a/packages/framework/tests/Test/MiddlewareTestCase.php
+++ b/packages/framework/tests/Test/MiddlewareTestCase.php
@@ -74,12 +74,16 @@ class MiddlewareTestCase extends TestCase
     protected function createCurrencyFacade(
         string $currencyCode = Currency::CODE_EUR,
         string $roundingType = Currency::ROUNDING_TYPE_HUNDREDTHS,
+        int $roundingPlaces = Currency::DEFAULT_ROUNDING_PLACES_PRICE_WITHOUT_VAT,
+        int $minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS,
     ): CurrencyFacade {
         $currencyFacade = $this->createStub(CurrencyFacade::class);
 
         $currency = $this->createStub(Currency::class);
         $currency->method('getCode')->willReturn($currencyCode);
         $currency->method('getRoundingType')->willReturn($roundingType);
+        $currency->method('getRoundingPlacesPriceWithoutVat')->willReturn($roundingPlaces);
+        $currency->method('getMinFractionDigits')->willReturn($minFractionDigits);
 
         $currencyFacade->method('getDomainDefaultCurrencyByDomainId')
             ->willReturn($currency);

--- a/packages/framework/tests/Test/Provider/TestOrderProvider.php
+++ b/packages/framework/tests/Test/Provider/TestOrderProvider.php
@@ -54,7 +54,7 @@ class TestOrderProvider
         $orderStatusData->name = ['en' => 'orderStatusName'];
         $orderData->status = static::createOrderStatusInstance($orderStatusData);
 
-        $orderData->currency = TestCurrencyProvider::getTestCurrency();
+        $orderData->fillCurrencyFieldsFromCurrency(TestCurrencyProvider::getTestCurrency());
 
         return $orderData;
     }

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderItemPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderItemPriceCalculationTest.php
@@ -13,7 +13,6 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
@@ -44,11 +43,11 @@ class OrderItemPriceCalculationTest extends TestCase
             new VatDataFactory(),
             $pricingSettingStub,
             new Rounding(),
-            $this->createCurrencyFacadeStub(),
         );
         $priceWithoutVat = $orderItemPriceCalculation->calculatePriceWithoutVatForInputPriceWithVat(
             $orderItemData,
             Domain::FIRST_DOMAIN_ID,
+            Currency::DEFAULT_ROUNDING_PLACES_PRICE_WITHOUT_VAT,
         );
 
         $this->assertThat($priceWithoutVat, new IsMoneyEqual(Money::create(900)));
@@ -77,15 +76,15 @@ class OrderItemPriceCalculationTest extends TestCase
             new VatDataFactory(),
             $pricingSettingMock,
             new Rounding(),
-            $this->createCurrencyFacadeStub(),
         );
 
         $order = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getDomainId', 'getCurrency'])
+            ->onlyMethods(['getDomainId', 'getCurrencyRoundingType', 'getCurrencyRoundingPlacesPriceWithoutVat'])
             ->getMock();
         $order->expects($this->once())->method('getDomainId')->willReturn(Domain::FIRST_DOMAIN_ID);
-        $order->expects($this->once())->method('getCurrency')->willReturn($this->createCurrencyStub());
+        $order->expects($this->once())->method('getCurrencyRoundingType')->willReturn(Currency::DEFAULT_ROUNDING_TYPE);
+        $order->expects($this->once())->method('getCurrencyRoundingPlacesPriceWithoutVat')->willReturn(Currency::DEFAULT_ROUNDING_PLACES_PRICE_WITHOUT_VAT);
 
         $orderItem = $this->getMockBuilder(OrderItem::class)
             ->disableOriginalConstructor()
@@ -95,33 +94,12 @@ class OrderItemPriceCalculationTest extends TestCase
         $orderItem->expects($this->once())->method('getUnitPriceWithVat')->willReturn(Money::create(100));
         $orderItem->expects($this->once())->method('getQuantity')->willReturn(2);
         $orderItem->expects($this->once())->method('getVatPercent')->willReturn('1');
-        $orderItem->expects($this->exactly(2))->method('getOrder')->willReturn($order);
+        $orderItem->expects($this->once())->method('getOrder')->willReturn($order);
 
         $totalPrice = $orderItemPriceCalculation->calculateTotalPrice($orderItem);
 
         $this->assertThat($totalPrice->getPriceWithVat(), new IsMoneyEqual(Money::create(200)));
         $this->assertThat($totalPrice->getPriceWithoutVat(), new IsMoneyEqual(Money::create(190)));
         $this->assertThat($totalPrice->getVatAmount(), new IsMoneyEqual(Money::create(10)));
-    }
-
-    private function createCurrencyStub(): Currency
-    {
-        $currency = $this->createStub(Currency::class);
-        $currency->method('getCode')->willReturn('CZK');
-        $currency->method('getRoundingType')->willReturn(Currency::DEFAULT_ROUNDING_TYPE);
-        $currency->method('getRoundingPlacesPriceWithoutVat')->willReturn(Currency::DEFAULT_ROUNDING_PLACES_PRICE_WITHOUT_VAT);
-
-        return $currency;
-    }
-
-    private function createCurrencyFacadeStub(): CurrencyFacade
-    {
-        $currencyFacadeStub = $this->createStub(CurrencyFacade::class);
-
-        $currencyFacadeStub->method('getDomainDefaultCurrencyByDomainId')->willReturn(
-            $this->createCurrencyStub(),
-        );
-
-        return $currencyFacadeStub;
     }
 }

--- a/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
@@ -10,10 +10,7 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItem;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
-use Shopsys\FrameworkBundle\Model\Payment\Payment;
-use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
 use Tests\FrameworkBundle\Test\IsMoneyEqual;
@@ -64,64 +61,37 @@ class OrderPriceCalculationTest extends TestCase
 
     public function testCalculateOrderRoundingPriceForOtherCurrency(): void
     {
-        $paymentData = new PaymentData();
-        $paymentData->czkRounding = true;
-        $payment = new Payment($paymentData);
-
-        $currencyData = new CurrencyData();
-        $currencyData->name = 'currencyName';
-        $currencyData->code = Currency::CODE_EUR;
-        $currencyData->exchangeRate = '1.0';
-        $currency = new Currency($currencyData);
         $orderTotalPrice = new Price(Money::create(100), Money::create(120));
 
         $roundingStub = $this->createStub(Rounding::class);
         $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
 
         $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
-        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice($payment, $currency, $orderTotalPrice);
+        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(true, Currency::CODE_EUR, Currency::DEFAULT_ROUNDING_TYPE, $orderTotalPrice);
 
         $this->assertNull($roundingPrice);
     }
 
     public function testCalculateOrderRoundingPriceForCzkWithoutRounding(): void
     {
-        $paymentData = new PaymentData();
-        $paymentData->czkRounding = false;
-        $payment = new Payment($paymentData);
-
-        $currencyData = new CurrencyData();
-        $currencyData->name = 'currencyName';
-        $currencyData->code = Currency::CODE_CZK;
-        $currencyData->exchangeRate = '1.0';
-        $currency = new Currency($currencyData);
         $orderTotalPrice = new Price(Money::create(100), Money::create(120));
 
         $roundingStub = $this->createStub(Rounding::class);
         $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
 
         $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
-        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice($payment, $currency, $orderTotalPrice);
+        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(false, Currency::CODE_CZK, Currency::DEFAULT_ROUNDING_TYPE, $orderTotalPrice);
 
         $this->assertNull($roundingPrice);
     }
 
     public function testCalculateOrderRoundingPriceDown(): void
     {
-        $paymentData = new PaymentData();
-        $paymentData->czkRounding = true;
-        $payment = new Payment($paymentData);
-
-        $currencyData = new CurrencyData();
-        $currencyData->name = 'currencyName';
-        $currencyData->code = Currency::CODE_CZK;
-        $currencyData->exchangeRate = '1.0';
-        $currency = new Currency($currencyData);
         $orderTotalPrice = new Price(Money::create(100), Money::create('120.3'));
 
         $roundingStub = $this->createStub(Rounding::class);
         $roundingStub->method(
-            'roundPriceWithVatByCurrency',
+            'roundPriceWithVat',
         )->willReturnCallback(
             function (Money $value) {
                 return $value->round(2);
@@ -132,8 +102,9 @@ class OrderPriceCalculationTest extends TestCase
 
         $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
         $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(
-            $payment,
-            $currency,
+            true,
+            Currency::CODE_CZK,
+            Currency::DEFAULT_ROUNDING_TYPE,
             $orderTotalPrice,
         )->getPriceWithVat();
 
@@ -142,20 +113,11 @@ class OrderPriceCalculationTest extends TestCase
 
     public function testCalculateOrderRoundingPriceUp(): void
     {
-        $paymentData = new PaymentData();
-        $paymentData->czkRounding = true;
-        $payment = new Payment($paymentData);
-
-        $currencyData = new CurrencyData();
-        $currencyData->name = 'currencyName';
-        $currencyData->code = Currency::CODE_CZK;
-        $currencyData->exchangeRate = '1.0';
-        $currency = new Currency($currencyData);
         $orderTotalPrice = new Price(Money::create(100), Money::create('120.9'));
 
         $roundingStub = $this->createStub(Rounding::class);
         $roundingStub->method(
-            'roundPriceWithVatByCurrency',
+            'roundPriceWithVat',
         )->willReturnCallback(
             function (Money $value) {
                 return $value->round(2);
@@ -166,8 +128,9 @@ class OrderPriceCalculationTest extends TestCase
 
         $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
         $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(
-            $payment,
-            $currency,
+            true,
+            Currency::CODE_CZK,
+            Currency::DEFAULT_ROUNDING_TYPE,
             $orderTotalPrice,
         )->getPriceWithVat();
 

--- a/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddlewareTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddlewareTest.php
@@ -39,6 +39,7 @@ class AddPaymentMiddlewareTest extends MiddlewareTestCase
         $actualOrderData = $result->orderData;
 
         $this->assertSame($actualOrderData->orderPayment?->payment, $payment);
+        $this->assertFalse($actualOrderData->paymentCzkRounding);
 
         $this->assertThat(
             $actualOrderData->getTotalPriceForItemTypes([OrderItemTypeEnum::TYPE_PAYMENT]),

--- a/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
@@ -131,7 +131,7 @@ class PaymentPriceCalculationTest extends TestCase
             ),
         );
 
-        $price = $paymentPriceCalculation->calculateIndependentPrice($payment, $currency, Domain::FIRST_DOMAIN_ID);
+        $price = $paymentPriceCalculation->calculateIndependentPrice($payment, Domain::FIRST_DOMAIN_ID, $currency->getRoundingType(), $currency->getRoundingPlacesPriceWithoutVat());
 
         $this->assertThat($price->getPriceWithoutVat(), new IsMoneyEqual($priceWithoutVat));
         $this->assertThat($price->getPriceWithVat(), new IsMoneyEqual($priceWithVat));
@@ -197,10 +197,11 @@ class PaymentPriceCalculationTest extends TestCase
 
         $price = $paymentPriceCalculation->calculatePrice(
             $payment,
-            $currency,
             $productsPrice,
             Domain::FIRST_DOMAIN_ID,
             $forceFreePrice,
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         if ($priceShouldBeFree) {

--- a/packages/framework/tests/Unit/Model/Pricing/BasePriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/BasePriceCalculationTest.php
@@ -70,7 +70,8 @@ class BasePriceCalculationTest extends TestCase
             $inputPrice,
             $inputPriceType,
             $vat,
-            $currency,
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         $this->assertThat($basePrice->getPriceWithoutVat(), new IsMoneyEqual($basePriceWithoutVat));

--- a/packages/framework/tests/Unit/Model/Pricing/PriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/PriceCalculationTest.php
@@ -102,7 +102,7 @@ class PriceCalculationTest extends TestCase
         $currencyData->code = 'currency code';
         $currency = new Currency($currencyData);
 
-        $actualVatAmount = $priceCalculation->getVatAmountByPriceWithVat($priceWithVat, $vat, $currency);
+        $actualVatAmount = $priceCalculation->getVatAmountByPriceWithVat($priceWithVat, $vat, $currency->getRoundingPlacesPriceWithoutVat());
 
         $this->assertThat($actualVatAmount, new IsMoneyEqual($expectedVatAmount));
     }

--- a/packages/framework/tests/Unit/Model/Pricing/RoundingTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/RoundingTest.php
@@ -68,14 +68,14 @@ class RoundingTest extends TestCase
         $currency = $this->createCurrency(Currency::ROUNDING_TYPE_INTEGER);
 
         $this->assertThat(
-            $rounding->roundPriceWithVatByCurrency($unroundedPrice, $currency),
+            $rounding->roundPriceWithVat($unroundedPrice, $currency->getRoundingType()),
             new IsMoneyEqual($expectedAsPriceWithVat),
         );
         $this->assertThat(
-            $rounding->roundPriceWithoutVat($unroundedPrice, $currency),
+            $rounding->roundPriceWithoutVat($unroundedPrice, $currency->getRoundingPlacesPriceWithoutVat()),
             new IsMoneyEqual($expectedAsPriceWithoutVat),
         );
-        $this->assertThat($rounding->roundVatAmount($unroundedPrice, $currency), new IsMoneyEqual($expectedAsVatAmount));
+        $this->assertThat($rounding->roundVatAmount($unroundedPrice, $currency->getRoundingPlacesPriceWithoutVat()), new IsMoneyEqual($expectedAsVatAmount));
     }
 
     public static function roundingPriceWithVatProvider(): array
@@ -138,7 +138,7 @@ class RoundingTest extends TestCase
         $currency = $this->createCurrency($roundingType);
 
         $rounding = new Rounding();
-        $roundedPrice = $rounding->roundPriceWithVatByCurrency($inputPrice, $currency);
+        $roundedPrice = $rounding->roundPriceWithVat($inputPrice, $currency->getRoundingType());
 
         $this->assertThat($roundedPrice, new IsMoneyEqual($outputPrice));
     }

--- a/packages/frontend-api/src/Component/Constraints/PaymentInExistingOrderValidator.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentInExistingOrderValidator.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
 use Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentNotFoundException;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrontendApiBundle\Model\Resolver\Order\Exception\OrderNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Resolver\Payment\Exception\PaymentNotFoundUserError;
 use Symfony\Component\Validator\Constraint;
@@ -24,6 +25,7 @@ class PaymentInExistingOrderValidator extends ConstraintValidator
         protected readonly OrderFacade $orderFacade,
         protected readonly PaymentFacade $paymentFacade,
         protected readonly GoPayBankSwiftFacade $goPayBankSwiftFacade,
+        protected readonly CurrencyFacade $currencyFacade,
     ) {
     }
 
@@ -61,10 +63,11 @@ class PaymentInExistingOrderValidator extends ConstraintValidator
             return;
         }
 
+        $currency = $this->currencyFacade->getByCode($order->getCurrencyCode());
         $goPayBankSwift = $this->goPayBankSwiftFacade->findBySwiftAndPaymentMethodAndCurrency(
             $paymentGoPayBankSwift,
             $goPayPaymentMethod,
-            $order->getCurrency(),
+            $currency,
         );
 
         if ($goPayBankSwift !== null) {

--- a/packages/frontend-api/src/Model/Order/OrderDataFactory.php
+++ b/packages/frontend-api/src/Model/Order/OrderDataFactory.php
@@ -51,7 +51,8 @@ class OrderDataFactory
     {
         $cloneOrderData = clone $orderData;
 
-        $cloneOrderData->currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId());
+        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId());
+        $cloneOrderData->fillCurrencyFieldsFromCurrency($currency);
 
         $cloneOrderData->country = $this->countryFacade->findByCode($input['country']);
 

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceQuery.php
@@ -49,10 +49,11 @@ class PriceQuery extends AbstractQuery
 
             return $this->paymentPriceCalculation->calculatePrice(
                 $payment,
-                $order->getCurrency(),
                 $order->getTotalProductsPrice(),
                 $order->getDomainId(),
                 $order->isFreeTransportAndPaymentApplied(),
+                $order->getCurrencyRoundingType(),
+                $order->getCurrencyRoundingPlacesPriceWithoutVat(),
             );
         }
 
@@ -73,10 +74,13 @@ class PriceQuery extends AbstractQuery
 
     protected function calculateIndependentPaymentPrice(Payment $payment): PriceInterface
     {
+        $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId());
+
         return $this->paymentPriceCalculation->calculateIndependentPrice(
             $payment,
-            $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId()),
             $this->domain->getId(),
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
     }
 

--- a/project-base/app/src/DataFixtures/Demo/CompanyOrderDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/CompanyOrderDataFixture.php
@@ -68,7 +68,7 @@ class CompanyOrderDataFixture extends AbstractReferenceFixture implements Depend
         $this->mapCompanyAddressDataToOrderData($orderData, $companyCustomer);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-3 day')->setTime(12, 40, 22);
 
         $this->createOrder(
@@ -89,7 +89,7 @@ class CompanyOrderDataFixture extends AbstractReferenceFixture implements Depend
         $this->mapCompanyAddressDataToOrderData($orderData, $companyCustomer);
         $this->mapDeliveryAddressDataToOrderData($orderData, $customerUser);
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-11 day')->setTime(4, 34, 19);
         $orderData->promoCode = 'promoCode123';
         $this->createOrder(
@@ -113,7 +113,7 @@ class CompanyOrderDataFixture extends AbstractReferenceFixture implements Depend
         $this->mapCompanyAddressDataToOrderData($orderData, $companyCustomer);
         $this->mapDeliveryAddressDataToOrderData($orderData, $customerUser);
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-3 day')->setTime(18, 27, 36);
         $order = $this->createOrder(
             $orderData,
@@ -133,7 +133,7 @@ class CompanyOrderDataFixture extends AbstractReferenceFixture implements Depend
         $this->mapCompanyAddressDataToOrderData($orderData, $companyCustomer);
         $this->mapDeliveryAddressDataToOrderData($orderData, $customerUser);
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-1 day')->setTime(18, 30, 01);
         $order = $this->createOrder(
             $orderData,
@@ -152,7 +152,7 @@ class CompanyOrderDataFixture extends AbstractReferenceFixture implements Depend
         $this->mapCompanyAddressDataToOrderData($orderData, $companyCustomer);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-2 day')->setTime(1, 46, 6);
         $this->createOrder(
             $orderData,
@@ -174,7 +174,7 @@ class CompanyOrderDataFixture extends AbstractReferenceFixture implements Depend
         $this->mapCompanyAddressDataToOrderData($orderData, $companyCustomer);
         $this->mapDeliveryAddressDataToOrderData($orderData, $customerUser);
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-1 day')->setTime(18, 30, 01);
         $this->createOrder(
             $orderData,

--- a/project-base/app/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/OrderDataFixture.php
@@ -92,7 +92,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-3 day')->setTime(12, 40, 22);
         $orderData->deliveredAt = (new DatePoint('now -2 day'))->setTime(14, 15, 10);
 
@@ -120,7 +120,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-11 day')->setTime(4, 34, 19);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR, Administrator::class);
         $orderData->promoCode = 'promoCode123';
@@ -149,7 +149,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-3 day')->setTime(18, 27, 36);
         $this->createOrder(
             $orderData,
@@ -175,7 +175,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-1 day')->setTime(18, 30, 01);
         $this->createOrder(
             $orderData,
@@ -199,7 +199,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-2 day')->setTime(1, 46, 6);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::SUPERADMINISTRATOR, Administrator::class);
         $this->createOrder(
@@ -226,7 +226,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-12 day')->setTime(0, 49, 0);
         $this->createOrder(
             $orderData,
@@ -255,7 +255,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-13 day')->setTime(23, 35, 15);
         $order = $this->createOrder(
             $orderData,
@@ -281,7 +281,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-5 day')->setTime(9, 11, 59);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::SUPERADMINISTRATOR, Administrator::class);
         $orderData->deliveredAt = (new DatePoint('now -1 day'))->setTime(16, 45, 30);
@@ -309,7 +309,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-14 day')->setTime(12, 54, 07);
         $this->createOrder(
             $orderData,
@@ -334,7 +334,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-7 day')->setTime(7, 2, 31);
         $orderData->promoCode = 'promoCode123';
         $order = $this->createOrder(
@@ -362,7 +362,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-7 day')->setTime(11, 28, 20);
         $this->createOrder(
             $orderData,
@@ -387,7 +387,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-10 day')->setTime(18, 3, 36);
         $orderData->deliveredAt = (new DatePoint('now -8 day'))->setTime(11, 30, 45);
         $this->createOrder(
@@ -412,7 +412,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-10 day')->setTime(23, 47, 11);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR, Administrator::class);
         $this->createOrder(
@@ -438,7 +438,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-35 day')->setTime(8, 14, 8);
         $orderData->deliveredAt = (new DatePoint('now -30 day'))->setTime(10, 20, 15);
         $order = $this->createOrder(
@@ -467,7 +467,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-11 day')->setTime(4, 43, 25);
         $this->createOrder(
             $orderData,
@@ -495,7 +495,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->companyNumber = '555555';
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-5 day')->setTime(3, 3, 12);
         $this->createOrder(
             $orderData,
@@ -533,7 +533,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->companyNumber = '555555';
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-13 day')->setTime(17, 34, 40);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR, Administrator::class);
         $this->createOrder(
@@ -577,7 +577,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->companyNumber = '555555';
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-6 day')->setTime(5, 7, 38);
         $order = $this->createOrder(
             $orderData,
@@ -621,7 +621,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->companyNumber = '555555';
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = new DatePoint();
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR, Administrator::class);
         $this->createOrder(
@@ -654,7 +654,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-1 day')->setTime(22, 51, 55);
         $order = $this->createOrder(
             $orderData,
@@ -699,7 +699,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryCountry = $this->getReference(CountryDataFixture::COUNTRY_SLOVAKIA, Country::class);
         $orderData->note = 'Prosím o dodání do pátku. Děkuji.';
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-4 day')->setTime(21, 23, 5);
         $this->createOrder(
             $orderData,
@@ -729,7 +729,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-4 day')->setTime(11, 14, 2);
         $this->createOrder(
             $orderData,
@@ -754,7 +754,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-7 day')->setTime(11, 10, 47);
         $this->createOrder(
             $orderData,
@@ -777,7 +777,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = (new DatePoint())->modify('-7 day')->setTime(11, 10, 47);
         $this->createOrder(
             $orderData,
@@ -879,7 +879,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->country = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
-        $orderData->currency = $domainDefaultCurrency;
+        $orderData->fillCurrencyFieldsFromCurrency($domainDefaultCurrency);
         $orderData->createdAt = new DatePoint();
         $this->createOrder(
             $orderData,

--- a/project-base/app/src/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/app/src/DataFixtures/Performance/OrderDataFixture.php
@@ -175,7 +175,8 @@ class OrderDataFixture
         $orderData->note = $this->faker->text(200);
         $orderData->createdAt = DatePoint::createFromMutable($this->faker->dateTimeBetween('-1 year', 'now'));
         $orderData->domainId = Domain::FIRST_DOMAIN_ID;
-        $orderData->currency = $this->persistentReferenceFacade->getReference(CurrencyDataFixture::CURRENCY_CZK, Currency::class);
+        $currency = $this->persistentReferenceFacade->getReference(CurrencyDataFixture::CURRENCY_CZK, Currency::class);
+        $orderData->fillCurrencyFieldsFromCurrency($currency);
 
         return $orderData;
     }

--- a/project-base/app/src/Model/Order/OrderDataFactory.php
+++ b/project-base/app/src/Model/Order/OrderDataFactory.php
@@ -15,6 +15,8 @@ use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory as BaseOrderDataFactory
  * @method \App\Model\Order\OrderData createFromOrder(\App\Model\Order\Order $order)
  * @method \App\Model\Order\OrderData fillZeroPrices(\App\Model\Order\OrderData $orderData)
  * @method void fillFromOrder(\App\Model\Order\OrderData $orderData, \App\Model\Order\Order $order)
+ * @method void fillDeliveryAddressFromOrder(\App\Model\Order\OrderData $orderData, \App\Model\Order\Order $order)
+ * @method void fillItemsFromOrder(\App\Model\Order\OrderData $orderData, \App\Model\Order\Order $order)
  */
 class OrderDataFactory extends BaseOrderDataFactory
 {

--- a/project-base/app/src/Model/Order/OrderFacade.php
+++ b/project-base/app/src/Model/Order/OrderFacade.php
@@ -27,7 +27,7 @@ use Shopsys\FrameworkBundle\Model\Order\OrderFacade as BaseOrderFacade;
  * @method \App\Model\Order\Order getByUrlHashAndDomain(string $urlHash, int $domainId)
  * @method \App\Model\Order\Order getByOrderNumberAndUser(string $orderNumber, \App\Model\Customer\User\CustomerUser $customerUser)
  * @method void refreshOrderItemsWithoutTransportAndPayment(\App\Model\Order\Order $order, \App\Model\Order\OrderData $orderData)
- * @method void calculateOrderItemDataPrices(\App\Model\Order\Item\OrderItemData $orderItemData, int $domainId, \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency)
+ * @method void calculateOrderItemDataPrices(\App\Model\Order\Item\OrderItemData $orderItemData, int $domainId, string $currencyRoundingType, int $roundingPlaces)
  * @method void updateTransportAndPaymentNamesInOrderData(\App\Model\Order\OrderData $orderData, \App\Model\Order\Order $order)
  * @method void setOrderPaymentStatusPageValidFromNow(\App\Model\Order\Order $order)
  * @method void changeOrderPayment(\App\Model\Order\Order $order, \App\Model\Payment\Payment $payment, bool $updatePaymentPrice = true)

--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -309,7 +309,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $orderData->deliveryCountry = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->note = 'note';
         $orderData->domainId = Domain::FIRST_DOMAIN_ID;
-        $orderData->currency = $this->getFirstDomainCurrency();
+        $orderData->fillCurrencyFieldsFromCurrency($this->getFirstDomainCurrency());
 
         $orderData = $this->orderProcessor->process(
             $orderInput,

--- a/project-base/app/tests/App/Functional/Model/Order/OrderFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Order/OrderFacadeTest.php
@@ -105,7 +105,7 @@ class OrderFacadeTest extends TransactionFunctionalTestCase
         $orderData->deliveryCountry = $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC, Country::class);
         $orderData->note = 'note';
         $orderData->domainId = Domain::FIRST_DOMAIN_ID;
-        $orderData->currency = $this->getReference(CurrencyDataFixture::CURRENCY_CZK, Currency::class);
+        $orderData->fillCurrencyFieldsFromCurrency($this->getReference(CurrencyDataFixture::CURRENCY_CZK, Currency::class));
 
         $orderInput = $this->orderInputFactory->create($this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID));
         $orderInput->addProduct($product, 1);

--- a/project-base/app/tests/App/Functional/PersonalData/PersonalDataExportXmlTest.php
+++ b/project-base/app/tests/App/Functional/PersonalData/PersonalDataExportXmlTest.php
@@ -157,7 +157,7 @@ class PersonalDataExportXmlTest extends TransactionFunctionalTestCase
     private function createOrder(Currency $currency, OrderStatus $status, Country $country): Order
     {
         $orderData = TestOrderProvider::getTestOrderData();
-        $orderData->currency = $currency;
+        $orderData->fillCurrencyFieldsFromCurrency($currency);
         $orderData->status = $status;
         $orderData->email = 'no-reply@shopsys.com';
         $orderData->createdAt = new DatePoint('2018-04-13');

--- a/project-base/app/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/app/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -285,7 +285,8 @@ abstract class GraphQlTestCase extends ApplicationTestCase
             ),
             PricingSetting::PRICE_TYPE_WITHOUT_VAT,
             $vat,
-            $currency,
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
 
         $basePrice = $basePrice->multiply($quantity);
@@ -298,7 +299,8 @@ abstract class GraphQlTestCase extends ApplicationTestCase
             $basePrice->getPriceWithVat(),
             PricingSetting::PRICE_TYPE_WITH_VAT,
             $vat,
-            $currency,
+            $currency->getRoundingType(),
+            $currency->getRoundingPlacesPriceWithoutVat(),
         );
     }
 

--- a/upgrade-notes/backend_20260312_111219.md
+++ b/upgrade-notes/backend_20260312_111219.md
@@ -1,0 +1,38 @@
+#### Order relations that can influence order item price calculations are now stored during order creation ([#4507](https://github.com/shopsys/shopsys/pull/4507))
+
+- `Shopsys\FrameworkBundle\Model\Order\Order::getCurrency()` method was removed, use `getCurrencyCode()`, `getCurrencyRoundingType()`, `getCurrencyRoundingPlacesPriceWithoutVat()`, `getCurrencyMinFractionDigits()`, and `isPaymentCzkRounding()` instead
+- `Shopsys\FrameworkBundle\Model\Order\OrderData::$currency` property was removed, use `$currencyCode`, `$currencyRoundingType`, `$currencyRoundingPlacesPriceWithoutVat`, `$currencyMinFractionDigits`, and `$paymentCzkRounding` properties instead or use `OrderData::fillCurrencyFieldsFromCurrency(Currency $currency)` to populate all currency fields at once
+- `Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory::createByLocaleAndCurrency()` was renamed to `createByLocaleAndMinFractionDigits(string $locale, int $minFractionDigits)`
+- `Shopsys\FrameworkBundle\Model\Pricing\Rounding` method signatures changed:
+
+    | Old method                                     | New method                                         |
+    | ---------------------------------------------- | -------------------------------------------------- |
+    | `roundPriceWithVatByCurrency(Money, Currency)` | `roundPriceWithVat(Money, string $roundingType)`   |
+    | `roundPriceWithoutVat(Money, Currency)`        | `roundPriceWithoutVat(Money, int $roundingPlaces)` |
+    | `roundVatAmount(Money, Currency)`              | `roundVatAmount(Money, int $roundingPlaces)`       |
+
+- `Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation` method signatures changed:
+
+    | Old method                                                        | New method                                                                   |
+    | ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+    | `getVatAmountByPriceWithVat(Money, Vat, Currency)`                | `getVatAmountByPriceWithVat(Money, Vat, int $roundingPlaces)`                |
+    | `getVatAmountByPriceWithVatForVatPercent(Money, float, Currency)` | `getVatAmountByPriceWithVatForVatPercent(Money, float, int $roundingPlaces)` |
+
+- `Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation::calculateRoundedBasePrice()` — parameter `Currency $currency` replaced by `string $roundingType, int $roundingPlaces`
+- `Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation` method signatures changed:
+    - `calculatePrice()` — `Currency $currency` parameter removed, new `string $roundingType` and `int $roundingPlaces` parameters added at end
+    - `calculateIndependentPrice()` — `Currency $currency` parameter removed, signature is now `(Payment $payment, int $domainId, string $roundingType, int $roundingPlaces)`
+- `Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation::calculateOrderRoundingPrice()` — parameters changed from `(Payment $payment, Currency $currency, PriceInterface $orderTotalPrice)` to `(bool $paymentCzkRounding, string $currencyCode, string $currencyRoundingType, PriceInterface $orderTotalPrice)`
+- `Shopsys\FrameworkBundle\Model\Order\PromoCode\DiscountCalculation` method signatures changed:
+    - `calculatePercentageDiscountRoundedByCurrency()` — `Currency $currency` replaced by `string $roundingType, int $roundingPlaces`
+    - `calculateNominalDiscount()` — `Currency $currency` replaced by `int $roundingPlaces`
+- `Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation` method signatures changed:
+    - `calculatePriceWithoutVatForInputPriceWithVat()` — new required third parameter `int $roundingPlaces`
+    - `calculatePriceWithVatForInputPriceWithoutVat()` — third parameter changed from `Currency $currency` to `string $currencyRoundingType`
+- `Shopsys\FrameworkBundle\Model\Payment\PaymentFacade::getPaymentPricesWithVatByCurrencyAndDomainIdIndexedByPaymentId()` was renamed to `getPaymentPricesWithVatByDomainIdIndexedByPaymentId(int $domainId, string $roundingType, int $roundingPlaces)`, `Currency $currency` parameter replaced by explicit `string $roundingType` and `int $roundingPlaces`
+- `Shopsys\FrameworkBundle\Model\Payment\PaymentInstructionFacade::createSpdString()` — fourth parameter changed from `Currency $currency` to `string $currencyCode`
+- Twig filter `priceWithCurrency(order.currency)` was renamed to `priceWithCurrencyByOrder(order)`, update your templates accordingly
+- Twig filter `priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, locale)` was renamed to `priceTextWithCurrencyByOrderAndLocale(order, locale)`, update your templates accordingly
+- Twig filter `currencySymbolByCurrencyId(order.currency.id)` was renamed to `currencySymbolByCode(order.currencyCode)`, update your templates accordingly
+- database migration `Version20260310120000` adds new columns to the `orders` table and migrates data from `currencies` and `payments` — this may take a significant amount of time on databases with a large number of orders
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- Having direct relation until now was causing problems when settings that influence price calculation changed over time. If order was saved after some time, it could cause changes in order that were not expected.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-freeze-order-prices-before-setting-change.odin.shopsys.cloud
  - https://cz.tl-freeze-order-prices-before-setting-change.odin.shopsys.cloud
  - https://tl-freeze-order-prices-before-setting-change.odin.shopsys.cloud/sk
<!-- Replace -->
