### PR TITLE
[GrapesJS] fix cross-domain template loading blocked by CSP

### DIFF
--- a/packages/administration/templates/form/type/GrapesJsType.html.twig
+++ b/packages/administration/templates/form/type/GrapesJsType.html.twig
@@ -1,16 +1,10 @@
 {% block grapes_js_widget %}
-    {% set domainByLocale = '' %}
-
-    {% if attr['data-locale'] is defined %}
-        {% set domainByLocale = getDomainUrlByLocale(attr['data-locale']) %}
-    {% endif %}
-
     <div class="d-none">{{ form_widget(form) }}</div>
     <button
             type="button"
             class="btn btn-info js-grapesjs-button"
             data-textarea-id="{{ form.vars.id }}"
-            data-template-url="{{ domainByLocale ~ constant('Shopsys\\FrameworkBundle\\Form\\GrapesJsType::GRAPESJS_TEMPLATE_PATH') }}"
+            data-template-url="{{ constant('Shopsys\\FrameworkBundle\\Form\\GrapesJsType::GRAPESJS_TEMPLATE_PATH') }}"
             data-elfinder-url="{{ url('elfinder', {instance: 'grapesJs'}) }}"
             data-allow-products="{{ form.vars.allow_products ? 'true':'false' }}"
     >

--- a/packages/framework/src/Twig/DomainExtension.php
+++ b/packages/framework/src/Twig/DomainExtension.php
@@ -8,7 +8,6 @@ use Override;
 use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -30,7 +29,6 @@ class DomainExtension extends AbstractExtension
             new TwigFunction('getDomain', $this->getDomain(...)),
             new TwigFunction('getDomainName', $this->getDomainNameById(...)),
             new TwigFunction('isMultidomain', $this->isMultidomain(...)),
-            new TwigFunction('getDomainUrlByLocale', $this->getDomainUrlByLocale(...)),
             new TwigFunction('getFirstDomain', $this->getFirstDomainConfig(...)),
             new TwigFunction('getDomainsCount', $this->getDomainsCount(...)),
         ];
@@ -54,17 +52,6 @@ class DomainExtension extends AbstractExtension
     public function isMultidomain(): bool
     {
         return $this->getDomain()->isMultidomain();
-    }
-
-    public function getDomainUrlByLocale(string $locale): string
-    {
-        foreach ($this->domain->getAll() as $domain) {
-            if ($domain->getLocale() === $locale) {
-                return $domain->getUrl();
-            }
-        }
-
-        throw new NoDomainSelectedException('Domain for locale `' . $locale . '` not found;');
     }
 
     public function getFirstDomainConfig(): DomainConfig

--- a/upgrade-notes/backend_20260327_211343.md
+++ b/upgrade-notes/backend_20260327_211343.md
@@ -1,0 +1,4 @@
+#### [GrapesJS] fix cross-domain template loading blocked by CSP ([#4531](https://github.com/shopsys/shopsys/pull/4531))
+
+- Twig function `getDomainUrlByLocale` has been removed from `\Shopsys\FrameworkBundle\Twig\DomainExtension` along with its backing method
+    - if you used this Twig function in your templates, replace it with your own implementation or use the existing `getDomain` / `getFirstDomain` Twig functions instead


### PR DESCRIPTION
#### Description, the reason for the PR

When editing multilocale blog article descriptions (or any GrapesJS field), the template URL was resolved per-locale to the corresponding domain (e.g., `https://example.cz/grapesjs-template`).
Since the admin always runs on the first domain (`https://example.com`), this resulted in a cross-origin AJAX request that was blocked by the `Content-Security-Policy` `connect-src` directive introduced in #4447.

Loading an arbitrary domain template based on the locale is just slightly better than use first domain every time.
The fix changes the template URL to a relative path (`/grapesjs-template`), which always resolves against the current (admin) domain, avoiding any cross-origin requests.

The now-unused `getDomainUrlByLocale` Twig function and its backing method in `DomainExtension` have been removed.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://mg-grapes-other-domain.odin.shopsys.cloud
  - https://cz.mg-grapes-other-domain.odin.shopsys.cloud
  - https://mg-grapes-other-domain.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1775127911.727559 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-grapes-other-domain.odin.shopsys.cloud
  - https://cz.mg-grapes-other-domain.odin.shopsys.cloud
  - https://mg-grapes-other-domain.odin.shopsys.cloud/sk
<!-- Replace -->
