### PR TITLE
removed heureka_category_id_seq that was kept by accident

### DIFF
--- a/packages/framework/src/Migrations/Version20260416140346.php
+++ b/packages/framework/src/Migrations/Version20260416140346.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20260416140346 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('DROP SEQUENCE IF EXISTS heureka_category_id_seq');
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR
In https://github.com/shopsys/shopsys/pull/4513 was all owned sequenced dropped, but heureka_category_id_seq had no owner, so it was omitted, even it was supposed to be removed. This PR fixes that.

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://tl-remove-already-dropped-sequence.odin.shopsys.cloud
  - https://cz.tl-remove-already-dropped-sequence.odin.shopsys.cloud
  - https://tl-remove-already-dropped-sequence.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1776684520.969589 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-remove-already-dropped-sequence.odin.shopsys.cloud
  - https://cz.tl-remove-already-dropped-sequence.odin.shopsys.cloud
  - https://tl-remove-already-dropped-sequence.odin.shopsys.cloud/sk
<!-- Replace -->
