### PR TITLE
GetStoreTest: public holiday date is now computed under mocked clock

### DIFF
--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
@@ -189,7 +189,7 @@ class GetStoreTest extends GraphQlTestCase
     #[DataProvider('openingHoursDataProvider')]
     public function testGetStoreOpeningHours(
         array $openingRangesModifiers,
-        ?DateTimeImmutable $publicHolidayDate,
+        bool $isPublicHolidayToday,
         array $publicHolidayExcludedStoresIds,
         string $expectedStatus,
         array $expectedOpeningRangesModifiers,
@@ -197,8 +197,9 @@ class GetStoreTest extends GraphQlTestCase
         $store = $this->updateStoreOpeningHours($openingRangesModifiers);
         $dayOfWeek = $this->getCurrentDayOfWeek();
 
-        if ($publicHolidayDate !== null) {
-            $this->createClosedDay($publicHolidayDate, $publicHolidayExcludedStoresIds);
+        if ($isPublicHolidayToday) {
+            $today = (new DatePoint())->setTimezone(new DateTimeZone('Europe/Prague'))->modify('today');
+            $this->createClosedDay($today, $publicHolidayExcludedStoresIds);
         }
 
         $response = $this->getResponseContentForGql(__DIR__ . '/graphql/StoreOpeningHoursQuery.graphql', [
@@ -225,7 +226,7 @@ class GetStoreTest extends GraphQlTestCase
             'openingRangesModifiers' => [
                 ['openingTime' => '-2 hour', 'closingTime' => '+2 hour'],
             ],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_OPEN,
             'expectedOpeningRangesModifiers' => [
@@ -237,7 +238,7 @@ class GetStoreTest extends GraphQlTestCase
             'openingRangesModifiers' => [
                 ['openingTime' => '-1 hour', 'closingTime' => '+1 hour'],
             ],
-            'publicHolidayDate' => static::getToday(),
+            'isPublicHolidayToday' => true,
             'publicHolidayExcludedStoresIds' => [1],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_CLOSED_SOON,
             'expectedOpeningRangesModifiers' => [
@@ -249,7 +250,7 @@ class GetStoreTest extends GraphQlTestCase
             'openingRangesModifiers' => [
                 ['openingTime' => '-1 hour', 'closingTime' => '+1 hour'],
             ],
-            'publicHolidayDate' => static::getToday(),
+            'isPublicHolidayToday' => true,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_CLOSED,
             'expectedOpeningRangesModifiers' => [],
@@ -257,7 +258,7 @@ class GetStoreTest extends GraphQlTestCase
 
         yield 'store not opened at all' => [
             'openingRangesModifiers' => [],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_CLOSED,
             'expectedOpeningRangesModifiers' => [],
@@ -267,7 +268,7 @@ class GetStoreTest extends GraphQlTestCase
             'openingRangesModifiers' => [
                 ['openingTime' => '+1 hour', 'closingTime' => '+2 hour'],
             ],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_OPEN_SOON,
             'expectedOpeningRangesModifiers' => [
@@ -279,7 +280,7 @@ class GetStoreTest extends GraphQlTestCase
             'openingRangesModifiers' => [
                 ['openingTime' => '-2 hour', 'closingTime' => '-1 hour'],
             ],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_CLOSED,
             'expectedOpeningRangesModifiers' => [
@@ -291,7 +292,7 @@ class GetStoreTest extends GraphQlTestCase
             'openingRangesModifiers' => [
                 ['openingTime' => '+1 hour', 'closingTime' => '-1 hour'],
             ],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_OPEN_SOON,
             'expectedOpeningRangesModifiers' => [
@@ -305,7 +306,7 @@ class GetStoreTest extends GraphQlTestCase
                 ['openingTime' => '-2 hour', 'closingTime' => '-1 hour'],
                 ['openingTime' => '+1 hour', 'closingTime' => '+2 hour'],
             ],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_OPEN_SOON,
             'expectedOpeningRangesModifiers' => [
@@ -321,7 +322,7 @@ class GetStoreTest extends GraphQlTestCase
                 ['openingTime' => '-2 hour', 'closingTime' => '+1 hour'],
                 ['openingTime' => '+2 hour', 'closingTime' => '+3 hour'],
             ],
-            'publicHolidayDate' => null,
+            'isPublicHolidayToday' => false,
             'publicHolidayExcludedStoresIds' => [],
             'expectedStatus' => StoreOpeningTypeEnum::STATUS_CLOSED_SOON,
             'expectedOpeningRangesModifiers' => [
@@ -536,11 +537,6 @@ class GetStoreTest extends GraphQlTestCase
         }
 
         return $this->now;
-    }
-
-    protected static function getToday(): DateTimeImmutable
-    {
-        return (new DatePoint())->setTimezone(new DateTimeZone('Europe/Prague'))->modify('today');
     }
 
     private function getFormattedTime(?string $modifier): ?string

--- a/upgrade-notes/backend_20260413_210652.md
+++ b/upgrade-notes/backend_20260413_210652.md
@@ -1,0 +1,3 @@
+#### fix GetStoreTest reliability around midnight ([#4551](https://github.com/shopsys/shopsys/pull/4551))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

getToday() was called in the static data provider before mockTime(), using the real clock — when UTC/Prague timezone date diverged near midnight, the closed day didn't match the mocked date, causing spurious failures
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-fix-store-test.odin.shopsys.cloud
  - https://cz.mg-fix-store-test.odin.shopsys.cloud
  - https://mg-fix-store-test.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776242426.487889 -->