### PR TITLE
[CRUD] Create and edit actions

### DIFF
--- a/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
+++ b/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
@@ -219,3 +219,34 @@ class Order implements Presentable
 ```
 
 Read more about implementing `Presentable` interface in the [Entity Naming](../reference/handlers.md#entity-naming) section.
+
+## 4. Configure Form
+
+To display forms on create and edit pages, override the `configureForm()` method in your CRUD controller. The method receives a Symfony `FormBuilderInterface` and the entity being edited (`null` for create).
+
+```php
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+{
+    $builder
+        ->add('name', TextType::class, [
+            'label' => t('Name'),
+            'required' => true,
+        ]);
+}
+```
+
+You can also use an existing FormType class:
+
+```php
+protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+{
+    $builder->add('order', OrderFormType::class, [
+        'order' => $entity,
+    ]);
+}
+```
+
+See [configureForm reference](../reference/crud-controller.md#configureformformbuilderinterface-builder-object-entity--null-void) for more details.

--- a/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
+++ b/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
@@ -63,7 +63,136 @@ class OrderController extends AbstractCrudController
 }
 ```
 
-This will enable Delete action in your CRUD controller. Similarly, you can create and register handlers for Create, Edit, and Detail actions by implementing the respective interfaces.
+This will enable Delete action in your CRUD controller.
+
+### Edit Handler Example
+
+To enable edit functionality, implement `EditHandlerInterface`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Order;
+
+use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
+
+class OrderEditHandler implements EditHandlerInterface
+{
+    public function __construct(
+        private readonly OrderFacade $orderFacade,
+        private readonly OrderDataFactory $orderDataFactory,
+    ) {
+    }
+
+    public function getById(int $id): object
+    {
+        return $this->orderFacade->getById($id);
+    }
+
+    public function createDataFromEntity(object $entity): object
+    {
+        return $this->orderDataFactory->createFromOrder($entity);
+    }
+
+    public function edit(object $entity, object $data): void
+    {
+        $this->orderFacade->edit($entity->getId(), $data);
+    }
+}
+```
+
+### Create Handler Example
+
+To enable create functionality, implement `CreateHandlerInterface`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Order;
+
+use Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface;
+
+class OrderCreateHandler implements CreateHandlerInterface
+{
+    public function __construct(
+        private readonly OrderFacade $orderFacade,
+        private readonly OrderDataFactory $orderDataFactory,
+    ) {
+    }
+
+    public function getById(int $id): object
+    {
+        return $this->orderFacade->getById($id);
+    }
+
+    public function createData(): object
+    {
+        return $this->orderDataFactory->create();
+    }
+
+    public function create(object $data): object
+    {
+        return $this->orderFacade->create($data);
+    }
+}
+```
+
+### Full CRUD Handler
+
+To enable all operations at once, implement `CrudHandlerInterface` which combines Delete, Edit, and Create:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Order;
+
+use Shopsys\AdministrationBundle\Component\Crud\Handler\CrudHandlerInterface;
+
+class OrderCrudHandler implements CrudHandlerInterface
+{
+    public function __construct(
+        private readonly OrderFacade $orderFacade,
+        private readonly OrderDataFactory $orderDataFactory,
+    ) {
+    }
+
+    public function getById(int $id): object
+    {
+        return $this->orderFacade->getById($id);
+    }
+
+    public function delete(object $entity): void
+    {
+        $this->orderFacade->deleteById($entity->getId());
+    }
+
+    public function createDataFromEntity(object $entity): object
+    {
+        return $this->orderDataFactory->createFromOrder($entity);
+    }
+
+    public function edit(object $entity, object $data): void
+    {
+        $this->orderFacade->edit($entity->getId(), $data);
+    }
+
+    public function createData(): object
+    {
+        return $this->orderDataFactory->create();
+    }
+
+    public function create(object $data): object
+    {
+        return $this->orderFacade->create($data);
+    }
+}
+```
 
 ## 3. Implement Entity String Representation
 

--- a/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
+++ b/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
@@ -222,15 +222,30 @@ Read more about implementing `Presentable` interface in the [Entity Naming](../r
 
 ## 4. Configure Form
 
-To display forms on create and edit pages, override the `configureForm()` method in your CRUD controller. The method receives a Symfony `FormBuilderInterface` and the entity being edited (`null` for create).
+To display forms on create and edit pages, override the `configureForm()` method in your CRUD controller. The method receives a `CrudFormConfigurator` and the entity being edited (`null` for create).
+
+You can use an existing FormType class:
 
 ```php
-use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\FormBuilderInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
 
-protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+protected function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
 {
-    $builder
+    $formConfigurator->useFormType(OrderFormType::class, [
+        'order' => $entity,
+    ]);
+}
+```
+
+Or build the form inline using the builder:
+
+```php
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+protected function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
+{
+    $formConfigurator->useBuilder()
         ->add('name', TextType::class, [
             'label' => t('Name'),
             'required' => true,
@@ -238,15 +253,4 @@ protected function configureForm(FormBuilderInterface $builder, ?object $entity 
 }
 ```
 
-You can also use an existing FormType class:
-
-```php
-protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
-{
-    $builder->add('order', OrderFormType::class, [
-        'order' => $entity,
-    ]);
-}
-```
-
-See [configureForm reference](../reference/crud-controller.md#configureformformbuilderinterface-builder-object-entity--null-void) for more details.
+See [configureForm reference](../reference/crud-controller.md#configureformcrudformconfigurator-formconfigurator-object-entity--null-void) for more details.

--- a/docs/administration/crud-controller/getting-started/extending-existing-crud-controller.md
+++ b/docs/administration/crud-controller/getting-started/extending-existing-crud-controller.md
@@ -54,6 +54,30 @@ public function configureDatagrid(Datagrid $datagrid): void
 }
 ```
 
+### Extending Forms
+
+Extensions can add fields to forms using the `configureForm()` method. This works **only when the original controller uses the builder mode** (`useBuilder()`). When the controller uses `useFormType()`, the form is fully defined by the FormType class and extensions cannot add fields via the builder.
+
+```php
+// OrderControllerExtension.php
+
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+public function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
+{
+    $formConfigurator->useBuilder()
+        ->add('internalNote', TextareaType::class, [
+            'label' => t('Internal note'),
+            'required' => false,
+        ]);
+}
+```
+
+!!! warning
+
+    Calling `useBuilder()` in an extension when the controller used `useFormType()` will throw `CrudFormAlreadyConfiguredException`. If you need to extend a form defined via FormType, use [Symfony's form extension mechanism](https://symfony.com/doc/current/form/create_form_type_extension.html) instead.
+
 ### Using Hooks
 
 Extensions can implement hook interfaces to add custom logic before, after, or on error during CRUD operations.

--- a/docs/administration/crud-controller/getting-started/extending-existing-crud-controller.md
+++ b/docs/administration/crud-controller/getting-started/extending-existing-crud-controller.md
@@ -54,11 +54,59 @@ public function configureDatagrid(Datagrid $datagrid): void
 }
 ```
 
-!!! tip "Using Hooks"
+### Using Hooks
 
-    Extensions can implement hook interfaces to add custom logic before, after, or on error during CRUD operations.
+Extensions can implement hook interfaces to add custom logic before, after, or on error during CRUD operations.
+See [Hooks System Reference](../reference/handlers.md#hooks-system) for complete documentation.
 
-    See [Hooks System Reference](../reference/handlers.md#hooks-system) for complete documentation.
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use Shopsys\AdministrationBundle\Component\Attributes\CrudControllerExtension;
+use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudEditHookExtensionInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudCreateHookExtensionInterface;
+use Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension;
+use Shopsys\FrameworkBundle\Controller\Admin\OrderCrudController;
+use Throwable;
+
+#[CrudControllerExtension(crudController: OrderCrudController::class)]
+class OrderControllerExtension extends AbstractCrudControllerExtension implements CrudEditHookExtensionInterface, CrudCreateHookExtensionInterface
+{
+    public function beforeEdit(object $entity, object $data): void
+    {
+        // Custom logic before saving edited entity
+    }
+
+    public function afterEdit(object $entity, object $data): void
+    {
+        // Custom logic after successful edit (e.g., clear cache, send notification)
+    }
+
+    public function onEditError(object $entity, object $data, Throwable $exception): void
+    {
+        // Custom error handling for edit failures
+    }
+
+    public function beforeCreate(object $data): void
+    {
+        // Custom logic before creating new entity
+    }
+
+    public function afterCreate(object $entity, object $data): void
+    {
+        // Custom logic after successful creation
+    }
+
+    public function onCreateError(object $data, Throwable $exception): void
+    {
+        // Custom error handling for create failures
+    }
+}
+```
 
 ## Multiple extensions for one CRUD Controller
 

--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -101,16 +101,29 @@ protected function configureQuery(QueryBuilder $queryBuilder): void
 }
 ```
 
-### `configureForm(FormBuilderInterface $builder, ?object $entity = null): void`
+### `configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void`
 
 Configure the form for create and edit pages. The `$entity` parameter is `null` for create action and contains the entity being edited for edit action.
 
-You can define form fields inline:
+The `CrudFormConfigurator` provides two mutually exclusive approaches — you must pick one:
+
+**Use an existing FormType class:**
 
 ```php
-protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+protected function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
 {
-    $builder
+    $formConfigurator->useFormType(BrandFormType::class, [
+        'brand' => $entity,
+    ]);
+}
+```
+
+**Or build the form inline using the builder:**
+
+```php
+protected function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
+{
+    $formConfigurator->useBuilder()
         ->add('name', TextType::class, [
             'label' => t('Name'),
             'required' => true,
@@ -122,16 +135,9 @@ protected function configureForm(FormBuilderInterface $builder, ?object $entity 
 }
 ```
 
-Or use an existing FormType:
+!!! warning "Mutually exclusive modes"
 
-```php
-protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
-{
-    $builder->add('brand', BrandFormType::class, [
-        'brand' => $entity,
-    ]);
-}
-```
+    Calling `useFormType()` after `useBuilder()` (or vice versa) throws `CrudFormAlreadyConfiguredException`. This also applies to [extensions](../getting-started/extending-existing-crud-controller.md#extending-forms) — if the controller uses `useFormType()`, extensions cannot call `useBuilder()`. When using `useBuilder()`, extensions can call `useBuilder()` too and will receive the same builder instance to add their fields.
 
 ## CRUD Config
 

--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -88,7 +88,7 @@ protected function configureDatagrid(Datagrid $datagrid): void
 }
 ```
 
-#### `configureQuery(QueryBuilder $queryBuilder): void`
+### `configureQuery(QueryBuilder $queryBuilder): void`
 
 Modify the query used to fetch entities for the list page.
 
@@ -98,6 +98,38 @@ protected function configureQuery(QueryBuilder $queryBuilder): void
     $queryBuilder
         ->andWhere('o.deleted = :deleted')
         ->setParameter('deleted', false);
+}
+```
+
+### `configureForm(FormBuilderInterface $builder, ?object $entity = null): void`
+
+Configure the form for create and edit pages. The `$entity` parameter is `null` for create action and contains the entity being edited for edit action.
+
+You can define form fields inline:
+
+```php
+protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+{
+    $builder
+        ->add('name', TextType::class, [
+            'label' => t('Name'),
+            'required' => true,
+        ])
+        ->add('description', TextareaType::class, [
+            'label' => t('Description'),
+            'required' => false,
+        ]);
+}
+```
+
+Or use an existing FormType:
+
+```php
+protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+{
+    $builder->add('brand', BrandFormType::class, [
+        'brand' => $entity,
+    ]);
 }
 ```
 

--- a/docs/administration/crud-controller/reference/handlers.md
+++ b/docs/administration/crud-controller/reference/handlers.md
@@ -17,8 +17,10 @@ Handlers use a hierarchical interface structure where each interface extends the
 ```
 HandlerInterface (base)
     └── ReadHandlerInterface (adds getById)
-        └── DeleteHandlerInterface (adds delete)
-            └── CrudHandlerInterface (marker for full CRUD)
+        ├── DeleteHandlerInterface (adds delete)
+        ├── EditHandlerInterface (adds createDataFromEntity, edit)
+        ├── CreateHandlerInterface (adds createData, create)
+        └── CrudHandlerInterface extends Delete + Edit + Create (marker for full CRUD)
 ```
 
 ### Choosing the Right Interface
@@ -31,7 +33,9 @@ Implement only the interface that matches your needs:
 |-----------|-------------|
 | `ReadHandlerInterface` | Detail/view-only pages |
 | `DeleteHandlerInterface` | Delete functionality |
-| `CrudHandlerInterface` | Full CRUD operations |
+| `EditHandlerInterface` | Edit functionality (retrieve entity data, save changes) |
+| `CreateHandlerInterface` | Create functionality (create empty data, persist new entity) |
+| `CrudHandlerInterface` | Full CRUD operations (combines Delete + Edit + Create) |
 
 !!! note "About HandlerInterface"
 

--- a/docs/administration/crud-controller/reference/handlers.md
+++ b/docs/administration/crud-controller/reference/handlers.md
@@ -92,6 +92,8 @@ Implement hook interfaces in your CRUD controller extensions:
 | Interface | When to Use | Methods Provided |
 |-----------|-------------|------------------|
 | `CrudDeleteHookExtensionInterface` | Extend delete operations with custom logic | `beforeDelete()`, `afterDelete()`, `onDeleteError()` |
+| `CrudEditHookExtensionInterface` | Extend edit operations with custom logic | `beforeEdit()`, `afterEdit()`, `onEditError()` |
+| `CrudCreateHookExtensionInterface` | Extend create operations with custom logic | `beforeCreate()`, `afterCreate()`, `onCreateError()` |
 
 ### Hook Execution Flow
 

--- a/packages/administration/src/Component/Config/ActionType.php
+++ b/packages/administration/src/Component/Config/ActionType.php
@@ -51,6 +51,14 @@ enum ActionType: string
         };
     }
 
+    public function isSubMenuRouteItem(): bool
+    {
+        return match ($this) {
+            self::DETAIL, self::CREATE, self::EDIT => true,
+            self::LIST, self::DELETE => false,
+        };
+    }
+
     /**
      * @param class-string<\Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface> $handlerClass
      * @return array<\Shopsys\AdministrationBundle\Component\Config\ActionType>

--- a/packages/administration/src/Component/Config/ActionType.php
+++ b/packages/administration/src/Component/Config/ActionType.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\AdministrationBundle\Component\Config;
 
+use Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Handler\CrudHandlerInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Handler\DeleteHandlerInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanCreate;
@@ -60,7 +62,9 @@ enum ActionType: string
 
         $actionsForHandlerInterface = [
             DeleteHandlerInterface::class => [self::DELETE],
-            CrudHandlerInterface::class => [self::DELETE],
+            EditHandlerInterface::class => [self::EDIT],
+            CreateHandlerInterface::class => [self::CREATE],
+            CrudHandlerInterface::class => [self::DELETE, self::EDIT, self::CREATE],
         ];
 
         $actions = [];

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -45,6 +45,8 @@ final class CrudConfig
      */
     private array $handlerClasses = [
         ActionType::DELETE->value => null,
+        ActionType::EDIT->value => null,
+        ActionType::CREATE->value => null,
     ];
 
     public function __construct(private readonly string $entityName)

--- a/packages/administration/src/Component/Crud/Extension/CrudCreateHookExtensionInterface.php
+++ b/packages/administration/src/Component/Crud/Extension/CrudCreateHookExtensionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Extension;
+
+use Throwable;
+
+interface CrudCreateHookExtensionInterface extends CrudHookableExtensionInterface
+{
+    public function beforeCreate(object $data): void;
+
+    public function afterCreate(object $entity, object $data): void;
+
+    public function onCreateError(object $data, Throwable $exception): void;
+}

--- a/packages/administration/src/Component/Crud/Extension/CrudEditHookExtensionInterface.php
+++ b/packages/administration/src/Component/Crud/Extension/CrudEditHookExtensionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Extension;
+
+use Throwable;
+
+interface CrudEditHookExtensionInterface extends CrudHookableExtensionInterface
+{
+    public function beforeEdit(object $entity, object $data): void;
+
+    public function afterEdit(object $entity, object $data): void;
+
+    public function onEditError(object $entity, object $data, Throwable $exception): void;
+}

--- a/packages/administration/src/Component/Crud/Form/CrudFormConfigurator.php
+++ b/packages/administration/src/Component/Crud/Form/CrudFormConfigurator.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Form;
+
+use Shopsys\AdministrationBundle\Component\Crud\Form\Exception\CrudFormAlreadyConfiguredException;
+use Shopsys\AdministrationBundle\Component\Crud\Form\Exception\CrudFormNotConfiguredException;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+class CrudFormConfigurator
+{
+    protected CrudFormMode $mode = CrudFormMode::UNCONFIGURED;
+
+    /**
+     * @var class-string<\Symfony\Component\Form\FormTypeInterface>|null
+     */
+    protected ?string $formTypeClass = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $formTypeOptions = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $formOptions = [];
+
+    protected ?FormBuilderInterface $builder = null;
+
+    public function __construct(
+        protected readonly FormFactoryInterface $formFactory,
+        protected readonly object $data,
+    ) {
+    }
+
+    /**
+     * Configures the form to use an existing FormType class
+     *
+     * @param class-string<\Symfony\Component\Form\FormTypeInterface> $formTypeClass #FormType
+     * @param array<string, mixed> $options #FormOption values
+     */
+    public function useFormType(string $formTypeClass, array $options = []): void
+    {
+        if ($this->mode !== CrudFormMode::UNCONFIGURED) {
+            throw CrudFormAlreadyConfiguredException::cannotSwitchMode($this->mode);
+        }
+
+        $this->formTypeClass = $formTypeClass;
+        $this->formTypeOptions = $options;
+        $this->mode = CrudFormMode::FORM_TYPE;
+    }
+
+    /**
+     * Returns a FormBuilderInterface for inline form definition
+     *
+     * Calling this method multiple times returns the same builder instance.
+     */
+    public function useBuilder(): FormBuilderInterface
+    {
+        if ($this->mode === CrudFormMode::FORM_TYPE) {
+            throw CrudFormAlreadyConfiguredException::cannotSwitchMode($this->mode);
+        }
+
+        if ($this->builder === null) {
+            $this->builder = $this->formFactory->createBuilder(data: $this->data, options: $this->formOptions);
+            $this->mode = CrudFormMode::BUILDER;
+        }
+
+        return $this->builder;
+    }
+
+    /**
+     * Sets a form option that will be applied when the form is built
+     *
+     * For FormType mode, the option is merged with (and overrides) options passed to useFormType().
+     * For Builder mode, options must be set before the first useBuilder() call.
+     */
+    public function setFormOption(string $name, mixed $value): static
+    {
+        if ($this->builder !== null) {
+            throw CrudFormAlreadyConfiguredException::cannotSetOptionAfterBuilderCreated();
+        }
+
+        $this->formOptions[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Returns a form option value
+     *
+     * Checks options set via setFormOption() first, then falls back to options
+     * passed to useFormType().
+     */
+    public function getFormOption(string $name, mixed $default = null): mixed
+    {
+        return $this->formOptions[$name] ?? $this->formTypeOptions[$name] ?? $default;
+    }
+
+    /**
+     * Builds and returns the configured Form
+     */
+    public function buildForm(): FormInterface
+    {
+        return match ($this->mode) {
+            CrudFormMode::FORM_TYPE => $this->formFactory->create($this->formTypeClass, $this->data, array_merge($this->formTypeOptions, $this->formOptions)),
+            CrudFormMode::BUILDER => $this->builder->getForm(),
+            CrudFormMode::UNCONFIGURED => throw new CrudFormNotConfiguredException(),
+        };
+    }
+
+    public function getMode(): CrudFormMode
+    {
+        return $this->mode;
+    }
+}

--- a/packages/administration/src/Component/Crud/Form/CrudFormConfigurator.php
+++ b/packages/administration/src/Component/Crud/Form/CrudFormConfigurator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\AdministrationBundle\Component\Crud\Form;
 
+use Shopsys\AdministrationBundle\Component\Config\ActionType;
 use Shopsys\AdministrationBundle\Component\Crud\Form\Exception\CrudFormAlreadyConfiguredException;
 use Shopsys\AdministrationBundle\Component\Crud\Form\Exception\CrudFormNotConfiguredException;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -34,6 +35,7 @@ class CrudFormConfigurator
     public function __construct(
         protected readonly FormFactoryInterface $formFactory,
         protected readonly object $data,
+        protected readonly ActionType $actionType,
     ) {
     }
 
@@ -116,5 +118,10 @@ class CrudFormConfigurator
     public function getMode(): CrudFormMode
     {
         return $this->mode;
+    }
+
+    public function getActionType(): ActionType
+    {
+        return $this->actionType;
     }
 }

--- a/packages/administration/src/Component/Crud/Form/CrudFormMode.php
+++ b/packages/administration/src/Component/Crud/Form/CrudFormMode.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Form;
+
+enum CrudFormMode: string
+{
+    case UNCONFIGURED = 'unconfigured';
+    case FORM_TYPE = 'formType';
+    case BUILDER = 'builder';
+}

--- a/packages/administration/src/Component/Crud/Form/Exception/CrudFormAlreadyConfiguredException.php
+++ b/packages/administration/src/Component/Crud/Form/Exception/CrudFormAlreadyConfiguredException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Form\Exception;
+
+use Exception;
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormMode;
+
+class CrudFormAlreadyConfiguredException extends Exception
+{
+    public static function cannotSwitchMode(CrudFormMode $currentMode): self
+    {
+        return new self(sprintf(
+            'Cannot change form configuration mode. The form is already configured in "%s" mode. You cannot combine useFormType() and useBuilder().',
+            $currentMode->value,
+        ));
+    }
+
+    public static function cannotSetOptionAfterBuilderCreated(): self
+    {
+        return new self('Cannot set form option after the builder has been created. Set form options before calling useBuilder().');
+    }
+}

--- a/packages/administration/src/Component/Crud/Form/Exception/CrudFormNotConfiguredException.php
+++ b/packages/administration/src/Component/Crud/Form/Exception/CrudFormNotConfiguredException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Form\Exception;
+
+use Exception;
+
+class CrudFormNotConfiguredException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Form has not been configured. Call useFormType() or useBuilder() in configureForm() first.');
+    }
+}

--- a/packages/administration/src/Component/Crud/Handler/CreateHandlerInterface.php
+++ b/packages/administration/src/Component/Crud/Handler/CreateHandlerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Handler;
+
+/**
+ * Handler interface for create operations
+ *
+ * This interface extends ReadHandlerInterface and adds create functionality for CRUD controllers.
+ */
+interface CreateHandlerInterface extends ReadHandlerInterface
+{
+    /**
+     * Creates an empty data transfer object with default values
+     *
+     * @return object The new data transfer object
+     */
+    public function createData(): object;
+
+    /**
+     * Creates a new entity from the provided data
+     *
+     * @param object $data The data transfer object with values for the new entity
+     * @return \Shopsys\FrameworkBundle\Component\Utils\Presentable The newly created entity
+     */
+    public function create(object $data): object;
+}

--- a/packages/administration/src/Component/Crud/Handler/CrudHandlerInterface.php
+++ b/packages/administration/src/Component/Crud/Handler/CrudHandlerInterface.php
@@ -10,6 +10,6 @@ namespace Shopsys\AdministrationBundle\Component\Crud\Handler;
  * This interface serves as a semantic marker that indicates a handler is intended to support
  * all CRUD operations (Create, Read, Update, Delete).
  */
-interface CrudHandlerInterface extends DeleteHandlerInterface
+interface CrudHandlerInterface extends DeleteHandlerInterface, EditHandlerInterface, CreateHandlerInterface
 {
 }

--- a/packages/administration/src/Component/Crud/Handler/EditHandlerInterface.php
+++ b/packages/administration/src/Component/Crud/Handler/EditHandlerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud\Handler;
+
+/**
+ * Handler interface for edit operations
+ *
+ * This interface extends ReadHandlerInterface and adds edit functionality for CRUD controllers.
+ */
+interface EditHandlerInterface extends ReadHandlerInterface
+{
+    /**
+     * Creates a data transfer object populated from the given entity
+     *
+     * @param object $entity The entity to create data from
+     * @return object The populated data transfer object
+     */
+    public function createDataFromEntity(object $entity): object;
+
+    /**
+     * Saves changes to the given entity using the provided data
+     *
+     * @param object $entity The entity to update
+     * @param object $data The data transfer object with updated values
+     */
+    public function edit(object $entity, object $data): void;
+}

--- a/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
+++ b/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
@@ -68,7 +68,7 @@ final class CrudMenuSubscriber implements EventSubscriberInterface
             }
 
             foreach ($config->getActions() as $action) {
-                if ($action === ActionType::DELETE) {
+                if ($action->isSubMenuRouteItem() === false) {
                     continue;
                 }
 

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -115,7 +115,7 @@ abstract class AbstractCrudController extends AdminBaseController
         $entity = $handler->getById($id);
         $data = $handler->createDataFromEntity($entity);
 
-        $formConfigurator = new CrudFormConfigurator($this->formFactory, $data);
+        $formConfigurator = new CrudFormConfigurator($this->formFactory, $data, ActionType::EDIT);
         $this->configureForm($formConfigurator, $entity);
         $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($formConfigurator, $entity));
 
@@ -184,7 +184,7 @@ abstract class AbstractCrudController extends AdminBaseController
         $handler = $this->definition->getHandlerForAction(ActionType::CREATE);
         $data = $handler->createData();
 
-        $formConfigurator = new CrudFormConfigurator($this->formFactory, $data);
+        $formConfigurator = new CrudFormConfigurator($this->formFactory, $data, ActionType::CREATE);
         $this->configureForm($formConfigurator, null);
         $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($formConfigurator, null));
 

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -11,7 +11,11 @@ use Shopsys\AdministrationBundle\Component\Config\ActionsConfig;
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 use Shopsys\AdministrationBundle\Component\Crud\Definition;
+use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudCreateHookExtensionInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudDeleteHookExtensionInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudEditHookExtensionInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
 use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\Orm\OrmAdapterFactory;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
@@ -21,7 +25,9 @@ use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
 use Throwable;
@@ -64,6 +70,13 @@ abstract class AbstractCrudController extends AdminBaseController
     {
     }
 
+    /**
+     * @param object|null $entity Null for create action, the existing entity for edit action
+     */
+    protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+    {
+    }
+
     public function listAction(): Response
     {
         $adapter = $this->ormAdapterFactory->create($this->definition->entityClass, function (QueryBuilder $queryBuilder): void {
@@ -93,19 +106,136 @@ abstract class AbstractCrudController extends AdminBaseController
         ]);
     }
 
-    public function editAction(int $id): Response
+    public function editAction(Request $request, int $id): Response
     {
+        /** @var \Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface $handler */
+        $handler = $this->definition->getHandlerForAction(ActionType::EDIT);
+        $entity = $handler->getById($id);
+        $data = $handler->createDataFromEntity($entity);
+
+        $builder = $this->createFormBuilder($data);
+        $this->configureForm($builder, $entity);
+        $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($builder, $entity));
+
+        $form = $builder->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $this->executeExtensions(fn (CrudEditHookExtensionInterface $extension) => $extension->beforeEdit($entity, $data), CrudEditHookExtensionInterface::class);
+                $handler->edit($entity, $data);
+                $this->executeExtensions(fn (CrudEditHookExtensionInterface $extension) => $extension->afterEdit($entity, $data), CrudEditHookExtensionInterface::class);
+
+                if ($this->isFlashMessageBagEmpty()) {
+                    $this->addSuccessFlashTwig(
+                        t('<strong>{{ objectName }}</strong> was saved successfully.'),
+                        [
+                            'objectName' => $entity->toHumanReadable(),
+                        ],
+                    );
+                }
+
+                return $this->redirect(
+                    $this->generateUrl(CrudTransformationHelper::generateRouteName($this->definition->controllerName, ActionType::LIST)),
+                );
+            } catch (Throwable $exception) {
+                $this->executeExtensions(fn (CrudEditHookExtensionInterface $extension) => $extension->onEditError($entity, $data, $exception), CrudEditHookExtensionInterface::class);
+                $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
+
+                if ($this->hasErrorMessages() === false) {
+                    $this->addErrorFlashTwig(
+                        t('An error occurred while saving <strong>{{ objectName }}</strong>.'),
+                        [
+                            'objectName' => $entity->toHumanReadable(),
+                        ],
+                    );
+                }
+
+                $this->logger->error(
+                    'Error from CrudController while running edit action',
+                    [
+                        'message' => $exception->getMessage(),
+                        'controllerClass' => static::class,
+                        'action' => ActionType::EDIT,
+                        'exception' => $exception,
+                        'entityClass' => $this->definition->entityClass,
+                        'entityId' => $id,
+                    ],
+                );
+            }
+        }
+
+        if ($form->isSubmitted() && !$form->isValid()) {
+            $this->addErrorFlashTwig(t('Please check the correctness of all data filled.'));
+        }
+
         return $this->render('@ShopsysAdministration/crud/edit.html.twig', [
             'title' => $this->definition->getConfig()->getTitle(ActionType::EDIT),
             'topActions' => $this->getConfiguredActions(ActionType::EDIT),
+            'form' => $form->createView(),
         ]);
     }
 
-    public function createAction(): Response
+    public function createAction(Request $request): Response
     {
+        /** @var \Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface $handler */
+        $handler = $this->definition->getHandlerForAction(ActionType::CREATE);
+        $data = $handler->createData();
+
+        $builder = $this->createFormBuilder($data);
+        $this->configureForm($builder, null);
+        $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($builder, null));
+
+        $form = $builder->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $this->executeExtensions(fn (CrudCreateHookExtensionInterface $extension) => $extension->beforeCreate($data), CrudCreateHookExtensionInterface::class);
+                $entity = $handler->create($data);
+                $this->executeExtensions(fn (CrudCreateHookExtensionInterface $extension) => $extension->afterCreate($entity, $data), CrudCreateHookExtensionInterface::class);
+
+                if ($this->isFlashMessageBagEmpty()) {
+                    $this->addSuccessFlashTwig(
+                        t('<strong>{{ objectName }}</strong> was created successfully.'),
+                        [
+                            'objectName' => $entity->toHumanReadable(),
+                        ],
+                    );
+                }
+
+                return $this->redirect(
+                    $this->generateUrl(CrudTransformationHelper::generateRouteName($this->definition->controllerName, ActionType::LIST)),
+                );
+            } catch (Throwable $exception) {
+                $this->executeExtensions(fn (CrudCreateHookExtensionInterface $extension) => $extension->onCreateError($data, $exception), CrudCreateHookExtensionInterface::class);
+                $this->eventDispatcher->dispatch(new SilencedExceptionEvent());
+
+                if ($this->hasErrorMessages() === false) {
+                    $this->addErrorFlashTwig(t('An error occurred while creating.'));
+                }
+
+                $this->logger->error(
+                    'Error from CrudController while running create action',
+                    [
+                        'message' => $exception->getMessage(),
+                        'controllerClass' => static::class,
+                        'action' => ActionType::CREATE,
+                        'exception' => $exception,
+                        'entityClass' => $this->definition->entityClass,
+                    ],
+                );
+            }
+        }
+
+        if ($form->isSubmitted() && !$form->isValid()) {
+            $this->addErrorFlashTwig(t('Please check the correctness of all data filled.'));
+        }
+
         return $this->render('@ShopsysAdministration/crud/new.html.twig', [
             'title' => $this->definition->getConfig()->getTitle(ActionType::CREATE),
             'topActions' => $this->getConfiguredActions(ActionType::CREATE),
+            'form' => $form->createView(),
         ]);
     }
 
@@ -151,7 +281,6 @@ abstract class AbstractCrudController extends AdminBaseController
                     'exception' => $exception,
                     'entityClass' => $this->definition->entityClass,
                     'entityId' => $id,
-                    'entityName' => $entity->toHumanReadable(),
                 ],
             );
         }

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -14,8 +14,7 @@ use Shopsys\AdministrationBundle\Component\Crud\Definition;
 use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudCreateHookExtensionInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudDeleteHookExtensionInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudEditHookExtensionInterface;
-use Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface;
-use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
 use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
 use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\Orm\OrmAdapterFactory;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
@@ -25,7 +24,7 @@ use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -48,6 +47,9 @@ abstract class AbstractCrudController extends AdminBaseController
 
     #[Required]
     public EventDispatcherInterface $eventDispatcher;
+
+    #[Required]
+    public FormFactoryInterface $formFactory;
 
     public function setDefinition(Definition $definition): void
     {
@@ -73,7 +75,7 @@ abstract class AbstractCrudController extends AdminBaseController
     /**
      * @param object|null $entity Null for create action, the existing entity for edit action
      */
-    protected function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+    protected function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
     {
     }
 
@@ -113,11 +115,11 @@ abstract class AbstractCrudController extends AdminBaseController
         $entity = $handler->getById($id);
         $data = $handler->createDataFromEntity($entity);
 
-        $builder = $this->createFormBuilder($data);
-        $this->configureForm($builder, $entity);
-        $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($builder, $entity));
+        $formConfigurator = new CrudFormConfigurator($this->formFactory, $data);
+        $this->configureForm($formConfigurator, $entity);
+        $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($formConfigurator, $entity));
 
-        $form = $builder->getForm();
+        $form = $formConfigurator->buildForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -182,11 +184,11 @@ abstract class AbstractCrudController extends AdminBaseController
         $handler = $this->definition->getHandlerForAction(ActionType::CREATE);
         $data = $handler->createData();
 
-        $builder = $this->createFormBuilder($data);
-        $this->configureForm($builder, null);
-        $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($builder, null));
+        $formConfigurator = new CrudFormConfigurator($this->formFactory, $data);
+        $this->configureForm($formConfigurator, null);
+        $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureForm($formConfigurator, null));
 
-        $form = $builder->getForm();
+        $form = $formConfigurator->buildForm();
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/packages/administration/src/Controller/AbstractCrudControllerExtension.php
+++ b/packages/administration/src/Controller/AbstractCrudControllerExtension.php
@@ -10,6 +10,7 @@ use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Form\FormBuilderInterface;
 
 #[AutoconfigureTag('shopsys.admin.crud_controllers')]
 abstract class AbstractCrudControllerExtension extends AdminBaseController
@@ -27,6 +28,10 @@ abstract class AbstractCrudControllerExtension extends AdminBaseController
     }
 
     public function configureQuery(QueryBuilder $queryBuilder): void
+    {
+    }
+
+    public function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
     {
     }
 }

--- a/packages/administration/src/Controller/AbstractCrudControllerExtension.php
+++ b/packages/administration/src/Controller/AbstractCrudControllerExtension.php
@@ -7,10 +7,10 @@ namespace Shopsys\AdministrationBundle\Controller;
 use Doctrine\ORM\QueryBuilder;
 use Shopsys\AdministrationBundle\Component\Config\ActionsConfig;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
-use Symfony\Component\Form\FormBuilderInterface;
 
 #[AutoconfigureTag('shopsys.admin.crud_controllers')]
 abstract class AbstractCrudControllerExtension extends AdminBaseController
@@ -31,7 +31,7 @@ abstract class AbstractCrudControllerExtension extends AdminBaseController
     {
     }
 
-    public function configureForm(FormBuilderInterface $builder, ?object $entity = null): void
+    public function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
     {
     }
 }

--- a/packages/administration/templates/crud/edit.html.twig
+++ b/packages/administration/templates/crud/edit.html.twig
@@ -9,5 +9,5 @@
 {% endblock %}
 
 {% block main_content %}
-    edit page
+    {{ form(form) }}
 {% endblock %}

--- a/packages/administration/templates/crud/new.html.twig
+++ b/packages/administration/templates/crud/new.html.twig
@@ -9,5 +9,5 @@
 {% endblock %}
 
 {% block main_content %}
-    new page
+    {{ form(form) }}
 {% endblock %}

--- a/packages/administration/tests/Unit/Component/Crud/Form/CrudFormConfiguratorTest.php
+++ b/packages/administration/tests/Unit/Component/Crud/Form/CrudFormConfiguratorTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AdministrationBundle\Unit\Component\Crud\Form;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Shopsys\AdministrationBundle\Component\Config\ActionType;
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
+use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormMode;
+use Shopsys\AdministrationBundle\Component\Crud\Form\Exception\CrudFormAlreadyConfiguredException;
+use Shopsys\AdministrationBundle\Component\Crud\Form\Exception\CrudFormNotConfiguredException;
+use stdClass;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
+
+final class CrudFormConfiguratorTest extends TestCase
+{
+    /**
+     * @var \Symfony\Component\Form\FormFactoryInterface|\PHPUnit\Framework\MockObject\Stub
+     */
+    private FormFactoryInterface $formFactoryStub;
+
+    private stdClass $data;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->formFactoryStub = $this->createStub(FormFactoryInterface::class);
+        $this->data = new stdClass();
+    }
+
+    public function testGetActionTypeReturnsValueFromConstructor(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $this->assertSame(ActionType::EDIT, $configurator->getActionType());
+    }
+
+    public function testInitialModeIsUnconfigured(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::CREATE);
+
+        $this->assertSame(CrudFormMode::UNCONFIGURED, $configurator->getMode());
+    }
+
+    public function testUseFormTypeSwitchesModeToFormType(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $configurator->useFormType(FormTypeInterface::class);
+
+        $this->assertSame(CrudFormMode::FORM_TYPE, $configurator->getMode());
+    }
+
+    public function testUseBuilderSwitchesModeToBuilder(): void
+    {
+        /** @var \Symfony\Component\Form\FormBuilderInterface|\PHPUnit\Framework\MockObject\Stub $builderStub */
+        $builderStub = $this->createStub(FormBuilderInterface::class);
+        $this->formFactoryStub->method('createBuilder')->willReturn($builderStub);
+
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::CREATE);
+
+        $configurator->useBuilder();
+
+        $this->assertSame(CrudFormMode::BUILDER, $configurator->getMode());
+    }
+
+    public function testUseFormTypeCalledTwiceThrowsException(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+        $configurator->useFormType(FormTypeInterface::class);
+
+        $this->expectException(CrudFormAlreadyConfiguredException::class);
+
+        $configurator->useFormType(FormTypeInterface::class);
+    }
+
+    public function testUseBuilderAfterUseFormTypeThrowsException(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+        $configurator->useFormType(FormTypeInterface::class);
+
+        $this->expectException(CrudFormAlreadyConfiguredException::class);
+
+        $configurator->useBuilder();
+    }
+
+    public function testUseFormTypeAfterUseBuilderThrowsException(): void
+    {
+        /** @var \Symfony\Component\Form\FormBuilderInterface|\PHPUnit\Framework\MockObject\Stub $builderStub */
+        $builderStub = $this->createStub(FormBuilderInterface::class);
+        $this->formFactoryStub->method('createBuilder')->willReturn($builderStub);
+
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::CREATE);
+        $configurator->useBuilder();
+
+        $this->expectException(CrudFormAlreadyConfiguredException::class);
+
+        $configurator->useFormType(FormTypeInterface::class);
+    }
+
+    public function testUseBuilderReturnsSameInstanceOnMultipleCalls(): void
+    {
+        /** @var \Symfony\Component\Form\FormBuilderInterface|\PHPUnit\Framework\MockObject\Stub $builderStub */
+        $builderStub = $this->createStub(FormBuilderInterface::class);
+        $this->formFactoryStub->method('createBuilder')->willReturn($builderStub);
+
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::CREATE);
+
+        $first = $configurator->useBuilder();
+        $second = $configurator->useBuilder();
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testSetFormOptionStoresValueRetrievableByGetFormOption(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $configurator->setFormOption('attr', ['class' => 'test']);
+
+        $this->assertSame(['class' => 'test'], $configurator->getFormOption('attr'));
+    }
+
+    public function testSetFormOptionReturnsSelfForFluentInterface(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $result = $configurator->setFormOption('key', 'value');
+
+        $this->assertSame($configurator, $result);
+    }
+
+    public function testSetFormOptionAfterBuilderCreatedThrowsException(): void
+    {
+        /** @var \Symfony\Component\Form\FormBuilderInterface|\PHPUnit\Framework\MockObject\Stub $builderStub */
+        $builderStub = $this->createStub(FormBuilderInterface::class);
+        $this->formFactoryStub->method('createBuilder')->willReturn($builderStub);
+
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::CREATE);
+        $configurator->useBuilder();
+
+        $this->expectException(CrudFormAlreadyConfiguredException::class);
+
+        $configurator->setFormOption('key', 'value');
+    }
+
+    public function testGetFormOptionPrioritizesFormOptionsOverFormTypeOptions(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+        $configurator->useFormType(FormTypeInterface::class, ['scenario' => 'original']);
+        $configurator->setFormOption('scenario', 'overridden');
+
+        $this->assertSame('overridden', $configurator->getFormOption('scenario'));
+    }
+
+    public function testGetFormOptionFallsBackToFormTypeOptions(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+        $configurator->useFormType(FormTypeInterface::class, ['scenario' => 'edit']);
+
+        $this->assertSame('edit', $configurator->getFormOption('scenario'));
+    }
+
+    public function testGetFormOptionReturnsDefaultWhenNotFound(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $this->assertSame('fallback', $configurator->getFormOption('nonexistent', 'fallback'));
+    }
+
+    public function testGetFormOptionReturnsNullByDefault(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $this->assertNull($configurator->getFormOption('nonexistent'));
+    }
+
+    public function testBuildFormWhenUnconfiguredThrowsException(): void
+    {
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::EDIT);
+
+        $this->expectException(CrudFormNotConfiguredException::class);
+
+        $configurator->buildForm();
+    }
+
+    public function testBuildFormInFormTypeModeCallsFactoryWithMergedOptions(): void
+    {
+        $formStub = $this->createStub(FormInterface::class);
+        $formFactoryMock = $this->createMock(FormFactoryInterface::class);
+        $formFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(
+                FormTypeInterface::class,
+                $this->data,
+                ['entity' => 'test', 'custom' => 'override'],
+            )
+            ->willReturn($formStub);
+
+        $configurator = new CrudFormConfigurator($formFactoryMock, $this->data, ActionType::EDIT);
+        $configurator->useFormType(FormTypeInterface::class, ['entity' => 'test', 'custom' => 'original']);
+        $configurator->setFormOption('custom', 'override');
+
+        $result = $configurator->buildForm();
+
+        $this->assertSame($formStub, $result);
+    }
+
+    public function testBuildFormInBuilderModeReturnsFormFromBuilder(): void
+    {
+        $formStub = $this->createStub(FormInterface::class);
+        /** @var \Symfony\Component\Form\FormBuilderInterface|\PHPUnit\Framework\MockObject\Stub $builderStub */
+        $builderStub = $this->createStub(FormBuilderInterface::class);
+        $builderStub->method('getForm')->willReturn($formStub);
+        $this->formFactoryStub->method('createBuilder')->willReturn($builderStub);
+
+        $configurator = new CrudFormConfigurator($this->formFactoryStub, $this->data, ActionType::CREATE);
+        $configurator->useBuilder();
+
+        $result = $configurator->buildForm();
+
+        $this->assertSame($formStub, $result);
+    }
+
+    public function testSetFormOptionBeforeUseFormTypeIsAllowed(): void
+    {
+        $formStub = $this->createStub(FormInterface::class);
+        $formFactoryMock = $this->createMock(FormFactoryInterface::class);
+        $formFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(
+                FormTypeInterface::class,
+                $this->data,
+                ['pre_option' => 'value'],
+            )
+            ->willReturn($formStub);
+
+        $configurator = new CrudFormConfigurator($formFactoryMock, $this->data, ActionType::CREATE);
+        $configurator->setFormOption('pre_option', 'value');
+        $configurator->useFormType(FormTypeInterface::class);
+
+        $configurator->buildForm();
+    }
+
+    public function testSetFormOptionAfterUseFormTypeIsAllowed(): void
+    {
+        $formStub = $this->createStub(FormInterface::class);
+        $formFactoryMock = $this->createMock(FormFactoryInterface::class);
+        $formFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(
+                FormTypeInterface::class,
+                $this->data,
+                ['post_option' => 'value'],
+            )
+            ->willReturn($formStub);
+
+        $configurator = new CrudFormConfigurator($formFactoryMock, $this->data, ActionType::EDIT);
+        $configurator->useFormType(FormTypeInterface::class);
+        $configurator->setFormOption('post_option', 'value');
+
+        $configurator->buildForm();
+    }
+}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -19,8 +19,14 @@ msgstr "%defaultCurrency% za 1 jednotku"
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr "<a href=\"%url%\">Zpět</a> na přihlašovací stránku."
 
+msgid "<strong>{{ objectName }}</strong> was created successfully."
+msgstr "Položka „<strong>{{ objectName }}</strong>\" byla úspěšně vytvořena."
+
 msgid "<strong>{{ objectName }}</strong> was deleted successfully."
 msgstr "Položka „<strong>{{ objectName }}</strong>\" byla úspěšně smazána."
+
+msgid "<strong>{{ objectName }}</strong> was saved successfully."
+msgstr "Položka „<strong>{{ objectName }}</strong>\" byla úspěšně uložena."
 
 msgid "Action"
 msgstr "Akce"
@@ -148,8 +154,14 @@ msgstr "Množství"
 msgid "An authentication exception occurred."
 msgstr "Došlo k výjimce během přihlášení."
 
+msgid "An error occurred while creating."
+msgstr "Při vytváření došlo k chybě."
+
 msgid "An error occurred while deleting <strong>{{ objectName }}</strong>."
 msgstr "Při odstraňování položky \"<strong>{{ objectName }}</strong>\" došlo k chybě."
+
+msgid "An error occurred while saving <strong>{{ objectName }}</strong>."
+msgstr "Při ukládání položky „<strong>{{ objectName }}</strong>\" došlo k chybě."
 
 msgid "Applicable variables"
 msgstr "Použitelné proměnné"
@@ -1542,6 +1554,9 @@ msgstr "Nastavení telefonních předvoleb"
 
 msgid "Pin"
 msgstr "Připnout"
+
+msgid "Please check the correctness of all data filled."
+msgstr "Prosím zkontrolujte správnost všech vyplněných údajů."
 
 msgid "Please excuse this error, we are working on fixing it. If needed, contact us on e-mail or by phone."
 msgstr "Omlouváme se za tuto chybu, pracujeme na její opravě. V případě potřeby nás kontaktujte e-mailem nebo telefonicky."

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -19,7 +19,13 @@ msgstr ""
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr ""
 
+msgid "<strong>{{ objectName }}</strong> was created successfully."
+msgstr ""
+
 msgid "<strong>{{ objectName }}</strong> was deleted successfully."
+msgstr ""
+
+msgid "<strong>{{ objectName }}</strong> was saved successfully."
 msgstr ""
 
 msgid "Action"
@@ -148,7 +154,13 @@ msgstr ""
 msgid "An authentication exception occurred."
 msgstr ""
 
+msgid "An error occurred while creating."
+msgstr ""
+
 msgid "An error occurred while deleting <strong>{{ objectName }}</strong>."
+msgstr ""
+
+msgid "An error occurred while saving <strong>{{ objectName }}</strong>."
 msgstr ""
 
 msgid "Applicable variables"
@@ -1541,6 +1553,9 @@ msgid "Phone prefixes settings"
 msgstr ""
 
 msgid "Pin"
+msgstr ""
+
+msgid "Please check the correctness of all data filled."
 msgstr ""
 
 msgid "Please excuse this error, we are working on fixing it. If needed, contact us on e-mail or by phone."

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -19,8 +19,14 @@ msgstr "%defaultCurrency% za jednotku"
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr "<a href=\"%url%\">Späť</a> na prihlasovaciu stránku."
 
+msgid "<strong>{{ objectName }}</strong> was created successfully."
+msgstr "Položka „<strong>{{ objectName }}</strong>\" bola úspešne vytvorená."
+
 msgid "<strong>{{ objectName }}</strong> was deleted successfully."
 msgstr "Položka \"<strong>{{ objectName }}</strong>\" bola úspešne vymazaná."
+
+msgid "<strong>{{ objectName }}</strong> was saved successfully."
+msgstr "Položka „<strong>{{ objectName }}</strong>\" bola úspešne uložená."
 
 msgid "Action"
 msgstr "Akcia"
@@ -148,8 +154,14 @@ msgstr "Suma"
 msgid "An authentication exception occurred."
 msgstr "Vyskytla sa výnimka overenia."
 
+msgid "An error occurred while creating."
+msgstr "Pri vytváraní došlo k chybe."
+
 msgid "An error occurred while deleting <strong>{{ objectName }}</strong>."
 msgstr "Pri odstraňovaní položky „<strong>{{ objectName }}</strong>\" došlo k chybe."
+
+msgid "An error occurred while saving <strong>{{ objectName }}</strong>."
+msgstr "Pri ukladaní položky „<strong>{{ objectName }}</strong>\" došlo k chybe."
 
 msgid "Applicable variables"
 msgstr "Použiteľné premenné"
@@ -1542,6 +1554,9 @@ msgstr "Nastavenia telefónnych predvolieb"
 
 msgid "Pin"
 msgstr "Pripnúť"
+
+msgid "Please check the correctness of all data filled."
+msgstr "Prosím skontrolujte správnosť všetkých vyplnených údajov."
 
 msgid "Please excuse this error, we are working on fixing it. If needed, contact us on e-mail or by phone."
 msgstr "Ospravedlňujeme sa za túto chybu, pracujeme na jej oprave. V prípade potreby nás kontaktujte e-mailom alebo telefonicky."


### PR DESCRIPTION
#### Description, the reason for the PR

This PR adds full create and edit functionality to the CRUD controller framework. Until now, CRUD controllers only supported listing and deleting entities — administrators had no way to create or edit
  records through the generic CRUD system and had to fall back to custom controllers.                                                                                                                            
   
  With this change, developers can implement `EditHandlerInterface`, `CreateHandlerInterface`, or the combined `CrudHandlerInterface` to enable form-based create and edit pages. Forms are configured through a new   
  `CrudFormConfigurator` that supports two approaches: using an existing Symfony `FormType` class, or building the form inline with a builder. The configurator automatically provides the current action type
  (create/edit) to both the controller and the form, making it easy to adjust form behavior based on the operation being performed. Extensions can hook into the create/edit lifecycle with                      
  `beforeCreate/afterCreate/onCreateError` and `beforeEdit/afterEdit/onEditError` callbacks, and can also extend forms when the builder mode is used.

  An example `AdministratorCrudController` in project-base demonstrates the full setup including a CRUD handler and form configuration.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-crud-forms.odin.shopsys.cloud
  - https://cz.jg-crud-forms.odin.shopsys.cloud
  - https://jg-crud-forms.odin.shopsys.cloud/sk
<!-- Replace -->
