### PR TITLE
recalculations: introduce constants for "all scopes" and "unscoped fields"

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/AbstractIndex.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractIndex.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 abstract class AbstractIndex
 {
     public const BATCH_SIZE = 100;
+    public const array ALL_FIELDS = [];
 
     abstract public static function getName(): string;
 
@@ -15,7 +16,11 @@ abstract class AbstractIndex
     /**
      * @param string[] $fields
      */
-    abstract public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array;
+    abstract public function getExportDataForIds(
+        int $domainId,
+        array $restrictToIds,
+        array $fields = self::ALL_FIELDS,
+    ): array;
 
     /**
      * @param string[] $fields
@@ -24,7 +29,7 @@ abstract class AbstractIndex
         int $domainId,
         int $lastProcessedId,
         int $batchSize,
-        array $fields = [],
+        array $fields = self::ALL_FIELDS,
     ): array;
 
     public function getExportBatchSize(): int

--- a/packages/framework/src/Component/Elasticsearch/IndexFacade.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexFacade.php
@@ -208,7 +208,7 @@ class IndexFacade
         AbstractIndex $index,
         IndexDefinition $indexDefinition,
         array $restrictToIds,
-        array $fields = [],
+        array $fields = AbstractIndex::ALL_FIELDS,
     ): void {
         $this->sqlLoggerFacade->temporarilyDisableLogging();
 

--- a/packages/framework/src/Model/Article/Elasticsearch/ArticleIndex.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/ArticleIndex.php
@@ -31,9 +31,9 @@ class ArticleIndex extends AbstractIndex
         int $domainId,
         int $lastProcessedId,
         int $batchSize,
-        array $fields = [],
+        array $fields = self::ALL_FIELDS,
     ): array {
-        if ($fields !== []) {
+        if ($fields !== self::ALL_FIELDS) {
             throw new UnsupportedFeatureException('Scoping export by fields is not supported for articles.');
         }
         $results = [];
@@ -49,9 +49,12 @@ class ArticleIndex extends AbstractIndex
      * @param string[] $fields
      */
     #[Override]
-    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
-    {
-        if ($fields !== []) {
+    public function getExportDataForIds(
+        int $domainId,
+        array $restrictToIds,
+        array $fields = self::ALL_FIELDS,
+    ): array {
+        if ($fields !== self::ALL_FIELDS) {
             throw new UnsupportedFeatureException('Scoping export by fields is not supported for articles.');
         }
         $results = [];

--- a/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleIndex.php
+++ b/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleIndex.php
@@ -36,9 +36,9 @@ class BlogArticleIndex extends AbstractIndex implements IndexSupportChangesOnlyI
         int $domainId,
         int $lastProcessedId,
         int $batchSize,
-        array $fields = [],
+        array $fields = self::ALL_FIELDS,
     ): array {
-        if ($fields !== []) {
+        if ($fields !== self::ALL_FIELDS) {
             throw new UnsupportedFeatureException('Scoping export by fields is not supported for blog articles.');
         }
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
@@ -56,9 +56,12 @@ class BlogArticleIndex extends AbstractIndex implements IndexSupportChangesOnlyI
      * @param string[] $fields
      */
     #[Override]
-    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
-    {
-        if ($fields !== []) {
+    public function getExportDataForIds(
+        int $domainId,
+        array $restrictToIds,
+        array $fields = self::ALL_FIELDS,
+    ): array {
+        if ($fields !== self::ALL_FIELDS) {
             throw new UnsupportedFeatureException('Scoping export by fields is not supported for blog articles.');
         }
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\QueryBuilder;
 use InvalidArgumentException;
 use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository;
@@ -70,7 +71,7 @@ class ProductExportRepository
         string $locale,
         int $lastProcessedId,
         int $batchSize,
-        array $fields = [],
+        array $fields = AbstractIndex::ALL_FIELDS,
     ): array {
         $queryBuilder = $this->createQueryBuilder($domainId)
             ->andWhere('p.id > :lastProcessedId')
@@ -419,7 +420,7 @@ class ProductExportRepository
     {
         $query = $queryBuilder->getQuery();
 
-        if (count($fields) === 0) {
+        if ($fields === AbstractIndex::ALL_FIELDS) {
             $fields = $this->productExportFieldProvider->getAll();
         }
 

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
@@ -29,8 +29,11 @@ class ProductIndex extends AbstractIndex
      * {@inheritdoc}
      */
     #[Override]
-    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
-    {
+    public function getExportDataForIds(
+        int $domainId,
+        array $restrictToIds,
+        array $fields = self::ALL_FIELDS,
+    ): array {
         return $this->productExportRepository->getProductsDataForIds(
             $domainId,
             $this->domain->getDomainConfigById($domainId)->getLocale(),
@@ -47,7 +50,7 @@ class ProductIndex extends AbstractIndex
         int $domainId,
         int $lastProcessedId,
         int $batchSize,
-        array $fields = [],
+        array $fields = self::ALL_FIELDS,
     ): array {
         return $this->productExportRepository->getProductsData(
             $domainId,

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
@@ -9,6 +9,8 @@ use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\Exception\ScopeRul
 
 class ProductExportScopeConfig
 {
+    public const array ALL_SCOPES = [];
+
     public const string SCOPE_NAME = 'product_name_scope';
     public const string SCOPE_UNIT = 'product_unit_scope';
     public const string SCOPE_BRAND = 'product_brand_scope';

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfigFacade.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfigFacade.php
@@ -31,7 +31,7 @@ class ProductExportScopeConfigFacade
      */
     public function shouldRecalculateVisibility(array $exportScopes): bool
     {
-        if (count($exportScopes) === 0) {
+        if ($exportScopes === ProductExportScopeConfig::ALL_SCOPES) {
             return true;
         }
 
@@ -49,7 +49,7 @@ class ProductExportScopeConfigFacade
      */
     public function shouldRecalculateSellingDenied(array $exportScopes): bool
     {
-        if (count($exportScopes) === 0) {
+        if ($exportScopes === ProductExportScopeConfig::ALL_SCOPES) {
             return true;
         }
 
@@ -67,7 +67,7 @@ class ProductExportScopeConfigFacade
      */
     public function shouldRecalculateGiftFlags(array $exportScopes): bool
     {
-        if (count($exportScopes) === 0) {
+        if ($exportScopes === ProductExportScopeConfig::ALL_SCOPES) {
             return true;
         }
 
@@ -86,7 +86,7 @@ class ProductExportScopeConfigFacade
      */
     protected function getMatchingRules(array $exportScopes): array
     {
-        if (count($exportScopes) === 0) {
+        if ($exportScopes === ProductExportScopeConfig::ALL_SCOPES) {
             return [];
         }
 

--- a/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessage.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
+
 class DispatchAllProductsMessage
 {
     /**
      * @param string[] $exportScopes
      */
-    public function __construct(public readonly array $exportScopes = [])
+    public function __construct(public readonly array $exportScopes = ProductExportScopeConfig::ALL_SCOPES)
     {
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/DispatchProductIdsBatchMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchProductIdsBatchMessage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
+
 class DispatchProductIdsBatchMessage
 {
     /**
@@ -12,7 +14,7 @@ class DispatchProductIdsBatchMessage
      */
     public function __construct(
         public readonly array $productIds = [],
-        public readonly array $exportScopes = [],
+        public readonly array $exportScopes = ProductExportScopeConfig::ALL_SCOPES,
         public readonly string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
     ) {
     }

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
 use Nette\Utils\Json;
 use Redis;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
 
 class ProductRecalculationDeduplicationFacade
 {
@@ -40,14 +41,14 @@ class ProductRecalculationDeduplicationFacade
         string $priority,
     ): array {
         if (!$this->isDeduplicationActive) {
-            return array_fill_keys($productIds, []);
+            return array_fill_keys($productIds, ProductExportScopeConfig::ALL_SCOPES);
         }
 
         $exportScopesIndexedByProductIds = $this->doGetStoredExportScopes($productIds, $priority);
 
         foreach ($exportScopesIndexedByProductIds as $productId => $exportScopesJson) {
             if ($exportScopesJson === false) {
-                $exportScopesJson = '[]';
+                $exportScopesJson = Json::encode(ProductExportScopeConfig::ALL_SCOPES);
             }
 
             $exportScopes = Json::decode($exportScopesJson, true);
@@ -117,13 +118,13 @@ class ProductRecalculationDeduplicationFacade
         $storedScopes = Json::decode($storedScopesJson, true);
 
         // all scopes are already stored; do not modify stored scopes
-        if ($storedScopes === []) {
+        if ($storedScopes === ProductExportScopeConfig::ALL_SCOPES) {
             return $storedScopesJson;
         }
 
         // requested all scopes; store all scopes
-        if ($requestedExportScopes === []) {
-            return '[]';
+        if ($requestedExportScopes === ProductExportScopeConfig::ALL_SCOPES) {
+            return Json::encode(ProductExportScopeConfig::ALL_SCOPES);
         }
 
         // all requested scopes already stored; do not modify stored scopes

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
@@ -26,7 +26,7 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
     public function dispatchProducts(
         array $products,
         string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
-        array $exportScopes = [],
+        array $exportScopes = ProductExportScopeConfig::ALL_SCOPES,
     ): void {
         $this->dispatchProductIds(
             array_map(static fn (Product $product) => $product->getId(), $products),
@@ -42,7 +42,7 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
     public function dispatchProductIds(
         array $productIds,
         string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
-        array $exportScopes = [],
+        array $exportScopes = ProductExportScopeConfig::ALL_SCOPES,
     ): void {
         $this->verifyExportScopes($exportScopes);
         $productIds = array_unique($productIds);
@@ -78,7 +78,7 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
     public function dispatchSingleProductId(
         int $productId,
         string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
-        array $exportScopes = [],
+        array $exportScopes = ProductExportScopeConfig::ALL_SCOPES,
     ): void {
         $this->dispatchProductIds([$productId], $productRecalculationPriorityEnum, $exportScopes);
     }
@@ -86,7 +86,7 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
     /**
      * @param string[] $exportScopes
      */
-    public function dispatchAllProducts(array $exportScopes = []): void
+    public function dispatchAllProducts(array $exportScopes = ProductExportScopeConfig::ALL_SCOPES): void
     {
         $this->verifyExportScopes($exportScopes);
         $this->messageBus->dispatch(new DispatchAllProductsMessage($exportScopes));

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcherExecutor.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcherExecutor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -26,7 +27,7 @@ class ProductRecalculationDispatcherExecutor
     public function dispatchProductIds(
         array $productIds,
         string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
-        array $exportScopes = [],
+        array $exportScopes = ProductExportScopeConfig::ALL_SCOPES,
     ): array {
         $productIdsWithMainVariants = $this->productRecalculationRepository->replaceVariantIdsWithMainVariantIds($productIds);
 

--- a/packages/framework/tests/Unit/Component/Elasticsearch/__fixtures/CategoryIndex.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/__fixtures/CategoryIndex.php
@@ -29,8 +29,11 @@ class CategoryIndex extends AbstractIndex
      * {@inheritdoc}
      */
     #[Override]
-    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
-    {
+    public function getExportDataForIds(
+        int $domainId,
+        array $restrictToIds,
+        array $fields = self::ALL_FIELDS,
+    ): array {
         throw new RuntimeException(sprintf('The %s() is not implemented.', __METHOD__));
     }
 
@@ -42,7 +45,7 @@ class CategoryIndex extends AbstractIndex
         int $domainId,
         int $lastProcessedId,
         int $batchSize,
-        array $fields = [],
+        array $fields = self::ALL_FIELDS,
     ): array {
         throw new RuntimeException(sprintf('The %s() is not implemented.', __METHOD__));
     }

--- a/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationDeduplicationFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationDeduplicationFacadeTest.php
@@ -8,6 +8,7 @@ use Nette\Utils\Json;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Redis;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
 use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade;
 use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum;
 use Tests\App\Test\TransactionFunctionalTestCase;
@@ -60,8 +61,8 @@ class ProductRecalculationDeduplicationFacadeTest extends TransactionFunctionalT
                 'initialData' => [],
                 'productIds' => [1, 2],
                 'expectedOutput' => [
-                    1 => [],
-                    2 => [],
+                    1 => ProductExportScopeConfig::ALL_SCOPES,
+                    2 => ProductExportScopeConfig::ALL_SCOPES,
                 ],
             ],
             'requested already stored id' => [
@@ -82,7 +83,7 @@ class ProductRecalculationDeduplicationFacadeTest extends TransactionFunctionalT
                 ],
                 'productIds' => [3],
                 'expectedOutput' => [
-                    3 => [],
+                    3 => ProductExportScopeConfig::ALL_SCOPES,
                 ],
             ],
             'requested mixed' => [
@@ -93,7 +94,7 @@ class ProductRecalculationDeduplicationFacadeTest extends TransactionFunctionalT
                 'productIds' => [1, 3],
                 'expectedOutput' => [
                     1 => ['scope1'],
-                    3 => [],
+                    3 => ProductExportScopeConfig::ALL_SCOPES,
                 ],
             ],
         ];
@@ -146,19 +147,19 @@ class ProductRecalculationDeduplicationFacadeTest extends TransactionFunctionalT
                 'expectedOutput' => [2],
                 'expectedStoredData' => [1 => ['scope1'], 2 => ['scope1']],
             ],
-            'already stored product id with scope [] (all); no id returned, no change in stored data' => [
-                'initialData' => [1 => []],
+            'already stored product id with all scopes (represented by an empty array); no id returned, no change in stored data' => [
+                'initialData' => [1 => ProductExportScopeConfig::ALL_SCOPES],
                 'productIds' => [1],
-                'scopes' => [],
+                'scopes' => ProductExportScopeConfig::ALL_SCOPES,
                 'expectedOutput' => [],
-                'expectedStoredData' => [1 => []],
+                'expectedStoredData' => [1 => ProductExportScopeConfig::ALL_SCOPES],
             ],
-            'initial data has some scope; passing scope []; scope [] is stored; product id is not returned' => [
+            'initial data has some scope; passing all scopes (represented by an empty array); all scopes are stored; product id is not returned' => [
                 'initialData' => [1 => ['scope1']],
                 'productIds' => [1],
-                'scopes' => [],
+                'scopes' => ProductExportScopeConfig::ALL_SCOPES,
                 'expectedOutput' => [],
-                'expectedStoredData' => [1 => []],
+                'expectedStoredData' => [1 => ProductExportScopeConfig::ALL_SCOPES],
             ],
             'passing new scope; scope is added to stored data; product id is not returned' => [
                 'initialData' => [1 => ['scope1']],

--- a/upgrade-notes/backend_20260316_172110.md
+++ b/upgrade-notes/backend_20260316_172110.md
@@ -1,0 +1,3 @@
+#### recalculations: introduce constants for "all scopes" and "all fields" ([#4511](https://github.com/shopsys/shopsys/pull/4511))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The empty arrays as a default values, implicitly meaning "all scopes"/"all fields", could have been unintuitive

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
closes #3505

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://rv-export-scopes.odin.shopsys.cloud
  - https://cz.rv-export-scopes.odin.shopsys.cloud
  - https://rv-export-scopes.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773764789.944319 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-export-scopes.odin.shopsys.cloud
  - https://cz.rv-export-scopes.odin.shopsys.cloud
  - https://rv-export-scopes.odin.shopsys.cloud/sk
<!-- Replace -->
