### PR TITLE
Add company identifiers to user entry GTM events

### DIFF
--- a/project-base/storefront/gtm/mappers/mapGtmUserEntryInfoFromCurrentCustomer.ts
+++ b/project-base/storefront/gtm/mappers/mapGtmUserEntryInfoFromCurrentCustomer.ts
@@ -6,6 +6,9 @@ export const mapGtmUserEntryInfoFromCurrentCustomer = ({
     email,
     firstName,
     lastName,
+    companyName,
+    companyNumber,
+    companyTaxNumber,
     loginInfo: { loginType, externalId },
 }: CurrentCustomerType): GtmUserEntryInfoType => ({
     id: uuid,
@@ -14,4 +17,7 @@ export const mapGtmUserEntryInfoFromCurrentCustomer = ({
     lastName,
     loginType,
     externalId,
+    companyName,
+    companyNumber,
+    companyVatNumber: companyTaxNumber,
 });

--- a/project-base/storefront/gtm/types/objects.ts
+++ b/project-base/storefront/gtm/types/objects.ts
@@ -135,4 +135,7 @@ export type GtmUserEntryInfoType = {
     lastName?: string;
     loginType?: TypeLoginTypeEnum;
     externalId?: string | null;
+    companyName?: string;
+    companyNumber?: string;
+    companyVatNumber?: string;
 };

--- a/project-base/storefront/vitest/gtm/mapGtmUserEntryInfoFromCurrentCustomer.test.ts
+++ b/project-base/storefront/vitest/gtm/mapGtmUserEntryInfoFromCurrentCustomer.test.ts
@@ -1,0 +1,36 @@
+import { TypeLoginTypeEnum } from 'graphql/types';
+import { mapGtmUserEntryInfoFromCurrentCustomer } from 'gtm/mappers/mapGtmUserEntryInfoFromCurrentCustomer';
+import { CurrentCustomerType } from 'types/customer';
+import { describe, expect, test } from 'vitest';
+
+describe('mapGtmUserEntryInfoFromCurrentCustomer', () => {
+    test('should map company fields for user entry GTM events', () => {
+        const currentCustomer = {
+            uuid: '9b2fafe7-f169-4448-92d0-abf649b8fb97',
+            email: 'lukas.fibiger@shopsys.com',
+            firstName: 'Jan',
+            lastName: 'Vopicka',
+            companyName: 'Zakoupil a Zbozil s.r.o.',
+            companyNumber: '123456',
+            companyTaxNumber: 'CZ123456',
+            loginInfo: {
+                loginType: TypeLoginTypeEnum.Web,
+                externalId: null,
+            },
+        } as CurrentCustomerType;
+
+        const result = mapGtmUserEntryInfoFromCurrentCustomer(currentCustomer);
+
+        expect(result).toEqual({
+            id: '9b2fafe7-f169-4448-92d0-abf649b8fb97',
+            email: 'lukas.fibiger@shopsys.com',
+            firstName: 'Jan',
+            lastName: 'Vopicka',
+            loginType: TypeLoginTypeEnum.Web,
+            externalId: null,
+            companyName: 'Zakoupil a Zbozil s.r.o.',
+            companyNumber: '123456',
+            companyVatNumber: 'CZ123456',
+        });
+    });
+});

--- a/upgrade-notes/storefront_20260504_121543.md
+++ b/upgrade-notes/storefront_20260504_121543.md
@@ -1,0 +1,4 @@
+#### Add company identifiers to user entry GTM events ([#4595](https://github.com/shopsys/shopsys/pull/4595))
+
+- `ec.login` and `ec.registration` GTM events now include `user.companyNumber` and `user.companyVatNumber` when company customer data is available
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

This PR extends storefront GTM tracking for customer entry events. Login and registration events now include company identification values in the user payload when the current customer has company data available.

The change keeps the existing login and registration event flow intact while making B2B customer identification available to GTM integrations.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4016-registration-login-company-fields.odin.shopsys.cloud
  - https://cz.tc-ssp-4016-registration-login-company-fields.odin.shopsys.cloud
  - https://tc-ssp-4016-registration-login-company-fields.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778740823.762539 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4016-registration-login-company-fields.odin.shopsys.cloud
  - https://cz.tc-ssp-4016-registration-login-company-fields.odin.shopsys.cloud
  - https://tc-ssp-4016-registration-login-company-fields.odin.shopsys.cloud/sk
<!-- Replace -->
