### PR TITLE
added new rounding to 0.05 for order total price

### DIFF
--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -20,6 +20,7 @@ use Shopsys\FrameworkBundle\Form\MessageType;
 use Shopsys\FrameworkBundle\Form\PriceAndVatTableByDomainsType;
 use Shopsys\FrameworkBundle\Model\GoPay\PaymentMethod\GoPayPaymentMethod;
 use Shopsys\FrameworkBundle\Model\GoPay\PaymentMethod\GoPayPaymentMethodFacade;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
@@ -47,6 +48,7 @@ final class PaymentFormType extends AbstractType
         private readonly Domain $domain,
         private readonly PaymentTypeProvider $paymentTypeProvider,
         private readonly PaymentInstructionFacade $paymentInstructionFacade,
+        private readonly OrderRoundingTypeEnum $orderRoundingTypeEnum,
     ) {
     }
 
@@ -163,9 +165,18 @@ final class PaymentFormType extends AbstractType
         ]);
 
         $builderPriceGroup
-            ->add('czkRounding', YesNoType::class, [
-                'label' => 'Order in CZK round to whole crowns',
-                'help' => t('Rounding item with 0 % VAT will be added to your order. It is used for payment in cash.'),
+            ->add('orderRoundingTypeByDomainId', MultidomainType::class, [
+                'entry_type' => ChoiceType::class,
+                'entry_options' => [
+                    'choices' => $this->orderRoundingTypeEnum->getAllIndexedByTranslations(),
+                ],
+                'display_mode' => 'columns',
+                'row_attr' => [
+                    'class' => 'mb-3',
+                ],
+                'label' => 'Order total rounding',
+                'required' => true,
+                'help' => t('Rounding item with 0 % VAT will be added to the order. It is used for payment in cash.'),
             ])
             ->add('pricesByDomains', PriceAndVatTableByDomainsType::class, [
                 'pricesIndexedByDomainId' => $this->paymentFacade->getPricesIndexedByDomainId($payment),

--- a/packages/framework/src/Migrations/Version20260319120000.php
+++ b/packages/framework/src/Migrations/Version20260319120000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20260319120000 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE payment_domains ADD COLUMN order_rounding_type VARCHAR(20) NOT NULL DEFAULT \'none\'');
+        $this->sql('
+            UPDATE payment_domains pd
+            SET order_rounding_type = \'whole\'
+            FROM payments p, setting_values sv, currencies c
+            WHERE pd.payment_id = p.id
+                AND p.czk_rounding = TRUE
+                AND sv.domain_id = pd.domain_id
+                AND sv.name = \'defaultDomainCurrencyId\'
+                AND c.id = CAST(sv.value AS integer)
+                AND c.code = \'CZK\'
+        ');
+        $this->sql('ALTER TABLE payment_domains ALTER COLUMN order_rounding_type DROP DEFAULT');
+        $this->sql('ALTER TABLE payments DROP COLUMN czk_rounding');
+
+        $this->sql('ALTER TABLE orders DROP COLUMN payment_czk_rounding');
+    }
+}

--- a/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Order\Item;
 
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\OrderItemUnitPricesAreInconsistentButTotalsAreNotForcedException;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException;
+use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 
 class OrderItemDataFactory
@@ -113,6 +116,19 @@ class OrderItemDataFactory
         }
 
         return true;
+    }
+
+    public function createRounding(PriceInterface $roundingPrice, DomainConfig $domainConfig): OrderItemData
+    {
+        $orderItemData = $this->create(OrderItemTypeEnum::TYPE_ROUNDING);
+
+        $orderItemData->setUnitPrice($roundingPrice);
+        $orderItemData->setTotalPrice($roundingPrice);
+        $orderItemData->vatPercent = '0';
+        $orderItemData->name = t('Rounding', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $domainConfig->getLocale());
+        $orderItemData->quantity = 1;
+
+        return $orderItemData;
     }
 
     public function createFromQuantifiedProduct(

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -376,12 +376,6 @@ class Order
     #[ORM\Column(type: 'integer')]
     protected $currencyMinFractionDigits;
 
-    /**
-     * @var bool
-     */
-    #[ORM\Column(type: 'boolean')]
-    protected $paymentCzkRounding;
-
     public function __construct(
         OrderData $orderData,
         string $orderNumber,
@@ -414,7 +408,6 @@ class Order
         $this->currencyRoundingType = $orderData->currencyRoundingType;
         $this->currencyRoundingPlacesPriceWithoutVat = $orderData->currencyRoundingPlacesPriceWithoutVat;
         $this->currencyMinFractionDigits = $orderData->currencyMinFractionDigits;
-        $this->paymentCzkRounding = $orderData->paymentCzkRounding;
     }
 
     /**
@@ -581,7 +574,6 @@ class Order
     protected function editOrderPayment(OrderData $orderData): void
     {
         $orderPaymentData = $orderData->orderPayment;
-        $this->paymentCzkRounding = $orderPaymentData->payment->isCzkRounding();
         $this->getPaymentItem()->edit($orderPaymentData);
     }
 
@@ -745,14 +737,6 @@ class Order
     public function getCurrencyMinFractionDigits()
     {
         return $this->currencyMinFractionDigits;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isPaymentCzkRounding()
-    {
-        return $this->paymentCzkRounding;
     }
 
     public function setTotalPrices(PriceInterface $orderTotalPrice, PriceInterface $productsTotalPrice): void

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -708,6 +708,25 @@ class Order
     }
 
     /**
+     * @param array<string> $excludedTypes
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
+     */
+    public function getTotalPriceExcludingItemTypes(array $excludedTypes)
+    {
+        $withoutVat = $this->totalPriceWithoutVat;
+        $withVat = $this->totalPriceWithVat;
+
+        foreach ($this->getItems() as $item) {
+            if (in_array($item->getType(), $excludedTypes, true)) {
+                $withoutVat = $withoutVat->subtract($item->getUnitPriceWithoutVat()->multiply($item->getQuantity()));
+                $withVat = $withVat->subtract($item->getUnitPriceWithVat()->multiply($item->getQuantity()));
+            }
+        }
+
+        return new Price($withoutVat, $withVat);
+    }
+
+    /**
      * @return string
      */
     public function getCurrencyCode()

--- a/packages/framework/src/Model/Order/OrderData.php
+++ b/packages/framework/src/Model/Order/OrderData.php
@@ -176,11 +176,6 @@ class OrderData
     public $currencyMinFractionDigits;
 
     /**
-     * @var bool|null
-     */
-    public $paymentCzkRounding;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null
      */
     public $createdAsAdministrator;

--- a/packages/framework/src/Model/Order/OrderDataFactory.php
+++ b/packages/framework/src/Model/Order/OrderDataFactory.php
@@ -76,7 +76,6 @@ class OrderDataFactory
         $orderData->currencyRoundingType = $order->getCurrencyRoundingType();
         $orderData->currencyRoundingPlacesPriceWithoutVat = $order->getCurrencyRoundingPlacesPriceWithoutVat();
         $orderData->currencyMinFractionDigits = $order->getCurrencyMinFractionDigits();
-        $orderData->paymentCzkRounding = $order->isPaymentCzkRounding();
         $orderData->createdAsAdministrator = $order->getCreatedAsAdministrator();
         $orderData->createdAsAdministratorName = $order->getCreatedAsAdministratorName();
         $orderData->orderTransport = $this->orderItemDataFactory->createFromOrderItem($order->getTransportItem());

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -359,7 +359,6 @@ class OrderFacade
 
         $orderData = $this->orderDataFactory->createFromOrder($order);
         $orderData->orderPayment = $orderPaymentData;
-        $orderData->paymentCzkRounding = $payment->isCzkRounding();
         $this->edit($order->getId(), $orderData);
     }
 

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -39,6 +39,7 @@ use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionDataFact
 use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
+use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation;
 use Shopsys\FrameworkBundle\Twig\NumberFormatterExtension;
@@ -254,11 +255,11 @@ class OrderFacade
         foreach ($orderData->getNewItemsWithoutTransportAndPayment() as $newOrderItemData) {
             $this->calculateOrderItemDataPrices($newOrderItemData, $order->getDomainId(), $order->getCurrencyRoundingType(), $order->getCurrencyRoundingPlacesPriceWithoutVat());
 
-            $newOrderItem = $this->orderItemFactory->createProduct(
-                $newOrderItemData,
-                $order,
-                null,
-            );
+            $newOrderItem = match ($newOrderItemData->type) {
+                OrderItemTypeEnum::TYPE_ROUNDING => $this->orderItemFactory->createRounding($newOrderItemData, $order),
+                OrderItemTypeEnum::TYPE_DISCOUNT => $this->orderItemFactory->createDiscount($newOrderItemData, $order),
+                default => $this->orderItemFactory->createProduct($newOrderItemData, $order, $newOrderItemData->product),
+            };
 
             if ($newOrderItemData->usePriceCalculation) {
                 continue;
@@ -359,7 +360,57 @@ class OrderFacade
 
         $orderData = $this->orderDataFactory->createFromOrder($order);
         $orderData->orderPayment = $orderPaymentData;
+
+        $this->recalculateRoundingForOrderData($orderData, $order, $payment, $paymentPrice);
+
         $this->edit($order->getId(), $orderData);
+    }
+
+    protected function recalculateRoundingForOrderData(
+        OrderData $orderData,
+        Order $order,
+        Payment $payment,
+        PriceInterface $paymentPrice,
+    ): void {
+        $totalExcludingRoundingAndPayment = $order->getTotalPriceExcludingItemTypes([OrderItemTypeEnum::TYPE_ROUNDING, OrderItemTypeEnum::TYPE_PAYMENT]);
+        $totalForRounding = new Price(
+            $totalExcludingRoundingAndPayment->getPriceWithoutVat()->add($paymentPrice->getPriceWithoutVat()),
+            $totalExcludingRoundingAndPayment->getPriceWithVat()->add($paymentPrice->getPriceWithVat()),
+        );
+
+        $roundingPrice = $this->orderPriceCalculation->calculateOrderRoundingPrice(
+            $payment,
+            $order->getCurrencyRoundingType(),
+            $totalForRounding,
+            $order->getDomainId(),
+        );
+
+        $existingRoundingItem = array_first($orderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING));
+        $needsRounding = $roundingPrice !== null && !$roundingPrice->isZero();
+
+        if ($existingRoundingItem !== null && $needsRounding) {
+            $existingRoundingItem->setUnitPrice($roundingPrice);
+            $existingRoundingItem->setTotalPrice($roundingPrice);
+
+            return;
+        }
+
+        if ($existingRoundingItem !== null) {
+            $orderData->items = array_filter(
+                $orderData->items,
+                static fn (OrderItemData $item) => $item->type !== OrderItemTypeEnum::TYPE_ROUNDING,
+            );
+
+            return;
+        }
+
+        if (!$needsRounding) {
+            return;
+        }
+
+        $domainConfig = $this->domain->getDomainConfigById($order->getDomainId());
+
+        $orderData->items[OrderData::NEW_ITEM_PREFIX . 'rounding'] = $this->orderItemDataFactory->createRounding($roundingPrice, $domainConfig);
     }
 
     public function updateTrackingNumber(Order $order, string $trackingNumber): void

--- a/packages/framework/src/Model/Order/OrderPriceCalculation.php
+++ b/packages/framework/src/Model/Order/OrderPriceCalculation.php
@@ -6,7 +6,8 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
-use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
+use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
@@ -16,6 +17,7 @@ class OrderPriceCalculation
     public function __construct(
         protected readonly OrderItemPriceCalculation $orderItemPriceCalculation,
         protected readonly Rounding $rounding,
+        protected readonly OrderRoundingTypeEnum $orderRoundingTypeEnum,
     ) {
     }
 
@@ -47,17 +49,19 @@ class OrderPriceCalculation
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
     public function calculateOrderRoundingPrice(
-        bool $paymentCzkRounding,
-        string $currencyCode,
+        Payment $payment,
         string $currencyRoundingType,
         PriceInterface $orderTotalPrice,
+        int $domainId,
     ): ?PriceInterface {
-        if (!$paymentCzkRounding || $currencyCode !== Currency::CODE_CZK) {
+        if (!$payment->hasOrderRoundingForDomain($domainId)) {
             return null;
         }
 
+        $orderRoundingType = $payment->getOrderRoundingTypeForDomain($domainId);
+
         $priceWithVat = $orderTotalPrice->getPriceWithVat();
-        $roundedPriceWithVat = $priceWithVat->round(0);
+        $roundedPriceWithVat = $this->orderRoundingTypeEnum->roundPrice($orderRoundingType, $priceWithVat);
 
         $roundingPrice = $this->rounding->roundPriceWithVat(
             $roundedPriceWithVat->subtract($priceWithVat),

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddleware.php
@@ -57,7 +57,6 @@ class AddPaymentMiddleware implements OrderProcessorMiddlewareInterface
         $orderData->addTotalPrice($paymentPrice, OrderItemTypeEnum::TYPE_PAYMENT);
 
         $orderData->orderPayment = $orderItemData;
-        $orderData->paymentCzkRounding = $payment->isCzkRounding();
         $orderData->goPayBankSwift = $orderProcessingData->orderInput->findAdditionalData(static::ADDITIONAL_DATA_GOPAY_BANK_SWIFT);
 
         $orderData->addItem($orderItemData);

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
@@ -5,23 +5,17 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware;
 
 use Override;
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
-use Shopsys\FrameworkBundle\Component\Translation\Translator;
-use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
 use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessingData;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessingStack;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
-use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
-use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
 
 class AddRoundingMiddleware implements OrderProcessorMiddlewareInterface
 {
     public function __construct(
         protected readonly CurrencyFacade $currencyFacade,
-        protected readonly Rounding $rounding,
         protected readonly OrderItemDataFactory $orderItemDataFactory,
         protected readonly OrderPriceCalculation $orderPriceCalculation,
     ) {
@@ -50,23 +44,10 @@ class AddRoundingMiddleware implements OrderProcessorMiddlewareInterface
         );
 
         if ($roundingPrice !== null && !$roundingPrice->isZero()) {
-            $orderData->addItem($this->createRoundingItemData($roundingPrice, $orderProcessingData->getDomainConfig()));
+            $orderData->addItem($this->orderItemDataFactory->createRounding($roundingPrice, $orderProcessingData->getDomainConfig()));
             $orderData->addTotalPrice($roundingPrice, OrderItemTypeEnum::TYPE_ROUNDING);
         }
 
         return $orderProcessingStack->processNext($orderProcessingData);
-    }
-
-    protected function createRoundingItemData(PriceInterface $roundingPrice, DomainConfig $domainConfig): OrderItemData
-    {
-        $orderItemData = $this->orderItemDataFactory->create(OrderItemTypeEnum::TYPE_ROUNDING);
-
-        $orderItemData->setUnitPrice($roundingPrice);
-        $orderItemData->setTotalPrice($roundingPrice);
-        $orderItemData->vatPercent = '0';
-        $orderItemData->name = t('Rounding', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $domainConfig->getLocale());
-        $orderItemData->quantity = 1;
-
-        return $orderItemData;
     }
 }

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddleware.php
@@ -43,10 +43,10 @@ class AddRoundingMiddleware implements OrderProcessorMiddlewareInterface
         $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($orderProcessingData->getDomainId());
 
         $roundingPrice = $this->orderPriceCalculation->calculateOrderRoundingPrice(
-            $payment->isCzkRounding(),
-            $currency->getCode(),
+            $payment,
             $currency->getRoundingType(),
             $orderData->totalPrice,
+            $orderProcessingData->getDomainId(),
         );
 
         if ($roundingPrice !== null && !$roundingPrice->isZero()) {

--- a/packages/framework/src/Model/Payment/OrderRoundingTypeEnum.php
+++ b/packages/framework/src/Model/Payment/OrderRoundingTypeEnum.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Payment;
+
+use Shopsys\FrameworkBundle\Component\Enum\AbstractEnum;
+use Shopsys\FrameworkBundle\Component\Enum\InvalidEnumCaseException;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+
+class OrderRoundingTypeEnum extends AbstractEnum
+{
+    public const string NONE = 'none';
+    public const string FIVE_CENTS = 'five_cents';
+    public const string WHOLE = 'whole';
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAllIndexedByTranslations(): array
+    {
+        return [
+            t('None') => self::NONE,
+            t('To five cents (0.05)') => self::FIVE_CENTS,
+            t('To whole numbers (1.00)') => self::WHOLE,
+        ];
+    }
+
+    public function roundPrice(string $roundingType, Money $price): Money
+    {
+        return match ($roundingType) {
+            self::NONE => $price,
+            self::FIVE_CENTS => $price->multiply(20)->round(0)->divide(20, 2),
+            self::WHOLE => $price->round(0),
+            default => throw new InvalidEnumCaseException(self::class, $roundingType),
+        };
+    }
+}

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -80,12 +80,6 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     protected $position;
 
     /**
-     * @var bool
-     */
-    #[ORM\Column(type: 'boolean')]
-    protected $czkRounding;
-
-    /**
      * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Payment\PaymentDomain>
      */
     #[ORM\OneToMany(targetEntity: PaymentDomain::class, mappedBy: 'payment', cascade: ['persist'], fetch: 'EXTRA_LAZY')]
@@ -125,7 +119,6 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     protected function setData(PaymentData $paymentData): void
     {
         $this->hidden = $paymentData->hidden;
-        $this->czkRounding = $paymentData->czkRounding;
         $this->type = $paymentData->type;
 
         if ($paymentData->type !== PaymentTypeEnum::TYPE_GOPAY) {
@@ -315,11 +308,19 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     }
 
     /**
+     * @return string
+     */
+    public function getOrderRoundingTypeForDomain(int $domainId)
+    {
+        return $this->getPaymentDomain($domainId)->getOrderRoundingType();
+    }
+
+    /**
      * @return bool
      */
-    public function isCzkRounding()
+    public function hasOrderRoundingForDomain(int $domainId)
     {
-        return $this->czkRounding;
+        return $this->getOrderRoundingTypeForDomain($domainId) !== OrderRoundingTypeEnum::NONE;
     }
 
     public function isGoPay(): bool
@@ -378,6 +379,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
             $paymentDomain->setAccountNumber($paymentData->accountNumberByDomainId[$domainId] ?? null);
             $paymentDomain->setIban($paymentData->ibanByDomainId[$domainId] ?? null);
             $paymentDomain->setBicSwift($paymentData->bicSwiftByDomainId[$domainId] ?? null);
+            $paymentDomain->setOrderRoundingType($paymentData->orderRoundingTypeByDomainId[$domainId] ?? OrderRoundingTypeEnum::NONE);
         }
     }
 
@@ -395,6 +397,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
                 $paymentData->accountNumberByDomainId[$domainId] ?? null,
                 $paymentData->ibanByDomainId[$domainId] ?? null,
                 $paymentData->bicSwiftByDomainId[$domainId] ?? null,
+                $paymentData->orderRoundingTypeByDomainId[$domainId] ?? OrderRoundingTypeEnum::NONE,
             );
             $this->domains->add($paymentDomain);
         }

--- a/packages/framework/src/Model/Payment/PaymentData.php
+++ b/packages/framework/src/Model/Payment/PaymentData.php
@@ -37,9 +37,9 @@ class PaymentData
     public $transports;
 
     /**
-     * @var bool
+     * @var array<int, string>
      */
-    public $czkRounding;
+    public $orderRoundingTypeByDomainId;
 
     /**
      * @var bool[]
@@ -99,7 +99,7 @@ class PaymentData
         $this->hidden = false;
         $this->enabled = [];
         $this->transports = [];
-        $this->czkRounding = false;
+        $this->orderRoundingTypeByDomainId = [];
         $this->pricesIndexedByDomainId = [];
         $this->vatsIndexedByDomainId = [];
         $this->goPayPaymentMethodByDomainId = [];

--- a/packages/framework/src/Model/Payment/PaymentDataFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentDataFactory.php
@@ -42,6 +42,7 @@ class PaymentDataFactory
             $paymentData->accountNumberByDomainId[$domainId] = null;
             $paymentData->ibanByDomainId[$domainId] = null;
             $paymentData->bicSwiftByDomainId[$domainId] = null;
+            $paymentData->orderRoundingTypeByDomainId[$domainId] = OrderRoundingTypeEnum::NONE;
         }
 
         foreach ($this->domain->getAllLocales() as $locale) {
@@ -64,7 +65,6 @@ class PaymentDataFactory
     protected function fillFromPayment(PaymentData $paymentData, Payment $payment): void
     {
         $paymentData->hidden = $payment->isHidden();
-        $paymentData->czkRounding = $payment->isCzkRounding();
         $paymentData->transports = $payment->getTransports();
 
         $translations = $payment->getTranslations();
@@ -92,6 +92,7 @@ class PaymentDataFactory
             $paymentData->accountNumberByDomainId[$domainId] = $payment->getAccountNumber($domainId);
             $paymentData->ibanByDomainId[$domainId] = $payment->getIban($domainId);
             $paymentData->bicSwiftByDomainId[$domainId] = $payment->getBicSwift($domainId);
+            $paymentData->orderRoundingTypeByDomainId[$domainId] = $payment->getOrderRoundingTypeForDomain($domainId);
         }
 
         $paymentData->image = $this->imageUploadDataFactory->createFromEntityAndType($payment);

--- a/packages/framework/src/Model/Payment/PaymentDomain.php
+++ b/packages/framework/src/Model/Payment/PaymentDomain.php
@@ -78,6 +78,12 @@ class PaymentDomain
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
     protected $bicSwift;
 
+    /**
+     * @var string
+     */
+    #[ORM\Column(type: 'string', length: 20)]
+    protected $orderRoundingType;
+
     public function __construct(
         Payment $payment,
         int $domainId,
@@ -87,6 +93,7 @@ class PaymentDomain
         ?string $accountNumber = null,
         ?string $iban = null,
         ?string $bic = null,
+        string $orderRoundingType = OrderRoundingTypeEnum::NONE,
     ) {
         $this->payment = $payment;
         $this->domainId = $domainId;
@@ -97,6 +104,7 @@ class PaymentDomain
         $this->accountNumber = $accountNumber;
         $this->iban = $iban;
         $this->bicSwift = $bic;
+        $this->orderRoundingType = $orderRoundingType;
     }
 
     /**
@@ -211,5 +219,21 @@ class PaymentDomain
     public function setBicSwift($bicSwift): void
     {
         $this->bicSwift = $bicSwift;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderRoundingType()
+    {
+        return $this->orderRoundingType;
+    }
+
+    /**
+     * @param string $orderRoundingType
+     */
+    public function setOrderRoundingType($orderRoundingType): void
+    {
+        $this->orderRoundingType = $orderRoundingType;
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -28,11 +28,13 @@ class PaymentFacade
         protected readonly PaymentPriceCalculation $paymentPriceCalculation,
         protected readonly PaymentFactory $paymentFactory,
         protected readonly PaymentPriceFactory $paymentPriceFactory,
+        protected readonly OrderRoundingTypeEnum $orderRoundingTypeEnum,
     ) {
     }
 
     public function create(PaymentData $paymentData): Payment
     {
+        $this->validateOrderRoundingTypes($paymentData);
         $payment = $this->paymentFactory->create($paymentData);
         $this->em->persist($payment);
         $this->em->flush();
@@ -48,6 +50,7 @@ class PaymentFacade
 
     public function edit(Payment $payment, PaymentData $paymentData): void
     {
+        $this->validateOrderRoundingTypes($paymentData);
         $payment->edit($paymentData);
         $this->updatePaymentPrices(
             $payment,
@@ -308,5 +311,12 @@ class PaymentFacade
             $transport,
             $domainId,
         );
+    }
+
+    protected function validateOrderRoundingTypes(PaymentData $paymentData): void
+    {
+        foreach ($paymentData->orderRoundingTypeByDomainId as $orderRoundingType) {
+            $this->orderRoundingTypeEnum->validateCase($orderRoundingType);
+        }
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentFactory.php
@@ -8,8 +8,9 @@ use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 
 class PaymentFactory
 {
-    public function __construct(protected readonly EntityNameResolver $entityNameResolver)
-    {
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
     }
 
     public function create(PaymentData $data): Payment

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2197,6 +2197,9 @@ msgstr "Žádný sklad není přiřazen"
 msgid "Nominal"
 msgstr "Nominální"
 
+msgid "None"
+msgstr "Žádné"
+
 msgid "Not possible to assign product to itself"
 msgstr "Nelze přiřadit produkt sám sobě"
 
@@ -2296,9 +2299,6 @@ msgstr "URL adresa detailu objednávky"
 msgid "Order has not been sent to GoPay"
 msgstr "Objednávka nebyla odeslána do GoPay"
 
-msgid "Order in CZK round to whole crowns"
-msgstr "Objednávku v CZK zaokrouhlit na celé koruny"
-
 msgid "Order information"
 msgstr "Informace o objednávce"
 
@@ -2322,6 +2322,9 @@ msgstr "Obsah stránky po odeslání objednávky"
 
 msgid "Order status"
 msgstr "Stav objednávky"
+
+msgid "Order total rounding"
+msgstr "Zaokrouhlení celkové ceny objednávky"
 
 msgid "Ordering"
 msgstr "Řazení"
@@ -2821,8 +2824,8 @@ msgstr "Role"
 msgid "Rounding"
 msgstr "Zaokrouhlení"
 
-msgid "Rounding item with 0 % VAT will be added to your order. It is used for payment in cash."
-msgstr "Do objednávky bude přidána zaokrouhlovací položka s 0% DPH. Používá se pro platbu v hotovosti."
+msgid "Rounding item with 0 % VAT will be added to the order. It is used for payment in cash."
+msgstr "K objednávce bude přidána položka zaokrouhlení s 0 % DPH. Používá se pro platbu v hotovosti."
 
 msgid "Rounding places of price without VAT and VAT amount"
 msgstr "Počet desetinných míst pro zaokrouhlování ceny bez DPH a částky DPH"
@@ -3304,11 +3307,17 @@ msgstr "TikTok URL"
 msgid "To fifty hundredths (halfs)"
 msgstr "Na padesátníky"
 
+msgid "To five cents (0.05)"
+msgstr "Na pětihaléře (0,05)"
+
 msgid "To hundredths (cents)"
 msgstr "Na setiny (haléře)"
 
 msgid "To whole numbers"
 msgstr "Na celá čísla (koruny)"
+
+msgid "To whole numbers (1.00)"
+msgstr "Na celá čísla (1,00)"
 
 msgid "Too many login attempts. Please try again later."
 msgstr "Příliš mnoho pokusů o přihlášení. Zkuste to prosím později."

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2197,6 +2197,9 @@ msgstr ""
 msgid "Nominal"
 msgstr ""
 
+msgid "None"
+msgstr ""
+
 msgid "Not possible to assign product to itself"
 msgstr ""
 
@@ -2296,9 +2299,6 @@ msgstr ""
 msgid "Order has not been sent to GoPay"
 msgstr ""
 
-msgid "Order in CZK round to whole crowns"
-msgstr ""
-
 msgid "Order information"
 msgstr ""
 
@@ -2321,6 +2321,9 @@ msgid "Order sent page content"
 msgstr ""
 
 msgid "Order status"
+msgstr ""
+
+msgid "Order total rounding"
 msgstr ""
 
 msgid "Ordering"
@@ -2821,7 +2824,7 @@ msgstr ""
 msgid "Rounding"
 msgstr ""
 
-msgid "Rounding item with 0 % VAT will be added to your order. It is used for payment in cash."
+msgid "Rounding item with 0 % VAT will be added to the order. It is used for payment in cash."
 msgstr ""
 
 msgid "Rounding places of price without VAT and VAT amount"
@@ -3304,10 +3307,16 @@ msgstr ""
 msgid "To fifty hundredths (halfs)"
 msgstr ""
 
+msgid "To five cents (0.05)"
+msgstr ""
+
 msgid "To hundredths (cents)"
 msgstr ""
 
 msgid "To whole numbers"
+msgstr ""
+
+msgid "To whole numbers (1.00)"
 msgstr ""
 
 msgid "Too many login attempts. Please try again later."

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -2197,6 +2197,9 @@ msgstr "Žiadny sklad nie je priradený"
 msgid "Nominal"
 msgstr "Nominálny"
 
+msgid "None"
+msgstr "Žiadne"
+
 msgid "Not possible to assign product to itself"
 msgstr "Nie je možné priradiť produkt sám sebe"
 
@@ -2296,9 +2299,6 @@ msgstr "URL adresa detailu objednávky"
 msgid "Order has not been sent to GoPay"
 msgstr "Objednávka nebola odoslaná do GoPay"
 
-msgid "Order in CZK round to whole crowns"
-msgstr "Objednávka v CZK zaokrúhlená na celé koruny"
-
 msgid "Order information"
 msgstr "Informácie o objednávke"
 
@@ -2322,6 +2322,9 @@ msgstr "Obsah stránky odoslanej objednávky"
 
 msgid "Order status"
 msgstr "Stav objednávky"
+
+msgid "Order total rounding"
+msgstr "Zaokrúhlenie celkovej ceny objednávky"
 
 msgid "Ordering"
 msgstr "Objednávanie"
@@ -2821,8 +2824,8 @@ msgstr "Roly"
 msgid "Rounding"
 msgstr "Zaokrúhlenie"
 
-msgid "Rounding item with 0 % VAT will be added to your order. It is used for payment in cash."
-msgstr "Do objednávky bude pridaná zaokrúhlovacia položka s 0% DPH. Používa sa pre platbu v hotovosti."
+msgid "Rounding item with 0 % VAT will be added to the order. It is used for payment in cash."
+msgstr "K objednávke bude pridaná položka zaokrúhlenia s 0 % DPH. Používa sa pre platbu v hotovosti."
 
 msgid "Rounding places of price without VAT and VAT amount"
 msgstr "Počet desatinných miest pre zaokrúhlovanie ceny bez DPH a čiastky DPH"
@@ -3304,11 +3307,17 @@ msgstr "TikTok URL"
 msgid "To fifty hundredths (halfs)"
 msgstr "Na päťdesätiny (polovice)"
 
+msgid "To five cents (0.05)"
+msgstr "Na päťcenty (0,05)"
+
 msgid "To hundredths (cents)"
 msgstr "Na stotstiny (centy)"
 
 msgid "To whole numbers"
 msgstr "Na celé čísla"
+
+msgid "To whole numbers (1.00)"
+msgstr "Na celé čísla (1,00)"
 
 msgid "Too many login attempts. Please try again later."
 msgstr "Príliš veľa pokúsov o prihlásenie. Skúste to znovu neskôr."

--- a/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace Tests\FrameworkBundle\Unit\Model\Order;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItem;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
+use Shopsys\FrameworkBundle\Model\Payment\Payment;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
+use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Tests\FrameworkBundle\Test\IsMoneyEqual;
 
 class OrderPriceCalculationTest extends TestCase
@@ -44,7 +49,7 @@ class OrderPriceCalculationTest extends TestCase
             ->method('calculateTotalPrice')
             ->willReturnMap($pricesMap);
 
-        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationMock, $roundingStub);
+        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationMock, $roundingStub, new OrderRoundingTypeEnum());
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->onlyMethods(['__construct', 'getItems'])
@@ -59,82 +64,98 @@ class OrderPriceCalculationTest extends TestCase
         $this->assertThat($orderTotalPrice->getProductPrice()->getPriceWithVat(), new IsMoneyEqual(Money::create(3200)));
     }
 
-    public function testCalculateOrderRoundingPriceForOtherCurrency(): void
+    public function testCalculateOrderRoundingPriceForNoneType(): void
     {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::NONE);
         $orderTotalPrice = new Price(Money::create(100), Money::create(120));
 
-        $roundingStub = $this->createStub(Rounding::class);
-        $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
+        $priceCalculation = $this->createOrderPriceCalculation();
 
-        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
-        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(true, Currency::CODE_EUR, Currency::DEFAULT_ROUNDING_TYPE, $orderTotalPrice);
-
-        $this->assertNull($roundingPrice);
+        $this->assertNull($priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_INTEGER, $orderTotalPrice, Domain::FIRST_DOMAIN_ID));
     }
 
-    public function testCalculateOrderRoundingPriceForCzkWithoutRounding(): void
+    public function testCalculateOrderRoundingPriceWholeDown(): void
     {
-        $orderTotalPrice = new Price(Money::create(100), Money::create(120));
-
-        $roundingStub = $this->createStub(Rounding::class);
-        $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
-
-        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
-        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(false, Currency::CODE_CZK, Currency::DEFAULT_ROUNDING_TYPE, $orderTotalPrice);
-
-        $this->assertNull($roundingPrice);
-    }
-
-    public function testCalculateOrderRoundingPriceDown(): void
-    {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::WHOLE);
         $orderTotalPrice = new Price(Money::create(100), Money::create('120.3'));
 
-        $roundingStub = $this->createStub(Rounding::class);
-        $roundingStub->method(
-            'roundPriceWithVat',
-        )->willReturnCallback(
-            function (Money $value) {
-                return $value->round(2);
-            },
-        );
-
-        $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
-
-        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
-        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(
-            true,
-            Currency::CODE_CZK,
-            Currency::DEFAULT_ROUNDING_TYPE,
-            $orderTotalPrice,
-        )->getPriceWithVat();
+        $priceCalculation = $this->createOrderPriceCalculation();
+        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_INTEGER, $orderTotalPrice, Domain::FIRST_DOMAIN_ID)->getPriceWithVat();
 
         $this->assertThat($roundingPrice, new IsMoneyEqual(Money::create('-0.3')));
     }
 
-    public function testCalculateOrderRoundingPriceUp(): void
+    public function testCalculateOrderRoundingPriceWholeUp(): void
     {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::WHOLE);
         $orderTotalPrice = new Price(Money::create(100), Money::create('120.9'));
 
-        $roundingStub = $this->createStub(Rounding::class);
-        $roundingStub->method(
-            'roundPriceWithVat',
-        )->willReturnCallback(
-            function (Money $value) {
-                return $value->round(2);
-            },
-        );
-
-        $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
-
-        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub);
-        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice(
-            true,
-            Currency::CODE_CZK,
-            Currency::DEFAULT_ROUNDING_TYPE,
-            $orderTotalPrice,
-        )->getPriceWithVat();
+        $priceCalculation = $this->createOrderPriceCalculation();
+        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_INTEGER, $orderTotalPrice, Domain::FIRST_DOMAIN_ID)->getPriceWithVat();
 
         $this->assertThat($roundingPrice, new IsMoneyEqual(Money::create('0.1')));
+    }
+
+    public function testCalculateOrderRoundingPriceForEurFiveCentsDown(): void
+    {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::FIVE_CENTS);
+        $orderTotalPrice = new Price(Money::create(100), Money::create('120.12'));
+
+        $priceCalculation = $this->createOrderPriceCalculation();
+        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_HUNDREDTHS, $orderTotalPrice, Domain::FIRST_DOMAIN_ID)->getPriceWithVat();
+
+        $this->assertThat($roundingPrice, new IsMoneyEqual(Money::create('-0.02')));
+    }
+
+    public function testCalculateOrderRoundingPriceForEurFiveCentsUp(): void
+    {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::FIVE_CENTS);
+        $orderTotalPrice = new Price(Money::create(100), Money::create('120.13'));
+
+        $priceCalculation = $this->createOrderPriceCalculation();
+        $roundingPrice = $priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_HUNDREDTHS, $orderTotalPrice, Domain::FIRST_DOMAIN_ID)->getPriceWithVat();
+
+        $this->assertThat($roundingPrice, new IsMoneyEqual(Money::create('0.02')));
+    }
+
+    public function testCalculateOrderRoundingPriceForEurAlreadyRounded(): void
+    {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::FIVE_CENTS);
+        $orderTotalPrice = new Price(Money::create(100), Money::create('120.15'));
+
+        $priceCalculation = $this->createOrderPriceCalculation();
+
+        $this->assertNull($priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_HUNDREDTHS, $orderTotalPrice, Domain::FIRST_DOMAIN_ID));
+    }
+
+    public function testFiveCentsRoundingOnIntegerRoundedCurrencyProducesNoRounding(): void
+    {
+        $payment = $this->createPayment(OrderRoundingTypeEnum::FIVE_CENTS);
+        $orderTotalPrice = new Price(Money::create(100), Money::create('120.12'));
+
+        $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
+        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, new Rounding(), new OrderRoundingTypeEnum());
+
+        $this->assertNull($priceCalculation->calculateOrderRoundingPrice($payment, Currency::ROUNDING_TYPE_INTEGER, $orderTotalPrice, Domain::FIRST_DOMAIN_ID));
+    }
+
+    private function createPayment(string $orderRoundingType): Payment
+    {
+        $paymentData = new PaymentData();
+        $paymentData->enabled = [Domain::FIRST_DOMAIN_ID => true];
+        $paymentData->vatsIndexedByDomainId = [Domain::FIRST_DOMAIN_ID => $this->createStub(Vat::class)];
+        $paymentData->orderRoundingTypeByDomainId = [Domain::FIRST_DOMAIN_ID => $orderRoundingType];
+
+        return new Payment($paymentData);
+    }
+
+    private function createOrderPriceCalculation(): OrderPriceCalculation
+    {
+        $roundingStub = $this->createStub(Rounding::class);
+        $roundingStub->method('roundPriceWithVat')->willReturnCallback(fn (Money $value) => $value->round(2));
+        $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
+
+        return new OrderPriceCalculation($orderItemPriceCalculationStub, $roundingStub, new OrderRoundingTypeEnum());
     }
 
     protected function createOrderProductStub(): OrderItem

--- a/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddlewareTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddPaymentMiddlewareTest.php
@@ -39,7 +39,6 @@ class AddPaymentMiddlewareTest extends MiddlewareTestCase
         $actualOrderData = $result->orderData;
 
         $this->assertSame($actualOrderData->orderPayment?->payment, $payment);
-        $this->assertFalse($actualOrderData->paymentCzkRounding);
 
         $this->assertThat(
             $actualOrderData->getTotalPriceForItemTypes([OrderItemTypeEnum::TYPE_PAYMENT]),

--- a/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddlewareTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddlewareTest.php
@@ -169,7 +169,6 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
 
         return new AddRoundingMiddleware(
             $this->createCurrencyFacade($currencyCode, $roundingType),
-            new Rounding(),
             $this->createOrderItemDataFactory(),
             $priceCalculation,
         );

--- a/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddlewareTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/AddRoundingMiddlewareTest.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
 use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\AddRoundingMiddleware;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
@@ -24,11 +25,8 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
 {
     use SetTranslatorTrait;
 
-    #[DataProvider('noRoundingAddedProvider')]
-    public function testNoRoundingIsAdded(
-        bool $czkRounding,
-        string $currencyCode,
-    ): void {
+    public function testNoRoundingIsAddedForPaymentWithoutOrderRounding(): void
+    {
         $expectedPrice = new Price(
             Money::create('100.52'),
             Money::create('121.63'),
@@ -41,35 +39,19 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
         $paymentData->name = ['en' => 'payment'];
         $paymentData->enabled = [1 => true];
         $paymentData->vatsIndexedByDomainId = [1 => $this->createVat()];
-        $paymentData->czkRounding = $czkRounding;
         $payment = new Payment($paymentData);
 
         $orderItemData = new OrderItemData();
         $orderItemData->payment = $payment;
         $orderProcessingData->orderData->orderPayment = $orderItemData;
 
-        $addRoundingMiddleware = $this->createAddRoundingMiddleware($currencyCode);
+        $addRoundingMiddleware = $this->createAddRoundingMiddleware();
 
         $result = $addRoundingMiddleware->handle($orderProcessingData, $this->createOrderProcessingStack());
         $actualOrderData = $result->orderData;
 
-        $actualRoundingItemsType = $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING);
-
-        $this->assertCount(0, $actualRoundingItemsType);
-
-        $this->assertThat(
-            $actualOrderData->totalPrice,
-            new IsPriceEqual($expectedPrice),
-        );
-    }
-
-    public static function noRoundingAddedProvider(): iterable
-    {
-        yield 'CZK currency without CZK rounding' => [false, Currency::CODE_CZK];
-
-        yield 'Non-CZK currency with CZK rounding' => [true, Currency::CODE_EUR];
-
-        yield 'Non-CZK currency without CZK rounding' => [false, Currency::CODE_EUR];
+        $this->assertCount(0, $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING));
+        $this->assertThat($actualOrderData->totalPrice, new IsPriceEqual($expectedPrice));
     }
 
     public function testNoRoundingIsAddedWithoutPayment(): void
@@ -87,14 +69,8 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
         $result = $addRoundingMiddleware->handle($orderProcessingData, $this->createOrderProcessingStack());
         $actualOrderData = $result->orderData;
 
-        $actualRoundingItemsType = $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING);
-
-        $this->assertCount(0, $actualRoundingItemsType);
-
-        $this->assertThat(
-            $actualOrderData->totalPrice,
-            new IsPriceEqual($expectedPrice),
-        );
+        $this->assertCount(0, $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING));
+        $this->assertThat($actualOrderData->totalPrice, new IsPriceEqual($expectedPrice));
     }
 
     #[DataProvider('roundingProvider')]
@@ -106,35 +82,27 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
         $this->setTranslator();
 
         $orderProcessingData = $this->createOrderProcessingData();
-
         $orderProcessingData->orderData->totalPrice = $inputPrice;
 
         $paymentData = new PaymentData();
         $paymentData->name = ['en' => 'payment'];
         $paymentData->enabled = [1 => true];
         $paymentData->vatsIndexedByDomainId = [1 => $this->createVat()];
-        $paymentData->czkRounding = true;
+        $paymentData->orderRoundingTypeByDomainId = [1 => OrderRoundingTypeEnum::WHOLE];
         $payment = new Payment($paymentData);
 
         $orderItemData = new OrderItemData();
         $orderItemData->payment = $payment;
         $orderProcessingData->orderData->orderPayment = $orderItemData;
 
-        $addRoundingMiddleware = $this->createAddRoundingMiddleware(Currency::CODE_CZK);
+        $addRoundingMiddleware = $this->createAddRoundingMiddleware();
 
         $result = $addRoundingMiddleware->handle($orderProcessingData, $this->createOrderProcessingStack());
         $actualOrderData = $result->orderData;
 
-        $actualRoundingItemsType = $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING);
-
-        $this->assertCount($expectedRoundingItemsCount, $actualRoundingItemsType);
+        $this->assertCount($expectedRoundingItemsCount, $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING));
         $this->assertCount($expectedRoundingItemsCount, $actualOrderData->items);
-
-        $this->assertThat(
-            $actualOrderData->totalPrice,
-            new IsPriceEqual($inputPrice->add($roundingPrice)),
-        );
-
+        $this->assertThat($actualOrderData->totalPrice, new IsPriceEqual($inputPrice->add($roundingPrice)));
         $this->assertThat(
             $actualOrderData->getTotalPriceForItemTypes([OrderItemTypeEnum::TYPE_ROUNDING]),
             new IsPriceEqual($roundingPrice),
@@ -156,14 +124,51 @@ class AddRoundingMiddlewareTest extends MiddlewareTestCase
         ];
     }
 
+    public function testEurFiveCentsRoundingIsAdded(): void
+    {
+        $this->setTranslator();
+
+        $orderProcessingData = $this->createOrderProcessingData();
+        $inputPrice = new Price(Money::create('100'), Money::create('120.12'));
+        $orderProcessingData->orderData->totalPrice = $inputPrice;
+
+        $paymentData = new PaymentData();
+        $paymentData->name = ['en' => 'payment'];
+        $paymentData->enabled = [1 => true];
+        $paymentData->vatsIndexedByDomainId = [1 => $this->createVat()];
+        $paymentData->orderRoundingTypeByDomainId = [1 => OrderRoundingTypeEnum::FIVE_CENTS];
+        $payment = new Payment($paymentData);
+
+        $orderItemData = new OrderItemData();
+        $orderItemData->payment = $payment;
+        $orderProcessingData->orderData->orderPayment = $orderItemData;
+
+        $addRoundingMiddleware = $this->createAddRoundingMiddleware(
+            Currency::CODE_EUR,
+            Currency::ROUNDING_TYPE_HUNDREDTHS,
+        );
+
+        $result = $addRoundingMiddleware->handle($orderProcessingData, $this->createOrderProcessingStack());
+        $actualOrderData = $result->orderData;
+
+        $this->assertCount(1, $actualOrderData->getItemsByType(OrderItemTypeEnum::TYPE_ROUNDING));
+
+        $expectedRoundingPrice = new Price(Money::create('-0.02'), Money::create('-0.02'));
+        $this->assertThat(
+            $actualOrderData->getTotalPriceForItemTypes([OrderItemTypeEnum::TYPE_ROUNDING]),
+            new IsPriceEqual($expectedRoundingPrice),
+        );
+    }
+
     private function createAddRoundingMiddleware(
         string $currencyCode = Currency::CODE_EUR,
+        string $roundingType = Currency::ROUNDING_TYPE_HUNDREDTHS,
     ): AddRoundingMiddleware {
         $orderItemPriceCalculationStub = $this->createStub(OrderItemPriceCalculation::class);
-        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, new Rounding());
+        $priceCalculation = new OrderPriceCalculation($orderItemPriceCalculationStub, new Rounding(), new OrderRoundingTypeEnum());
 
         return new AddRoundingMiddleware(
-            $this->createCurrencyFacade($currencyCode),
+            $this->createCurrencyFacade($currencyCode, $roundingType),
             new Rounding(),
             $this->createOrderItemDataFactory(),
             $priceCalculation,

--- a/project-base/app/src/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/PaymentDataFixture.php
@@ -12,13 +12,16 @@ use Override;
 use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\GoPay\PaymentMethod\GoPayPaymentMethod;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentTypeEnum;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceConverter;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 
@@ -41,6 +44,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
         private readonly PaymentFacade $paymentFacade,
         private readonly PaymentDataFactory $paymentDataFactory,
         private readonly PriceConverter $priceConverter,
+        private readonly CurrencyFacade $currencyFacade,
     ) {
     }
 
@@ -102,7 +106,14 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
             $paymentData->name[$locale] = t('Cash', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
 
-        $paymentData->czkRounding = true;
+        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataDomainIds() as $domainId) {
+            $domainCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
+
+            if ($domainCurrency->getCode() === Currency::CODE_CZK) {
+                $paymentData->orderRoundingTypeByDomainId[$domainId] = OrderRoundingTypeEnum::WHOLE;
+            }
+        }
+        $paymentData->orderRoundingTypeByDomainId[Domain::THIRD_DOMAIN_ID] = OrderRoundingTypeEnum::FIVE_CENTS;
 
         $this->setPriceForAllDomainDefaultCurrencies($paymentData, Money::zero());
         $this->createPayment(self::PAYMENT_CASH, $paymentData, [TransportDataFixture::TRANSPORT_PERSONAL]);
@@ -240,7 +251,6 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
             $paymentData->description[$locale] = t('Quick and Safe payment via bank account transfer.', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
             $paymentData->instructions[$locale] = t('<b>You have chosen GoPay Payment, you will be shown a payment gateway.</b>', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
-        $paymentData->czkRounding = false;
         $paymentData->hidden = false;
         $this->createPayment(self::PAYMENT_GOPAY_BANK_ACCOUNT, $paymentData, [
             TransportDataFixture::TRANSPORT_PERSONAL,
@@ -269,8 +279,6 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
             $paymentData->description[$locale] = '';
             $paymentData->instructions[$locale] = t('<b>You have chosen GoPay Payment, you will be shown a payment gateway.</b>', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
-        $paymentData->czkRounding = false;
-
         $paymentData->hidden = false;
         $this->createPayment(self::PAYMENT_GOPAY_CARD, $paymentData, [
             TransportDataFixture::TRANSPORT_PERSONAL,

--- a/project-base/app/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/project-base/app/src/Model/Order/Item/OrderItemDataFactory.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory as BaseOrderIt
  * @method void fillFromOrderItem(\App\Model\Order\Item\OrderItemData $orderItemData, \App\Model\Order\Item\OrderItem $orderItem)
  * @method \App\Model\Order\Item\OrderItemData create(string $orderItemType)
  * @method \App\Model\Order\Item\OrderItemData createFromQuantifiedProduct(\Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct $quantifiedProduct, \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPriceInterface $quantifiedItemPrice, string $locale)
+ * @method \App\Model\Order\Item\OrderItemData createRounding(\Shopsys\FrameworkBundle\Model\Pricing\PriceInterface $roundingPrice, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
  */
 class OrderItemDataFactory extends BaseOrderItemDataFactory
 {

--- a/project-base/app/src/Model/Order/OrderFacade.php
+++ b/project-base/app/src/Model/Order/OrderFacade.php
@@ -38,6 +38,7 @@ use Shopsys\FrameworkBundle\Model\Order\OrderFacade as BaseOrderFacade;
  * @property \App\Model\Payment\PaymentFacade $paymentFacade
  * @method void updatePaymentByLastPaymentTransaction(\App\Model\Order\Order $order)
  * @method void processWithdrawalRequest(\App\Model\Order\Order $order, \App\Model\Order\OrderData $orderData)
+ * @method void recalculateRoundingForOrderData(\App\Model\Order\OrderData $orderData, \App\Model\Order\Order $order, \App\Model\Payment\Payment $payment, \Shopsys\FrameworkBundle\Model\Pricing\PriceInterface $paymentPrice)
  */
 class OrderFacade extends BaseOrderFacade
 {

--- a/project-base/app/src/Model/Payment/PaymentFacade.php
+++ b/project-base/app/src/Model/Payment/PaymentFacade.php
@@ -23,13 +23,14 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade as BasePaymentFacade;
  * @property \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
  * @property \App\Model\Transport\TransportRepository $transportRepository
  * @method \App\Model\Payment\Payment getEnabledOnDomainByUuid(string $uuid, int $domainId)
- * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Payment\PaymentRepository $paymentRepository, \App\Model\Transport\TransportRepository $transportRepository, \Shopsys\FrameworkBundle\Model\Payment\PaymentVisibilityCalculation $paymentVisibilityCalculation, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade, \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade, \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation $paymentPriceCalculation, \Shopsys\FrameworkBundle\Model\Payment\PaymentFactory $paymentFactory, \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory $paymentPriceFactory)
+ * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Payment\PaymentRepository $paymentRepository, \App\Model\Transport\TransportRepository $transportRepository, \Shopsys\FrameworkBundle\Model\Payment\PaymentVisibilityCalculation $paymentVisibilityCalculation, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade, \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade, \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation $paymentPriceCalculation, \Shopsys\FrameworkBundle\Model\Payment\PaymentFactory $paymentFactory, \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory $paymentPriceFactory, \Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum $orderRoundingTypeEnum)
  * @method \App\Model\Payment\Payment[] getVisibleOnCurrentDomainByTransport(\App\Model\Transport\Transport $transport)
  * @method \App\Model\Payment\Payment[] getVisibleForOrder(\App\Model\Order\Order $order)
  * @method \App\Model\Payment\Payment[] getVisibleOnDomainByTransport(int $domainId, \App\Model\Transport\Transport $transport)
  * @method bool isPaymentVisibleAndEnabledOnCurrentDomain(\App\Model\Payment\Payment $payment)
  * @method \App\Model\Payment\Payment[] getVisibleOnCurrentDomain()
  * @method \App\Model\Payment\Payment|null findPaymentByExternalMethodTransportAndDomainId(string $externalPaymentMethod, \App\Model\Transport\Transport $transport, int $domainId)
+ * @method void validateOrderRoundingTypes(\App\Model\Payment\PaymentData $paymentData)
  */
 class PaymentFacade extends BasePaymentFacade
 {

--- a/project-base/app/tests/App/Functional/Model/Order/OrderFacadeEditTest.php
+++ b/project-base/app/tests/App/Functional/Model/Order/OrderFacadeEditTest.php
@@ -21,9 +21,6 @@ use Tests\FrameworkBundle\Test\IsMoneyEqual;
 final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 {
     private const int ORDER_ID = 10;
-    private const int PRODUCT_ITEM_ID = 45;
-    private const int TRANSPORT_ITEM_ID = 46;
-    private const int PAYMENT_ITEM_ID = 47;
 
     private Order $order;
 
@@ -62,7 +59,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
-        $orderItem = $this->getOrderItemById($this->order, self::PRODUCT_ITEM_ID);
+        $orderItem = $this->order->getProductItems()[0];
 
         if ($this->getInputPriceType() === PricingSetting::PRICE_TYPE_WITH_VAT) {
             $this->assertThat($orderItem->getUnitPriceWithVat(), new IsMoneyEqual(Money::create(100)));
@@ -95,7 +92,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
-        $orderItem = $this->getOrderItemById($this->order, self::PRODUCT_ITEM_ID);
+        $orderItem = $this->order->getProductItems()[0];
         $this->assertThat($orderItem->getUnitPriceWithVat(), new IsMoneyEqual(Money::create(100)));
         $this->assertThat($orderItem->getUnitPriceWithoutVat(), new IsMoneyEqual(Money::create(50)));
         $this->assertThat($orderItem->getTotalPriceWithVat(), new IsMoneyEqual(Money::create(950)));
@@ -184,7 +181,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
-        $orderItem = $this->getOrderItemById($this->order, self::TRANSPORT_ITEM_ID);
+        $orderItem = $this->order->getTransportItem();
 
         if ($this->getInputPriceType() === PricingSetting::PRICE_TYPE_WITH_VAT) {
             $this->assertThat($orderItem->getUnitPriceWithVat(), new IsMoneyEqual(Money::create(100)));
@@ -216,7 +213,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
-        $orderItem = $this->getOrderItemById($this->order, self::TRANSPORT_ITEM_ID);
+        $orderItem = $this->order->getTransportItem();
         $this->assertThat($orderItem->getUnitPriceWithVat(), new IsMoneyEqual(Money::create(100)));
         $this->assertThat($orderItem->getUnitPriceWithoutVat(), new IsMoneyEqual(Money::create(50)));
         $this->assertThat($orderItem->getTotalPriceWithVat(), new IsMoneyEqual(Money::create(100)));
@@ -242,7 +239,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
-        $orderItem = $this->getOrderItemById($this->order, self::PAYMENT_ITEM_ID);
+        $orderItem = $this->order->getPaymentItem();
 
         if ($this->getInputPriceType() === PricingSetting::PRICE_TYPE_WITH_VAT) {
             $this->assertThat($orderItem->getUnitPriceWithVat(), new IsMoneyEqual(Money::create(100)));
@@ -274,7 +271,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
 
         $this->orderFacade->edit(self::ORDER_ID, $orderData);
 
-        $orderItem = $this->getOrderItemById($this->order, self::PAYMENT_ITEM_ID);
+        $orderItem = $this->order->getPaymentItem();
         $this->assertThat($orderItem->getUnitPriceWithVat(), new IsMoneyEqual(Money::create(100)));
         $this->assertThat($orderItem->getUnitPriceWithoutVat(), new IsMoneyEqual(Money::create(50)));
         $this->assertThat($orderItem->getTotalPriceWithoutVat(), new IsMoneyEqual(Money::create(50)));
@@ -299,20 +296,6 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
         throw new OrderItemNotFoundException(sprintf(
             'Order item with the name "%s" was not found in the order.',
             $name,
-        ));
-    }
-
-    private function getOrderItemById(Order $order, int $orderItemId): OrderItem
-    {
-        foreach ($order->getItems() as $orderItem) {
-            if ($orderItem->getId() === $orderItemId) {
-                return $orderItem;
-            }
-        }
-
-        throw new OrderItemNotFoundException(sprintf(
-            'Order item id `%d` not found.',
-            $orderItemId,
         ));
     }
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/RoundingPriceInCartTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/RoundingPriceInCartTest.php
@@ -11,7 +11,10 @@ use App\DataFixtures\Demo\TransportDataFixture;
 use App\Model\Product\Product;
 use Override;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactory;
 use Shopsys\FrameworkBundle\Model\Store\Store;
@@ -26,6 +29,16 @@ class RoundingPriceInCartTest extends GraphQlTestCase
      * @inject
      */
     private CurrencyDataFactory $currencyDataFactory;
+
+    /**
+     * @inject
+     */
+    private PaymentFacade $paymentFacade;
+
+    /**
+     * @inject
+     */
+    private PaymentDataFactory $paymentDataFactory;
 
     #[Override]
     protected function setUp(): void
@@ -90,6 +103,11 @@ class RoundingPriceInCartTest extends GraphQlTestCase
         $currencyCzk = $this->currencyFacade->edit($currencyCzk->getId(), $currencyData);
 
         $this->currencyFacade->setDomainDefaultCurrency($currencyCzk, Domain::FIRST_DOMAIN_ID);
+
+        $cashPayment = $this->getReference(PaymentDataFixture::PAYMENT_CASH, Payment::class);
+        $cashPaymentData = $this->paymentDataFactory->createFromPayment($cashPayment);
+        $cashPaymentData->orderRoundingTypeByDomainId[Domain::FIRST_DOMAIN_ID] = OrderRoundingTypeEnum::WHOLE;
+        $this->paymentFacade->edit($cashPayment, $cashPaymentData);
     }
 
     public function createCartWithProductTransportAndPayment(): string

--- a/project-base/app/tests/FrontendApiBundle/Functional/Payment/ChangePaymentInOrderMutationTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Payment/ChangePaymentInOrderMutationTest.php
@@ -13,8 +13,15 @@ use GoPay\Definition\Response\PaymentStatus;
 use PHPUnit\Framework\Attributes\Group;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
+use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory;
+use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+use Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionDataFactory;
 use Shopsys\FrameworkBundle\Model\Payment\Transaction\PaymentTransactionFacade;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrontendApiBundle\Component\Constraints\PaymentInExistingOrder;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
@@ -29,6 +36,26 @@ class ChangePaymentInOrderMutationTest extends GraphQlTestCase
      * @inject
      */
     private PaymentTransactionFacade $paymentTransactionFacade;
+
+    /**
+     * @inject
+     */
+    private PaymentFacade $paymentFacade;
+
+    /**
+     * @inject
+     */
+    private PaymentDataFactory $paymentDataFactory;
+
+    /**
+     * @inject
+     */
+    private OrderFacade $orderFacade;
+
+    /**
+     * @inject
+     */
+    private OrderDataFactory $orderDataFactory;
 
     public function testChangePaymentInOrderRespectsFreeTransportSetting(): void
     {
@@ -204,6 +231,40 @@ class ChangePaymentInOrderMutationTest extends GraphQlTestCase
         $violations = $this->getErrorsExtensionValidationFromResponse($response);
 
         self::assertSame(PaymentInExistingOrder::INVALID_PAYMENT_SWIFT_ERROR, $violations['input'][0]['code']);
+    }
+
+    public function testChangePaymentInOrderCreatesRoundingItem(): void
+    {
+        if ($this->getFirstDomainCurrency()->getRoundingType() === Currency::ROUNDING_TYPE_INTEGER) {
+            $this->markTestSkipped('Rounding item cannot be created for currencies that already round to whole numbers');
+        }
+
+        $order = $this->getReference(OrderDataFixture::ORDER_WITH_GOPAY_PAYMENT_1, Order::class);
+        $goPayBankAccount = $this->getReference(PaymentDataFixture::PAYMENT_GOPAY_BANK_ACCOUNT, Payment::class);
+
+        $paymentData = $this->paymentDataFactory->createFromPayment($goPayBankAccount);
+        $paymentData->orderRoundingTypeByDomainId[Domain::FIRST_DOMAIN_ID] = OrderRoundingTypeEnum::WHOLE;
+        $this->paymentFacade->edit($goPayBankAccount, $paymentData);
+
+        $orderData = $this->orderDataFactory->createFromOrder($order);
+        $orderData->currencyRoundingType = Currency::ROUNDING_TYPE_HUNDREDTHS;
+        $this->orderFacade->edit($order->getId(), $orderData);
+        $this->em->clear();
+
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/ChangePaymentInOrderMutation.graphql', [
+            'input' => [
+                'orderUuid' => $order->getUuid(),
+                'paymentUuid' => $goPayBankAccount->getUuid(),
+            ],
+        ]);
+
+        $responseData = $this->getResponseDataForGraphQlType($response, 'ChangePaymentInOrder');
+
+        $roundingItems = array_filter(
+            $responseData['items'],
+            static fn (array $item) => $item['type'] === OrderItemTypeEnum::TYPE_ROUNDING,
+        );
+        $this->assertNotEmpty($roundingItems);
     }
 
     private function findPaymentItem(array $items): array

--- a/project-base/storefront/pages/order-confirmation.tsx
+++ b/project-base/storefront/pages/order-confirmation.tsx
@@ -91,6 +91,7 @@ const OrderConfirmationPage: FC<ServerSidePropsType> = () => {
 
     const orderPayment = orderData.order.items.find((item) => item.type === TypeOrderItemTypeEnum.Payment);
     const orderTransport = orderData.order.items.find((item) => item.type === TypeOrderItemTypeEnum.Transport);
+    const orderRounding = orderData.order.items.find((item) => item.type === TypeOrderItemTypeEnum.Rounding);
 
     return (
         <>
@@ -154,6 +155,7 @@ const OrderConfirmationPage: FC<ServerSidePropsType> = () => {
 
                             <OrderConfirmationSummary
                                 promoCode={orderData.order.promoCode}
+                                roundingPrice={orderRounding?.totalPrice}
                                 totalPrice={orderData.order.totalPrice}
                                 payment={{
                                     name: orderPayment?.name,

--- a/project-base/storefront/pages/order-payment-confirmation.tsx
+++ b/project-base/storefront/pages/order-payment-confirmation.tsx
@@ -87,6 +87,7 @@ const OrderPaymentConfirmationPage: FC<ServerSidePropsType> = () => {
 
     const orderPayment = order.items.find((item) => item.type === TypeOrderItemTypeEnum.Payment);
     const orderTransport = order.items.find((item) => item.type === TypeOrderItemTypeEnum.Transport);
+    const orderRounding = order.items.find((item) => item.type === TypeOrderItemTypeEnum.Rounding);
 
     return (
         <>
@@ -144,6 +145,7 @@ const OrderPaymentConfirmationPage: FC<ServerSidePropsType> = () => {
 
                             <OrderConfirmationSummary
                                 promoCode={order.promoCode}
+                                roundingPrice={orderRounding?.totalPrice}
                                 totalPrice={order.totalPrice}
                                 payment={{
                                     name: orderPayment?.name,

--- a/upgrade-notes/backend_20260323_161143.md
+++ b/upgrade-notes/backend_20260323_161143.md
@@ -1,0 +1,5 @@
+#### Added new rounding to 0.05 for order total price ([#4522](https://github.com/shopsys/shopsys/pull/4522))
+
+- replace usages of `\Shopsys\FrameworkBundle\Model\Payment\PaymentData::$czkRounding` (bool) with `\Shopsys\FrameworkBundle\Model\Payment\PaymentData::$orderRoundingTypeByDomainId` (string[] indexed by domain ID) using values from `\Shopsys\FrameworkBundle\Model\Payment\OrderRoundingTypeEnum` (`none`, `five_cents`, `whole`)
+- replace `\Shopsys\FrameworkBundle\Model\Payment\Payment::isCzkRounding()` with `\Shopsys\FrameworkBundle\Model\Payment\Payment::hasOrderRoundingForDomain(int $domainId)` and `\Shopsys\FrameworkBundle\Model\Payment\Payment::getOrderRoundingTypeForDomain(int $domainId)`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- In Slovakia there is need to round order prices to five cents for cash payment, we already had setting (czkRounding) for whole numbers
- This was reworked to ommit information about for what currency it is used and made more generally
- New solution is prepared for other possible needs in the future

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)























----
:globe_with_meridians: Live Preview:
  - https://tl-rounding-to-fives.odin.shopsys.cloud
  - https://cz.tl-rounding-to-fives.odin.shopsys.cloud
  - https://tl-rounding-to-fives.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776671499.259889 -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-rounding-to-fives.odin.shopsys.cloud
  - https://cz.tl-rounding-to-fives.odin.shopsys.cloud
  - https://tl-rounding-to-fives.odin.shopsys.cloud/sk
<!-- Replace -->
