### PR TITLE
Fixed running console commands with --profile option

### DIFF
--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -8,6 +8,7 @@ use Override;
 use PharIo\Version\Version;
 use Shopsys\FrameworkBundle\Component\Context\AdminContext;
 use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
+use Shopsys\FrameworkBundle\Component\Context\FrontendApiContext;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
@@ -40,17 +41,17 @@ class ShopsysFrameworkDataCollector extends DataCollector
             'systemTimeZone' => date_default_timezone_get(),
         ];
 
-        if ($this->contextResolver->isCurrentContext(AdminContext::class)) {
-            $this->data['inAdmin'] = true;
-            $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneForAdmin()->getName();
-            $this->data['adminLocale'] = $this->administratorLocalizationFacade->getCurrentAdminLocaleOrDefault();
-            $this->data['currentDomainId'] = 0;
-        } else {
+        if ($this->contextResolver->isCurrentContext(FrontendApiContext::class)) {
             $this->data['inAdmin'] = false;
             $this->data['currentDomainId'] = $this->domain->getId();
             $this->data['currentDomainName'] = $this->domain->getName();
             $this->data['currentDomainLocale'] = $this->domain->getLocale();
             $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName();
+        } else {
+            $this->data['inAdmin'] = $this->contextResolver->isCurrentContext(AdminContext::class);
+            $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneForAdmin()->getName();
+            $this->data['adminLocale'] = $this->administratorLocalizationFacade->getCurrentAdminLocaleOrDefault();
+            $this->data['currentDomainId'] = 0;
         }
     }
 


### PR DESCRIPTION
#### Description, the reason for the PR

Running any console command with Symfony's `--profile` option caused a crash because the profiler's data collector tried to read the current domain outside of a request context, where no domain is set.

The data collector now only reads domain-specific information when running in the FrontendApi context, where the current domain is always reliably available. In all other contexts (admin, console), it falls back to non-domain-specific data collection. This makes the `--profile` option usable for debugging console commands.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-profile.odin.shopsys.cloud
  - https://cz.mg-fix-profile.odin.shopsys.cloud
  - https://mg-fix-profile.odin.shopsys.cloud/sk
<!-- Replace -->
