### PR TITLE
Fix last visited products showing fewer items when some are unavailable

### DIFF
--- a/project-base/storefront/components/Blocks/Product/LastVisitedProducts/LastVisitedProductsContent.tsx
+++ b/project-base/storefront/components/Blocks/Product/LastVisitedProducts/LastVisitedProductsContent.tsx
@@ -2,6 +2,7 @@ import { ProductsSlider, VISIBLE_SLIDER_ITEMS_LAST_VISITED } from 'components/Bl
 import { SkeletonModuleLastVisitedProducts } from 'components/Blocks/Skeleton/SkeletonModuleLastVisitedProducts';
 import { useProductsByCatnums } from 'graphql/requests/products/queries/ProductsByCatnumsQuery.generated';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
+import { LAST_VISITED_DISPLAYED_ITEMS } from './lastVisitedProductsUtils';
 
 type LastVisitedProductsProps = {
     productsCatnums: string[];
@@ -12,7 +13,7 @@ export const LastVisitedProductsContent: FC<LastVisitedProductsProps> = ({ produ
         variables: { catnums: productsCatnums },
     });
 
-    const lastVisitedProducts = productsData?.productsByCatnums;
+    const lastVisitedProducts = productsData?.productsByCatnums.slice(0, LAST_VISITED_DISPLAYED_ITEMS);
 
     if (!lastVisitedProducts && !areProductsFetching) {
         return null;

--- a/project-base/storefront/components/Blocks/Product/LastVisitedProducts/lastVisitedProductsUtils.ts
+++ b/project-base/storefront/components/Blocks/Product/LastVisitedProducts/lastVisitedProductsUtils.ts
@@ -1,7 +1,8 @@
 import { useEffect, useEffectEvent } from 'react';
 import { useCookiesStore } from 'store/useCookiesStore';
 
-const LAST_VISITED_MAX_ITEMS = 10;
+const LAST_VISITED_STORED_ITEMS = 15;
+export const LAST_VISITED_DISPLAYED_ITEMS = 10;
 
 export const useLastVisitedProductView = (visitedProduct: string) => {
     const lastVisitedProductsCatnums = useCookiesStore((state) => state.lastVisitedProductsCatnums);
@@ -13,7 +14,7 @@ export const useLastVisitedProductView = (visitedProduct: string) => {
         );
 
         setCookiesStoreState({
-            lastVisitedProductsCatnums: newLastVisitedProductsCatnums.slice(0, LAST_VISITED_MAX_ITEMS),
+            lastVisitedProductsCatnums: newLastVisitedProductsCatnums.slice(0, LAST_VISITED_STORED_ITEMS),
         });
     });
 

--- a/project-base/storefront/vitest/components/Blocks/Product/LastVisitedProducts/LastVisitedProductsContent.test.tsx
+++ b/project-base/storefront/vitest/components/Blocks/Product/LastVisitedProducts/LastVisitedProductsContent.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { LastVisitedProductsContent } from 'components/Blocks/Product/LastVisitedProducts/LastVisitedProductsContent';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mockUseProductsByCatnums = vi.fn();
+
+vi.mock('graphql/requests/products/queries/ProductsByCatnumsQuery.generated', () => ({
+    useProductsByCatnums: () => [mockUseProductsByCatnums()],
+}));
+
+vi.mock('components/Blocks/Product/ProductsSlider', () => ({
+    ProductsSlider: ({ products }: { products: Array<{ catalogNumber: string }> }) => (
+        <div data-testid="products-slider">
+            {products.map((product) => (
+                <div key={product.catalogNumber} data-testid="slider-product">
+                    {product.catalogNumber}
+                </div>
+            ))}
+        </div>
+    ),
+    VISIBLE_SLIDER_ITEMS_LAST_VISITED: 5,
+}));
+
+vi.mock('components/Blocks/Skeleton/SkeletonModuleLastVisitedProducts', () => ({
+    SkeletonModuleLastVisitedProducts: () => <div data-testid="last-visited-skeleton" />,
+}));
+
+const buildProducts = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({ catalogNumber: `product-${i + 1}` }));
+
+describe('LastVisitedProductsContent', () => {
+    beforeEach(() => {
+        mockUseProductsByCatnums.mockReset();
+    });
+
+    test('displays at most 10 products even when more are returned', () => {
+        mockUseProductsByCatnums.mockReturnValue({
+            data: { productsByCatnums: buildProducts(15) },
+            fetching: false,
+        });
+
+        render(<LastVisitedProductsContent productsCatnums={buildProducts(15).map((p) => p.catalogNumber)} />);
+
+        const rendered = screen.getAllByTestId('slider-product');
+        expect(rendered).toHaveLength(10);
+        expect(rendered[0]).toHaveTextContent('product-1');
+        expect(rendered.at(-1)).toHaveTextContent('product-10');
+    });
+
+    test('displays all products when fewer than 10 are returned', () => {
+        mockUseProductsByCatnums.mockReturnValue({
+            data: { productsByCatnums: buildProducts(7) },
+            fetching: false,
+        });
+
+        render(<LastVisitedProductsContent productsCatnums={buildProducts(7).map((p) => p.catalogNumber)} />);
+
+        expect(screen.getAllByTestId('slider-product')).toHaveLength(7);
+    });
+
+    test('renders the skeleton while products are still fetching', () => {
+        mockUseProductsByCatnums.mockReturnValue({
+            data: undefined,
+            fetching: true,
+        });
+
+        render(<LastVisitedProductsContent productsCatnums={['product-1']} />);
+
+        expect(screen.getByTestId('last-visited-skeleton')).toBeInTheDocument();
+        expect(screen.queryByTestId('products-slider')).not.toBeInTheDocument();
+    });
+});

--- a/project-base/storefront/vitest/components/Blocks/Product/LastVisitedProducts/lastVisitedProductsUtils.test.ts
+++ b/project-base/storefront/vitest/components/Blocks/Product/LastVisitedProducts/lastVisitedProductsUtils.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from '@testing-library/react';
+import { useLastVisitedProductView } from 'components/Blocks/Product/LastVisitedProducts/lastVisitedProductsUtils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mockSetCookiesStoreState = vi.fn();
+let mockStoredCatnums: string[] | undefined;
+
+vi.mock('store/useCookiesStore', () => ({
+    useCookiesStore: (selector: (state: any) => unknown) =>
+        selector({
+            lastVisitedProductsCatnums: mockStoredCatnums,
+            setCookiesStoreState: mockSetCookiesStoreState,
+        }),
+}));
+
+const getLastStoredCatnums = (): string[] => {
+    const lastCall = mockSetCookiesStoreState.mock.calls.at(-1);
+    return lastCall?.[0].lastVisitedProductsCatnums;
+};
+
+const buildCatnums = (count: number, prefix = 'product-'): string[] =>
+    Array.from({ length: count }, (_, i) => `${prefix}${i + 1}`);
+
+describe('useLastVisitedProductView', () => {
+    beforeEach(() => {
+        mockStoredCatnums = undefined;
+        mockSetCookiesStoreState.mockClear();
+    });
+
+    test('stores the visited product when the cookie is empty', () => {
+        mockStoredCatnums = undefined;
+
+        renderHook(() => useLastVisitedProductView('new-product'));
+
+        expect(getLastStoredCatnums()).toEqual(['new-product']);
+    });
+
+    test('prepends the visited product to existing catnums', () => {
+        mockStoredCatnums = ['existing-1', 'existing-2'];
+
+        renderHook(() => useLastVisitedProductView('new-product'));
+
+        expect(getLastStoredCatnums()).toEqual(['new-product', 'existing-1', 'existing-2']);
+    });
+
+    test('deduplicates when the visited product is already stored', () => {
+        mockStoredCatnums = ['existing-1', 'revisited', 'existing-2'];
+
+        renderHook(() => useLastVisitedProductView('revisited'));
+
+        expect(getLastStoredCatnums()).toEqual(['revisited', 'existing-1', 'existing-2']);
+    });
+
+    test('keeps lists shorter than the storage cap intact', () => {
+        mockStoredCatnums = buildCatnums(10, 'existing-');
+
+        renderHook(() => useLastVisitedProductView('new-product'));
+
+        const stored = getLastStoredCatnums();
+        expect(stored).toHaveLength(11);
+        expect(stored[0]).toBe('new-product');
+    });
+
+    test('stores up to 15 items when adding to a full list of 14', () => {
+        mockStoredCatnums = buildCatnums(14, 'existing-');
+
+        renderHook(() => useLastVisitedProductView('new-product'));
+
+        const stored = getLastStoredCatnums();
+        expect(stored).toHaveLength(15);
+        expect(stored[0]).toBe('new-product');
+        expect(stored.at(-1)).toBe('existing-14');
+    });
+
+    test('caps storage at 15 items and drops the oldest when a new product is added to a full list', () => {
+        mockStoredCatnums = buildCatnums(15, 'existing-');
+
+        renderHook(() => useLastVisitedProductView('new-product'));
+
+        const stored = getLastStoredCatnums();
+        expect(stored).toHaveLength(15);
+        expect(stored[0]).toBe('new-product');
+        expect(stored).not.toContain('existing-15');
+        expect(stored.at(-1)).toBe('existing-14');
+    });
+});

--- a/upgrade-notes/storefront_20260413_140500.md
+++ b/upgrade-notes/storefront_20260413_140500.md
@@ -1,0 +1,6 @@
+#### Last visited products now store more items than displayed ([#4549](https://github.com/shopsys/shopsys/pull/4549))
+
+- the constant `LAST_VISITED_MAX_ITEMS` in `lastVisitedProductsUtils.ts` was removed and replaced with `LAST_VISITED_STORED_ITEMS` (15, private) and `LAST_VISITED_DISPLAYED_ITEMS` (10, exported)
+    - if you relied on `LAST_VISITED_MAX_ITEMS`, use `LAST_VISITED_DISPLAYED_ITEMS` instead
+- the last visited products cookie now stores up to 15 items, but only 10 are displayed, so hidden or unavailable products no longer reduce the visible count
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The "Last Visited Products" slider could show fewer than 10 products when some of the stored items became hidden or unavailable. This happened because the feature stored exactly 10 product catalogue numbers — the same number it displayed. When the API filtered out unavailable products, there were no extras to fill the gap.

Now, 15 items are stored in the cookie while only 10 are displayed. The extra buffer ensures that even if a few products become unavailable, the slider still shows the expected number of items.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://mg-last-visited.odin.shopsys.cloud
  - https://cz.mg-last-visited.odin.shopsys.cloud
  - https://mg-last-visited.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776425277.805429 -->