### PR TITLE
Fixed demo payment transaction statuses to prevent cron errors

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/PaymentTransactionDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/PaymentTransactionDataFixture.php
@@ -25,11 +25,11 @@ class PaymentTransactionDataFixture extends AbstractReferenceFixture implements 
     public function load(ObjectManager $manager): void
     {
         $order = $this->getReference(OrderDataFixture::ORDER_WITH_GOPAY_PAYMENT_1, Order::class);
-        $this->createPaymentTransaction($order, 'TR-123456', PaymentStatus::CREATED);
+        $this->createPaymentTransaction($order, 'TR-123456', PaymentStatus::CANCELED);
 
         $order = $this->getReference(OrderDataFixture::ORDER_WITH_GOPAY_PAYMENT_14, Order::class);
-        $this->createPaymentTransaction($order, '12454321', PaymentStatus::CREATED);
-        $this->createPaymentTransaction($order, '52467431', PaymentStatus::CREATED);
+        $this->createPaymentTransaction($order, '12454321', PaymentStatus::TIMEOUTED);
+        $this->createPaymentTransaction($order, '52467431', PaymentStatus::CANCELED);
     }
 
     /**

--- a/upgrade-notes/backend_20260327_213956.md
+++ b/upgrade-notes/backend_20260327_213956.md
@@ -1,0 +1,3 @@
+#### Fixed demo data payment transaction statuses to prevent cron errors ([#4532](https://github.com/shopsys/shopsys/pull/4532))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Demo data payment transactions were created with `CREATED` status, causing the GoPay cron job to attempt updating non-existing payment transactions and fail. Changed statuses to final ones (`CANCELED`, `TIMEOUTED`) so the cron skips them.

#### Fixes issues


#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







----
:globe_with_meridians: Live Preview:
  - https://mg-demo-data-gopay.odin.shopsys.cloud
  - https://cz.mg-demo-data-gopay.odin.shopsys.cloud
  - https://mg-demo-data-gopay.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1774859879.760439 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-demo-data-gopay.odin.shopsys.cloud
  - https://cz.mg-demo-data-gopay.odin.shopsys.cloud
  - https://mg-demo-data-gopay.odin.shopsys.cloud/sk
<!-- Replace -->
