### PR TITLE
Removed ReadyCategorySeoMix programatical dependency on $selectedCategorySeoMixCombinationJson

### DIFF
--- a/packages/administration/templates/content/categorySeo/listGrid.html.twig
+++ b/packages/administration/templates/content/categorySeo/listGrid.html.twig
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block grid_value_cell_id_parameters %}
-    {% for parameterNameParameterValuePair in getReadyCategoryMixCombinationParametersPairsIterator(row.selectedCategorySeoMixCombinationJson) %}
+    {% for parameterNameParameterValuePair in getReadyCategoryMixCombinationParametersPairsIterator(row.rcsmId) %}
         {{ parameterNameParameterValuePair }}<br>
     {% endfor %}
 {% endblock %}

--- a/packages/framework/src/Controller/Admin/CategorySeoController.php
+++ b/packages/framework/src/Controller/Admin/CategorySeoController.php
@@ -25,6 +25,7 @@ use Shopsys\FrameworkBundle\Model\CategorySeo\CategorySeoFiltersData;
 use Shopsys\FrameworkBundle\Model\CategorySeo\Exception\ReadyCategorySeoMixNotFoundException;
 use Shopsys\FrameworkBundle\Model\CategorySeo\Exception\ReadyCategorySeoMixUrlsContainBadDomainUrlException;
 use Shopsys\FrameworkBundle\Model\CategorySeo\Exception\ReadyCategorySeoMixUrlsDoNotContainUrlForCorrectDomainException;
+use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMix;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixData;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixDataFactory;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade;
@@ -188,25 +189,25 @@ class CategorySeoController extends AdminBaseController
             // A little hack - when you need form sent data to create that same form - need for friendly URLs
             $sentReadyCategorySeoCombinationFormData = $request->request->all('ready_category_seo_combination_form');
             $selectedCategorySeoMixCombinationJson = $sentReadyCategorySeoCombinationFormData['selectedCategorySeoMixCombinationJson'] ?? null;
+        }
 
-            $selectedCategorySeoMixCombination = $selectedCategorySeoMixCombinationJson === null ? null : $this->selectedCategorySeoMixCombinationFactory->createFromJson(
-                $selectedCategorySeoMixCombinationJson,
-            );
-        } else {
-            $selectedCategorySeoMixCombination = $this->selectedCategorySeoMixCombinationFactory->createFromJson(
-                $selectedCategorySeoMixCombinationJson,
-            );
+        $selectedCategorySeoMixCombination = $selectedCategorySeoMixCombinationJson === null ? null : $this->selectedCategorySeoMixCombinationFactory->createFromJson(
+            $selectedCategorySeoMixCombinationJson,
+        );
+
+        if ($selectedCategorySeoMixCombination !== null) {
+            $existingReadyCategorySeoMix = $this->readyCategorySeoMixFacade->findBySelectedCategorySeoMixCombination($selectedCategorySeoMixCombination);
+
+            if ($existingReadyCategorySeoMix !== null) {
+                return $this->redirectToRoute('admin_categoryseo_readycombination_edit', [
+                    'id' => $existingReadyCategorySeoMix->getId(),
+                ]);
+            }
         }
 
         $readyCategorySeoMixData = $this->readyCategorySeoMixDataFactory->createReadyCategorySeoMixData($selectedCategorySeoMixCombination);
 
         $this->storeJsonsToReadyCategorySeoMixData($readyCategorySeoMixData, $categorySeoFilterFormTypeAllQueries, $selectedCategorySeoMixCombination);
-
-        if ($categorySeoFilterFormTypeAllQueries === null
-            && $readyCategorySeoMixData->categorySeoFilterFormTypeAllQueriesJson !== null
-        ) {
-            $categorySeoFilterFormTypeAllQueries = json_decode($readyCategorySeoMixData->categorySeoFilterFormTypeAllQueriesJson, true, 512, JSON_THROW_ON_ERROR);
-        }
 
         if ($categorySeoFilterFormTypeAllQueries !== null) {
             $newCombinationsUrl = $this->getUrlWithCategoryIdAndAllQueryParameters(
@@ -219,6 +220,60 @@ class CategorySeoController extends AdminBaseController
             $newCombinationsUrl = $this->generateUrl('admin_categoryseo_list');
         }
 
+        $selfUrl = $this->generateUrl(
+            'admin_categoryseo_readycombination',
+            [
+                'categoryId' => $categoryId,
+                'categorySeoFilterFormTypeAllQueries' => $categorySeoFilterFormTypeAllQueries,
+                'selectedCategorySeoMixCombinationJson' => $selectedCategorySeoMixCombination !== null ? $this->selectedCategorySeoMixCombinationFactory->createJsonFromSelectedCategorySeoMixCombination($selectedCategorySeoMixCombination) : null,
+            ],
+        );
+
+        return $this->renderReadyCombinationForm(
+            $request,
+            $selectedCategorySeoMixCombination,
+            $readyCategorySeoMixData,
+            $categorySeoFilterFormTypeAllQueries,
+            $newCombinationsUrl,
+            $selfUrl,
+        );
+    }
+
+    #[Route(path: '/seo/category/ready-combination/edit/{id}', name: 'admin_categoryseo_readycombination_edit', requirements: ['id' => '\d+'])]
+    #[CanEdit(methods: [HttpMethod::POST])]
+    #[CanView(methods: [HttpMethod::GET])]
+    public function readyCombinationEditAction(Request $request, int $id): Response
+    {
+        try {
+            $readyCategorySeoMix = $this->readyCategorySeoMixFacade->getById($id);
+        } catch (ReadyCategorySeoMixNotFoundException) {
+            throw $this->createNotFoundException();
+        }
+
+        $selectedCategorySeoMixCombination = $this->createSelectedCategorySeoMixCombinationFromReadyCategorySeoMix($readyCategorySeoMix);
+        $readyCategorySeoMixData = $this->readyCategorySeoMixDataFactory->createReadyCategorySeoMixData($selectedCategorySeoMixCombination);
+
+        $newCombinationsUrl = $this->generateUrl('admin_categoryseo_list');
+        $selfUrl = $this->generateUrl('admin_categoryseo_readycombination_edit', ['id' => $id]);
+
+        return $this->renderReadyCombinationForm(
+            $request,
+            $selectedCategorySeoMixCombination,
+            $readyCategorySeoMixData,
+            null,
+            $newCombinationsUrl,
+            $selfUrl,
+        );
+    }
+
+    protected function renderReadyCombinationForm(
+        Request $request,
+        ?SelectedCategorySeoMixCombination $selectedCategorySeoMixCombination,
+        ReadyCategorySeoMixData $readyCategorySeoMixData,
+        ?array $categorySeoFilterFormTypeAllQueries,
+        string $newCombinationsUrl,
+        string $selfUrl,
+    ): Response {
         $readyCategorySeoCombinationFormType = $this->createForm(ReadyCategorySeoCombinationFormType::class, $readyCategorySeoMixData, [
             'method' => 'POST',
             'new_combination_url' => $newCombinationsUrl,
@@ -233,15 +288,6 @@ class CategorySeoController extends AdminBaseController
                 $selectedCategorySeoMixCombination,
             );
 
-            $selfUrl = $this->generateUrl(
-                'admin_categoryseo_readycombination',
-                [
-                    'categoryId' => $categoryId,
-                    'categorySeoFilterFormTypeAllQueries' => $categorySeoFilterFormTypeAllQueries,
-                    'selectedCategorySeoMixCombinationJson' => $this->selectedCategorySeoMixCombinationFactory->createJsonFromSelectedCategorySeoMixCombination($selectedCategorySeoMixCombination),
-                ],
-            );
-
             try {
                 $this->readyCategorySeoMixFacade->createOrEdit(
                     $selectedCategorySeoMixCombination,
@@ -254,7 +300,7 @@ class CategorySeoController extends AdminBaseController
                     ['url' => $selfUrl],
                 );
 
-                return $this->redirect($newCombinationsUrl);
+                return $this->redirectToRoute('admin_categoryseo_list');
             } catch (ReadyCategorySeoMixUrlsContainBadDomainUrlException) {
                 $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
                 $this->addErrorFlash(t('Fill URL only for selected domain'));
@@ -274,6 +320,25 @@ class CategorySeoController extends AdminBaseController
             ),
             'selectedCategorySeoMixCombinationDomainConfig' => $this->domain->getDomainConfigById($selectedCategorySeoMixCombination->getDomainId()),
         ]);
+    }
+
+    protected function createSelectedCategorySeoMixCombinationFromReadyCategorySeoMix(
+        ReadyCategorySeoMix $readyCategorySeoMix,
+    ): SelectedCategorySeoMixCombination {
+        $parameterValueIdsByParameterIds = [];
+
+        foreach ($readyCategorySeoMix->getReadyCategorySeoMixParameterParameterValues() as $readyCategorySeoMixParameterParameterValue) {
+            $parameterValueIdsByParameterIds[$readyCategorySeoMixParameterParameterValue->getParameter()->getId()]
+                = $readyCategorySeoMixParameterParameterValue->getParameterValue()->getId();
+        }
+
+        return $this->selectedCategorySeoMixCombinationFactory->create(
+            $readyCategorySeoMix->getDomainId(),
+            $readyCategorySeoMix->getCategory()->getId(),
+            $readyCategorySeoMix->getFlag()?->getId(),
+            $readyCategorySeoMix->getOrdering(),
+            $parameterValueIdsByParameterIds,
+        );
     }
 
     #[Route(path: '/seo/category/ready-combination/delete/{id}', requirements: ['id' => '\d+'])]

--- a/packages/framework/src/Migrations/Version20260424085853.php
+++ b/packages/framework/src/Migrations/Version20260424085853.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20260424085853 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE ready_category_seo_mix_parameter_parameter_values DROP CONSTRAINT fk_428d0df01452663e');
+        $this->sql('ALTER TABLE ready_category_seo_mix_parameter_parameter_values ADD CONSTRAINT fk_428d0df01452663e FOREIGN KEY (parameter_value_id) REFERENCES parameter_values (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMix.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMix.php
@@ -265,12 +265,4 @@ class ReadyCategorySeoMix
     {
         return $this->uuid;
     }
-
-    /**
-     * @return string|null
-     */
-    public function getSelectedCategorySeoMixCombinationJson()
-    {
-        return $this->selectedCategorySeoMixCombinationJson;
-    }
 }

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixGridFactory.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixGridFactory.php
@@ -37,13 +37,12 @@ class ReadyCategorySeoMixGridFactory
 
         $grid->addColumn('categoryName', 'categoryName', t('Category name'));
         $grid->addColumn('friendlyUrlSlug', 'fuSlug', t('Main URL'));
-        $grid->addColumn('parameters', 'rcsm.selectedCategorySeoMixCombinationJson', t('Combination of parameters and their values'));
+        $grid->addColumn('parameters', 'rcsmId', t('Combination of parameters and their values'));
         $grid->addColumn('flagName', 'flagName', t('Flag'));
         $grid->addColumn('ordering', 'rcsm.ordering', t('Ordering'));
 
-        $grid->addEditActionColumn('admin_categoryseo_readycombination', [
-            'categoryId' => 'categoryId',
-            'selectedCategorySeoMixCombinationJson' => 'rcsm.selectedCategorySeoMixCombinationJson',
+        $grid->addEditActionColumn('admin_categoryseo_readycombination_edit', [
+            'id' => 'rcsmId',
         ]);
         $grid->addDeleteActionColumn('admin_categoryseo_delete', ['id' => 'rcsmId']);
 
@@ -57,7 +56,7 @@ class ReadyCategorySeoMixGridFactory
     public function getAllByDomainIdQueryBuilder(int $domainId, string $locale): QueryBuilder
     {
         return $this->em->createQueryBuilder()
-            ->select('rcsm.id as rcsmId, c.id as categoryId, ct.name as categoryName, fu.slug as fuSlug, rcsm.selectedCategorySeoMixCombinationJson, ft.name as flagName, rcsm.ordering')
+            ->select('rcsm.id as rcsmId, c.id as categoryId, ct.name as categoryName, fu.slug as fuSlug, ft.name as flagName, rcsm.ordering')
             ->from(ReadyCategorySeoMix::class, 'rcsm')
             ->andWhere('rcsm.domainId = :domainId')
             ->join('rcsm.category', 'c')

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixParameterParameterValue.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMixParameterParameterValue.php
@@ -31,7 +31,7 @@ class ReadyCategorySeoMixParameterParameterValue
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue
      */
-    #[ORM\JoinColumn(name: 'parameter_value_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'parameter_value_id', referencedColumnName: 'id', nullable: false)]
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: ParameterValue::class)]
     protected $parameterValue;

--- a/packages/framework/src/Twig/CategorySeoExtension.php
+++ b/packages/framework/src/Twig/CategorySeoExtension.php
@@ -8,8 +8,6 @@ use Generator;
 use Override;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade;
-use Shopsys\FrameworkBundle\Model\CategorySeo\SelectedCategorySeoMixCombinationFactory;
-use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -17,10 +15,8 @@ use Twig\TwigFunction;
 class CategorySeoExtension extends AbstractExtension
 {
     public function __construct(
-        protected readonly ParameterFacade $parameterFacade,
         protected readonly DomainRouterFactory $domainRouterFactory,
         protected readonly ReadyCategorySeoMixFacade $readyCategorySeoMixFacade,
-        protected readonly SelectedCategorySeoMixCombinationFactory $selectedCategorySeoMixCombinationFactory,
     ) {
     }
 
@@ -36,13 +32,12 @@ class CategorySeoExtension extends AbstractExtension
         ];
     }
 
-    public function getReadyCategoryMixCombinationParametersPairsIterator(
-        string $selectedCategorySeoMixCombinationJson,
-    ): Generator {
-        $selectedCategorySeoMixCombination = $this->selectedCategorySeoMixCombinationFactory->createFromJson($selectedCategorySeoMixCombinationJson);
+    public function getReadyCategoryMixCombinationParametersPairsIterator(int $readyCategorySeoMixId): Generator
+    {
+        $readyCategorySeoMix = $this->readyCategorySeoMixFacade->getById($readyCategorySeoMixId);
 
-        foreach ($selectedCategorySeoMixCombination->getParameterValueIdsByParameterIds() as $parameterId => $parameterValueId) {
-            yield $this->parameterFacade->getById($parameterId)->getName() . ': ' . $this->parameterFacade->getParameterValueById($parameterValueId)->getText();
+        foreach ($readyCategorySeoMix->getReadyCategorySeoMixParameterParameterValues() as $readyCategorySeoMixParameterParameterValue) {
+            yield $readyCategorySeoMixParameterParameterValue->getParameter()->getName() . ': ' . $readyCategorySeoMixParameterParameterValue->getParameterValue()->getText();
         }
     }
 

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\App\Smoke\Http;
 
+use App\DataFixtures\Demo\ReadyCategorySeoDataFixture;
 use App\DataFixtures\Demo\UnitDataFixture;
 use App\DataFixtures\Demo\VatDataFixture;
 use App\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
+use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMix;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule;
 use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;
@@ -344,6 +346,16 @@ class RouteConfigCustomization
                 $config->changeDefaultRequestDataSet('Check route with data-fixture parameters.')
                     ->setParameter('categoryId', 8)
                     ->setParameter('selectedCategorySeoMixCombinationJson', '{"domainId":1,"categoryId":8,"flagId":1,"ordering":null,"parameterValueIdsByParameterIds":{"38":75,"40":79,"37":73,"39":77}}');
+            })
+            ->customizeByRouteName('admin_categoryseo_readycombination_edit', function (RouteConfig $config): void {
+                $readyCategorySeoMix = $this->getPersistentReference(
+                    ReadyCategorySeoDataFixture::READY_CATEGORY_SEO_ELECTRONICS_WITHOUT_HDMI_PROMOTION,
+                    Domain::FIRST_DOMAIN_ID,
+                    ReadyCategorySeoMix::class,
+                );
+
+                $config->changeDefaultRequestDataSet('Edit existing ready category SEO mix from fixtures.')
+                    ->setParameter('id', $readyCategorySeoMix->getId());
             })
             ->customizeByRouteName('admin_unused_friendly_url_delete', function (RouteConfig $config): void {
                 $config->changeDefaultRequestDataSet('Unused friendly URL may be deleted only when there is any and CSRF token is provided')

--- a/upgrade-notes/backend_20260424_093253.md
+++ b/upgrade-notes/backend_20260424_093253.md
@@ -1,0 +1,3 @@
+#### Ensure that the parameter value cannot be removed if the category seo mix depends on it ([#4579](https://github.com/shopsys/shopsys/pull/4579))
+
+- before applying migration `Version20260424085853`, review whether any existing `ready_category_seo_mixes` rows reference `parameter_values` IDs that no longer exist; update those SEO mixes first, otherwise the migration would fail

--- a/upgrade-notes/backend_20260424_093253.md
+++ b/upgrade-notes/backend_20260424_093253.md
@@ -1,3 +1,4 @@
 #### Ensure that the parameter value cannot be removed if the category seo mix depends on it ([#4579](https://github.com/shopsys/shopsys/pull/4579))
 
 - before applying migration `Version20260424085853`, review whether any existing `ready_category_seo_mixes` rows reference `parameter_values` IDs that no longer exist; update those SEO mixes first, otherwise the migration would fail
+- editing a ready category SEO mix moved to a dedicated action at route `admin_categoryseo_readycombination_edit` (path `/seo/category/ready-combination/edit/{id}`); the existing `admin_categoryseo_readycombination` route is now wizard-only (creates a new mix for a combination and redirects to the edit route if one already exists for that combination) so update your project appropriately


### PR DESCRIPTION
#### Description, the reason for the PR
- It was possible to delete parameter value that was associated with SEO Category, which would cause some troubles after. Updated foreign key introduced to prevent this.
- $selectedCategorySeoMixCombinationJson is now only used for uniqueness of selected combination and nothing else
- new and edit actions has been split in order to have more clear code

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://tl-restrict-deleting-parameter-values.odin.shopsys.cloud
  - https://cz.tl-restrict-deleting-parameter-values.odin.shopsys.cloud
  - https://tl-restrict-deleting-parameter-values.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777534323.347679 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-restrict-deleting-parameter-values.odin.shopsys.cloud
  - https://cz.tl-restrict-deleting-parameter-values.odin.shopsys.cloud
  - https://tl-restrict-deleting-parameter-values.odin.shopsys.cloud/sk
<!-- Replace -->
