### PR TITLE
useErrorHandler now applies customMessage only for application toasts

### DIFF
--- a/docs/storefront/error-handling.md
+++ b/docs/storefront/error-handling.md
@@ -386,9 +386,11 @@ const MyFormComponent = () => {
 };
 ```
 
-### Login form pattern (showing actual API errors)
+`customMessage` is applied only to toasts originating from application errors. Validation and network toasts always keep their specific messages.
 
-To show the actual API error message (e.g., "Invalid credentials") instead of a generic message, omit the `customMessage` option:
+### Login form pattern (showing actual application API errors)
+
+To show the actual application API error message (e.g., "Invalid credentials") instead of a generic message, omit the `customMessage` option:
 
 ```typescript
 const handleError = useErrorHandler({
@@ -470,12 +472,12 @@ const onSubmit = async (data: FormData) => {
 
 ### Hook options reference
 
-| Option           | Type                                                 | Description                              |
-| ---------------- | ---------------------------------------------------- | ---------------------------------------- |
-| `form`           | `UseFormReturn<TFormValues>`                         | Form instance for setting field errors   |
-| `gtmOrigin`      | `GtmMessageOriginType`                               | GTM tracking origin (default: `other`)   |
-| `customMessage`  | `string`                                             | Override error message for toasts        |
-| `customHandlers` | `Partial<Record<ApplicationErrorsType, () => void>>` | Custom handlers for specific error types |
+| Option           | Type                                                 | Description                                        |
+| ---------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| `form`           | `UseFormReturn<TFormValues>`                         | Form instance for setting field errors             |
+| `gtmOrigin`      | `GtmMessageOriginType`                               | GTM tracking origin (default: `other`)             |
+| `customMessage`  | `string`                                             | Override toast message for application errors only |
+| `customHandlers` | `Partial<Record<ApplicationErrorsType, () => void>>` | Custom handlers for specific error types           |
 
 ## Error Code Reference
 

--- a/project-base/storefront/utils/errors/ErrorOrchestrator.ts
+++ b/project-base/storefront/utils/errors/ErrorOrchestrator.ts
@@ -8,7 +8,13 @@ import {
 } from 'utils/errors/applicationErrors';
 
 export type ErrorDecision =
-    | { action: 'toast'; message: string; errorType: ApplicationErrorsType; severity: 'error' | 'warning' }
+    | {
+          action: 'toast';
+          message: string;
+          errorType: ApplicationErrorsType;
+          severity: 'error' | 'warning';
+          origin: 'validation' | 'application' | 'network';
+      }
     | { action: 'form-field'; fieldName: string; message: string }
     | { action: 'silent-log' }
     | { action: 'ignore' }
@@ -59,6 +65,7 @@ class ErrorOrchestratorImpl {
                             message: error.message,
                             errorType: 'default',
                             severity: 'error',
+                            origin: 'validation',
                         });
                     }
                 }
@@ -87,7 +94,7 @@ class ErrorOrchestratorImpl {
             } else if (isNoFlashMessageError(type)) {
                 decisions.push({ action: 'silent-log' });
             } else if (isFlashMessageError(type)) {
-                decisions.push({ action: 'toast', message, errorType: type, severity: 'error' });
+                decisions.push({ action: 'toast', message, errorType: type, severity: 'error', origin: 'application' });
             }
         }
 
@@ -99,6 +106,7 @@ class ErrorOrchestratorImpl {
                     message: parsed.networkError,
                     errorType: 'default',
                     severity: 'error',
+                    origin: 'network',
                 });
             }
         }

--- a/project-base/storefront/utils/errors/useErrorHandler.ts
+++ b/project-base/storefront/utils/errors/useErrorHandler.ts
@@ -48,9 +48,13 @@ export function useErrorHandler<TFormValues extends FieldValues = FieldValues>(
             for (const decision of decisions) {
                 switch (decision.action) {
                     case 'toast':
-                        showErrorMessage(customMessage ?? decision.message, context.gtmOrigin, {
-                            errorType: decision.errorType,
-                        });
+                        showErrorMessage(
+                            decision.origin === 'application' && customMessage ? customMessage : decision.message,
+                            context.gtmOrigin,
+                            {
+                                errorType: decision.errorType,
+                            },
+                        );
                         break;
 
                     case 'form-field':

--- a/project-base/storefront/vitest/utils/errors/useErrorHandler.test.ts
+++ b/project-base/storefront/vitest/utils/errors/useErrorHandler.test.ts
@@ -1,0 +1,113 @@
+import { renderHook } from '@testing-library/react';
+import { CombinedError } from 'urql';
+import { useErrorHandler } from 'utils/errors/useErrorHandler';
+import { showErrorMessage } from 'utils/toasts/showErrorMessage';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('utils/i18n/useTranslationWrapper', () => ({
+    default: () => ({
+        t: (key: string) => key,
+        lang: 'en',
+    }),
+}));
+
+vi.mock('utils/toasts/showErrorMessage', () => ({
+    showErrorMessage: vi.fn(),
+}));
+
+describe('useErrorHandler', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('keeps validation toast message even when customMessage is set', () => {
+        const { result } = renderHook(() => useErrorHandler({ customMessage: 'Generic complaint error' }));
+
+        const error = new CombinedError({
+            graphQLErrors: [
+                {
+                    message: 'Validation failed',
+                    extensions: {
+                        validation: {
+                            'input.nonExistingFieldForValidationToast': [
+                                { message: 'Specific validation message', code: 'invalid' },
+                            ],
+                        },
+                    },
+                },
+            ],
+        });
+
+        result.current(error);
+
+        expect(showErrorMessage).toHaveBeenCalledWith(
+            'Specific validation message',
+            expect.anything(),
+            expect.objectContaining({ errorType: 'default' }),
+        );
+    });
+
+    test('uses custom message for application errors', () => {
+        const { result } = renderHook(() => useErrorHandler({ customMessage: 'Generic complaint error' }));
+
+        const error = new CombinedError({
+            graphQLErrors: [
+                {
+                    message: 'Invalid credentials.',
+                    extensions: {
+                        userCode: 'invalid-credentials',
+                    },
+                },
+            ],
+        });
+
+        result.current(error);
+
+        expect(showErrorMessage).toHaveBeenCalledWith(
+            'Generic complaint error',
+            expect.anything(),
+            expect.objectContaining({ errorType: 'invalid-credentials' }),
+        );
+    });
+
+    test('uses custom message only for application toast when validation and application errors are combined', () => {
+        const { result } = renderHook(() => useErrorHandler({ customMessage: 'Generic complaint error' }));
+
+        const error = new CombinedError({
+            graphQLErrors: [
+                {
+                    message: 'Validation failed',
+                    extensions: {
+                        validation: {
+                            'input.nonExistingFieldForMixedValidationToast': [
+                                { message: 'Specific validation message', code: 'invalid' },
+                            ],
+                        },
+                    },
+                },
+                {
+                    message: 'Cart not found.',
+                    extensions: {
+                        userCode: 'cart-not-found',
+                    },
+                },
+            ],
+        });
+
+        result.current(error);
+
+        expect(showErrorMessage).toHaveBeenCalledTimes(2);
+        expect(showErrorMessage).toHaveBeenNthCalledWith(
+            1,
+            'Specific validation message',
+            expect.anything(),
+            expect.objectContaining({ errorType: 'default' }),
+        );
+        expect(showErrorMessage).toHaveBeenNthCalledWith(
+            2,
+            'Generic complaint error',
+            expect.anything(),
+            expect.objectContaining({ errorType: 'cart-not-found' }),
+        );
+    });
+});

--- a/upgrade-notes/storefront_20260414_104104.md
+++ b/upgrade-notes/storefront_20260414_104104.md
@@ -1,0 +1,8 @@
+#### useErrorHandler now applies customMessage only for application toasts ([#4557](https://github.com/shopsys/shopsys/pull/4557))
+
+- `customMessage` is now applied only to application errors (`application` toast)
+- validation errors keep their specific validation messages and are not overridden by a generic message
+- we added toast origin distinction (`validation` / `application` / `network`) and tests for the mixed-error scenario
+- when a response contained both validation and application errors, the validation message was overridden by `customMessage`, which was confusing for users
+- the goal is to keep precise form validation feedback while still allowing a user-friendly generic message for application errors
+- see #project-base-diff


### PR DESCRIPTION
#### Description, the reason for the PR
useErrorHandler now applies customMessage only for application toasts

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3950-fix-validation-errors.odin.shopsys.cloud
  - https://cz.tc-ssp-3950-fix-validation-errors.odin.shopsys.cloud
  - https://tc-ssp-3950-fix-validation-errors.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776666302.319849 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3950-fix-validation-errors.odin.shopsys.cloud
  - https://cz.tc-ssp-3950-fix-validation-errors.odin.shopsys.cloud
  - https://tc-ssp-3950-fix-validation-errors.odin.shopsys.cloud/sk
<!-- Replace -->
