### PR TITLE
move ProductEntityFieldMapper::getFlags() from project-base to the frontend-api package

### DIFF
--- a/packages/administration/assets/src/js/initComponents.js
+++ b/packages/administration/assets/src/js/initComponents.js
@@ -81,7 +81,7 @@ function initPopover($container) {
     $container.filterAllNodes('[data-bs-toggle="popover"]').each(function () {
         const originalTrigger = this.getAttribute('data-bs-trigger');
 
-        if (isTouchDevice && originalTrigger && originalTrigger.includes('hover')) {
+        if (isTouchDevice && originalTrigger?.includes('hover')) {
             this.setAttribute('data-bs-trigger', 'click');
         }
 

--- a/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
@@ -9,6 +9,7 @@ use Overblog\DataLoader\DataLoaderInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Collection\ProductCollectionFacade;
@@ -46,6 +47,7 @@ class ProductEntityFieldMapper
         protected readonly ProductRepository $productRepository,
         protected readonly ParameterRepository $parameterRepository,
         protected readonly ParameterValueFileResolver $parameterValueFileResolver,
+        protected readonly PricingGroupSettingFacade $pricingGroupSettingFacade,
     ) {
     }
 
@@ -297,5 +299,40 @@ class ProductEntityFieldMapper
     public function getPromotionFreeQuantity(Product $product): ?int
     {
         return $product->getPromotionXy($this->domain->getId())?->getFreeQuantity();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    public function getFlags(Product $product): array
+    {
+        $flags = $product->getFlags($this->domain->getId());
+
+        $flagsIndexedById = [];
+
+        foreach ($flags as $flag) {
+            $flagsIndexedById[$flag->getId()] = $flag;
+        }
+
+        $variants = [];
+
+        if ($product->isMainVariant() === true) {
+            $variants = $this->productRepository->getAllSellableVariantsByMainVariant(
+                $product,
+                $this->domain->getId(),
+                $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($this->domain->getId()),
+            );
+        }
+
+        foreach ($variants as $variant) {
+            $variantFlags = $variant->getFlags($this->domain->getId());
+
+            foreach ($variantFlags as $variantFlag) {
+                $flagsIndexedById[$variantFlag->getId()] = $variantFlag;
+            }
+        }
+        ksort($flagsIndexedById);
+
+        return array_values($flagsIndexedById);
     }
 }

--- a/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
@@ -64,6 +64,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\DataMapper\ProductEntityFi
  * @property \App\Model\Product\Parameter\ParameterRepository $parameterRepository
  * @method array getParameters(\App\Model\Product\Product $product)
  * @method \GraphQL\Executor\Promise\Promise getRelatedProductsPromise(\App\Model\Product\Product $product)
+ * @method \App\Model\Product\Flag\Flag[] getFlags(\App\Model\Product\Product $product)
  */
 class ProductEntityFieldMapper extends BaseProductEntityFieldMapper
 {
@@ -89,7 +90,7 @@ class ProductEntityFieldMapper extends BaseProductEntityFieldMapper
         ProductRepository $productRepository,
         ParameterRepository $parameterRepository,
         ParameterValueFileResolver $parameterValueFileResolver,
-        protected readonly PricingGroupSettingFacade $pricingGroupSettingFacade,
+        PricingGroupSettingFacade $pricingGroupSettingFacade,
         protected readonly BreadcrumbFacade $breadcrumbFacade,
         protected readonly DataLoaderInterface $categoriesBatchLoader,
         protected readonly DataLoaderInterface $brandsBatchLoader,
@@ -113,6 +114,7 @@ class ProductEntityFieldMapper extends BaseProductEntityFieldMapper
             $productRepository,
             $parameterRepository,
             $parameterValueFileResolver,
+            $pricingGroupSettingFacade,
         );
     }
 
@@ -129,41 +131,6 @@ class ProductEntityFieldMapper extends BaseProductEntityFieldMapper
     public function getCatalogNumber(Product $product): string
     {
         return $product->getCatnum();
-    }
-
-    /**
-     * @return \App\Model\Product\Flag\Flag[]
-     */
-    public function getFlags(Product $product): array
-    {
-        $flags = $product->getFlags($this->domain->getId());
-
-        $flagsIndexedById = [];
-
-        foreach ($flags as $flag) {
-            $flagsIndexedById[$flag->getId()] = $flag;
-        }
-
-        $variants = [];
-
-        if ($product->isMainVariant() === true) {
-            $variants = $this->productRepository->getAllSellableVariantsByMainVariant(
-                $product,
-                $this->domain->getId(),
-                $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($this->domain->getId()),
-            );
-        }
-
-        foreach ($variants as $variant) {
-            $variantFlags = $variant->getFlags($this->domain->getId());
-
-            foreach ($variantFlags as $variantFlag) {
-                $flagsIndexedById[$variantFlag->getId()] = $variantFlag;
-            }
-        }
-        ksort($flagsIndexedById);
-
-        return array_values($flagsIndexedById);
     }
 
     /**

--- a/upgrade-notes/backend_20260316_145759.md
+++ b/upgrade-notes/backend_20260316_145759.md
@@ -1,0 +1,5 @@
+#### move ProductEntityFieldMapper::getFlags() from project-base to the frontend-api package ([#4509](https://github.com/shopsys/shopsys/pull/4509))
+
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the frontend-api package:
+    - `getFlags()` method from `App\FrontendApi\Resolver\Products\DataMapper\ProductEntityFieldMapper` to `Shopsys\FrontendApiBundle\Model\Resolver\Products\DataMapper\ProductEntityFieldMapper`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Put the code where it belongs
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
closes #3566 

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-move-flags.odin.shopsys.cloud
  - https://cz.rv-move-flags.odin.shopsys.cloud
  - https://rv-move-flags.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773744085.153769 -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-move-flags.odin.shopsys.cloud
  - https://cz.rv-move-flags.odin.shopsys.cloud
  - https://rv-move-flags.odin.shopsys.cloud/sk
<!-- Replace -->
