### PR TITLE
ignored security advisory for not-patched-yet dependency hybridauth/hybridauth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -246,6 +246,11 @@
         }
     },
     "config": {
+        "audit": {
+            "ignore": {
+                "CVE-2026-4587": "No fix yet, see https://github.com/advisories/GHSA-r3hf-q3mf-7h6w"
+            }
+        },
         "preferred-install": "dist",
         "component-dir": "project-base/app/web/components",
         "sort-packages": true,

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -56,6 +56,11 @@
         "shopsys/coding-standards": "19.0.x-dev"
     },
     "config": {
+        "audit": {
+            "ignore": {
+                "CVE-2026-4587": "No fix yet, see https://github.com/advisories/GHSA-r3hf-q3mf-7h6w"
+            }
+        },
         "allow-plugins": {
             "symfony/flex": true,
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -169,6 +169,11 @@
         "security-check": "security-checker security:check"
     },
     "config": {
+        "audit": {
+            "ignore": {
+                "CVE-2026-4587": "No fix yet, see https://github.com/advisories/GHSA-r3hf-q3mf-7h6w"
+            }
+        },
         "process-timeout": 1200,
         "preferred-install": "dist",
         "component-dir": "web/components",


### PR DESCRIPTION
#### Description, the reason for the PR

CVE found in the hybridauth/hybridauth is not yet resolved. This PR adds it into audit ignore, so the Platform may be installed. 
Next steps would follow.

see:
- https://github.com/advisories/GHSA-r3hf-q3mf-7h6w
- https://github.com/hybridauth/hybridauth/issues/1444

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-ignore-advisory.odin.shopsys.cloud
  - https://cz.mg-ignore-advisory.odin.shopsys.cloud
  - https://mg-ignore-advisory.odin.shopsys.cloud/sk
<!-- Replace -->
