### PR TITLE
Optimize Cypress failure artifacts

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -160,16 +160,24 @@ test:storefront-acceptance:
     <<: *only-default
     tags:
         - tests
-#    parallel:
-#        matrix:
-#            -   GROUP: "authentication"
-#            -   GROUP: "cart"
-#            -   GROUP: "order"
-#            -   GROUP: "transportAndPayment"
-#            -   GROUP: "visits"
-#            -   GROUP: "ssr"
-#            -   GROUP: "others"
-
+    #    parallel:
+    #        matrix:
+    #            -   GROUP: "authentication"
+    #            -   GROUP: "b2b"
+    #            -   GROUP: "cart"
+    #            -   GROUP: "comparison"
+    #            -   GROUP: "complaints"
+    #            -   GROUP: "customerUsers"
+    #            -   GROUP: "filterAndSort"
+    #            -   GROUP: "freeShipping"
+    #            -   GROUP: "limitedUser"
+    #            -   GROUP: "order"
+    #            -   GROUP: "seoCategory"
+    #            -   GROUP: "ssr"
+    #            -   GROUP: "stores"
+    #            -   GROUP: "transportAndPayment"
+    #            -   GROUP: "visits"
+    #            -   GROUP: "others"
     artifacts:
         paths:
             - ./storefront/cypress/videos/

--- a/project-base/storefront/cypress/cypress.config.ts
+++ b/project-base/storefront/cypress/cypress.config.ts
@@ -50,6 +50,18 @@ export default defineConfig({
         setupNodeEvents(on, config) {
             configureVisualRegression(on);
 
+            // Delete videos of passing specs so CI failure artifacts stay under upload limits.
+            on('after:spec', (_spec, results) => {
+                if (results?.video) {
+                    const failed = results.tests?.some((t) =>
+                        t.attempts?.some((a) => a.state === 'failed'),
+                    );
+                    if (!failed && fs.existsSync(results.video)) {
+                        fs.unlinkSync(results.video);
+                    }
+                }
+            });
+
             on('before:browser:launch', (browser, launchOptions) => {
                 if (browser.family === 'chromium' && browser.name !== 'electron') {
                     launchOptions.args.push(

--- a/upgrade-notes/storefront_20260420_104410.md
+++ b/upgrade-notes/storefront_20260420_104410.md
@@ -1,0 +1,13 @@
+#### Optimize GitLab Cypress failure artifacts ([#4566](https://github.com/shopsys/shopsys/pull/4566))
+
+Previously, `test:storefront-acceptance` failed with `413 Request Entity Too Large` when uploading its failure artifacts — the combined size of videos, screenshots, and snapshotDiffs for the full Cypress suite exceeded the runner's upload limit, leaving developers with no artifacts to diagnose the failure.
+
+The fix uses an `after:spec` hook in `cypress.config.ts` to delete the video file of any spec where all tests passed. Failure artifacts are then naturally scoped to the spec files that actually failed:
+
+- `videos/` — only kept for spec files with at least one failing test (or a test that needed retries)
+- `screenshots/` — Cypress already captures these only on failure (no change needed)
+- `snapshotDiffs/` — already only generated on visual regression failure (no change needed)
+
+`test:storefront-acceptance` now uploads full failure artifacts (`videos`, `screenshots`, `snapshotDiffs`, and service logs `php-fpm`/`webserver`/`storefront`) on failure. Because videos are filtered to only failing specs, total artifact size stays well under the upload limit in normal failure scenarios.
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Problem                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                        
test:storefront-acceptance in GitLab CI was failing with 413 Request Entity Too Large when uploading its failure artifacts. The combined size of videos, screenshots, and snapshotDiffs for the full Cypress suite (~41 tests) exceeded the runner's upload limit, leaving developers with no artifacts to diagnose failures.                                                                                                                                                                              
                                                                                                                                                                                                                                                        
GitHub Actions was unaffected due to different runner/docker-compose stack configuration (out of scope for this PR).                                                                                                                                  
          
 Solution                                                                                                                                                                                                                                              
                                                                                                                                                
  - Added an after:spec hook in cypress.config.ts that deletes the video file of any spec where all tests passed                                                                                                                                        
  - test:storefront-acceptance now uploads full failure artifacts (videos, screenshots, snapshotDiffs + service logs), but videos are naturally scoped to failing specs only
  - Total artifact size stays well under the upload limit in normal failure scenarios                                                                                                                                                                   
                                                                                                                                                                                                                                                        
 Result                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                        
  - Green runs upload no artifacts                                                                                                                                                                                                                      
  - On failure, the developer gets one artifact zip with: videos of failing specs, screenshots captured at the failing step, visual regression diffs, and service logs (php-fpm, webserver, storefront)
  - No more 413, no manual steps required   

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3980-gitlab-cypress.odin.shopsys.cloud
  - https://cz.tc-ssp-3980-gitlab-cypress.odin.shopsys.cloud
  - https://tc-ssp-3980-gitlab-cypress.odin.shopsys.cloud/sk
<!-- Replace -->
