### PR TITLE
nginx: avoid storefront fallback for missing content locale overrides

### DIFF
--- a/project-base/app/orchestration/kubernetes/configmap/nginx.yaml
+++ b/project-base/app/orchestration/kubernetes/configmap/nginx.yaml
@@ -239,6 +239,21 @@ data:
                 proxy_pass {{S3_ENDPOINT}}/{{PROJECT_NAME}}/web/$1/$image_id.$image_extension;
             }
 
+            # user translation overrides are fetched server-to-server by the storefront
+            # return a plain 404 on miss so storefront does not render an error page with the internal Host header
+            location ~ ^/(?:[^/]+/)?content(-test)?/locales/ {
+                proxy_intercept_errors  on;
+                error_page              404 = @404;
+
+                proxy_http_version      1.1;
+                proxy_set_header        Authorization "";
+                proxy_buffering         off;
+                proxy_hide_header       Access-Control-Allow-Origin;
+                proxy_hide_header       Access-Control-Allow-Credentials;
+
+                proxy_pass              {{S3_ENDPOINT}}/{{PROJECT_NAME}}/web$request_uri;
+            }
+
             location ~ ^/(content)/ {
                 proxy_intercept_errors  on;
                 error_page              404 = $custom_error_target;

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -100,6 +100,12 @@ server {
         try_files /$1/$image_id.$image_extension @storefront;
     }
 
+    # user translation overrides are fetched server-to-server by the storefront
+    # return a plain 404 on miss so storefront does not render an error page with the internal Host header
+    location ~ ^/(?:[^/]+/)?content(-test)?/locales/ {
+        try_files $uri =404;
+    }
+
     # location for static files, try to serve the file directly, render storefront 404 page if file does not exist
     location ~ ^/(?:[^/]+/)?(public|content(-test)?)/ {
         location ~ /\. {

--- a/upgrade-notes/backend_20260427_140051.md
+++ b/upgrade-notes/backend_20260427_140051.md
@@ -1,0 +1,3 @@
+#### nginx: avoid storefront fallback for missing content locale overrides ([#4581](https://github.com/shopsys/shopsys/pull/4581))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Storefront fetches user translation override files from `/content/locales/...` through a server-to-server request. When the file was missing, nginx fell back to the storefront error page instead of returning a plain 404.

That fallback is not suitable for this endpoint. It can return an HTML error response generated under the internal host context, while the storefront only needs to know whether the override file exists. This PR changes nginx handling for locale override files so missing files return a plain 404 directly.

As a result, storefront can safely detect that no locale override is available without going through the storefront fallback path.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-locales-json.odin.shopsys.cloud
  - https://cz.rv-fix-locales-json.odin.shopsys.cloud
  - https://rv-fix-locales-json.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777967257.714889 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-locales-json.odin.shopsys.cloud
  - https://cz.rv-fix-locales-json.odin.shopsys.cloud
  - https://rv-fix-locales-json.odin.shopsys.cloud/sk
<!-- Replace -->
