### PR TITLE
fixed promo code limit/flags editing

### DIFF
--- a/packages/framework/src/Model/Order/PromoCode/PromoCodeFacade.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCodeFacade.php
@@ -102,15 +102,17 @@ class PromoCodeFacade
      */
     protected function refreshPromoCodeLimits(PromoCode $promoCode, array $limits): void
     {
-        $this->promoCodeLimitRepository->deleteByPromoCodeId($promoCode->getId());
+        $this->removeExistingPromoCodeLimits($promoCode);
 
         if ($promoCode->isFreeTransportAndPaymentType()) {
             return;
         }
 
         foreach ($limits as $limit) {
-            $limit->setPromoCode($promoCode);
-            $this->em->persist($limit);
+            $promoCodeLimit = clone $limit;
+            $promoCodeLimit->setPromoCode($promoCode);
+
+            $this->em->persist($promoCodeLimit);
         }
 
         $this->em->flush();
@@ -269,11 +271,31 @@ class PromoCodeFacade
      */
     protected function refreshPromoCodeFlags(PromoCode $promoCode, array $flags): void
     {
-        $this->promoCodeFlagRepository->deleteByPromoCodeId($promoCode->getId());
+        $this->removeExistingPromoCodeFlags($promoCode);
 
         foreach ($flags as $flag) {
-            $flag->setPromoCode($promoCode);
-            $this->em->persist($flag);
+            $promoCodeFlag = clone $flag;
+            $promoCodeFlag->setPromoCode($promoCode);
+
+            $this->em->persist($promoCodeFlag);
+        }
+
+        $this->em->flush();
+    }
+
+    protected function removeExistingPromoCodeLimits(PromoCode $promoCode): void
+    {
+        foreach ($this->promoCodeLimitRepository->getLimitsByPromoCodeId($promoCode->getId()) as $promoCodeLimit) {
+            $this->em->remove($promoCodeLimit);
+        }
+
+        $this->em->flush();
+    }
+
+    protected function removeExistingPromoCodeFlags(PromoCode $promoCode): void
+    {
+        foreach ($this->promoCodeFlagRepository->getFlagsByPromoCodeId($promoCode->getId()) as $promoCodeFlag) {
+            $this->em->remove($promoCodeFlag);
         }
 
         $this->em->flush();

--- a/project-base/app/tests/App/Functional/Model/Order/PromoCodeFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Order/PromoCodeFacadeTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Model\Order;
+
+use App\DataFixtures\Demo\FlagDataFixture;
+use App\DataFixtures\Demo\PromoCodeDataFixture;
+use App\Model\Product\Flag\Flag;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFlag\PromoCodeFlag;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFlag\PromoCodeFlagFactory;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFlag\PromoCodeFlagRepository;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeLimit\PromoCodeLimit;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeLimit\PromoCodeLimitFactory;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeLimit\PromoCodeLimitRepository;
+use Tests\App\Test\TransactionFunctionalTestCase;
+
+final class PromoCodeFacadeTest extends TransactionFunctionalTestCase
+{
+    /**
+     * @inject
+     */
+    private PromoCodeFacade $promoCodeFacade;
+
+    /**
+     * @inject
+     */
+    private PromoCodeDataFactory $promoCodeDataFactory;
+
+    /**
+     * @inject
+     */
+    private PromoCodeLimitFactory $promoCodeLimitFactory;
+
+    /**
+     * @inject
+     */
+    private PromoCodeFlagFactory $promoCodeFlagFactory;
+
+    /**
+     * @inject
+     */
+    private PromoCodeFlagRepository $promoCodeFlagRepository;
+
+    /**
+     * @inject
+     */
+    private PromoCodeLimitRepository $promoCodeLimitRepository;
+
+    public function testEditPromoCodeLimits(): void
+    {
+        $promoCode = $this->getReferenceForDomain(
+            PromoCodeDataFixture::VALID_PROMO_CODE,
+            Domain::FIRST_DOMAIN_ID,
+            PromoCode::class,
+        );
+        $promoCodeData = $this->promoCodeDataFactory->createFromPromoCode($promoCode);
+
+        $expectedLimits = [
+            ...$this->mapPromoCodeLimits($promoCodeData->limits),
+            ['fromPrice' => '100.000000', 'discount' => '20.000000'],
+        ];
+
+        $promoCodeData->limits[] = $this->promoCodeLimitFactory->create('100', '20');
+
+        $this->promoCodeFacade->edit($promoCode->getId(), $promoCodeData);
+        $this->em->clear();
+
+        $limits = $this->promoCodeLimitRepository->getLimitsByPromoCodeId($promoCode->getId());
+
+        $this->assertSame(
+            $expectedLimits,
+            $this->mapPromoCodeLimits($limits),
+        );
+    }
+
+    public function testEditPromoCodeFlags(): void
+    {
+        $promoCode = $this->getReferenceForDomain(
+            PromoCodeDataFixture::PROMO_CODE_FOR_NEW_PRODUCT,
+            Domain::FIRST_DOMAIN_ID,
+            PromoCode::class,
+        );
+        $promoCodeData = $this->promoCodeDataFactory->createFromPromoCode($promoCode);
+
+        $expectedFlags = [
+            ...$this->mapPromoCodeFlags($promoCodeData->flags),
+            ['flagId' => $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId(), 'type' => PromoCodeFlag::TYPE_EXCLUSIVE],
+        ];
+
+        $promoCodeData->flags[] = $this->promoCodeFlagFactory->create(
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class),
+            PromoCodeFlag::TYPE_EXCLUSIVE,
+        );
+
+        $this->promoCodeFacade->edit($promoCode->getId(), $promoCodeData);
+        $this->em->clear();
+
+        $flags = $this->promoCodeFlagRepository->getFlagsByPromoCodeId($promoCode->getId());
+
+        $this->assertEqualsCanonicalizing(
+            $expectedFlags,
+            $this->mapPromoCodeFlags($flags),
+        );
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeLimit\PromoCodeLimit[] $limits
+     * @return array<int, array{fromPrice: string, discount: string}>
+     */
+    private function mapPromoCodeLimits(array $limits): array
+    {
+        return array_map(
+            static function (PromoCodeLimit $limit) {
+                return ['fromPrice' => $limit->getFromPrice(), 'discount' => $limit->getDiscount()];
+            },
+            $limits,
+        );
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFlag\PromoCodeFlag[] $flags
+     * @return array<int, array{flagId: int, type: string}>
+     */
+    private function mapPromoCodeFlags(array $flags): array
+    {
+        return array_map(
+            static function (PromoCodeFlag $flag) {
+                return ['flagId' => $flag->getFlag()->getId(), 'type' => $flag->getType()];
+            },
+            $flags,
+        );
+    }
+}

--- a/upgrade-notes/backend_20260415_061043.md
+++ b/upgrade-notes/backend_20260415_061043.md
@@ -1,0 +1,3 @@
+#### add test to confirm promo code limits/flags edit works properly ([#4562](https://github.com/shopsys/shopsys/pull/4562))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Editing an existing promo code now correctly saves changes in the limits and flags sections.

This change recreates those relations during edit, so newly added or updated limits and flags are stored consistently after saving an existing promo code, regardless of if promo code was edited via form submission or programmatically. 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







----
:globe_with_meridians: Live Preview:
  - https://mg-fix-promo-limits.odin.shopsys.cloud
  - https://cz.mg-fix-promo-limits.odin.shopsys.cloud
  - https://mg-fix-promo-limits.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776757582.569739 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-promo-limits.odin.shopsys.cloud
  - https://cz.mg-fix-promo-limits.odin.shopsys.cloud
  - https://mg-fix-promo-limits.odin.shopsys.cloud/sk
<!-- Replace -->
