### PR TITLE
fix articles ordering

### DIFF
--- a/packages/framework/src/Controller/Admin/ArticleController.php
+++ b/packages/framework/src/Controller/Admin/ArticleController.php
@@ -196,7 +196,12 @@ class ArticleController extends AdminBaseController
     #[CanEdit]
     public function saveOrderingAction(Request $request): JsonResponse
     {
-        $this->articleFacade->saveOrdering($request->request->all('rowIdsByGridId'));
+        $rowIdsByGridId = array_map(
+            static fn (array $rowIds): array => array_map('json_decode', $rowIds),
+            $request->request->all('rowIdsByGridId'),
+        );
+
+        $this->articleFacade->saveOrdering($rowIdsByGridId);
 
         $responseData = ['success' => true];
 

--- a/packages/framework/src/Model/Article/ArticleFacade.php
+++ b/packages/framework/src/Model/Article/ArticleFacade.php
@@ -102,7 +102,7 @@ class ArticleFacade
     }
 
     /**
-     * @param int[][] $rowIdsByGridId
+     * @param array<string, array<int|string, int>> $rowIdsByGridId
      */
     public function saveOrdering(array $rowIdsByGridId): void
     {


### PR DESCRIPTION
#### Description, the reason for the PR
- array map with json_decode ensures row ids to be integers required by ArticleFacade::saveOrdering() method
- unified solution with general GridController::saveOrderingAction()
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-articles-fix.odin.shopsys.cloud
  - https://cz.rv-articles-fix.odin.shopsys.cloud
  - https://rv-articles-fix.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777886358.638709 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-articles-fix.odin.shopsys.cloud
  - https://cz.rv-articles-fix.odin.shopsys.cloud
  - https://rv-articles-fix.odin.shopsys.cloud/sk
<!-- Replace -->
