### PR TITLE
Symfony profiler: add Shopsys panel with domain and context details

### DIFF
--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\Collector;
 use Override;
 use PharIo\Version\Version;
 use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Context\ConsoleContext;
 use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
 use Shopsys\FrameworkBundle\Component\Context\FrontendApiContext;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -37,21 +38,27 @@ class ShopsysFrameworkDataCollector extends DataCollector
         $this->data = [
             'version' => ShopsysFrameworkBundle::VERSION,
             'docsVersion' => $this->resolveDocsVersion(ShopsysFrameworkBundle::VERSION),
+            'docsUrl' => sprintf('https://docs.shopsys.com/en/%s/', $this->resolveDocsVersion(ShopsysFrameworkBundle::VERSION)),
             'domains' => $this->domain->getAll(),
             'systemTimeZone' => date_default_timezone_get(),
+            'inAdmin' => false,
+            'currentContext' => $this->resolveCurrentContext(),
+            'currentDomainId' => 0,
+            'currentDomainName' => 'N/A',
+            'currentDomainLocale' => 'N/A',
+            'adminLocale' => 'N/A',
+            'displayTimeZone' => 'N/A',
         ];
 
         if ($this->contextResolver->isCurrentContext(FrontendApiContext::class)) {
-            $this->data['inAdmin'] = false;
             $this->data['currentDomainId'] = $this->domain->getId();
             $this->data['currentDomainName'] = $this->domain->getName();
             $this->data['currentDomainLocale'] = $this->domain->getLocale();
             $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName();
-        } else {
-            $this->data['inAdmin'] = $this->contextResolver->isCurrentContext(AdminContext::class);
-            $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneForAdmin()->getName();
+        } elseif ($this->contextResolver->isCurrentContext(AdminContext::class)) {
+            $this->data['inAdmin'] = true;
             $this->data['adminLocale'] = $this->administratorLocalizationFacade->getCurrentAdminLocaleOrDefault();
-            $this->data['currentDomainId'] = 0;
+            $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneForAdmin()->getName();
         }
     }
 
@@ -97,9 +104,31 @@ class ShopsysFrameworkDataCollector extends DataCollector
         return $this->data['inAdmin'];
     }
 
+    public function getCurrentContext(): string
+    {
+        return $this->data['currentContext'];
+    }
+
     public function getAdminLocale(): string
     {
         return $this->data['adminLocale'];
+    }
+
+    protected function resolveCurrentContext(): string
+    {
+        if ($this->contextResolver->isCurrentContext(AdminContext::class)) {
+            return 'Administration';
+        }
+
+        if ($this->contextResolver->isCurrentContext(FrontendApiContext::class)) {
+            return 'Frontend API';
+        }
+
+        if ($this->contextResolver->isCurrentContext(ConsoleContext::class)) {
+            return 'Console';
+        }
+
+        return 'Unknown';
     }
 
     /**
@@ -114,6 +143,11 @@ class ShopsysFrameworkDataCollector extends DataCollector
     public function getDocsVersion(): string
     {
         return $this->data['docsVersion'];
+    }
+
+    public function getDocsUrl(): string
+    {
+        return $this->data['docsUrl'];
     }
 
     public function getSystemTimeZone(): string

--- a/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
+++ b/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
@@ -55,10 +55,103 @@
         <div class="sf-toolbar-info-group">
             <div class="sf-toolbar-info-piece">
                 <b>Resources</b>
-                <span><a href="https://docs.shopsys.com/en/{{ collector.docsVersion }}/" target="_blank" rel="help">Documentation</a></span>
+                <span><a href="{{ collector.docsUrl }}" target="_blank" rel="help">Documentation</a></span>
             </div>
         </div>
     {% endset %}
 
-    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with {'link': false, additional_classes: 'sf-toolbar-block-right'} %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with {'link': true, additional_classes: 'sf-toolbar-block-right'} %}
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+        <span class="icon">
+            <img width="24" height="24" alt="Shopsys" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAMAAADXqc3KAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAXFQTFRFAAAA////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////iIJ5mQAAAHt0Uk5TAAnGsIhGFAEO//zbdQwHe5O5+P7aNGlyE3Hh9mQEWezmYAVKvUUK8v2nJBK8zzflNaBssmP7HVXYA15qyxYPfKGij/mUAlbvX3jE87OL+u7wgFepF6qX05mlwI6SuEyuGXm0hy2twtIfnWvDPVj0Wm0aS8rZqH9dYZvJigjPOQAAAVJJREFUeJxtUmdXwkAQPCzgBkRNFKMRghEJgliioQgCirGLLfaGgl2w119v7hIkPJwPt5O5ncztvUOoCktDY1Oz1Ybq0AIAlN3RWrfhbGvvoIHp7KpRXd1OXNieXuD63FXdw3v7CREGfOAdrMh+jxgYChofoWEIj1T6RyEc/HOP0dS4ziQRJiymvElZjuAa5ZmY0W+L4zVihylcExyTnCZ6SkoLeDsDM+Qgs1mYUzCbX+AWsWcJlhFr9SPFsQKr2MOuQS6tzRNdT6INZhMh91YWtlXs2QF6l+SgPdjXVsXB8S4yeYbOkRx0AIck5+g4RBrZE9BzTuWcar6z1BlkJWzJx+DcrF8AJRGmFALeYlW/BL4g6Dx4Bdc3hq7egnwnVLqKItw/6LRU1v9v4LEM8tMzHt1dkswHib+8ytTb+8enRgVUg3yC0x6CiP6B+vXt+zELv8X1L+4rtB6IAAAAAElFTkSuQmCC" />
+        </span>
+        <strong>Shopsys</strong>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h1>Shopsys Framework</h1>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.version }}</span>
+            <span class="label">Version</span>
+        </div>
+        <div class="metric">
+            <span class="value">{{ collector.systemTimeZone }}</span>
+            <span class="label">System TimeZone</span>
+        </div>
+        <div class="metric">
+            <span class="value">{{ collector.displayTimeZone }}</span>
+            <span class="label">Display TimeZone</span>
+        </div>
+    </div>
+
+    <h2>Data</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Key</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Context</td>
+                <td>{{ collector.currentContext }}</td>
+            </tr>
+            {% if collector.inAdmin %}
+                <tr>
+                    <td>Admin locale</td>
+                    <td>{{ collector.adminLocale }}</td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td>Current domain</td>
+                    <td>{{ collector.currentDomainName }} (ID: {{ collector.currentDomainId }})</td>
+                </tr>
+                <tr>
+                    <td>Locale</td>
+                    <td>{{ collector.currentDomainLocale }}</td>
+                </tr>
+            {% endif %}
+        </tbody>
+    </table>
+
+    <h2>Available Domains</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Locale</th>
+                <th>Type</th>
+                <th>URL</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for domain in collector.domains %}
+                <tr{% if domain.id is same as(collector.currentDomainId) %} class="status-success"{% endif %}>
+                    <td>{{ domain.id }}</td>
+                    <td>{{ domain.name }}</td>
+                    <td>{{ domain.locale }}</td>
+                    <td>{{ domain.type }}</td>
+                    <td><a href="{{ domain.url }}" target="_blank" rel="noopener">{{ domain.url }}</a></td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <h2>Resources</h2>
+    <table>
+        <tbody>
+            <tr>
+                <td>Documentation</td>
+                <td><a href="{{ collector.docsUrl }}" target="_blank" rel="help noopener">{{ collector.docsUrl }}</a></td>
+            </tr>
+        </tbody>
+    </table>
 {% endblock %}


### PR DESCRIPTION
#### Description, the reason for the PR

  This PR adds a dedicated Shopsys panel to the Symfony profiler so developers can see the current Shopsys context directly while debugging.

<img width="1276" height="733" alt="image" src="https://github.com/user-attachments/assets/dbe2ce0d-6b25-451d-800b-8df9e7b13da8" />


  <!-- If you have introduced a new feature, please update docs -->

  #### Fixes issues
  N/A

  #### License Agreement for contributions

  - [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-shopsys-profiler.odin.shopsys.cloud
  - https://cz.rv-shopsys-profiler.odin.shopsys.cloud
  - https://rv-shopsys-profiler.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1775731030.260539 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-shopsys-profiler.odin.shopsys.cloud
  - https://cz.rv-shopsys-profiler.odin.shopsys.cloud
  - https://rv-shopsys-profiler.odin.shopsys.cloud/sk
<!-- Replace -->
