### PR TITLE
added GTM noscript iframe fallback

### DIFF
--- a/project-base/storefront/pages/_document.tsx
+++ b/project-base/storefront/pages/_document.tsx
@@ -6,6 +6,7 @@ import { logException } from 'utils/errors/logException';
 interface MyDocumentInitialProps extends DocumentInitialProps {
     htmlLang: string;
     publicConfig: PublicRuntimeConfig;
+    gtmId: string;
 }
 
 // Browser warning translations (must be simple object, no imports - this runs before React hydrates)
@@ -157,21 +158,23 @@ class MyDocument extends Document<MyDocumentInitialProps> {
         const initialProps = await Document.getInitialProps(context);
 
         let htmlLang = 'en';
+        let gtmId = '';
 
         try {
             const domainConfig = getDomainConfig(context);
             htmlLang = domainConfig.defaultLocale;
+            gtmId = domainConfig.gtmId;
         } catch (error) {
             logException(error);
         }
 
         const publicConfig = getPublicConfig();
 
-        return { ...initialProps, htmlLang, publicConfig };
+        return { ...initialProps, htmlLang, publicConfig, gtmId };
     }
 
     render() {
-        const { htmlLang, publicConfig } = this.props;
+        const { htmlLang, publicConfig, gtmId } = this.props;
         const warningTranslation = getBrowserWarningTranslation(htmlLang);
         const envJson = serializeConfigForHtml(publicConfig);
 
@@ -185,6 +188,17 @@ class MyDocument extends Document<MyDocumentInitialProps> {
                     <script dangerouslySetInnerHTML={{ __html: BROWSER_WARNING_SCRIPT }} />
                 </Head>
                 <body>
+                    {gtmId.length > 0 && (
+                        <noscript>
+                            <iframe
+                                height="0"
+                                src={`https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(gtmId)}`}
+                                style={{ display: 'none', visibility: 'hidden' }}
+                                title="Google Tag Manager"
+                                width="0"
+                            />
+                        </noscript>
+                    )}
                     <div id="browser-warning-banner" role="alert">
                         <div className="bwb-content">
                             <svg

--- a/upgrade-notes/storefront_20260429_135919.md
+++ b/upgrade-notes/storefront_20260429_135919.md
@@ -1,0 +1,3 @@
+#### added GTM noscript iframe fallback ([#4586](https://github.com/shopsys/shopsys/pull/4586))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Adds a Google Tag Manager <noscript> iframe fallback in _document.tsx so GTM tracking continues to work for users with JavaScript disabled, with the gtmId sourced from the domain config.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4003-gtm-noscript.odin.shopsys.cloud
  - https://cz.tc-ssp-4003-gtm-noscript.odin.shopsys.cloud
  - https://tc-ssp-4003-gtm-noscript.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777898292.668149 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4003-gtm-noscript.odin.shopsys.cloud
  - https://cz.tc-ssp-4003-gtm-noscript.odin.shopsys.cloud
  - https://tc-ssp-4003-gtm-noscript.odin.shopsys.cloud/sk
<!-- Replace -->
