### PR TITLE
cli build-phar workflow: set target_commitish for release

### DIFF
--- a/packages/cli/.github/workflows/build-phar.yaml
+++ b/packages/cli/.github/workflows/build-phar.yaml
@@ -87,6 +87,7 @@ jobs:
                 with:
                     files: shopsys.phar
                     tag_name: ${{ steps.release_tag.outputs.tag }}
+                    target_commitish: ${{ github.sha }}
                     name: ${{ steps.release_tag.outputs.tag }}
                     prerelease: ${{ steps.release_tag.outputs.is_prerelease == 'true' }}
                     generate_release_notes: ${{ steps.release_tag.outputs.replace_existing != 'true' }}


### PR DESCRIPTION
#### Description, the reason for the PR
When testing new changes before merging them into the main branch, the built tag looks like it has been built from the default branch due to the missing `target_commitish` setting. So it looks like this, which is confusing:

<img width="1213" height="680" alt="Screenshot (8)" src="https://github.com/user-attachments/assets/ced5d407-d317-4f84-b3ee-56760f11df9c" />

After this change, the release contains the proper information:

<img width="1236" height="733" alt="image" src="https://github.com/user-attachments/assets/adcab6e8-e714-4268-b612-d89d62cabaac" />


#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-cli-trigger.odin.shopsys.cloud
  - https://cz.rv-cli-trigger.odin.shopsys.cloud
  - https://rv-cli-trigger.odin.shopsys.cloud/sk
<!-- Replace -->
