### PR TITLE
[CRUD] fix translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,6 +184,7 @@
         "symfony/serializer": "^7.4",
         "symfony/service-contracts": "^3.5",
         "symfony/stopwatch": "^7.4",
+        "symfony/string": "^7.4",
         "symfony/translation": "^7.4",
         "symfony/twig-bundle": "^7.4",
         "symfony/ux-icons": "^2.22",

--- a/docs/administration/crud-controller/getting-started/creating-a-new-crud-controller.md
+++ b/docs/administration/crud-controller/getting-started/creating-a-new-crud-controller.md
@@ -30,7 +30,7 @@ That's it! Now you have a new Crud Controller that is automatically registered a
 
 ## 2. Configure Crud Controller (Optional)
 
-You can implement the `configure()` method to customize the general behavior of the controller:
+You can implement the `configure()` method to customize the controller behavior:
 
 ```php
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
@@ -39,11 +39,16 @@ use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 public function configure(CrudConfig $config): void
 {
     $config
-        ->setTitle(ActionType::LIST, t('Orders')) // Set the title of the list page
+        ->setTitle(ActionType::LIST, t('Orders management')) // Set the custom title of the list page
         ->setMenuSection('customers') // Set the menu section where the controller will be placed
     ;
 }
 ```
+
+!!! info
+
+    Default page titles and menu labels are generated automatically from the entity class name.
+
 
 More configuration options can be found in the [Crud Config](../reference/crud-controller.md#crud-config) reference.
 

--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -46,7 +46,8 @@ Configure general behavior of the controller. Customizable options are available
 protected function configure(CrudConfig $config): void
 {
     $config
-        ->setTitle(ActionType::LIST, t('Products'))
+        ->setTitle(ActionType::LIST, t('All products'))
+        ->setMenuTitle(t('Products management'))
         ->setMenuSection('products');
 }
 ```
@@ -104,11 +105,30 @@ protected function configureQuery(QueryBuilder $queryBuilder): void
 
 The `CrudConfig` class is used to configure the behavior of the Crud Controller. It is used in the `configure` method of the Crud Controller.
 
+### Default titles
+
+Page titles and the menu label are generated automatically from the entity class name using English singular/plural inflection. For example, entity `OrderItem` produces menu title "Order items", etc.
+
+These generated names are registered as translation keys automatically — no manual `t()` wrapping is needed for defaults.
+
 ### Methods
 
 #### `setTitle(ActionType $actionType, string $title)`
 
-This method allows you to set the title for the given page type. The title is displayed in the page header.
+Sets a custom title for a specific page type. The title is displayed in the page header. Overrides the auto-generated default for the given action.
+
+```php
+$config->setTitle(ActionType::LIST, t('All orders'));
+$config->setTitle(ActionType::CREATE, t('New order'));
+```
+
+#### `setMenuTitle(string $menuTitle)`
+
+Sets a custom title for the menu item. By default, the pluralized entity name is used (e.g. "Orders" for `Order` entity).
+
+```php
+$config->setMenuTitle(t('Orders management'));
+```
 
 #### `enableAction(ActionType|array $actions)` and `disableAction(ActionType|array $actions)`
 

--- a/packages/administration/composer.json
+++ b/packages/administration/composer.json
@@ -39,6 +39,7 @@
         "symfony/http-foundation": "^7.4",
         "symfony/http-kernel": "^7.4",
         "symfony/routing": "^7.4",
+        "symfony/string": "^7.4",
         "symfony/translation": "^7.4",
         "symfony/ux-icons": "^2.22",
         "twig/twig": "^3.14.0"

--- a/packages/administration/config/services.yaml
+++ b/packages/administration/config/services.yaml
@@ -41,6 +41,10 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Shopsys\AdministrationBundle\Component\Translation\CrudEntityNameExtractor:
+        tags:
+            - { name: jms_translation.file_visitor }
+
     Shopsys\AdministrationBundle\Controller\:
         resource: '../src/Controller/'
         tags: [ 'controller.service_arguments' ]

--- a/packages/administration/src/Component/Config/ActionsConfig.php
+++ b/packages/administration/src/Component/Config/ActionsConfig.php
@@ -29,7 +29,7 @@ class ActionsConfig
     {
         $this->add(
             ActionType::LIST,
-            Action::create(ActionType::CREATE->value, t('New'))
+            Action::create(ActionType::CREATE->value, t('Create new item'))
                 ->linkToCrud($controllerClass, ActionType::CREATE)
                 ->setIcon('circle-plus')
                 ->displayIf(function () use ($defaultActions): bool {

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -17,7 +17,7 @@ final class CrudConfig
      */
     private array $customPageTitles;
 
-    public ?string $menuTitle = null;
+    private ?string $menuTitle = null;
 
     private bool $fullDisabled = false;
 

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -47,20 +47,13 @@ final class CrudConfig
         ActionType::DELETE->value => null,
     ];
 
-    public function __construct(string $entityName)
+    public function __construct(private readonly string $entityName)
     {
-        $this->customPageTitles = [
-            ActionType::CREATE->value => t('Creating new %entity_name%', ['%entity_name%' => $entityName]),
-            ActionType::EDIT->value => t('Editing %entity_name%', ['%entity_name%' => $entityName]),
-            ActionType::LIST->value => t('%entity_name% Overview', ['%entity_name%' => $entityName]),
-            ActionType::DETAIL->value => t('Viewing %entity_name%', ['%entity_name%' => $entityName]),
-        ];
+        $this->customPageTitles = [];
 
         $this->enabledActions = new ArrayCollection([
             ActionType::LIST,
         ]);
-
-        $this->menuTitle = t('%entity_name% Overview', ['%entity_name%' => $entityName]);
     }
 
     /**
@@ -301,6 +294,7 @@ final class CrudConfig
         return new CrudConfigData(
             $this->customPageTitles,
             $this->menuTitle,
+            $this->entityName,
             $this->fullDisabled,
             $this->enabledActions->toArray(),
             $this->menuSection,

--- a/packages/administration/src/Component/Config/CrudConfigData.php
+++ b/packages/administration/src/Component/Config/CrudConfigData.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\AdministrationBundle\Component\Config;
 
 use RuntimeException;
+use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 
 final readonly class CrudConfigData
 {
@@ -44,11 +46,14 @@ final readonly class CrudConfigData
             return $this->customPageTitles[$pageType->value];
         }
 
+        $singularEntityName = Translator::staticTrans(CrudTransformationHelper::toSingularEntityName($this->entityName));
+        $pluralEntityName = Translator::staticTrans(CrudTransformationHelper::toPluralEntityName($this->entityName));
+
         return match ($pageType) {
-            ActionType::CREATE => t('Creating new %entity_name%', ['%entity_name%' => $this->entityName]),
-            ActionType::EDIT => t('Editing %entity_name%', ['%entity_name%' => $this->entityName]),
-            ActionType::LIST => t('%entity_name% Overview', ['%entity_name%' => $this->entityName]),
-            ActionType::DETAIL => t('Viewing %entity_name%', ['%entity_name%' => $this->entityName]),
+            ActionType::CREATE => t('Creating new %entity_name%', ['%entity_name%' => $singularEntityName]),
+            ActionType::EDIT => t('Editing %entity_name%', ['%entity_name%' => $singularEntityName]),
+            ActionType::LIST => $pluralEntityName,
+            ActionType::DETAIL => $singularEntityName,
             default => '',
         };
     }
@@ -59,7 +64,7 @@ final readonly class CrudConfigData
             return $this->menuTitle;
         }
 
-        return t('%entity_name% Overview', ['%entity_name%' => $this->entityName]);
+        return Translator::staticTrans(CrudTransformationHelper::toPluralEntityName($this->entityName));
     }
 
     /**

--- a/packages/administration/src/Component/Config/CrudConfigData.php
+++ b/packages/administration/src/Component/Config/CrudConfigData.php
@@ -16,6 +16,7 @@ final readonly class CrudConfigData
     public function __construct(
         private array $customPageTitles,
         private ?string $menuTitle,
+        private string $entityName,
         private bool $fullDisabled,
         private array $enabledActions,
         private string $menuSection,
@@ -39,12 +40,26 @@ final readonly class CrudConfigData
 
     public function getTitle(ActionType $pageType): string
     {
-        return $this->customPageTitles[$pageType->value] ?? '';
+        if (isset($this->customPageTitles[$pageType->value])) {
+            return $this->customPageTitles[$pageType->value];
+        }
+
+        return match ($pageType) {
+            ActionType::CREATE => t('Creating new %entity_name%', ['%entity_name%' => $this->entityName]),
+            ActionType::EDIT => t('Editing %entity_name%', ['%entity_name%' => $this->entityName]),
+            ActionType::LIST => t('%entity_name% Overview', ['%entity_name%' => $this->entityName]),
+            ActionType::DETAIL => t('Viewing %entity_name%', ['%entity_name%' => $this->entityName]),
+            default => '',
+        };
     }
 
     public function getMenuTitle(): string
     {
-        return $this->menuTitle;
+        if ($this->menuTitle !== null) {
+            return $this->menuTitle;
+        }
+
+        return t('%entity_name% Overview', ['%entity_name%' => $this->entityName]);
     }
 
     /**
@@ -66,7 +81,7 @@ final readonly class CrudConfigData
 
     public function isFullDisabled(): bool
     {
-        return $this->fullDisabled;
+        return $this->fullDisabled || count($this->enabledActions) === 0;
     }
 
     public function getMenuSection(): string

--- a/packages/administration/src/Component/Crud/CrudAdminRoleProvider.php
+++ b/packages/administration/src/Component/Crud/CrudAdminRoleProvider.php
@@ -36,8 +36,8 @@ final class CrudAdminRoleProvider implements CoreRoleProviderInterface
     #[Override]
     public function configureRoles(RoleCollection $roleCollection): void
     {
-        foreach ($this->crudControllerRegistry->getItems() as $crudControllerDefinition) {
-            $config = $crudControllerDefinition->getConfig();
+        foreach ($this->crudControllerRegistry->getAll() as $crudControllerDefinition) {
+            $config = $crudControllerDefinition->config;
 
             if ($config->isFullDisabled() || $config->getCustomRoleConstant() !== null) {
                 continue;

--- a/packages/administration/src/Component/Crud/CrudControllerInitializer.php
+++ b/packages/administration/src/Component/Crud/CrudControllerInitializer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud;
+
+use Override;
+use Shopsys\AdministrationBundle\Controller\AbstractCrudController;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Sets Definition on the current CRUD controller before action execution.
+ * Runs at request time (after locale is set) to ensure correct translations.
+ */
+final class CrudControllerInitializer implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly CrudControllerRegistry $crudControllerRegistry,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => ['onKernelController', 1000],
+        ];
+    }
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        $controller = $event->getController();
+
+        if (is_array($controller)) {
+            $controller = $controller[0];
+        }
+
+        if ($controller instanceof AbstractCrudController) {
+            $controller->setDefinition(
+                $this->crudControllerRegistry->getDefinition($controller::class),
+            );
+        }
+    }
+}

--- a/packages/administration/src/Component/Crud/CrudControllerRegistry.php
+++ b/packages/administration/src/Component/Crud/CrudControllerRegistry.php
@@ -21,9 +21,19 @@ final class CrudControllerRegistry
     public const string CRUD_CONTROLLERS_EXTENSIONS_PARAMETER = 'shopsys.admin.crud_controllers_extensions';
 
     /**
-     * @var \Shopsys\AdministrationBundle\Component\Crud\Definition[]|null
+     * @var array<class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, array{controllerName: string, entityClass: class-string, entityName: string}>|null
      */
-    private ?array $items = null;
+    private ?array $resolvedMetadata = null;
+
+    /**
+     * @var array<class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, \Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension[]>|null
+     */
+    private ?array $resolvedExtensions = null;
+
+    /**
+     * @var array<class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, \Shopsys\AdministrationBundle\Component\Crud\Definition>
+     */
+    private array $definitions = [];
 
     /**
      * @param array<int, array{class: class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, entityClass: string}> $crudControllers
@@ -39,85 +49,71 @@ final class CrudControllerRegistry
     ) {
     }
 
-    private function buildDefinitions(): void
+    /**
+     * Returns all registered CRUD controllers with metadata and config (including disabled).
+     *
+     * @return \Shopsys\AdministrationBundle\Component\Crud\CrudRegistryItem[]
+     */
+    public function getAll(): array
     {
-        $this->items = [];
-        $extensionsByCrudController = $this->loadExtensions($this->crudControllerExtensions);
+        $items = [];
 
-        foreach ($this->crudControllers as $crudController) {
-            $controllerClass = $crudController['class'];
-
-            $this->addItem($controllerClass, $crudController['entityClass'], $extensionsByCrudController[$controllerClass] ?? []);
+        foreach ($this->getResolvedMetadata() as $controllerClass => $meta) {
+            $items[] = new CrudRegistryItem(
+                controllerClass: $controllerClass,
+                controllerName: $meta['controllerName'],
+                entityClass: $meta['entityClass'],
+                entityName: $meta['entityName'],
+                config: $this->buildConfig($controllerClass),
+            );
         }
+
+        return $items;
+    }
+
+    /**
+     * Returns full Definition for a specific controller (with handlers, extensions).
+     * Definitions are cached per controller for the lifetime of the request.
+     *
+     * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
+     */
+    public function getDefinition(string $controllerClass): Definition
+    {
+        if (!isset($this->definitions[$controllerClass])) {
+            $metadata = $this->getResolvedMetadata();
+
+            Assert::keyExists($metadata, $controllerClass, 'CRUD controller class is not registered.');
+
+            $meta = $metadata[$controllerClass];
+            $config = $this->buildConfig($controllerClass);
+            $extensions = $this->getResolvedExtensions()[$controllerClass] ?? [];
+
+            $this->definitions[$controllerClass] = new Definition(
+                $controllerClass,
+                $meta['controllerName'],
+                $meta['entityClass'],
+                $meta['entityName'],
+                $config,
+                $extensions,
+                $this->loadHandlers($config->getHandlerClasses()),
+            );
+        }
+
+        return $this->definitions[$controllerClass];
     }
 
     /**
      * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
-     * @param class-string $entityClass
-     * @param \Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension[] $extensions
      */
-    private function addItem(string $controllerClass, string $entityClass, array $extensions): void
+    private function buildConfig(string $controllerClass): CrudConfigData
     {
-        $entityClass = $this->entityNameResolver->resolve($entityClass);
-        $entityName = (new ReflectionClass($entityClass))->getShortName();
-        $controllerName = (new ReflectionClass($controllerClass))->getShortName();
+        $meta = $this->getResolvedMetadata()[$controllerClass];
+        $extensions = $this->getResolvedExtensions()[$controllerClass] ?? [];
 
         /** @var \Shopsys\AdministrationBundle\Controller\AbstractCrudController $crudController */
         $crudController = $this->container->get($controllerClass);
-        $config = $this->loadCrudConfiguration($controllerClass, $entityName, $extensions);
 
-        $item = new Definition(
-            $controllerClass,
-            $controllerName,
-            $entityClass,
-            $entityName,
-            $config,
-            $extensions,
-            $this->loadHandlers($config->getHandlerClasses()),
-        );
-
-        $crudController->setDefinition($item);
-
-        $this->items[$controllerClass] = $item;
-    }
-
-    /**
-     * @return \Shopsys\AdministrationBundle\Component\Crud\Definition[]
-     */
-    public function getItems(): array
-    {
-        if ($this->items === null) {
-            $this->buildDefinitions();
-        }
-
-        return $this->items;
-    }
-
-    /**
-     * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
-     */
-    public function getItem(string $controllerClass): Definition
-    {
-        $items = $this->getItems();
-
-        Assert::keyExists($items, $controllerClass, 'CRUD controller class is not registered.');
-
-        return $items[$controllerClass];
-    }
-
-    /**
-     * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
-     * @param \Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension[] $extensions
-     */
-    private function loadCrudConfiguration(
-        string $controllerClass,
-        string $entityName,
-        array $extensions,
-    ): CrudConfigData {
-        /** @var \Shopsys\AdministrationBundle\Controller\AbstractCrudController $crudController */
-        $crudController = $this->container->get($controllerClass);
-
-        $config = new CrudConfig($entityName);
+        $config = new CrudConfig($meta['entityName']);
         $crudController->configure($config);
 
         foreach ($extensions as $extension) {
@@ -128,33 +124,56 @@ final class CrudControllerRegistry
     }
 
     /**
-     * @param array<int, array{extensionClass: string, controllerClass: string, priority: int}> $extensions
+     * @return array<class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, array{controllerName: string, entityClass: class-string, entityName: string}>
+     */
+    private function getResolvedMetadata(): array
+    {
+        if ($this->resolvedMetadata === null) {
+            $this->resolvedMetadata = [];
+
+            foreach ($this->crudControllers as $crudController) {
+                $controllerClass = $crudController['class'];
+                $entityClass = $this->entityNameResolver->resolve($crudController['entityClass']);
+
+                $this->resolvedMetadata[$controllerClass] = [
+                    'controllerName' => (new ReflectionClass($controllerClass))->getShortName(),
+                    'entityClass' => $entityClass,
+                    'entityName' => (new ReflectionClass($entityClass))->getShortName(),
+                ];
+            }
+        }
+
+        return $this->resolvedMetadata;
+    }
+
+    /**
      * @return array<class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, \Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension[]>
      */
-    private function loadExtensions(array $extensions): array
+    private function getResolvedExtensions(): array
     {
-        $queueByController = [];
+        if ($this->resolvedExtensions === null) {
+            $this->resolvedExtensions = [];
+            $queueByController = [];
 
-        foreach ($extensions as $extension) {
-            if (isset($queueByController[$extension['controllerClass']]) === false) {
-                $queueByController[$extension['controllerClass']] = new SplPriorityQueue();
+            foreach ($this->crudControllerExtensions as $extension) {
+                if (isset($queueByController[$extension['controllerClass']]) === false) {
+                    $queueByController[$extension['controllerClass']] = new SplPriorityQueue();
+                }
+
+                $queueByController[$extension['controllerClass']]->insert(
+                    $this->container->get($extension['extensionClass']),
+                    $extension['priority'],
+                );
             }
 
-            $queueByController[$extension['controllerClass']]->insert(
-                $this->container->get($extension['extensionClass']),
-                $extension['priority'],
-            );
+            foreach ($queueByController as $controller => $queue) {
+                $queue->top();
+                $queue->setExtractFlags(SplPriorityQueue::EXTR_DATA);
+                $this->resolvedExtensions[$controller] = array_reverse(iterator_to_array($queue));
+            }
         }
 
-        $extensionsByCrudController = [];
-
-        foreach ($queueByController as $controller => $queue) {
-            $queue->top();
-            $queue->setExtractFlags(SplPriorityQueue::EXTR_DATA);
-            $extensionsByCrudController[$controller] = array_reverse(iterator_to_array($queue));
-        }
-
-        return $extensionsByCrudController;
+        return $this->resolvedExtensions;
     }
 
     /**

--- a/packages/administration/src/Component/Crud/CrudControllerRegistry.php
+++ b/packages/administration/src/Component/Crud/CrudControllerRegistry.php
@@ -11,7 +11,6 @@ use Shopsys\AdministrationBundle\Component\Config\CrudConfigData;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use SplPriorityQueue;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Webmozart\Assert\Assert;
 
@@ -41,7 +40,8 @@ final class CrudControllerRegistry
      */
     public function __construct(
         private readonly EntityNameResolver $entityNameResolver,
-        private readonly ContainerInterface $container,
+        #[TaggedLocator('shopsys.admin.crud_controllers')]
+        private readonly ServiceLocator $controllers,
         #[TaggedLocator('shopsys.admin.crud_handler')]
         private readonly ServiceLocator $handlers,
         private readonly array $crudControllers = [],
@@ -111,7 +111,7 @@ final class CrudControllerRegistry
         $extensions = $this->getResolvedExtensions()[$controllerClass] ?? [];
 
         /** @var \Shopsys\AdministrationBundle\Controller\AbstractCrudController $crudController */
-        $crudController = $this->container->get($controllerClass);
+        $crudController = $this->controllers->get($controllerClass);
 
         $config = new CrudConfig($meta['entityName']);
         $crudController->configure($config);
@@ -161,7 +161,7 @@ final class CrudControllerRegistry
                 }
 
                 $queueByController[$extension['controllerClass']]->insert(
-                    $this->container->get($extension['extensionClass']),
+                    $this->controllers->get($extension['extensionClass']),
                     $extension['priority'],
                 );
             }

--- a/packages/administration/src/Component/Crud/CrudRegistryItem.php
+++ b/packages/administration/src/Component/Crud/CrudRegistryItem.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud;
+
+use Shopsys\AdministrationBundle\Component\Config\CrudConfigData;
+use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
+
+final readonly class CrudRegistryItem
+{
+    /**
+     * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
+     * @param class-string $entityClass
+     */
+    public function __construct(
+        public string $controllerClass,
+        public string $controllerName,
+        public string $entityClass,
+        public string $entityName,
+        public CrudConfigData $config,
+    ) {
+    }
+
+    public function getRoleConstant(): string
+    {
+        return CrudTransformationHelper::generateRoleConstant($this->controllerName, $this->config->getCustomRoleConstant());
+    }
+}

--- a/packages/administration/src/Component/Crud/Definition.php
+++ b/packages/administration/src/Component/Crud/Definition.php
@@ -71,7 +71,7 @@ final readonly class Definition
 
     public function getRoleConstant(): string
     {
-        return $this->getConfig()->getCustomRoleConstant() ?? 'ROLE_CRUD_' . strtoupper(CrudTransformationHelper::transformToRouteName($this->controllerName));
+        return CrudTransformationHelper::generateRoleConstant($this->controllerName, $this->getConfig()->getCustomRoleConstant());
     }
 
     public function getHandlerForAction(ActionType $actionType): HandlerInterface

--- a/packages/administration/src/Component/Crud/Helper/CrudTransformationHelper.php
+++ b/packages/administration/src/Component/Crud/Helper/CrudTransformationHelper.php
@@ -48,6 +48,11 @@ final class CrudTransformationHelper
         return 'admin_crud_' . self::transformToRouteName($controllerName) . '_' . $pageType->value;
     }
 
+    public static function generateRoleConstant(string $controllerName, ?string $customRoleConstant = null): string
+    {
+        return $customRoleConstant ?? 'ROLE_CRUD_' . strtoupper(self::transformToRouteName($controllerName));
+    }
+
     /**
      * Remove "CrudController" or "Controller" from controller name to be able to use it with routes
      */

--- a/packages/administration/src/Component/Crud/Helper/CrudTransformationHelper.php
+++ b/packages/administration/src/Component/Crud/Helper/CrudTransformationHelper.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Shopsys\AdministrationBundle\Component\Crud\Helper;
 
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
+use Symfony\Component\String\Inflector\EnglishInflector;
+use Symfony\Component\String\UnicodeString;
 
 final class CrudTransformationHelper
 {
+    private static ?EnglishInflector $inflector = null;
+
     /**
      * Transform CrudController name to string that can be used to define route name in snake_case format
      *
@@ -17,10 +21,7 @@ final class CrudTransformationHelper
      */
     public static function transformToRouteName(string $controllerName): string
     {
-        return $controllerName
-            |> self::getCleanControllerName(...)
-            |> (fn ($v) => preg_replace('/(?<!^)[A-Z]/', '_$0', $v))
-            |> strtolower(...);
+        return (string)new UnicodeString(self::getCleanControllerName($controllerName))->snake();
     }
 
     public static function generateController(string $controllerClass, ActionType $pageType): string
@@ -37,27 +38,57 @@ final class CrudTransformationHelper
      */
     public static function transformToRouteUrl(string $controllerName): string
     {
-        return $controllerName
-            |> self::getCleanControllerName(...)
-            |> (fn ($v) => preg_replace('/(?<!^)[A-Z]/', '-$0', $v))
-            |> strtolower(...);
+        return (string)new UnicodeString(self::getCleanControllerName($controllerName))->kebab();
     }
 
     public static function generateRouteName(string $controllerName, ActionType $pageType): string
     {
-        return 'admin_crud_' . self::transformToRouteName($controllerName) . '_' . $pageType->value;
+        return sprintf('admin_crud_%s_%s', self::transformToRouteName($controllerName), $pageType->value);
     }
 
     public static function generateRoleConstant(string $controllerName, ?string $customRoleConstant = null): string
     {
-        return $customRoleConstant ?? 'ROLE_CRUD_' . strtoupper(self::transformToRouteName($controllerName));
+        return $customRoleConstant ?? (string)new UnicodeString('ROLE_CRUD_' . self::transformToRouteName($controllerName))->upper();
+    }
+
+    /**
+     * Converts PascalCase entity class short name to human-readable singular form (ucfirst).
+     *
+     * Example:
+     *     OrderItem => Order item
+     *     Category => Category
+     */
+    public static function toSingularEntityName(string $entityName): string
+    {
+        $humanized = (string)new UnicodeString($entityName)->snake()->replace('_', ' ');
+
+        return ucfirst(self::getInflector()->singularize($humanized)[0]);
+    }
+
+    /**
+     * Converts PascalCase entity class short name to human-readable plural form (ucfirst).
+     *
+     * Example:
+     *     OrderItem => Order items
+     *     Category => Categories
+     */
+    public static function toPluralEntityName(string $entityName): string
+    {
+        $humanized = (string)new UnicodeString($entityName)->snake()->replace('_', ' ');
+
+        return ucfirst(self::getInflector()->pluralize($humanized)[0]);
     }
 
     /**
      * Remove "CrudController" or "Controller" from controller name to be able to use it with routes
      */
-    public static function getCleanControllerName(string $controllerName): string
+    private static function getCleanControllerName(string $controllerName): string
     {
         return str_replace(['CrudController', 'Controller'], '', $controllerName);
+    }
+
+    private static function getInflector(): EnglishInflector
+    {
+        return self::$inflector ??= new EnglishInflector();
     }
 }

--- a/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
+++ b/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
@@ -35,8 +35,8 @@ final class CrudMenuSubscriber implements EventSubscriberInterface
     {
         $rootMenu = $event->getMenu();
 
-        foreach ($this->crudControllerRegistry->getItems() as $item) {
-            $config = $item->getConfig();
+        foreach ($this->crudControllerRegistry->getAll() as $item) {
+            $config = $item->config;
 
             if ($config->isFullDisabled()) {
                 continue;
@@ -56,7 +56,7 @@ final class CrudMenuSubscriber implements EventSubscriberInterface
                 $menu = $menu->getChild($submenuSection);
             }
 
-            $route = $this->crudRouteProvider->generate($item, ActionType::LIST);
+            $route = $this->crudRouteProvider->getRouteItem($item->controllerClass, ActionType::LIST);
             $parent = $menu->addChild($route->getRouteName(), [
                 'route' => $route->getRouteName(),
                 'display' => $config->isVisibleInMenu(),
@@ -72,7 +72,7 @@ final class CrudMenuSubscriber implements EventSubscriberInterface
                     continue;
                 }
 
-                $route = $this->crudRouteProvider->generate($item, $action);
+                $route = $this->crudRouteProvider->getRouteItem($item->controllerClass, $action);
 
                 $parent->addChild($route->getRouteName(), [
                     'route' => $route->getRouteName(),

--- a/packages/administration/src/Component/Router/CrudControllerRouteLoader.php
+++ b/packages/administration/src/Component/Router/CrudControllerRouteLoader.php
@@ -5,20 +5,13 @@ declare(strict_types=1);
 namespace Shopsys\AdministrationBundle\Component\Router;
 
 use Override;
-use Shopsys\AdministrationBundle\Component\Crud\CrudControllerRegistry;
-use Shopsys\AdministrationBundle\Component\Crud\Definition;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\RouteCollection;
 
 final class CrudControllerRouteLoader extends Loader
 {
-    public const string IS_CRUD_CONTROLLER = '_crud_controller';
-    public const string CRUD_ACTION = '_crud_action';
-    public const string CRUD_ROLE_CONSTANT = '_crud_role_constant';
-
     public function __construct(
-        private readonly CrudControllerRegistry $crudControllerRegistry,
         private readonly CrudRouteProvider $crudRouteProvider,
     ) {
         parent::__construct();
@@ -32,8 +25,8 @@ final class CrudControllerRouteLoader extends Loader
     {
         $routes = new RouteCollection();
 
-        foreach ($this->crudControllerRegistry->getItems() as $item) {
-            $this->addRoutesForController($routes, $item);
+        foreach ($this->crudRouteProvider->getAll() as $routeItem) {
+            $routes->add($routeItem->getRouteName(), $routeItem->getRoute());
         }
 
         return $routes;
@@ -54,21 +47,5 @@ final class CrudControllerRouteLoader extends Loader
     #[Override]
     public function setResolver(LoaderResolverInterface $resolver): void
     {
-        // No implementation needed
-    }
-
-    private function addRoutesForController(RouteCollection $routes, Definition $item): void
-    {
-        foreach ($item->getConfig()->getActions() as $actionType) {
-            $routeItem = $this->crudRouteProvider->generate($item, $actionType);
-
-            $route = $routeItem->getRoute();
-
-            $route->setDefault(self::IS_CRUD_CONTROLLER, true);
-            $route->setDefault(self::CRUD_ACTION, $actionType->value);
-            $route->setDefault(self::CRUD_ROLE_CONSTANT, $item->getRoleConstant());
-
-            $routes->add($routeItem->getRouteName(), $route);
-        }
     }
 }

--- a/packages/administration/src/Component/Router/CrudRouteItem.php
+++ b/packages/administration/src/Component/Router/CrudRouteItem.php
@@ -22,9 +22,13 @@ final class CrudRouteItem
         return $this->controller;
     }
 
+    /**
+     * Returns a clone to prevent mutation of the cached original
+     * (Symfony's RouteCollection::addPrefix() mutates Route objects in place)
+     */
     public function getRoute(): Route
     {
-        return $this->route;
+        return clone $this->route;
     }
 
     public function getRouteName(): string

--- a/packages/administration/src/Component/Router/CrudRouteProvider.php
+++ b/packages/administration/src/Component/Router/CrudRouteProvider.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Shopsys\AdministrationBundle\Component\Router;
 
+use InvalidArgumentException;
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
-use Shopsys\AdministrationBundle\Component\Crud\Definition;
+use Shopsys\AdministrationBundle\Component\Crud\CrudControllerRegistry;
 use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
+use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Symfony\Component\Routing\Route;
 
 final class CrudRouteProvider
 {
+    public const string IS_CRUD_CONTROLLER = '_crud_controller';
+    public const string CRUD_ACTION = '_crud_action';
+    public const string CRUD_ROLE_CONSTANT = '_crud_role_constant';
+
     /**
      * @var array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, array{
      *     path: string,
@@ -46,21 +52,69 @@ final class CrudRouteProvider
         ],
     ];
 
-    public function generate(Definition $item, ActionType $pageType): CrudRouteItem
+    public function __construct(
+        private readonly CrudControllerRegistry $crudControllerRegistry,
+        private readonly InMemoryCache $inMemoryCache,
+    ) {
+    }
+
+    /**
+     * @return array<string, \Shopsys\AdministrationBundle\Component\Router\CrudRouteItem>
+     */
+    public function getAll(): array
     {
-        return new CrudRouteItem(
-            controller: CrudTransformationHelper::generateController($item->controllerClass, $pageType),
-            route: $this->generateRoute($item, $pageType, $item->getConfig()->getRoutePrefix()),
-            routeName: CrudTransformationHelper::generateRouteName($item->controllerName, $pageType),
-            pageType: $pageType,
+        return $this->inMemoryCache->getOrSaveValue(
+            self::class,
+            function () {
+                $routeItems = [];
+
+                foreach ($this->crudControllerRegistry->getAll() as $registryItem) {
+                    foreach ($registryItem->config->getActions() as $actionType) {
+                        $routeItem = $this->createRouteItem(
+                            $registryItem->controllerClass,
+                            $registryItem->controllerName,
+                            $registryItem->config->getRoutePrefix(),
+                            $registryItem->getRoleConstant(),
+                            $actionType,
+                        );
+
+                        $cacheKey = $registryItem->controllerClass . '::' . $actionType->value;
+                        $routeItems[$cacheKey] = $routeItem;
+                    }
+                }
+
+                return $routeItems;
+            },
+            'all',
         );
     }
 
-    private function generateRoute(
-        Definition $item,
-        ActionType $pageType,
+    /**
+     * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
+     */
+    public function getRouteItem(string $controllerClass, ActionType $pageType): CrudRouteItem
+    {
+        $cacheKey = $controllerClass . '::' . $pageType->value;
+        $allRouteItems = $this->getAll();
+
+        if (!isset($allRouteItems[$cacheKey])) {
+            throw new InvalidArgumentException(sprintf(
+                'Route item for controller "%s" and action "%s" not found.',
+                $controllerClass,
+                $pageType->value,
+            ));
+        }
+
+        return $allRouteItems[$cacheKey];
+    }
+
+    private function createRouteItem(
+        string $controllerClass,
+        string $controllerName,
         ?string $routePrefix,
-    ): Route {
+        string $roleConstant,
+        ActionType $pageType,
+    ): CrudRouteItem {
         $routeConfig = self::DEFAULT_ROUTES_CONFIG[$pageType->value];
         $routePath = '/';
 
@@ -68,13 +122,21 @@ final class CrudRouteProvider
             $routePath .= CrudTransformationHelper::transformToRouteUrl(trim($routePrefix, '/')) . '/';
         }
 
-        $routePath .= CrudTransformationHelper::transformToRouteUrl($item->controllerName) . $routeConfig['path'];
+        $routePath .= CrudTransformationHelper::transformToRouteUrl($controllerName) . $routeConfig['path'];
 
-        return new Route(
-            $routePath,
-            [
-                '_controller' => CrudTransformationHelper::generateController($item->controllerClass, $pageType),
-            ],
+        $route = new Route($routePath, [
+            '_controller' => CrudTransformationHelper::generateController($controllerClass, $pageType),
+        ]);
+
+        $route->setDefault(self::IS_CRUD_CONTROLLER, true);
+        $route->setDefault(self::CRUD_ACTION, $pageType->value);
+        $route->setDefault(self::CRUD_ROLE_CONSTANT, $roleConstant);
+
+        return new CrudRouteItem(
+            controller: CrudTransformationHelper::generateController($controllerClass, $pageType),
+            route: $route,
+            routeName: CrudTransformationHelper::generateRouteName($controllerName, $pageType),
+            pageType: $pageType,
         );
     }
 }

--- a/packages/administration/src/Component/Security/AccessControl/RouteAccessControlDataProvider.php
+++ b/packages/administration/src/Component/Security/AccessControl/RouteAccessControlDataProvider.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionException;
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
-use Shopsys\AdministrationBundle\Component\Router\CrudControllerRouteLoader;
+use Shopsys\AdministrationBundle\Component\Router\CrudRouteProvider;
 use Shopsys\AdministrationBundle\Component\Security\Attribute\AttributeProcessor;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Router\AdministrationRouterFactory;
@@ -221,15 +221,15 @@ final class RouteAccessControlDataProvider implements AccessControlDataProviderI
     ): array {
         $reflectionClass = new ReflectionClass($controllerClass);
         $attributeRules = $this->attributeProcessor->processMethod($reflectionClass, $reflectionClass->getMethod($method));
-        $isCrudController = $route->getDefault(CrudControllerRouteLoader::IS_CRUD_CONTROLLER) === true;
+        $isCrudController = $route->getDefault(CrudRouteProvider::IS_CRUD_CONTROLLER) === true;
 
         if (count($attributeRules) > 0 || $isCrudController === false) {
             return $attributeRules;
         }
 
         /** @var \Shopsys\AdministrationBundle\Component\Config\ActionType $action */
-        $action = ActionType::from($route->getDefault(CrudControllerRouteLoader::CRUD_ACTION));
-        $roleConstant = $route->getDefault(CrudControllerRouteLoader::CRUD_ROLE_CONSTANT);
+        $action = ActionType::from($route->getDefault(CrudRouteProvider::CRUD_ACTION));
+        $roleConstant = $route->getDefault(CrudRouteProvider::CRUD_ROLE_CONSTANT);
 
         $crudRules = [];
 

--- a/packages/administration/src/Component/Translation/CrudEntityNameExtractor.php
+++ b/packages/administration/src/Component/Translation/CrudEntityNameExtractor.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Translation;
+
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitor\NameResolver;
+use ReflectionClass;
+use Shopsys\AdministrationBundle\Component\Attributes\CrudController;
+use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
+use SplFileInfo;
+use Twig\Node\Node as TwigNode;
+
+/**
+ * Extracts singular and plural entity names from #[CrudController] attributes for translation.
+ */
+final class CrudEntityNameExtractor implements FileVisitorInterface, NodeVisitor
+{
+    private NodeTraverser $traverser;
+
+    private MessageCatalogue $catalogue;
+
+    private SplFileInfo $file;
+
+    public function __construct()
+    {
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor(new NameResolver());
+        $this->traverser->addVisitor($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
+    {
+        $this->file = $file;
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function enterNode(Node $node): int|Node|null
+    {
+        if (!$node instanceof Class_ || $node->attrGroups === []) {
+            return null;
+        }
+
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($this->isCrudControllerAttribute($attr)) {
+                    $this->extractEntityNames($attr);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isCrudControllerAttribute(Attribute $attr): bool
+    {
+        return $attr->name instanceof FullyQualified
+            && (string)$attr->name === CrudController::class;
+    }
+
+    private function extractEntityNames(Attribute $attr): void
+    {
+        $entityClass = $this->resolveEntityClass($attr);
+
+        if ($entityClass === null || !class_exists($entityClass)) {
+            return;
+        }
+
+        $entityName = (new ReflectionClass($entityClass))->getShortName();
+        $singular = CrudTransformationHelper::toSingularEntityName($entityName);
+        $plural = CrudTransformationHelper::toPluralEntityName($entityName);
+
+        $this->addMessage($singular, $attr->getStartLine());
+        $this->addMessage($plural, $attr->getStartLine());
+    }
+
+    private function resolveEntityClass(Attribute $attr): ?string
+    {
+        foreach ($attr->args as $arg) {
+            $isEntityClassArg = ($arg->name !== null && $arg->name->name === 'entityClass')
+                || ($arg->name === null);
+
+            if ($isEntityClassArg && $arg->value instanceof Node\Expr\ClassConstFetch) {
+                return (string)$arg->value->class;
+            }
+        }
+
+        return null;
+    }
+
+    private function addMessage(string $messageId, int $line): void
+    {
+        $message = new Message($messageId);
+        $message->addSource(new FileSource($this->file->getFilename(), $line));
+
+        $this->catalogue->add($message);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function beforeTraverse(array $nodes): ?array
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function leaveNode(Node $node): int|Node|null
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function afterTraverse(array $nodes): ?array
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue): null
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast): null
+    {
+        return null;
+    }
+}

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -19,12 +19,14 @@ use Shopsys\AdministrationBundle\Component\Datagrid\DatagridFactory;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
 use Throwable;
 
+#[AutoconfigureTag('shopsys.admin.crud_controllers')]
 abstract class AbstractCrudController extends AdminBaseController
 {
     protected Definition $definition;

--- a/packages/administration/src/Controller/AbstractCrudControllerExtension.php
+++ b/packages/administration/src/Controller/AbstractCrudControllerExtension.php
@@ -9,7 +9,9 @@ use Shopsys\AdministrationBundle\Component\Config\ActionsConfig;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
+#[AutoconfigureTag('shopsys.admin.crud_controllers')]
 abstract class AbstractCrudControllerExtension extends AdminBaseController
 {
     public function configure(CrudConfig $config): void

--- a/packages/administration/tests/Unit/Component/Crud/Helper/CrudTransformationHelperTest.php
+++ b/packages/administration/tests/Unit/Component/Crud/Helper/CrudTransformationHelperTest.php
@@ -51,7 +51,7 @@ class CrudTransformationHelperTest extends TestCase
             ],
             'ABCController with consecutive capitals' => [
                 'controllerName' => 'ABCController',
-                'expectedRouteName' => 'a_b_c',
+                'expectedRouteName' => 'abc',
             ],
             'class name without suffix' => [
                 'controllerName' => 'PriceList',
@@ -145,7 +145,7 @@ class CrudTransformationHelperTest extends TestCase
             ],
             'ABCController with consecutive capitals' => [
                 'controllerName' => 'ABCController',
-                'expectedRouteUrl' => 'a-b-c',
+                'expectedRouteUrl' => 'abc',
             ],
             'class name without suffix' => [
                 'controllerName' => 'PriceList',
@@ -154,43 +154,47 @@ class CrudTransformationHelperTest extends TestCase
         ];
     }
 
-    #[DataProvider('getCleanControllerNameDataProvider')]
-    public function testGetCleanControllerName(string $controllerName, string $expectedCleanName): void
-    {
-        $result = CrudTransformationHelper::getCleanControllerName($controllerName);
+    #[DataProvider('generateRoleConstantDataProvider')]
+    public function testGenerateRoleConstant(
+        string $controllerName,
+        ?string $customRoleConstant,
+        string $expectedRoleConstant,
+    ): void {
+        $result = CrudTransformationHelper::generateRoleConstant($controllerName, $customRoleConstant);
 
-        $this->assertSame($expectedCleanName, $result);
+        $this->assertSame($expectedRoleConstant, $result);
     }
 
     /**
-     * @return array<string, array{controllerName: string, expectedCleanName: string}>
+     * @return array<string, array{controllerName: string, customRoleConstant: string|null, expectedRoleConstant: string}>
      */
-    public static function getCleanControllerNameDataProvider(): array
+    public static function generateRoleConstantDataProvider(): array
     {
         return [
-            'removes CrudController suffix' => [
-                'controllerName' => 'ProductCrudController',
-                'expectedCleanName' => 'Product',
+            'generates from controller name' => [
+                'controllerName' => 'OrderController',
+                'customRoleConstant' => null,
+                'expectedRoleConstant' => 'ROLE_CRUD_ORDER',
             ],
-            'removes Controller suffix' => [
-                'controllerName' => 'OrdersController',
-                'expectedCleanName' => 'Orders',
-            ],
-            'prefers CrudController over Controller' => [
-                'controllerName' => 'UserRoleCrudController',
-                'expectedCleanName' => 'UserRole',
-            ],
-            'handles name without suffix' => [
-                'controllerName' => 'SimpleClass',
-                'expectedCleanName' => 'SimpleClass',
-            ],
-            'handles PriceList example' => [
+            'generates from multi-word controller name' => [
                 'controllerName' => 'PriceListController',
-                'expectedCleanName' => 'PriceList',
+                'customRoleConstant' => null,
+                'expectedRoleConstant' => 'ROLE_CRUD_PRICE_LIST',
             ],
-            'handles empty suffix removal' => [
-                'controllerName' => 'Admin',
-                'expectedCleanName' => 'Admin',
+            'generates from CrudController suffix' => [
+                'controllerName' => 'UserRoleCrudController',
+                'customRoleConstant' => null,
+                'expectedRoleConstant' => 'ROLE_CRUD_USER_ROLE',
+            ],
+            'uses custom role constant when provided' => [
+                'controllerName' => 'OrderController',
+                'customRoleConstant' => 'ROLE_CUSTOM_ORDER',
+                'expectedRoleConstant' => 'ROLE_CUSTOM_ORDER',
+            ],
+            'custom role constant takes priority' => [
+                'controllerName' => 'PriceListController',
+                'customRoleConstant' => 'ROLE_PRICING',
+                'expectedRoleConstant' => 'ROLE_PRICING',
             ],
         ];
     }

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -16,9 +16,6 @@ msgstr "%defaultCurrency% za 1 %currentCurrency%"
 msgid "%defaultCurrency% per unit"
 msgstr "%defaultCurrency% za 1 jednotku"
 
-msgid "%entity_name% Overview"
-msgstr "Přehled %entity_name%"
-
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr "<a href=\"%url%\">Zpět</a> na přihlašovací stránku."
 
@@ -2151,9 +2148,6 @@ msgstr "Velmi slabé"
 
 msgid "View allowed recipients."
 msgstr "Zobrazit povolené příjemce."
-
-msgid "Viewing %entity_name%"
-msgstr "Detail %entity_name%"
 
 msgid "Visibility and sellability for unlogged customers"
 msgstr "Viditelnost a prodejnost pro neregistrované zákazníky"

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -1150,9 +1150,6 @@ msgstr "Název"
 msgid "Navigation"
 msgstr "Navigace"
 
-msgid "New"
-msgstr "Vytvořit"
-
 msgid "New SEO page"
 msgstr "Nová SEO stránka"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -1150,9 +1150,6 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-msgid "New"
-msgstr ""
-
 msgid "New SEO page"
 msgstr ""
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -16,9 +16,6 @@ msgstr ""
 msgid "%defaultCurrency% per unit"
 msgstr ""
 
-msgid "%entity_name% Overview"
-msgstr ""
-
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr ""
 
@@ -2150,9 +2147,6 @@ msgid "Very Weak"
 msgstr ""
 
 msgid "View allowed recipients."
-msgstr ""
-
-msgid "Viewing %entity_name%"
 msgstr ""
 
 msgid "Visibility and sellability for unlogged customers"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -16,9 +16,6 @@ msgstr "%defaultCurrency% za 1 %currentCurrency%"
 msgid "%defaultCurrency% per unit"
 msgstr "%defaultCurrency% za jednotku"
 
-msgid "%entity_name% Overview"
-msgstr "Prehľad %entity_name%"
-
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr "<a href=\"%url%\">Späť</a> na prihlasovaciu stránku."
 
@@ -2151,9 +2148,6 @@ msgstr "Veľmi slabé"
 
 msgid "View allowed recipients."
 msgstr "Zobraziť povolených príjemcov."
-
-msgid "Viewing %entity_name%"
-msgstr "Zobrazenie %entity_name%"
 
 msgid "Visibility and sellability for unlogged customers"
 msgstr "Viditeľnosť a predateľnosť pre neprihlásených zákazníkov"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -1150,9 +1150,6 @@ msgstr "Názov"
 msgid "Navigation"
 msgstr "Navigácia"
 
-msgid "New"
-msgstr "Nový"
-
 msgid "New SEO page"
 msgstr "Nová SEO stránka"
 

--- a/upgrade-notes/backend_20260417_163043.md
+++ b/upgrade-notes/backend_20260417_163043.md
@@ -1,0 +1,10 @@
+#### [CRUD] fix translations ([#4527](https://github.com/shopsys/shopsys/pull/4527))
+
+- method `getItems()` in `Shopsys\AdministrationBundle\Component\Crud\CrudControllerRegistry` was renamed to `getAll()` and now returns `Shopsys\AdministrationBundle\Component\Crud\CrudRegistryItem[]` instead of `Shopsys\AdministrationBundle\Component\Crud\Definition[]`
+    - access config via `$item->config` property, controller class via `$item->controllerClass`, entity class via `$item->entityClass`
+- method `getItem()` in `Shopsys\AdministrationBundle\Component\Crud\CrudControllerRegistry` was renamed to `getDefinition()`
+- method `generate()` in `Shopsys\AdministrationBundle\Component\Router\CrudRouteProvider` was replaced by `getRouteItem(string $controllerClass, ActionType $pageType)` - pass the controller class string instead of a `Shopsys\AdministrationBundle\Component\Crud\Definition` object
+- constants `IS_CRUD_CONTROLLER`, `CRUD_ACTION`, and `CRUD_ROLE_CONSTANT` have been moved from `Shopsys\AdministrationBundle\Component\Router\CrudControllerRouteLoader` to `Shopsys\AdministrationBundle\Component\Router\CrudRouteProvider`
+- property `$menuTitle` in `Shopsys\AdministrationBundle\Component\Config\CrudConfig` is now private - use `setMenuTitle()` method instead of direct property access
+- method `getCleanControllerName()` in `Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper` is now private - use `transformToRouteName()` or `transformToRouteUrl()` instead
+- route names for CRUD controllers with consecutive capital letters in their name changed (e.g., `ABCController` now generates route name `abc` instead of `a_b_c`) - if you reference such routes by name, update them accordingly


### PR DESCRIPTION
#### Description, the reason for the PR

Separates CRUD route loading and role provision from request-time definition building to fix locale/translation issues. Previously, `CrudControllerRouteLoader::load()` triggered `getItems()` which built full
  Definition objects — including `t()` translations — during route compilation before the request locale was set. This caused all translated strings to be cached with the default locale.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














----
:globe_with_meridians: Live Preview:
  - https://jg-crud-translations-fix.odin.shopsys.cloud
  - https://cz.jg-crud-translations-fix.odin.shopsys.cloud
  - https://jg-crud-translations-fix.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776437660.335019 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-crud-translations-fix.odin.shopsys.cloud
  - https://cz.jg-crud-translations-fix.odin.shopsys.cloud
  - https://jg-crud-translations-fix.odin.shopsys.cloud/sk
<!-- Replace -->
