### PR TITLE
eliminated n+1 query during cron run

### DIFF
--- a/packages/framework/src/Component/Cron/CronModuleFacade.php
+++ b/packages/framework/src/Component/Cron/CronModuleFacade.php
@@ -31,11 +31,15 @@ class CronModuleFacade
      */
     public function scheduleModules(array $cronModuleConfigs): void
     {
+        $allModulesIndexedByServiceId = $this->findAllIndexedByServiceId();
+
         foreach ($cronModuleConfigs as $cronModuleConfig) {
-            $cronModule = $this->cronModuleRepository->getCronModuleByServiceId($cronModuleConfig->getServiceId());
+            $serviceId = $cronModuleConfig->getServiceId();
+            $cronModule = $allModulesIndexedByServiceId[$serviceId] ?? $this->cronModuleRepository->getCronModuleByServiceId($serviceId);
             $cronModule->schedule();
-            $this->em->flush();
         }
+
+        $this->em->flush();
     }
 
     /**


### PR DESCRIPTION
#### Description, the reason for the PR

Every time the `shopsys:cron` command runs, it schedules cron modules by loading each one individually from the database — one `SELECT` query per module. With ~20 registered cron modules, this produces an N+1 query pattern reported by Sentry (~1.7K events over 90 days).

This change preloads all cron modules in a single query before the scheduling loop and also batches the flush into one transaction instead of flushing after each module.

For example while running a service instance:

**Before** (21 queries, 7.39 ms):
<img width="935" height="290" alt="before" src="https://github.com/user-attachments/assets/d0d78f0a-17c6-4407-9cf3-353a8e142e8a" />

<!-- 📎 Drag & drop ~/Desktop/before.png here -->

**After** (8 queries, 4.03 ms):
<img width="935" height="295" alt="after" src="https://github.com/user-attachments/assets/a66b5974-1659-42b2-8d38-9de508c2104e" />

<!-- 📎 Drag & drop ~/Desktop/after.png here -->

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-cron-n-1.odin.shopsys.cloud
  - https://cz.mg-cron-n-1.odin.shopsys.cloud
  - https://mg-cron-n-1.odin.shopsys.cloud/sk
<!-- Replace -->
