### PR TITLE
SEO category filters now keep latest state on rapid toggles

### DIFF
--- a/project-base/storefront/utils/arrays/mergeNullableArrays.ts
+++ b/project-base/storefront/utils/arrays/mergeNullableArrays.ts
@@ -1,6 +1,0 @@
-export const mergeNullableArrays = <T>(array1: T[] | undefined | null, array2: T[] | undefined | null) => {
-    const nonNullableArray1 = array1 ? array1 : [];
-    const nonNullableArray2 = array2 ? array2 : [];
-
-    return [...nonNullableArray1, ...nonNullableArray2];
-};

--- a/project-base/storefront/utils/seoCategories/queryParamsUtils.ts
+++ b/project-base/storefront/utils/seoCategories/queryParamsUtils.ts
@@ -1,18 +1,75 @@
 import { DefaultProductFiltersMapType } from 'store/slices/createSeoCategorySlice';
 import { useSessionStore } from 'store/useSessionStore';
 import { FilterOptionsParameterUrlQueryType, FilterOptionsUrlQueryType } from 'types/productFilter';
-import { mergeNullableArrays } from 'utils/arrays/mergeNullableArrays';
+
+const isSliderParameter = (parameter: FilterOptionsParameterUrlQueryType) =>
+    typeof parameter.minimalValue === 'number' || typeof parameter.maximalValue === 'number';
+
+const mergeUniqueArrays = <T>(...values: Array<T[] | undefined | null>): T[] =>
+    Array.from(new Set(values.flatMap((value) => value ?? [])));
+
+const toggleSetValue = (set: Set<string>, changedUuid: string): void => {
+    if (!set.delete(changedUuid)) {
+        set.add(changedUuid);
+    }
+};
+
+const buildMergedParameters = (
+    defaultParameters: DefaultProductFiltersMapType['parameters'],
+    updatedParameters: FilterOptionsParameterUrlQueryType[] | undefined,
+): FilterOptionsParameterUrlQueryType[] => {
+    const checkboxParametersMap = new Map(
+        Array.from(defaultParameters).map(([parameterUuid, parameterValues]) => [
+            parameterUuid,
+            new Set(parameterValues),
+        ]),
+    );
+    const sliderParametersMap = new Map<string, FilterOptionsParameterUrlQueryType>();
+
+    for (const parameter of updatedParameters ?? []) {
+        if (isSliderParameter(parameter)) {
+            sliderParametersMap.set(parameter.parameter, {
+                parameter: parameter.parameter,
+                minimalValue: parameter.minimalValue,
+                maximalValue: parameter.maximalValue,
+            });
+
+            continue;
+        }
+
+        const values = checkboxParametersMap.get(parameter.parameter) ?? new Set<string>();
+
+        for (const value of parameter.values ?? []) {
+            values.add(value);
+        }
+
+        checkboxParametersMap.set(parameter.parameter, values);
+    }
+
+    const checkboxParameters = Array.from(checkboxParametersMap)
+        .map(([parameterUuid, parameterValues]) => ({
+            parameter: parameterUuid,
+            values: Array.from(parameterValues),
+        }))
+        .filter(({ values }) => values.length > 0);
+
+    return [...checkboxParameters, ...Array.from(sliderParametersMap.values())];
+};
+
+const getChangedDefaultFiltersWithOverride = (
+    defaultProductFiltersMap: DefaultProductFiltersMapType,
+    filter: FilterOptionsUrlQueryType | null,
+    override: Partial<FilterOptionsUrlQueryType>,
+): FilterOptionsUrlQueryType => getChangedDefaultFilters(defaultProductFiltersMap, { ...filter, ...override });
 
 export const getChangedDefaultFiltersAfterFlagChange = (
     defaultProductFiltersMap: DefaultProductFiltersMapType,
     filter: FilterOptionsUrlQueryType | null,
     changedFlagUuid: string,
 ): FilterOptionsUrlQueryType => {
-    if (!defaultProductFiltersMap.flags.delete(changedFlagUuid)) {
-        defaultProductFiltersMap.flags.add(changedFlagUuid);
-    }
+    toggleSetValue(defaultProductFiltersMap.flags, changedFlagUuid);
 
-    return getChangedDefaultFilters(defaultProductFiltersMap, filter);
+    return getChangedDefaultFiltersWithOverride(defaultProductFiltersMap, filter, { flags: undefined });
 };
 
 export const getChangedDefaultFiltersAfterBrandChange = (
@@ -20,11 +77,9 @@ export const getChangedDefaultFiltersAfterBrandChange = (
     filter: FilterOptionsUrlQueryType | null,
     changedBrandUuid: string,
 ): FilterOptionsUrlQueryType => {
-    if (!defaultProductFiltersMap.brands.delete(changedBrandUuid)) {
-        defaultProductFiltersMap.brands.add(changedBrandUuid);
-    }
+    toggleSetValue(defaultProductFiltersMap.brands, changedBrandUuid);
 
-    return getChangedDefaultFilters(defaultProductFiltersMap, filter);
+    return getChangedDefaultFiltersWithOverride(defaultProductFiltersMap, filter, { brands: undefined });
 };
 
 export const getChangedDefaultFiltersAfterParameterChange = (
@@ -33,43 +88,37 @@ export const getChangedDefaultFiltersAfterParameterChange = (
     changedParameterUuid: string,
     changedParameterValueUuid: string,
 ): FilterOptionsUrlQueryType => {
-    const matchingDefaultParameter = defaultProductFiltersMap.parameters.get(changedParameterUuid);
-    if (matchingDefaultParameter) {
-        if (!matchingDefaultParameter.delete(changedParameterValueUuid)) {
-            matchingDefaultParameter.add(changedParameterValueUuid);
-        }
-    } else {
-        defaultProductFiltersMap.parameters.set(changedParameterUuid, new Set([changedParameterValueUuid]));
-    }
+    const selectedParameterValues = defaultProductFiltersMap.parameters.get(changedParameterUuid) ?? new Set<string>();
+    toggleSetValue(selectedParameterValues, changedParameterValueUuid);
+    defaultProductFiltersMap.parameters.set(changedParameterUuid, selectedParameterValues);
 
-    return getChangedDefaultFilters(defaultProductFiltersMap, filter);
+    return getChangedDefaultFiltersWithOverride(defaultProductFiltersMap, filter, {
+        parameters: filter?.parameters?.filter(isSliderParameter),
+    });
 };
 
 export const getChangedDefaultFiltersAfterSliderParameterChange = (
     defaultProductFiltersMap: DefaultProductFiltersMapType,
     filter: FilterOptionsUrlQueryType | null,
-    changedaParameterUuid: string,
+    changedParameterUuid: string,
     minimalValue: number | undefined,
     maximalValue: number | undefined,
 ): FilterOptionsUrlQueryType => {
-    const selectedParameters: FilterOptionsParameterUrlQueryType[] = Array.from(defaultProductFiltersMap.parameters)
-        .map(([defaultParameterUuid, defaultParameterValues]) => ({
-            parameter: defaultParameterUuid,
-            values: Array.from(defaultParameterValues),
-        }))
-        .filter(({ values }) => values.length !== 0);
+    const updatedSliderParameters = (filter?.parameters ?? []).filter(
+        (parameter) => isSliderParameter(parameter) && parameter.parameter !== changedParameterUuid,
+    );
 
-    selectedParameters.push({
-        parameter: changedaParameterUuid,
-        minimalValue,
-        maximalValue,
+    if (typeof minimalValue === 'number' || typeof maximalValue === 'number') {
+        updatedSliderParameters.push({
+            parameter: changedParameterUuid,
+            minimalValue,
+            maximalValue,
+        });
+    }
+
+    return getChangedDefaultFiltersWithOverride(defaultProductFiltersMap, filter, {
+        parameters: updatedSliderParameters,
     });
-
-    return {
-        ...filter,
-        flags: Array.from(defaultProductFiltersMap.flags),
-        parameters: selectedParameters,
-    };
 };
 
 export const getChangedDefaultFiltersAfterPriceChange = (
@@ -116,14 +165,9 @@ export const getChangedDefaultFilters = (
     onlyInStock: updatedFilter?.onlyInStock,
     minimalPrice: updatedFilter?.minimalPrice,
     maximalPrice: updatedFilter?.maximalPrice,
-    brands: mergeNullableArrays(Array.from(defaultFilter.brands), updatedFilter?.brands),
-    flags: mergeNullableArrays(Array.from(defaultFilter.flags), updatedFilter?.flags),
-    parameters: Array.from(defaultFilter.parameters)
-        .map(([defaultParameterUuid, defaultParameterValues]) => ({
-            parameter: defaultParameterUuid,
-            values: Array.from(defaultParameterValues),
-        }))
-        .filter(({ values }) => values.length !== 0),
+    brands: mergeUniqueArrays(Array.from(defaultFilter.brands), updatedFilter?.brands),
+    flags: mergeUniqueArrays(Array.from(defaultFilter.flags), updatedFilter?.flags),
+    parameters: buildMergedParameters(defaultFilter.parameters, updatedFilter?.parameters),
 });
 
 export const useRedirectFromSeoCategory = () => {

--- a/project-base/storefront/vitest/utils/queryParams/useUpdateFilter.updateFilterBrands.test.ts
+++ b/project-base/storefront/vitest/utils/queryParams/useUpdateFilter.updateFilterBrands.test.ts
@@ -262,4 +262,33 @@ describe('useUpdateFilter().updateFilterBrands tests', () => {
         expect(setWasRedirectedFromSeoCategoryMock).toBeCalledTimes(1);
         expect(setWasRedirectedFromSeoCategoryMock).toBeCalledWith(true);
     });
+
+    test('rapidly toggling the same brand in SEO category should keep the latest state', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ BRANDS: true }));
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: TypeProductOrderingModeEnum.PriceAsc,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+                setWasRedirectedFromSeoCategory: setWasRedirectedFromSeoCategoryMock,
+            });
+        });
+
+        const { updateFilterBrandsQuery } = useUpdateFilterQuery();
+
+        updateFilterBrandsQuery('test-brand');
+        updateFilterBrandsQuery('test-brand');
+
+        const secondPushFilterAsString = mockPush.mock.calls[1][0].query[FILTER_QUERY_PARAMETER_NAME];
+        const secondPushFilter = JSON.parse(secondPushFilterAsString);
+
+        expect(secondPushFilter.brands).toStrictEqual(Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()));
+        expect(secondPushFilter.brands).not.toContain('test-brand');
+    });
 });

--- a/project-base/storefront/vitest/utils/queryParams/useUpdateFilter.updateFilterFlags.test.ts
+++ b/project-base/storefront/vitest/utils/queryParams/useUpdateFilter.updateFilterFlags.test.ts
@@ -262,4 +262,74 @@ describe('useUpdateFilter().updateFilterFlags tests', () => {
         expect(setWasRedirectedFromSeoCategoryMock).toBeCalledTimes(1);
         expect(setWasRedirectedFromSeoCategoryMock).toBeCalledWith(true);
     });
+
+    test('rapidly toggling the same flag in SEO category should keep the latest state', () => {
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: TypeProductOrderingModeEnum.PriceAsc,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+                setWasRedirectedFromSeoCategory: setWasRedirectedFromSeoCategoryMock,
+            });
+        });
+
+        const { updateFilterFlagsQuery } = useUpdateFilterQuery();
+
+        updateFilterFlagsQuery('test-flag');
+        updateFilterFlagsQuery('test-flag');
+
+        const secondPushFilterAsString = mockPush.mock.calls[1][0].query[FILTER_QUERY_PARAMETER_NAME];
+        const secondPushFilter = JSON.parse(secondPushFilterAsString);
+
+        expect(secondPushFilter.flags).toStrictEqual(Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()));
+        expect(secondPushFilter.flags).not.toContain('test-flag');
+    });
+
+    test('changing flag in SEO category should keep already selected slider parameter value', () => {
+        (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
+            asPath: CATEGORY_URL,
+            push: mockPush,
+            query: {
+                [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                    parameters: [
+                        {
+                            parameter: 'slider-parameter-1',
+                            minimalValue: 100,
+                            maximalValue: 1000,
+                        },
+                    ],
+                }),
+            },
+        }));
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: TypeProductOrderingModeEnum.PriceAsc,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+                setWasRedirectedFromSeoCategory: setWasRedirectedFromSeoCategoryMock,
+            });
+        });
+
+        useUpdateFilterQuery().updateFilterFlagsQuery('test-flag');
+
+        const pushedFilterAsString = mockPush.mock.calls[0][0].query[FILTER_QUERY_PARAMETER_NAME];
+        const pushedFilter = JSON.parse(pushedFilterAsString);
+
+        expect(mockPush.mock.calls[0][0].query.categorySlug).toBe(ORIGINAL_CATEGORY_URL);
+        expect(pushedFilter.flags).toStrictEqual([...Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()), 'test-flag']);
+        expect(pushedFilter.parameters).toContainEqual({
+            parameter: 'slider-parameter-1',
+            minimalValue: 100,
+            maximalValue: 1000,
+        });
+    });
 });

--- a/project-base/storefront/vitest/utils/queryParams/useUpdateFilter.updateFilterParameters.test.ts
+++ b/project-base/storefront/vitest/utils/queryParams/useUpdateFilter.updateFilterParameters.test.ts
@@ -653,6 +653,7 @@ describe('useUpdateFilter().updateFilterParameters tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
                         flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
@@ -677,6 +678,7 @@ describe('useUpdateFilter().updateFilterParameters tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
                         flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
@@ -703,6 +705,35 @@ describe('useUpdateFilter().updateFilterParameters tests', () => {
         );
         expect(setWasRedirectedFromSeoCategoryMock).toBeCalledTimes(1);
         expect(setWasRedirectedFromSeoCategoryMock).toBeCalledWith(true);
+    });
+
+    test('rapidly toggling the same checkbox parameter in SEO category should keep the latest state', () => {
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: TypeProductOrderingModeEnum.PriceAsc,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+                setWasRedirectedFromSeoCategory: setWasRedirectedFromSeoCategoryMock,
+            });
+        });
+
+        const { updateFilterParametersQuery } = useUpdateFilterQuery();
+
+        updateFilterParametersQuery('default-parameter-2', 'default-parameter-value-5');
+        updateFilterParametersQuery('default-parameter-2', 'default-parameter-value-5');
+
+        const secondPushFilterAsString = mockPush.mock.calls[1][0].query[FILTER_QUERY_PARAMETER_NAME];
+        const secondPushFilter = JSON.parse(secondPushFilterAsString);
+        const defaultParameter = secondPushFilter.parameters.find(
+            (parameter: { parameter: string }) => parameter.parameter === 'default-parameter-2',
+        );
+
+        expect(defaultParameter.values).toStrictEqual(['default-parameter-value-3', 'default-parameter-value-4']);
+        expect(defaultParameter.values).not.toContain('default-parameter-value-5');
     });
 
     test('changing slider parameter should not redirect from SEO category if slider parameters are not SEO-sensitive', () => {

--- a/upgrade-notes/storefront_20260414_120633.md
+++ b/upgrade-notes/storefront_20260414_120633.md
@@ -1,0 +1,6 @@
+#### SEO category filters now keep latest state on rapid toggles ([#4559](https://github.com/shopsys/shopsys/pull/4559))
+
+- Fixed SEO category filter query merging so rapid repeated toggles keep the latest state.
+- Prevented stale query params from re-introducing removed SEO-sensitive values (flags, brands, and checkbox parameters).
+- Added regression tests for rapid toggling scenarios.
+- see #project-base-diff


### PR DESCRIPTION
#### Description, the reason for the PR
Fixes a race-condition-like behavior in SEO category filters where rapid toggling could re-add stale values from query params and make filters appear “stuck.”
The update ensures the latest user action wins for SEO-sensitive flags, brands, and parameter values, and adds regression tests for rapid toggling scenarios.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3967-fix-filters.odin.shopsys.cloud
  - https://cz.tc-ssp-3967-fix-filters.odin.shopsys.cloud
  - https://tc-ssp-3967-fix-filters.odin.shopsys.cloud/sk
<!-- Replace -->
