### PR TITLE
Add maps.googleapis.com to default CSP script-src

### DIFF
--- a/packages/framework/src/Migrations/Version20260208091423.php
+++ b/packages/framework/src/Migrations/Version20260208091423.php
@@ -14,7 +14,7 @@ class Version20260208091423 extends AbstractMigration implements CdnAwareInterfa
     protected const string CSP_FRAME_ANCESTORS_DIRECTIVE = "frame-ancestors 'self'";
     protected const string CSP_DEFAULT_SRC_VALUE = "'self' https: 'unsafe-inline' data:";
     protected const string CSP_SCRIPT_SRC_VALUE =
-        "'self' 'unsafe-inline' https://www.googletagmanager.com *.usersnap.com https://widget.packeta.com https://cdnjs.cloudflare.com https://*.gopay.com https://*.gopay.cz";
+        "'self' 'unsafe-inline' https://www.googletagmanager.com *.usersnap.com https://widget.packeta.com https://cdnjs.cloudflare.com https://*.gopay.com https://*.gopay.cz https://maps.googleapis.com";
 
     protected ?CdnFacade $cdnFacade = null;
 


### PR DESCRIPTION
#### Description, the reason for the PR

Google Maps scripts were blocked by the Content Security Policy introduced in #4447. The store locator page (and any other page embedding Google Maps) failed to load the map because `maps.googleapis.com` was not included in the `script-src` directive.

This adds `https://maps.googleapis.com` to the default CSP `script-src` whitelist in the migration, so Google Maps works out of the box without requiring manual CSP adjustments by the administrator.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-maps-csp.odin.shopsys.cloud
  - https://cz.mg-maps-csp.odin.shopsys.cloud
  - https://mg-maps-csp.odin.shopsys.cloud/sk
<!-- Replace -->
