### PR TITLE
Fixed GrapesJS video preview in Safari

### DIFF
--- a/project-base/app/assets/js/admin/grapesjs/plugins/web/iframe.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/web/iframe.js
@@ -2,10 +2,13 @@ import grapesjs from 'grapesjs';
 
 const IFRAME_WIDTH_ATTRIBUTE = 'width';
 const IFRAME_HEIGHT_ATTRIBUTE = 'height';
+const VIDEO_EMBED_URL_PATTERN = /(youtube(-nocookie)?\.com\/embed|player\.vimeo\.com\/video)/;
+
+const isVideoEmbed = element => VIDEO_EMBED_URL_PATTERN.test(element.getAttribute('src') ?? '');
 
 export default grapesjs.plugins.add('iframe', editor => {
     editor.DomComponents.addType('iframe', {
-        isComponent: el => el.tagName === 'IFRAME',
+        isComponent: element => element.tagName?.toUpperCase() === 'IFRAME' && !isVideoEmbed(element),
         model: {
             init() {
                 this.on(`change:attributes:${IFRAME_WIDTH_ATTRIBUTE}`, this.handleWidthChange);

--- a/project-base/app/assets/js/admin/grapesjs/plugins/web/video.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/web/video.js
@@ -1,6 +1,202 @@
 import grapesjs from 'grapesjs';
 
+const YOUTUBE_PROVIDERS = ['yt', 'ytnc'];
+const YOUTUBE_REFERRER_POLICY = 'strict-origin-when-cross-origin';
+const YOUTUBE_ALLOW =
+    'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+const DEPRECATED_YOUTUBE_TRAIT_NAMES = ['modestbranding'];
+const EDITOR_PREVIEW_WIDTH = '800px';
+const EDITOR_PREVIEW_HEIGHT = '450px';
+
+const applyStyles = (element, styles) => {
+    Object.assign(element.style, styles);
+
+    return element;
+};
+
+const getYoutubeVideoId = videoId => videoId.split('?')[0].split('&')[0];
+
+const createYoutubeThumbnail = () =>
+    applyStyles(document.createElement('img'), {
+        height: '100%',
+        objectFit: 'cover',
+        width: '100%',
+    });
+
+const createPlayIcon = () =>
+    applyStyles(document.createElement('span'), {
+        borderBottom: '14px solid transparent',
+        borderLeft: '22px solid #fff',
+        borderTop: '14px solid transparent',
+        height: '0',
+        left: '50%',
+        position: 'absolute',
+        top: '50%',
+        transform: 'translate(-35%, -50%)',
+        width: '0',
+    });
+
+const createPlayButton = () => {
+    const playButton = applyStyles(document.createElement('span'), {
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        borderRadius: '12px',
+        boxSizing: 'border-box',
+        height: '64px',
+        left: '50%',
+        position: 'absolute',
+        top: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '86px',
+    });
+
+    playButton.appendChild(createPlayIcon());
+
+    return playButton;
+};
+
+const createYoutubeThumbnailPreview = (model, pointerEventsClass) => {
+    const videoId = getYoutubeVideoId(model.get('videoId'));
+    const preview = applyStyles(document.createElement('div'), {
+        alignItems: 'center',
+        backgroundColor: '#252525',
+        display: 'flex',
+        height: '100%',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        position: 'relative',
+        width: '100%',
+    });
+
+    preview.className = `${pointerEventsClass} gjs-video-preview`;
+
+    if (videoId) {
+        const thumbnail = createYoutubeThumbnail();
+        thumbnail.alt = '';
+        thumbnail.src = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+
+        preview.appendChild(thumbnail);
+    }
+
+    preview.appendChild(createPlayButton());
+
+    return preview;
+};
+
+const setYoutubePreviewDimensions = element =>
+    applyStyles(element, {
+        height: EDITOR_PREVIEW_HEIGHT,
+        maxWidth: '100%',
+        width: EDITOR_PREVIEW_WIDTH,
+    });
+
+const removeDeprecatedYoutubeTraits = traits =>
+    traits.filter(({ name }) => !DEPRECATED_YOUTUBE_TRAIT_NAMES.includes(name));
+
+const removeUrlParameter = (url, parameterName) =>
+    url.replace(new RegExp(`([?&])${parameterName}=[^&]*`, 'g'), '').replace('?&', '?');
+
+const escapeHtmlAttribute = value => String(value).replace(/"/g, '&quot;');
+
+const getExportIframeSrc = model => {
+    const provider = model.get('provider');
+
+    if (provider === 'yt') {
+        return model.getYoutubeSrc();
+    }
+
+    if (provider === 'ytnc') {
+        return model.getYoutubeNoCookieSrc();
+    }
+
+    if (provider === 'vi') {
+        return model.getVimeoSrc();
+    }
+
+    return '';
+};
+
+const createIframeHtml = model => {
+    const attributes = {
+        ...model.getAttributes(),
+        src: getExportIframeSrc(model),
+        allowfullscreen: 'allowfullscreen',
+    };
+
+    if (YOUTUBE_PROVIDERS.includes(model.get('provider'))) {
+        attributes.referrerpolicy = YOUTUBE_REFERRER_POLICY;
+        attributes.allow = YOUTUBE_ALLOW;
+    }
+
+    const htmlAttributes = Object.entries(attributes)
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([attribute, value]) => `${attribute}="${escapeHtmlAttribute(value)}"`)
+        .join(' ');
+
+    return `<iframe ${htmlAttributes}></iframe>`;
+};
+
 export default grapesjs.plugins.add('video', (editor, _options) => {
+    const videoType = editor.DomComponents.getType('video');
+    const videoModel = videoType.model;
+    const videoView = videoType.view;
+
+    editor.DomComponents.addType('video', {
+        extend: 'video',
+        isComponent: videoModel.isComponent,
+        model: {
+            getYoutubeTraits() {
+                return removeDeprecatedYoutubeTraits(videoModel.prototype.getYoutubeTraits.call(this));
+            },
+            getYoutubeSrc() {
+                return removeUrlParameter(videoModel.prototype.getYoutubeSrc.call(this), 'modestbranding');
+            },
+            toHTML() {
+                if (this.get('provider') === 'vi' || YOUTUBE_PROVIDERS.includes(this.get('provider'))) {
+                    return createIframeHtml(this);
+                }
+
+                return videoModel.prototype.toHTML.call(this);
+            },
+            getAttrToHTML() {
+                const attr = videoModel.prototype.getAttrToHTML.call(this);
+
+                if (YOUTUBE_PROVIDERS.includes(this.get('provider'))) {
+                    attr.referrerpolicy = YOUTUBE_REFERRER_POLICY;
+                    attr.allow = YOUTUBE_ALLOW;
+                }
+
+                return attr;
+            },
+        },
+        view: {
+            render() {
+                videoView.prototype.render.call(this);
+
+                if (YOUTUBE_PROVIDERS.includes(this.model.get('provider'))) {
+                    setYoutubePreviewDimensions(this.el);
+                }
+
+                return this;
+            },
+            updateSrc() {
+                if (YOUTUBE_PROVIDERS.includes(this.model.get('provider'))) {
+                    this.updateProvider();
+                    setYoutubePreviewDimensions(this.el);
+
+                    return;
+                }
+
+                videoView.prototype.updateSrc.call(this);
+            },
+            renderYoutube() {
+                return createYoutubeThumbnailPreview(this.model, `${this.ppfx}no-pointer`);
+            },
+            renderYoutubeNoCookie() {
+                return createYoutubeThumbnailPreview(this.model, `${this.ppfx}no-pointer`);
+            },
+        },
+    });
+
     editor.Blocks.add('video', {
         category: 'basic-objects',
         attributes: { class: 'fa fa-youtube-play' },

--- a/project-base/app/assets/styles/admin/grapesjs.scss
+++ b/project-base/app/assets/styles/admin/grapesjs.scss
@@ -178,6 +178,26 @@
     border-color: #009bd9;
 }
 
+.gjs-field-checkbox {
+    position: relative;
+
+    input[type='checkbox'] {
+        cursor: pointer;
+        display: block;
+        height: 100%;
+        inset: 0;
+        margin: 0;
+        opacity: 0;
+        position: absolute;
+        width: 100%;
+        z-index: 1;
+    }
+
+    .gjs-chk-icon {
+        pointer-events: none;
+    }
+}
+
 .gjs-pn-btn:hover {
     color: #009bd9;
 }

--- a/upgrade-notes/backend_20260430_115228.md
+++ b/upgrade-notes/backend_20260430_115228.md
@@ -1,0 +1,8 @@
+#### Fixed GrapesJS video preview in Safari ([#4590](https://github.com/shopsys/shopsys/pull/4590))
+
+- YouTube embeds started showing `Error 153 - Video player configuration error` in the GrapesJS editor preview in Safari. The issue affected only the editor preview; saved content still needs to render a real YouTube iframe on the storefront.
+- YouTube videos are now rendered in the editor as a custom thumbnail placeholder with a play icon instead of loading the real YouTube iframe. This means YouTube videos are no longer playable directly inside the editor, and playback should be tested on the storefront after saving the article.
+- Existing YouTube and YouTube no-cookie embeds are still parsed as video components when reopening saved content in the editor.
+- The deprecated YouTube `modestbranding` option was removed from the editor UI because YouTube no longer supports it and the parameter has no effect.
+- Autoplay behavior still depends on browser policies and may be blocked by the browser, especially for videos with sound or before the user interacts with the page.
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Replaces the live YouTube/Vimeo iframe in the GrapesJS editor with a static thumbnail preview to avoid Safari playback issues, and ensures the exported <iframe> carries proper referrerpolicy and allow attributes. Also removes the deprecated modestbranding trait and makes GrapesJS checkbox traits clickable across the whole field. 

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4012-grapes-safari-video.odin.shopsys.cloud
  - https://cz.tc-ssp-4012-grapes-safari-video.odin.shopsys.cloud
  - https://tc-ssp-4012-grapes-safari-video.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777554158.862119 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4012-grapes-safari-video.odin.shopsys.cloud
  - https://cz.tc-ssp-4012-grapes-safari-video.odin.shopsys.cloud
  - https://tc-ssp-4012-grapes-safari-video.odin.shopsys.cloud/sk
<!-- Replace -->
