### PR TITLE
UserConsentForm: GTM consent update event now uses current form valuesvy

### DIFF
--- a/project-base/storefront/components/Blocks/UserConsent/UserConsentForm.tsx
+++ b/project-base/storefront/components/Blocks/UserConsent/UserConsentForm.tsx
@@ -22,13 +22,12 @@ export const UserConsentForm: FC<UserConsentFormProps> = ({ onSetCallback }) => 
     const formMeta = useUserConsentFormMeta();
     const [{ data: settingsData }] = useSettingsQuery();
     const userConsentPolicyArticleUrl = settingsData?.settings?.userConsentPolicyArticleUrl;
-    const userConsent = usePersistStore((store) => store.userConsent);
     const updateUserConsent = usePersistStore((store) => store.updateUserConsent);
 
     const saveUserConsentChoices = () => {
         const formValues = formProviderMethods.getValues();
         updateUserConsent(formValues);
-        onGtmConsentUpdateEventHandler(getGtmConsentInfo(userConsent));
+        onGtmConsentUpdateEventHandler(getGtmConsentInfo(formValues));
 
         if (onSetCallback) {
             onSetCallback();

--- a/project-base/storefront/vitest/components/Blocks/UserConsent/UserConsentForm.test.tsx
+++ b/project-base/storefront/vitest/components/Blocks/UserConsent/UserConsentForm.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { UserConsentForm } from 'components/Blocks/UserConsent/UserConsentForm';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { onGtmConsentUpdateEventHandlerMock, storeState, updateUserConsentMock } = vi.hoisted(() => ({
+    onGtmConsentUpdateEventHandlerMock: vi.fn(),
+    storeState: {
+        userConsent: {
+            marketing: false,
+            preferences: false,
+            statistics: false,
+        },
+    },
+    updateUserConsentMock: vi.fn(),
+}));
+
+vi.mock('graphql/requests/settings/queries/SettingsQuery.generated', () => ({
+    useSettingsQuery: () => [
+        {
+            data: {
+                settings: {
+                    userConsentPolicyArticleUrl: '/user-consent',
+                },
+            },
+        },
+    ],
+}));
+
+vi.mock('gtm/handlers/onGtmConsentUpdateEventHandler', () => ({
+    onGtmConsentUpdateEventHandler: onGtmConsentUpdateEventHandlerMock,
+}));
+
+vi.mock('next-translate/Trans', () => ({
+    default: ({ defaultTrans }: { defaultTrans: string }) => <span>{defaultTrans}</span>,
+}));
+
+vi.mock('store/usePersistStore', () => ({
+    usePersistStore: (selector: any) =>
+        selector({
+            userConsent: storeState.userConsent,
+            updateUserConsent: updateUserConsentMock,
+        }),
+}));
+
+vi.mock('utils/i18n/useTranslationWrapper', () => ({
+    default: () => ({
+        lang: 'en',
+        t: (key: string) => key,
+    }),
+}));
+
+describe('UserConsentForm', () => {
+    beforeEach(() => {
+        storeState.userConsent = {
+            marketing: false,
+            preferences: false,
+            statistics: false,
+        };
+    });
+
+    test('sends GTM consent update event with currently selected form values', () => {
+        render(<UserConsentForm />);
+
+        fireEvent.click(screen.getByRole('switch', { name: 'Toggle marketing consent' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Submit form to save your choices' }));
+
+        expect(updateUserConsentMock).toHaveBeenCalledWith({
+            marketing: true,
+            preferences: false,
+            statistics: false,
+        });
+        expect(onGtmConsentUpdateEventHandlerMock).toHaveBeenCalledWith({
+            marketing: 'granted',
+            preferences: 'denied',
+            statistics: 'denied',
+        });
+    });
+});

--- a/upgrade-notes/storefront_20260429_124711.md
+++ b/upgrade-notes/storefront_20260429_124711.md
@@ -1,0 +1,3 @@
+#### UserConsentForm: GTM consent update event now uses current form values ([#4585](https://github.com/shopsys/shopsys/pull/4585))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixes the GTM consent update event, which was sending stale data from the store instead of the values the user just submitted in the form. Adds a vitest test verifying that the event is dispatched with the currently selected form values.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4005-gtm-consent.odin.shopsys.cloud
  - https://cz.tc-ssp-4005-gtm-consent.odin.shopsys.cloud
  - https://tc-ssp-4005-gtm-consent.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777899962.703129 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4005-gtm-consent.odin.shopsys.cloud
  - https://cz.tc-ssp-4005-gtm-consent.odin.shopsys.cloud
  - https://tc-ssp-4005-gtm-consent.odin.shopsys.cloud/sk
<!-- Replace -->
