### PR TITLE
admin: removed duplicate <li> wrapper from side menu items

### DIFF
--- a/packages/administration/templates/partial/side_menu.html.twig
+++ b/packages/administration/templates/partial/side_menu.html.twig
@@ -26,13 +26,11 @@
 
 {% block item %}
     {% if item.displayed %}
-        <li class="nav-item active">
-            {%- if item.hasChildren -%}
-                {{ block('dropdown_element') }}
-            {%- else -%}
-                {{ block('simple_element') }}
-            {%- endif -%}
-        </li>
+        {%- if item.hasChildren -%}
+            {{ block('dropdown_element') }}
+        {%- else -%}
+            {{ block('simple_element') }}
+        {%- endif -%}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
#### Description, the reason for the PR

The admin side menu was rendered with invalid HTML — every menu item was wrapped twice in `<li>` elements. The outer wrapper in the `item` block also hard-coded the `active` class on every item regardless of state, which gave browsers misleading markup to work with.

The outer wrapper has been removed. The `simple_element` and `dropdown_element` blocks already produce their own `<li class="nav-item">`, so the rendered menu is now valid HTML and only items that should be marked active actually are.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://mg-fix-menu-html.odin.shopsys.cloud
  - https://cz.mg-fix-menu-html.odin.shopsys.cloud
  - https://mg-fix-menu-html.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777545731.380089 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-menu-html.odin.shopsys.cloud
  - https://cz.mg-fix-menu-html.odin.shopsys.cloud
  - https://mg-fix-menu-html.odin.shopsys.cloud/sk
<!-- Replace -->
