### PR TITLE
extracted protected methods from createOrderMutation()

### DIFF
--- a/packages/frontend-api/src/Model/Mutation/Order/CreateOrderMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Order/CreateOrderMutation.php
@@ -7,14 +7,19 @@ namespace Shopsys\FrontendApiBundle\Model\Mutation\Order;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Validator\InputValidator;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
+use Shopsys\FrameworkBundle\Model\Order\Order;
+use Shopsys\FrameworkBundle\Model\Order\OrderData;
 use Shopsys\FrameworkBundle\Model\Order\PlaceOrderFacade;
+use Shopsys\FrameworkBundle\Model\Order\Processing\OrderInput;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\SetDeliveryAddressByDeliveryAddressUuidMiddleware;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
 use Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade;
+use Shopsys\FrontendApiBundle\Model\Cart\CartWithModificationsResult;
 use Shopsys\FrontendApiBundle\Model\Mutation\AbstractMutation;
 use Shopsys\FrontendApiBundle\Model\Order\CreateOrderResult;
 use Shopsys\FrontendApiBundle\Model\Order\CreateOrderResultFactory;
@@ -42,16 +47,14 @@ class CreateOrderMutation extends AbstractMutation
     public function createOrderMutation(Argument $argument, InputValidator $validator): CreateOrderResult
     {
         $customerUser = $this->currentCustomerUser->findCurrentCustomerUser();
-        $validationGroups = $this->computeValidationGroups($argument, $customerUser);
-        $validator->validate($validationGroups);
-
-        $orderData = $this->orderDataFactory->createOrderDataFromArgument($argument);
-
         $input = $argument['input'];
-        $cartUuid = $input['cartUuid'];
-        $cart = $this->cartApiFacade->getCartCreateIfNotExists($customerUser, $cartUuid);
+        $deliveryAddressUuid = $input['deliveryAddressUuid'];
 
-        $cartWithModifications = $this->cartWatcherFacade->getCheckedCartWithModifications($cart);
+        $this->validateCreateOrderMutation($argument, $validator, $customerUser);
+
+        $cart = $this->getCartForCreateOrderMutation($input, $customerUser);
+
+        $cartWithModifications = $this->getCheckedCartWithModifications($cart);
 
         if ($cartWithModifications->isCartModified()) {
             return $this->createOrderResultFactory->getCreateOrderResultByCartWithModifications(
@@ -59,22 +62,68 @@ class CreateOrderMutation extends AbstractMutation
             );
         }
 
-        /** @var string|null $deliveryAddressUuid */
-        $deliveryAddressUuid = $input['deliveryAddressUuid'];
-
-        $orderInput = $this->orderInputFactory->createFromCart($cart, $this->domain->getCurrentDomainConfig());
-        $orderInput->addAdditionalData(SetDeliveryAddressByDeliveryAddressUuidMiddleware::DELIVERY_ADDRESS_UUID, $deliveryAddressUuid);
-
-        $orderData = $this->orderProcessor->process(
-            $orderInput,
-            $orderData,
-        );
-
-        $order = $this->placeOrderFacade->placeOrder($orderData, $deliveryAddressUuid);
+        $order = $this->createOrderFromCart($argument, $cart, $deliveryAddressUuid);
 
         $this->cartApiFacade->deleteCart($cart);
 
         return $this->createOrderResultFactory->getCreateOrderResultByOrder($order);
+    }
+
+    protected function validateCreateOrderMutation(
+        Argument $argument,
+        InputValidator $validator,
+        ?CustomerUser $customerUser,
+    ): void {
+        $validationGroups = $this->computeValidationGroups($argument, $customerUser);
+        $validator->validate($validationGroups);
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    protected function getCartForCreateOrderMutation(array $input, ?CustomerUser $customerUser): Cart
+    {
+        /** @var string|null $cartUuid */
+        $cartUuid = $input['cartUuid'];
+
+        return $this->cartApiFacade->getCartCreateIfNotExists($customerUser, $cartUuid);
+    }
+
+    protected function getCheckedCartWithModifications(Cart $cart): CartWithModificationsResult
+    {
+        return $this->cartWatcherFacade->getCheckedCartWithModifications($cart);
+    }
+
+    protected function createOrderFromCart(
+        Argument $argument,
+        Cart $cart,
+        ?string $deliveryAddressUuid,
+    ): Order {
+        $processedOrderData = $this->getProcessedOrderData($argument, $cart, $deliveryAddressUuid);
+
+        return $this->placeOrderFacade->placeOrder($processedOrderData, $deliveryAddressUuid);
+    }
+
+    protected function getProcessedOrderData(
+        Argument $argument,
+        Cart $cart,
+        ?string $deliveryAddressUuid,
+    ): OrderData {
+        $orderData = $this->orderDataFactory->createOrderDataFromArgument($argument);
+        $orderInput = $this->createOrderInputFromCart($cart, $deliveryAddressUuid);
+
+        return $this->orderProcessor->process($orderInput, $orderData);
+    }
+
+    protected function createOrderInputFromCart(Cart $cart, ?string $deliveryAddressUuid): OrderInput
+    {
+        $orderInput = $this->orderInputFactory->createFromCart($cart, $this->domain->getCurrentDomainConfig());
+        $orderInput->addAdditionalData(
+            SetDeliveryAddressByDeliveryAddressUuidMiddleware::DELIVERY_ADDRESS_UUID,
+            $deliveryAddressUuid,
+        );
+
+        return $orderInput;
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Mutation/Order/CreateOrderMutation.php
+++ b/project-base/app/src/FrontendApi/Mutation/Order/CreateOrderMutation.php
@@ -12,6 +12,12 @@ use Shopsys\FrontendApiBundle\Model\Mutation\Order\CreateOrderMutation as BaseCr
  * @property \App\Model\Order\PlaceOrderFacade $placeOrderFacade
  * @method __construct(\App\FrontendApi\Model\Order\OrderDataFactory $orderDataFactory, \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser, \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade, \Shopsys\FrontendApiBundle\Model\Order\CreateOrderResultFactory $createOrderResultFactory, \Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade $cartWatcherFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor $orderProcessor, \App\Model\Order\PlaceOrderFacade $placeOrderFacade, \Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory $orderInputFactory)
  * @method string[] computeValidationGroups(\Overblog\GraphQLBundle\Definition\Argument $argument, \App\Model\Customer\User\CustomerUser|null $currentCustomerUser)
+ * @method void validateCreateOrderMutation(\Overblog\GraphQLBundle\Definition\Argument $argument, \Overblog\GraphQLBundle\Validator\InputValidator $validator, \App\Model\Customer\User\CustomerUser|null $customerUser)
+ * @method \App\Model\Cart\Cart getCartForCreateOrderMutation(array<string,mixed> $input, \App\Model\Customer\User\CustomerUser|null $customerUser)
+ * @method \Shopsys\FrontendApiBundle\Model\Cart\CartWithModificationsResult getCheckedCartWithModifications(\App\Model\Cart\Cart $cart)
+ * @method \App\Model\Order\Order createOrderFromCart(\Overblog\GraphQLBundle\Definition\Argument $argument, \App\Model\Cart\Cart $cart, string|null $deliveryAddressUuid)
+ * @method \App\Model\Order\OrderData getProcessedOrderData(\Overblog\GraphQLBundle\Definition\Argument $argument, \App\Model\Cart\Cart $cart, string|null $deliveryAddressUuid)
+ * @method \Shopsys\FrameworkBundle\Model\Order\Processing\OrderInput createOrderInputFromCart(\App\Model\Cart\Cart $cart, string|null $deliveryAddressUuid)
  */
 class CreateOrderMutation extends BaseCreateOrderMutation
 {


### PR DESCRIPTION
#### Description, the reason for the PR

This PR makes the Frontend API order creation flow easier to customize.

Until now, `CreateOrderMutation` handled validation, cart loading, cart modification checks, order data processing, order placement, and cart cleanup in one large method. That made project-specific changes harder to implement because even a small adjustment often meant overriding or duplicating a broad piece of logic.

The mutation is now split into smaller protected steps while keeping the existing behavior unchanged. This makes extensions more targeted, reduces the amount of code that needs to be replaced in custom projects, and lowers the risk of regressions when adjusting only one part of the order creation process.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-order-mutation-dx.odin.shopsys.cloud
  - https://cz.mg-order-mutation-dx.odin.shopsys.cloud
  - https://mg-order-mutation-dx.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776258558.093209 -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-order-mutation-dx.odin.shopsys.cloud
  - https://cz.mg-order-mutation-dx.odin.shopsys.cloud
  - https://mg-order-mutation-dx.odin.shopsys.cloud/sk
<!-- Replace -->
