### PR TITLE
Preserve expired-token error code across backend and storefront

### DIFF
--- a/packages/frontend-api/src/Model/Token/Exception/ExpiredTokenUserMessageException.php
+++ b/packages/frontend-api/src/Model/Token/Exception/ExpiredTokenUserMessageException.php
@@ -6,4 +6,5 @@ namespace Shopsys\FrontendApiBundle\Model\Token\Exception;
 
 class ExpiredTokenUserMessageException extends TokenUserMessageException
 {
+    protected const string CODE = 'expired-token';
 }

--- a/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
+++ b/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
@@ -8,6 +8,7 @@ use GraphQL\Error\FormattedError;
 use Lcobucci\JWT\Token\RegisteredClaims;
 use Override;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
+use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\InvalidTokenUserMessageException;
 use Shopsys\FrontendApiBundle\Model\User\FrontendApiUser;
 use Shopsys\FrontendApiBundle\Model\User\FrontendApiUserProvider;
@@ -99,13 +100,15 @@ class TokenAuthenticator extends AbstractAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         $formattedError = FormattedError::createFromException($exception);
-        $formattedError['extensions']['userCode'] = 'invalid-token';
+        $formattedError['extensions']['userCode'] = $exception instanceof UserErrorWithCodeInterface
+            ? $exception->getUserErrorCode()
+            : 'invalid-token';
 
         $responseData = [
             'errors' => [$formattedError],
         ];
 
-        return new JsonResponse($responseData, Response::HTTP_UNAUTHORIZED);
+        return new JsonResponse($responseData, Response::HTTP_OK);
     }
 
     public function getCredentials(Request $request): ?string

--- a/packages/frontend-api/src/Model/Token/TokenFacade.php
+++ b/packages/frontend-api/src/Model/Token/TokenFacade.php
@@ -20,6 +20,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\ExpiredTokenUserMessageException;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\InvalidTokenUserMessageException;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\NotVerifiedTokenUserMessageException;
+use Shopsys\FrontendApiBundle\Model\Token\Exception\TokenUserMessageException;
 use Shopsys\FrontendApiBundle\Model\User\FrontendApiUser;
 use Throwable;
 
@@ -102,6 +103,10 @@ class TokenFacade
 
             return $token;
         } catch (Throwable $throwable) {
+            if ($throwable instanceof TokenUserMessageException) {
+                throw $throwable;
+            }
+
             throw new InvalidTokenUserMessageException();
         }
     }

--- a/packages/frontend-api/tests/Unit/Model/Token/TokenAuthenticatorTest.php
+++ b/packages/frontend-api/tests/Unit/Model/Token/TokenAuthenticatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Unit\Model\Token;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
+use Shopsys\FrontendApiBundle\Model\Token\Exception\ExpiredTokenUserMessageException;
+use Shopsys\FrontendApiBundle\Model\Token\Exception\InvalidTokenUserMessageException;
+use Shopsys\FrontendApiBundle\Model\Token\TokenAuthenticator;
+use Shopsys\FrontendApiBundle\Model\Token\TokenFacade;
+use Shopsys\FrontendApiBundle\Model\User\FrontendApiUserProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+class TokenAuthenticatorTest extends TestCase
+{
+    public function testOnAuthenticationFailureReturnsExpiredTokenErrorWithHttpOkStatus(): void
+    {
+        $tokenAuthenticator = $this->createTokenAuthenticator();
+
+        $response = $tokenAuthenticator->onAuthenticationFailure(
+            new Request(),
+            new ExpiredTokenUserMessageException('Token is expired. Please renew.'),
+        );
+
+        $responseData = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('expired-token', $responseData['errors'][0]['extensions']['userCode']);
+    }
+
+    public function testOnAuthenticationFailureReturnsInvalidTokenErrorWithHttpOkStatus(): void
+    {
+        $tokenAuthenticator = $this->createTokenAuthenticator();
+
+        $response = $tokenAuthenticator->onAuthenticationFailure(
+            new Request(),
+            new InvalidTokenUserMessageException('Token is not valid.'),
+        );
+
+        $responseData = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('invalid-token', $responseData['errors'][0]['extensions']['userCode']);
+    }
+
+    private function createTokenAuthenticator(): TokenAuthenticator
+    {
+        return new TokenAuthenticator(
+            $this->createStub(TokenFacade::class),
+            $this->createStub(FrontendApiUserProvider::class),
+            $this->createStub(CustomerUserFacade::class),
+        );
+    }
+}

--- a/packages/frontend-api/tests/Unit/Model/Token/TokenFacadeTest.php
+++ b/packages/frontend-api/tests/Unit/Model/Token/TokenFacadeTest.php
@@ -110,6 +110,20 @@ class TokenFacadeTest extends TestCase
         ];
     }
 
+    public function testGetTokenByStringThrowsExpiredTokenExceptionForExpiredToken(): void
+    {
+        $tokenFacade = $this->createTokenFacade();
+        $expiredToken = $this->createToken(
+            null,
+            null,
+            new DatePoint()->modify('- 5 minutes'),
+        );
+
+        $this->expectException(ExpiredTokenUserMessageException::class);
+
+        $tokenFacade->getTokenByString($expiredToken->toString());
+    }
+
     private function createTokenFacade(): TokenFacade
     {
         $domain = $this->createDomain();

--- a/project-base/storefront/urql/authExchange.ts
+++ b/project-base/storefront/urql/authExchange.ts
@@ -11,6 +11,7 @@ import { getTokensFromCookies } from 'utils/auth/getTokensFromCookies';
 import { removeTokensFromCookies } from 'utils/auth/removeTokensFromCookies';
 import { setTokensToCookies } from 'utils/auth/setTokensToCookies';
 import { DomainConfigType } from 'utils/domain/domainConfig';
+import { isAuthError } from 'utils/errors/isAuthError';
 
 const isRefreshTokenMutation = (operation: Operation) => {
     return (
@@ -61,7 +62,7 @@ const addAuthToOperation = (
  * Check whether error returned from API is an authentication error
  */
 const didAuthError = (error: CombinedError): boolean => {
-    return error.response?.status === 401;
+    return isAuthError(error);
 };
 
 const doTryRefreshToken = async (

--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -12,6 +12,7 @@ import { ErrorOrchestrator } from 'utils/errors/ErrorOrchestrator';
 import { getErrorMessage } from 'utils/errors/errorMessageMapper';
 import { isExpectedPriceFilterError } from 'utils/errors/expectedErrors';
 import { getUserFriendlyErrors } from 'utils/errors/friendlyErrorMessageParser';
+import { isAuthError } from 'utils/errors/isAuthError';
 import { isWithErrorDebugging, isWithToastAndConsoleErrorDebugging } from 'utils/errors/isWithErrorDebugging';
 import { logException } from 'utils/errors/logException';
 import { mapGraphqlErrorForDevelopment } from 'utils/errors/mapGraphqlErrorForDevelopment';
@@ -88,8 +89,7 @@ export const getErrorExchange =
                         throw new Error('Internal Server Error');
                     }
 
-                    const isAuthError = error.response?.status === 401;
-                    if (isAuthError) {
+                    if (isAuthError(error)) {
                         removeTokensFromCookies(domainConfig, context);
 
                         return;

--- a/project-base/storefront/utils/errors/applicationErrors.ts
+++ b/project-base/storefront/utils/errors/applicationErrors.ts
@@ -75,6 +75,7 @@ const ApplicationErrors = {
     // No-log codes (expected errors, handled by specific code)
     'COMPARISON-product-already-in-list': 'no-log',
     'COMPARISON-product-not-in-list': 'no-log',
+    'expired-token': 'no-log',
     'invalid-account-or-password': 'no-log',
     'invalid-token': 'no-log',
     'no-result-found-for-slug': 'no-log',

--- a/project-base/storefront/utils/errors/handleServerSideErrorResponseForFriendlyUrls.ts
+++ b/project-base/storefront/utils/errors/handleServerSideErrorResponseForFriendlyUrls.ts
@@ -1,6 +1,7 @@
 import { GetServerSidePropsContext } from 'next';
 import { CombinedError } from 'urql';
 import { getLoginUrlWithRedirect } from 'utils/auth/getLoginUrlWithRedirect';
+import { isAuthError } from 'utils/errors/isAuthError';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
 import { isExpectedPriceFilterError } from './expectedErrors';
 import { isWithErrorDebugging } from './isWithErrorDebugging';
@@ -13,7 +14,7 @@ export const handleServerSideErrorResponseForFriendlyUrls = (
     domainUrl: string,
     urlSlug: string | undefined = undefined,
 ) => {
-    if (error?.response.status === 401) {
+    if (isAuthError(error)) {
         const redirectTargetUrlWithLeadingSlash = getInternationalizedStaticUrls(['/login'], domainUrl)[0];
 
         return {

--- a/project-base/storefront/utils/errors/isAuthError.ts
+++ b/project-base/storefront/utils/errors/isAuthError.ts
@@ -1,0 +1,17 @@
+import { CombinedError } from 'urql';
+
+const authErrorUserCodes = ['expired-token', 'invalid-token'] as const;
+
+export const isAuthError = (error: CombinedError | undefined): boolean => {
+    if (!error) {
+        return false;
+    }
+
+    if (error.response?.status === 401) {
+        return true;
+    }
+
+    return error.graphQLErrors.some((graphQlError) =>
+        authErrorUserCodes.some((userCode) => graphQlError.extensions.userCode === userCode),
+    );
+};

--- a/project-base/storefront/vitest/urql/errorExchange.test.ts
+++ b/project-base/storefront/vitest/urql/errorExchange.test.ts
@@ -1,0 +1,101 @@
+import { parse } from 'graphql';
+import { CombinedError, Operation } from 'urql';
+import { getErrorExchange } from 'urql/errorExchange';
+import { describe, expect, test, vi } from 'vitest';
+import { fromValue, toPromise } from 'wonka';
+
+const { removeTokensFromCookiesMock, logExceptionMock, showErrorMessageMock } = vi.hoisted(() => ({
+    removeTokensFromCookiesMock: vi.fn(),
+    logExceptionMock: vi.fn(),
+    showErrorMessageMock: vi.fn(),
+}));
+
+vi.mock('utils/auth/removeTokensFromCookies', () => ({
+    removeTokensFromCookies: removeTokensFromCookiesMock,
+}));
+
+vi.mock('utils/errors/logException', () => ({
+    logException: logExceptionMock,
+}));
+
+vi.mock('utils/toasts/showErrorMessage', () => ({
+    showErrorMessage: showErrorMessageMock,
+}));
+
+describe('getErrorExchange', () => {
+    test('should clear auth cookies for graphql auth errors returned with HTTP 200', async () => {
+        const domainConfig = {
+            url: 'http://example.com',
+        };
+        const operation = {
+            key: 1,
+            kind: 'query',
+            query: parse('query TestQuery { __typename }'),
+            variables: {},
+            context: {},
+        } as Operation;
+        const error = new CombinedError({
+            response: new Response(null, { status: 200 }),
+            graphQLErrors: [
+                {
+                    message: 'Token is expired. Please renew.',
+                    extensions: { userCode: 'expired-token' },
+                },
+            ],
+        });
+        const exchange = getErrorExchange(
+            ((value: string) => value) as never,
+            domainConfig as never,
+        )({
+            forward: () =>
+                fromValue({
+                    operation,
+                    error,
+                } as never),
+        } as never);
+
+        removeTokensFromCookiesMock.mockClear();
+
+        await toPromise(exchange(fromValue(operation)));
+
+        expect(removeTokensFromCookiesMock).toHaveBeenCalledWith(domainConfig, undefined);
+    });
+
+    test('should not clear auth cookies for non-auth graphql errors', async () => {
+        const domainConfig = {
+            url: 'http://example.com',
+        };
+        const operation = {
+            key: 1,
+            kind: 'query',
+            query: parse('query TestQuery { __typename }'),
+            variables: {},
+            context: {},
+        } as Operation;
+        const error = new CombinedError({
+            response: new Response(null, { status: 200 }),
+            graphQLErrors: [
+                {
+                    message: 'Category not found.',
+                    extensions: { userCode: 'category-not-found' },
+                },
+            ],
+        });
+        const exchange = getErrorExchange(
+            ((value: string) => value) as never,
+            domainConfig as never,
+        )({
+            forward: () =>
+                fromValue({
+                    operation,
+                    error,
+                } as never),
+        } as never);
+
+        removeTokensFromCookiesMock.mockClear();
+
+        await toPromise(exchange(fromValue(operation)));
+
+        expect(removeTokensFromCookiesMock).not.toHaveBeenCalled();
+    });
+});

--- a/project-base/storefront/vitest/utils/errors/applicationErrors.test.ts
+++ b/project-base/storefront/vitest/utils/errors/applicationErrors.test.ts
@@ -38,6 +38,7 @@ describe('isFlashMessageError', () => {
 
     test('should return false for no-log codes', () => {
         expect(isFlashMessageError('no-result-found-for-slug')).toBe(false);
+        expect(isFlashMessageError('expired-token')).toBe(false);
         expect(isFlashMessageError('invalid-token')).toBe(false);
         expect(isFlashMessageError('seo-page-not-found')).toBe(false);
     });
@@ -99,6 +100,7 @@ describe('isNoFlashMessageError', () => {
     });
 
     test('should return false for no-log codes', () => {
+        expect(isNoFlashMessageError('expired-token')).toBe(false);
         expect(isNoFlashMessageError('no-result-found-for-slug')).toBe(false);
         expect(isNoFlashMessageError('invalid-token')).toBe(false);
     });
@@ -113,6 +115,7 @@ describe('isNoLogError', () => {
     test.each([
         'COMPARISON-product-already-in-list',
         'COMPARISON-product-not-in-list',
+        'expired-token',
         'invalid-account-or-password',
         'invalid-token',
         'no-result-found-for-slug',
@@ -209,6 +212,7 @@ describe('error code classification coverage', () => {
             // No-log codes
             'COMPARISON-product-already-in-list',
             'COMPARISON-product-not-in-list',
+            'expired-token',
             'invalid-account-or-password',
             'invalid-token',
             'no-result-found-for-slug',

--- a/project-base/storefront/vitest/utils/errors/handleServerSideErrorResponseForFriendlyUrls.test.ts
+++ b/project-base/storefront/vitest/utils/errors/handleServerSideErrorResponseForFriendlyUrls.test.ts
@@ -69,6 +69,31 @@ describe('handleServerSideErrorResponseForFriendlyUrls', () => {
         });
     });
 
+    test('returns redirect to login for graphql auth errors returned with HTTP 200', () => {
+        const error = createCombinedError({
+            graphQLErrors: [
+                {
+                    message: 'Token is expired. Please renew.',
+                    extensions: { userCode: 'expired-token' },
+                },
+            ],
+        });
+
+        const result = handleServerSideErrorResponseForFriendlyUrls(
+            error,
+            null,
+            createMockContext(),
+            'https://example.com',
+        );
+
+        expect(result).toEqual({
+            redirect: {
+                destination: '/login?r=redirect-target',
+                permanent: false,
+            },
+        });
+    });
+
     test('throws on 500 server error (debugging off)', () => {
         const error = createCombinedError({
             graphQLErrors: [{ extensions: { code: 500 } }],

--- a/project-base/storefront/vitest/utils/errors/isAuthError.test.ts
+++ b/project-base/storefront/vitest/utils/errors/isAuthError.test.ts
@@ -1,0 +1,59 @@
+import { CombinedError } from 'urql';
+import { isAuthError } from 'utils/errors/isAuthError';
+import { describe, expect, test } from 'vitest';
+
+describe('isAuthError', () => {
+    test('should return false for undefined error', () => {
+        expect(isAuthError(undefined)).toBe(false);
+    });
+
+    test('should return true for HTTP 401 responses', () => {
+        const error = new CombinedError({
+            response: new Response(null, { status: 401 }),
+        });
+
+        expect(isAuthError(error)).toBe(true);
+    });
+
+    test('should return true for expired-token graphql errors', () => {
+        const error = new CombinedError({
+            response: new Response(null, { status: 200 }),
+            graphQLErrors: [
+                {
+                    message: 'Token is expired. Please renew.',
+                    extensions: { userCode: 'expired-token' },
+                },
+            ],
+        });
+
+        expect(isAuthError(error)).toBe(true);
+    });
+
+    test('should return true for invalid-token graphql errors', () => {
+        const error = new CombinedError({
+            response: new Response(null, { status: 200 }),
+            graphQLErrors: [
+                {
+                    message: 'Token is not valid.',
+                    extensions: { userCode: 'invalid-token' },
+                },
+            ],
+        });
+
+        expect(isAuthError(error)).toBe(true);
+    });
+
+    test('should return false for non-auth graphql errors', () => {
+        const error = new CombinedError({
+            response: new Response(null, { status: 200 }),
+            graphQLErrors: [
+                {
+                    message: 'Category not found.',
+                    extensions: { userCode: 'category-not-found' },
+                },
+            ],
+        });
+
+        expect(isAuthError(error)).toBe(false);
+    });
+});

--- a/upgrade-notes/backend_20260414_180244.md
+++ b/upgrade-notes/backend_20260414_180244.md
@@ -1,0 +1,3 @@
+#### token auth errors now preserve expired-token across backend and storefront ([#4560](https://github.com/shopsys/shopsys/pull/4560))
+
+- Frontend API token authentication failures are now returned with HTTP code 200 instead of previous 401 code with GraphQL error `extensions.userCode` values `expired-token` and `invalid-token`, update your application to reflect it

--- a/upgrade-notes/storefront_20260414_180244.md
+++ b/upgrade-notes/storefront_20260414_180244.md
@@ -1,0 +1,5 @@
+#### token auth errors now preserve expired-token across backend and storefront ([#4560](https://github.com/shopsys/shopsys/pull/4560))
+
+- if you override `project-base/storefront/urql/authExchange.ts`, `project-base/storefront/urql/errorExchange.ts`, or `project-base/storefront/utils/errors/handleServerSideErrorResponseForFriendlyUrls.ts`, update your auth handling to treat GraphQL error `extensions.userCode` values `expired-token` and `invalid-token` as authentication failures even when the response status is `200`
+- if you override `project-base/storefront/utils/errors/applicationErrors.ts`, add `expired-token` to the no-log application error codes
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Until now, every token authentication failure in the Frontend API was reported to the storefront with the same `invalid-token` user code and an HTTP 401 response. That meant an expired token — a normal, expected situation after a period of inactivity — was indistinguishable from a genuinely invalid token, so the storefront could not react to it appropriately (e.g. trigger a silent token refresh or show a friendly "please sign in again" flow).

This PR makes the backend preserve the original error code thrown during token processing. When a token is expired, the API now returns the `expired-token` user code; when it is malformed or otherwise invalid, it keeps returning `invalid-token`. The authentication endpoint also returns HTTP 200 with the GraphQL error payload instead of HTTP 401, so the error travels through the GraphQL pipeline like any other user error.

On the storefront side, auth-error detection was updated to recognize these GraphQL user codes in addition to the legacy HTTP 401 check. As a result, expired sessions are detected reliably, tokens are cleared, server-side requests redirect to the login page, and the `expired-token` code is classified as a no-log error so expired sessions no longer produce noise in error logs.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







----
:globe_with_meridians: Live Preview:
  - https://mg-http-auth.odin.shopsys.cloud
  - https://cz.mg-http-auth.odin.shopsys.cloud
  - https://mg-http-auth.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776754739.197929 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-http-auth.odin.shopsys.cloud
  - https://cz.mg-http-auth.odin.shopsys.cloud
  - https://mg-http-auth.odin.shopsys.cloud/sk
<!-- Replace -->
