### PR TITLE
VolumeDriver: use alias to `elFinderVolumeFlysystem` only if the alias does not exist

### DIFF
--- a/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
+++ b/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
@@ -308,4 +308,6 @@ class VolumeDriver extends Driver
     }
 }
 
-class_alias(VolumeDriver::class, 'elFinderVolumeFlysystem');
+if (!class_exists('elFinderVolumeFlysystem', false)) {
+    class_alias(VolumeDriver::class, 'elFinderVolumeFlysystem');
+}


### PR DESCRIPTION
#### Description, the reason for the PR
... 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
closes #3637

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-opcache-fix.odin.shopsys.cloud
  - https://cz.rv-opcache-fix.odin.shopsys.cloud
  - https://rv-opcache-fix.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773732034.447379 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-opcache-fix.odin.shopsys.cloud
  - https://cz.rv-opcache-fix.odin.shopsys.cloud
  - https://rv-opcache-fix.odin.shopsys.cloud/sk
<!-- Replace -->
