### PR TITLE
Autocomplete GTM reports found result counts

### DIFF
--- a/docs/storefront/gtm/events.md
+++ b/docs/storefront/gtm/events.md
@@ -193,8 +193,8 @@ export type GtmAutocompleteResultsViewEventType = GtmEventInterface<
   {
     autocompleteResults: {
       keyword: string; // the search keyword entered by the user
-      results: number; // the number of search results displayed to the user
-      sections: { [key in GtmSectionType]: number }; // an object that maps each section of search results to the number of results in that particular section
+      results: number; // the number of search results found for the user
+      sections: { [key in GtmSectionType]: number }; // an object that maps each section of search results to the number of found results in that particular section
     };
   }
 >;

--- a/project-base/storefront/gtm/factories/getGtmAutocompleteResultsViewEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmAutocompleteResultsViewEvent.ts
@@ -6,8 +6,14 @@ export const getGtmAutocompleteResultsViewEvent = (
     searchResult: TypeAutocompleteSearchQuery,
     keyword: string,
 ): GtmAutocompleteResultsViewEventType => {
-    const category = searchResult.categoriesSearch.edges?.length ?? 0;
-    const product = searchResult.productsSearch.edges?.length ?? 0;
+    const category = getAutocompleteSectionResultsCount(
+        searchResult.categoriesSearch.totalCount,
+        searchResult.categoriesSearch.edges?.length ?? 0,
+    );
+    const product = getAutocompleteSectionResultsCount(
+        searchResult.productsSearch.totalCount,
+        searchResult.productsSearch.edges?.length ?? 0,
+    );
     const brand = searchResult.brandSearch.length;
     const article = searchResult.articlesSearch.length;
 
@@ -30,3 +36,6 @@ export const getGtmAutocompleteResultsViewEvent = (
         _clear: true,
     };
 };
+
+const getAutocompleteSectionResultsCount = (totalCount: number, displayedCount: number): number =>
+    totalCount >= 0 ? totalCount : displayedCount;

--- a/project-base/storefront/vitest/gtm/getGtmAutocompleteResultsViewEvent.test.ts
+++ b/project-base/storefront/vitest/gtm/getGtmAutocompleteResultsViewEvent.test.ts
@@ -1,0 +1,101 @@
+import { TypeAutocompleteSearchQuery } from 'graphql/requests/search/queries/AutocompleteSearchQuery.generated';
+import { TypeProductOrderingModeEnum } from 'graphql/types';
+import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { getGtmAutocompleteResultsViewEvent } from 'gtm/factories/getGtmAutocompleteResultsViewEvent';
+import { describe, expect, test } from 'vitest';
+
+const autocompleteSearchResult = {
+    articlesSearch: [
+        {
+            __typename: 'ArticleSite',
+            uuid: '92c929d6-0fc5-4df2-8dbd-b7a94b2d9629',
+            name: 'Smart article',
+            slug: '/smart-article',
+            placement: 'footer',
+            external: false,
+        },
+    ],
+    brandSearch: [{ __typename: 'Brand', name: 'Smart brand', slug: '/smart-brand' }],
+    categoriesSearch: {
+        __typename: 'CategoryConnection',
+        totalCount: 7,
+        edges: [
+            {
+                __typename: 'CategoryEdge',
+                node: {
+                    __typename: 'Category',
+                    uuid: 'd6034ed4-0c54-4f7f-ab98-0f0bff5e4af1',
+                    name: 'Smart category',
+                    slug: '/smart-category',
+                },
+            },
+        ],
+    },
+    productsSearch: {
+        __typename: 'ProductConnection',
+        orderingMode: TypeProductOrderingModeEnum.Relevance,
+        defaultOrderingMode: null,
+        totalCount: 23,
+        productFilterOptions: {
+            __typename: 'ProductFilterOptions',
+            minimalPrice: '0',
+            maximalPrice: '0',
+            inStock: 0,
+            brands: null,
+            flags: null,
+            parameters: null,
+        },
+        pageInfo: { __typename: 'PageInfo', hasNextPage: true },
+        edges: [{ __typename: 'ProductEdge', node: null }],
+    },
+} satisfies TypeAutocompleteSearchQuery;
+
+describe('getGtmAutocompleteResultsViewEvent', () => {
+    test('should count found autocomplete results instead of displayed results', () => {
+        const result = getGtmAutocompleteResultsViewEvent(autocompleteSearchResult, 'smart');
+
+        expect(result).toEqual({
+            event: GtmEventType.autocomplete_results_view,
+            autocompleteResults: {
+                keyword: 'smart',
+                results: 32,
+                sections: {
+                    category: 7,
+                    product: 23,
+                    brand: 1,
+                    article: 1,
+                },
+            },
+            _clear: true,
+        });
+    });
+
+    test('should fall back to displayed results count when found results count is not provided by the search provider', () => {
+        const result = getGtmAutocompleteResultsViewEvent(
+            {
+                ...autocompleteSearchResult,
+                categoriesSearch: {
+                    ...autocompleteSearchResult.categoriesSearch,
+                    totalCount: -1,
+                },
+                productsSearch: {
+                    ...autocompleteSearchResult.productsSearch,
+                    totalCount: -1,
+                },
+            },
+            'smart',
+        );
+
+        expect(result).toMatchObject({
+            autocompleteResults: {
+                results: 4,
+                sections: {
+                    category: 1,
+                    product: 1,
+                    brand: 1,
+                    article: 1,
+                },
+            },
+        });
+    });
+});

--- a/upgrade-notes/storefront_20260504_105410.md
+++ b/upgrade-notes/storefront_20260504_105410.md
@@ -1,0 +1,5 @@
+#### Autocomplete GTM reports found result counts ([#4593](https://github.com/shopsys/shopsys/pull/4593))
+
+- `ec.autocomplete_results_view` GTM event now reports found result counts in `autocompleteResults.results` and `autocompleteResults.sections.product/category` when the search provider provides total counts
+- if your GTM setup expects displayed autocomplete item counts, update it to use the new found-result semantics
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The autocomplete results GTM event now reports the number of found results for product and category sections when this information is available. This makes the data layer match the intended analytics meaning instead of only reporting how many items were rendered in the autocomplete popup.

When a search provider cannot provide total autocomplete counts, such as Luigi's Box autocomplete, the event falls back to the number of returned results. This prevents invalid negative values from being pushed to the data layer while keeping the best available count for that provider.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4015-autocomplete-result-counts.odin.shopsys.cloud
  - https://cz.tc-ssp-4015-autocomplete-result-counts.odin.shopsys.cloud
  - https://tc-ssp-4015-autocomplete-result-counts.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778047262.557419 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4015-autocomplete-result-counts.odin.shopsys.cloud
  - https://cz.tc-ssp-4015-autocomplete-result-counts.odin.shopsys.cloud
  - https://tc-ssp-4015-autocomplete-result-counts.odin.shopsys.cloud/sk
<!-- Replace -->
