### PR TITLE
[CRUD] Menu icon can be set for CrudController

### DIFF
--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -110,24 +110,9 @@ The `CrudConfig` class is used to configure the behavior of the Crud Controller.
 
 This method allows you to set the title for the given page type. The title is displayed in the page header.
 
-#### `setMenuSection(string $menuSection, ?string $submenuSection = null)`
-
-You can specify where the Crud Controller will be displayed in the administration menu.
-
-`$menuSection` is the name of the root-level menu item.
-`$submenuSection` can be used to specify a submenu item.
-
-Examples:
-- `$config->setMenuSection('products')` will create Crud controller item under `Products` section
-- `$config->setMenuSection('customers', 'promo_codes')` will create Crud controller under `Customers -> Promo Codes` section
-
-#### `visibleInMenu(bool $visible)`
-
-Specify if the CRUD Controller should be visible or not in the administration menu. This can be useful if you want to create a controller that is not directly accessible by the user or should be accessed from another controller.
-
 #### `enableAction(ActionType|array $actions)` and `disableAction(ActionType|array $actions)`
 
-Those methods are used to enable or disable actions for the given entity. 
+Those methods are used to enable or disable actions for the given entity.
 
 If you want for example to disable the `delete` action you can simply call `$config->disableAction(ActionType::DELETE)`.
 
@@ -138,10 +123,6 @@ If you want for example to disable the `delete` action you can simply call `$con
 #### `disable(bool $disabled)`
 
 Fully disable the CRUD Controller that will not be accessible by the user.
-
-#### `setRoutePrefix(string $routePrefix)`
-
-Set a prefix for the CRUD Controller routes. The prefix is added to the base URL of the CRUD Controller.
 
 #### `setCustomRoleConstant(?string $roleConstant)`
 
@@ -155,6 +136,9 @@ By default, Menu section is used as role section. If you want to use a custom ro
 
 Role sections can be found in the `Shopsys\AdministrationBundle\Component\Security\Role\AdminRoleSectionsProvider` class.
 
+#### `setRoutePrefix(string $routePrefix)`
+
+Set a prefix for the CRUD Controller routes. The prefix is added to the base URL of the CRUD Controller.
 
 Example:
 
@@ -170,3 +154,32 @@ Example:
 ```
 
 The URL for the `list` action will be `/admin/new/products/` instead of `/admin/products/`.
+
+
+#### `visibleInMenu(bool $visible)`
+
+Specify if the CRUD Controller should be visible or not in the administration menu. This can be useful if you want to create a controller that is not directly accessible by the user or should be accessed from another controller.
+
+#### `setMenuSection(string $menuSection, ?string $submenuSection = null)`
+
+You can specify where the Crud Controller will be displayed in the administration menu.
+
+`$menuSection` is the name of the root-level menu item.
+`$submenuSection` can be used to specify a submenu item.
+
+Examples:
+- `$config->setMenuSection('products')` will create Crud controller item under `Products` section
+- `$config->setMenuSection('customers', 'promo_codes')` will create Crud controller under `Customers -> Promo Codes` section
+
+#### `setMenuIcon(string $icon)`
+
+Set an icon for the root-level CRUD menu item created by this controller. The icon is only applied when the controller is placed directly under the menu root (i.e. when `menuSection` is the root).
+Icons are not used for CRUD items in nested menu sections.
+
+Example:
+
+```php
+$config
+    ->setMenuIcon('cart')
+;
+```

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -38,6 +38,8 @@ final class CrudConfig
 
     private ?string $customRoleSection = null;
 
+    private ?string $menuIcon = null;
+
     /**
      * @var array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, class-string<\Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface>|null>
      */
@@ -211,6 +213,18 @@ final class CrudConfig
     }
 
     /**
+     * Set icon for root-level menu item. Only applicable when menu section is 'root' (1st level).
+     *
+     * @return $this
+     */
+    public function setMenuIcon(string $icon): self
+    {
+        $this->menuIcon = $icon;
+
+        return $this;
+    }
+
+    /**
      * @template T of \Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface
      *
      * Register handler class or classes for CRUD actions.
@@ -296,6 +310,7 @@ final class CrudConfig
             $this->customRoleConstant,
             $this->customRoleSection,
             $this->handlerClasses,
+            $this->menuIcon,
         );
     }
 }

--- a/packages/administration/src/Component/Config/CrudConfigData.php
+++ b/packages/administration/src/Component/Config/CrudConfigData.php
@@ -25,6 +25,7 @@ final readonly class CrudConfigData
         private ?string $customRoleConstant,
         private ?string $customRoleSection,
         private array $handlerClasses,
+        private ?string $menuIcon,
     ) {
         foreach ($this->enabledActions as $action) {
             if (array_key_exists($action->value, $this->handlerClasses) && $this->handlerClasses[$action->value] === null) {
@@ -104,5 +105,10 @@ final readonly class CrudConfigData
     public function getHandlerClasses(): array
     {
         return $this->handlerClasses;
+    }
+
+    public function getMenuIcon(): ?string
+    {
+        return $this->menuIcon;
     }
 }

--- a/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
+++ b/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
@@ -63,6 +63,10 @@ final class CrudMenuSubscriber implements EventSubscriberInterface
                 'label' => $config->getMenuTitle(),
             ]);
 
+            if ($config->getMenuIcon() !== null && $menu === $rootMenu) {
+                $parent->setExtra('icon', $config->getMenuIcon());
+            }
+
             foreach ($config->getActions() as $action) {
                 if ($action === ActionType::DELETE) {
                     continue;


### PR DESCRIPTION
#### Description, the reason for the PR
... 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://jg-crud-menu-icon.odin.shopsys.cloud
  - https://cz.jg-crud-menu-icon.odin.shopsys.cloud
  - https://jg-crud-menu-icon.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776260998.102239 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-crud-menu-icon.odin.shopsys.cloud
  - https://cz.jg-crud-menu-icon.odin.shopsys.cloud
  - https://jg-crud-menu-icon.odin.shopsys.cloud/sk
<!-- Replace -->
