### PR TITLE
Fix child form attr defaults being overridden in MultidomainType

### DIFF
--- a/packages/form-types-bundle/src/MultidomainType.php
+++ b/packages/form-types-bundle/src/MultidomainType.php
@@ -41,7 +41,6 @@ final class MultidomainType extends AbstractType
                 $domainOptions = $entryOptions;
             }
 
-            $domainOptions['attr']['data-domain-id'] = $domainId;
             $domainOptions['label'] = false;
 
             $builder->add((string)$domainId, $options['entry_type'], $domainOptions);
@@ -61,6 +60,14 @@ final class MultidomainType extends AbstractType
         ]);
 
         $resolver->setAllowedValues('display_mode', ['stacked', 'columns']);
+    }
+
+    #[Override]
+    public function finishView(FormView $view, FormInterface $form, array $options): void
+    {
+        foreach ($view->children as $domainId => $childView) {
+            $childView->vars['attr']['data-domain-id'] = $domainId;
+        }
     }
 
     /**


### PR DESCRIPTION
#### Description, the reason for the PR

When a form type with default HTML attributes was used as  `entry_type` inside `MultidomainType` (e.g. `DatePickerType` which sets `data-js-datepicker`), those attributes were silently dropped. As a result, the datepicker JavaScript behavior never activated for multidomain  date fields. 
                           
The root cause was that `MultidomainType` set `data-domain-id` via form options in `buildForm()`, which caused Symfony's OptionsResolver to use that explicitly-passed `attr` array instead of the entry type's defaults. Moving the `data-domain-id` injection to `finishView()` after the child view is fully built ensures both the entry type's own attributes and `data-domain-id` are present on the rendered input. 

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-multidomain-attr.odin.shopsys.cloud
  - https://cz.rv-fix-multidomain-attr.odin.shopsys.cloud
  - https://rv-fix-multidomain-attr.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1775651808.866259 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-multidomain-attr.odin.shopsys.cloud
  - https://cz.rv-fix-multidomain-attr.odin.shopsys.cloud
  - https://rv-fix-multidomain-attr.odin.shopsys.cloud/sk
<!-- Replace -->
