### PR TITLE
it is now possible to make a link to specific domain tab

### DIFF
--- a/packages/administration/src/Component/Domain/AdminDomainQueryParameterSubscriber.php
+++ b/packages/administration/src/Component/Domain/AdminDomainQueryParameterSubscriber.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Domain;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AdminDomainQueryParameterSubscriber implements EventSubscriberInterface
+{
+    public const string QUERY_PARAMETER_NAME = 'switchAdminDomainTo';
+
+    public function __construct(
+        protected readonly ContextResolverInterface $contextResolver,
+        protected readonly Domain $domain,
+        protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
+    ) {
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest() || !$this->contextResolver->isCurrentContext(AdminContext::class)) {
+            return;
+        }
+
+        $domainId = $this->getDomainIdFromRequest($event->getRequest());
+
+        if ($domainId === null || !in_array($domainId, $this->domain->getAllIds(), true)) {
+            return;
+        }
+
+        $this->adminDomainTabsFacade->setSelectedDomainId($domainId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', 95]],
+        ];
+    }
+
+    protected function getDomainIdFromRequest(Request $request): ?int
+    {
+        return $request->query->filter(
+            self::QUERY_PARAMETER_NAME,
+            null,
+            FILTER_VALIDATE_INT,
+            ['flags' => FILTER_NULL_ON_FAILURE],
+        );
+    }
+}

--- a/packages/framework/src/Twig/RequiredSettingExtension.php
+++ b/packages/framework/src/Twig/RequiredSettingExtension.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Twig;
 use DateTimeImmutable;
 use Override;
 use Psr\Clock\ClockInterface;
+use Shopsys\AdministrationBundle\Component\Domain\AdminDomainQueryParameterSubscriber;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Model\Country\CountryFacade;
@@ -157,7 +158,7 @@ class RequiredSettingExtension extends AbstractExtension
                 $this->requiredSettingsMessages[] = t(
                     '<a href="%url%">Term and conditions article for domain %domainName% is not set.</a>',
                     [
-                        '%url%' => $this->router->generate('admin_legalconditions_termsandconditions'),
+                        '%url%' => $this->generateUrlWithSelectedDomainTab('admin_legalconditions_termsandconditions', $domainId),
                         '%domainName%' => $domainConfig->getName(),
                     ],
                 );
@@ -167,7 +168,7 @@ class RequiredSettingExtension extends AbstractExtension
                 $this->requiredSettingsMessages[] = t(
                     '<a href="%url%">Privacy policy article for domain %domainName% is not set.</a>',
                     [
-                        '%url%' => $this->router->generate('admin_legalconditions_privacypolicy'),
+                        '%url%' => $this->generateUrlWithSelectedDomainTab('admin_legalconditions_privacypolicy', $domainId),
                         '%domainName%' => $domainConfig->getName(),
                     ],
                 );
@@ -177,12 +178,22 @@ class RequiredSettingExtension extends AbstractExtension
                 $this->requiredSettingsMessages[] = t(
                     '<a href="%url%">User consent policy article for domain %domainName% is not set.</a>',
                     [
-                        '%url%' => $this->router->generate('admin_userconsentpolicy_setting'),
+                        '%url%' => $this->generateUrlWithSelectedDomainTab('admin_userconsentpolicy_setting', $domainId),
                         '%domainName%' => $domainConfig->getName(),
                     ],
                 );
             }
         }
+    }
+
+    protected function generateUrlWithSelectedDomainTab(string $routeName, int $domainId): string
+    {
+        return $this->router->generate(
+            $routeName,
+            [
+                AdminDomainQueryParameterSubscriber::QUERY_PARAMETER_NAME => $domainId,
+            ],
+        );
     }
 
     protected function checkAllSliderNumericValuesAreSet(): void


### PR DESCRIPTION
#### Description, the reason for the PR
This PR makes domain-specific administration pages directly linkable.

Until now, pages with administration domain tabs have always opened in the domain stored in the administrator session. That meant links could lead to the correct agenda, but not to the correct domain tab. In practice, administrators still had to switch the domain manually before they could fix the reported problem.

This change adds support for switching the selected administration domain directly from a link. As a result, links from domain-specific warnings, such as required settings notifications, can open the target page in the exact domain context that needs attention.


https://github.com/user-attachments/assets/ca8dd285-757f-480c-b857-683fa11dea4a



#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-link-to-domain-tab.odin.shopsys.cloud
  - https://cz.mg-link-to-domain-tab.odin.shopsys.cloud
  - https://mg-link-to-domain-tab.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1774615392.647149 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-link-to-domain-tab.odin.shopsys.cloud
  - https://cz.mg-link-to-domain-tab.odin.shopsys.cloud
  - https://mg-link-to-domain-tab.odin.shopsys.cloud/sk
<!-- Replace -->
