### PR TITLE
Fix CVE-2026-4587 by bumping hybridauth to 3.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "guzzlehttp/guzzle": "^7.5",
         "helios-ag/fm-elfinder-bundle": "^13.0",
         "heureka/overeno-zakazniky": "^4.0.1",
-        "hybridauth/hybridauth": "^3.11",
+        "hybridauth/hybridauth": "^3.13.0",
         "jdorn/sql-formatter": "^1.2",
         "jms/metadata": "^2.6.1",
         "jms/serializer-bundle": "^5.0",
@@ -248,11 +248,6 @@
         }
     },
     "config": {
-        "audit": {
-            "ignore": {
-                "CVE-2026-4587": "No fix yet, see https://github.com/advisories/GHSA-r3hf-q3mf-7h6w"
-            }
-        },
         "preferred-install": "dist",
         "component-dir": "project-base/app/web/components",
         "sort-packages": true,

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.5",
         "elasticsearch/elasticsearch": "^7.6.1",
-        "hybridauth/hybridauth": "^3.11",
+        "hybridauth/hybridauth": "^3.13.0",
         "lcobucci/jwt": "^5.4",
         "overblog/graphql-bundle": "^1.9",
         "overblog/graphiql-bundle": "^1.0",
@@ -56,11 +56,6 @@
         "shopsys/coding-standards": "19.0.x-dev"
     },
     "config": {
-        "audit": {
-            "ignore": {
-                "CVE-2026-4587": "No fix yet, see https://github.com/advisories/GHSA-r3hf-q3mf-7h6w"
-            }
-        },
         "allow-plugins": {
             "symfony/flex": true,
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -169,11 +169,6 @@
         "security-check": "security-checker security:check"
     },
     "config": {
-        "audit": {
-            "ignore": {
-                "CVE-2026-4587": "No fix yet, see https://github.com/advisories/GHSA-r3hf-q3mf-7h6w"
-            }
-        },
         "process-timeout": 1200,
         "preferred-install": "dist",
         "component-dir": "web/components",


### PR DESCRIPTION
#### Description, the reason for the PR

The `hybridauth/hybridauth` library had a known security vulnerability (CVE-2026-4587) that was previously suppressed via Composer audit ignore entries because no fix was available. Version 3.13.0 resolves this vulnerability, so this PR bumps the version constraint and removes the audit ignore workarounds across all composer.json files.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-bump-hybridauth.odin.shopsys.cloud
  - https://cz.mg-bump-hybridauth.odin.shopsys.cloud
  - https://mg-bump-hybridauth.odin.shopsys.cloud/sk
<!-- Replace -->
