### PR TITLE
admin: product edit TOC now use only card-title H3 to render items

### DIFF
--- a/packages/framework/assets/js/admin/components/Product.js
+++ b/packages/framework/assets/js/admin/components/Product.js
@@ -14,7 +14,7 @@ export default class Product {
         const $productDetailNavigation = $container.find('.toc .nav');
         const sections = [];
 
-        $('#product_form h3').each(function () {
+        $('#product_form h3.card-title').each(function () {
             const $title = $(this);
 
             const $navigationItem = $(`<span class="nav-link cursor-pointer">${$title.text()}</span>`);


### PR DESCRIPTION
#### Description, the reason for the PR

Fixes an issue when any H3 placed into the description would render as a table of contents item.

This was, for example, in demo data http://127.0.0.1:8000/admin/product/edit/2

<img width="841" height="968" alt="Snímek obrazovky 2026-03-27 v 19 42 44" src="https://github.com/user-attachments/assets/0f540878-7588-480d-8791-bc9ab639e1ce" />

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-admin-product-toc-fix.odin.shopsys.cloud
  - https://cz.mg-admin-product-toc-fix.odin.shopsys.cloud
  - https://mg-admin-product-toc-fix.odin.shopsys.cloud/sk
<!-- Replace -->
