### PR TITLE
Add product ecommerce data to watchdog GTM event

### DIFF
--- a/project-base/storefront/components/Blocks/Popup/WatchdogPopup.tsx
+++ b/project-base/storefront/components/Blocks/Popup/WatchdogPopup.tsx
@@ -4,6 +4,8 @@ import { CheckboxControlled } from 'components/Forms/Checkbox/CheckboxControlled
 import { Form, FormBlockWrapper, FormButtonWrapper, FormContentWrapper } from 'components/Forms/Form/Form';
 import { TextInputControlled } from 'components/Forms/TextInput/TextInputControlled';
 import { Popup } from 'components/Layout/Popup/Popup';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
+import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { useCreateWatchdogMutation } from 'graphql/requests/watchDog/mutations/CreateWatchdogMutation.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
@@ -11,24 +13,28 @@ import { onGtmCreateWatchdotEventHandler } from 'gtm/handlers/onGtmCreateWatchdo
 import { FormProvider, SubmitHandler } from 'react-hook-form';
 import { useSessionStore } from 'store/useSessionStore';
 import { WatchdogFormType } from 'types/form';
+import { WatchDogProductType } from 'types/product';
 import { useErrorHandler } from 'utils/errors/useErrorHandler';
 import { blurInput } from 'utils/forms/blurInput';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 import { showSuccessMessage } from 'utils/toasts/showSuccessMessage';
 
 type WatchdogPopupProps = {
-    productUuid: string;
+    product: WatchDogProductType;
+    listIndex?: number;
 };
 
-export const WatchdogPopup: FC<WatchdogPopupProps> = ({ productUuid }) => {
+export const WatchdogPopup: FC<WatchdogPopupProps> = ({ product, listIndex }) => {
     const { t } = useTranslation();
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
     const user = useCurrentCustomerData();
     const [, createWatchdog] = useCreateWatchdogMutation();
+    const domainConfig = useDomainConfig();
+    const { canSeePrices } = useAuthorization();
 
     const [formProviderMethods] = useWatchdogForm({
         email: user?.email ?? '',
-        productUuid,
+        productUuid: product.uuid,
         gdprAgreement: false,
     });
     const formMeta = useWatchdogFormMeta();
@@ -56,7 +62,7 @@ export const WatchdogPopup: FC<WatchdogPopupProps> = ({ productUuid }) => {
         updatePortalContent(null);
         showSuccessMessage(t('Your watchdog has been created'));
 
-        onGtmCreateWatchdotEventHandler(watchdogFormData);
+        onGtmCreateWatchdotEventHandler(watchdogFormData, product, domainConfig, !canSeePrices, listIndex);
     };
 
     return (

--- a/project-base/storefront/components/Blocks/Product/ProductAction.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductAction.tsx
@@ -39,17 +39,7 @@ export const ProductAction: FC<ProductActionProps> = ({
     }
 
     if (product.isCurrentlyOutOfStock) {
-        return (
-            <WatchDogButton
-                availability={product.availability}
-                buttonSize="medium"
-                className="self-start"
-                isInquiryType={product.isInquiryType}
-                productIsSellingDenied={product.isSellingDenied}
-                productName={product.name}
-                productUuid={product.uuid}
-            />
-        );
+        return <WatchDogButton buttonSize="medium" className="self-start" listIndex={listIndex} product={product} />;
     }
 
     if (!product.isMainVariant && product.isInquiryType) {

--- a/project-base/storefront/components/Blocks/Product/Watchdog/WatchDogButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/Watchdog/WatchDogButton.tsx
@@ -1,9 +1,10 @@
 import { WatchdogIcon } from 'components/Basic/Icon/WatchdogIcon';
 import { Button } from 'components/Forms/Button/Button';
-import { TypeAvailability, TypeAvailabilityStatusEnum } from 'graphql/types';
+import { TypeAvailabilityStatusEnum } from 'graphql/types';
 import dynamic from 'next/dynamic';
 import { useSessionStore } from 'store/useSessionStore';
 import { twJoin } from 'tailwind-merge';
+import { WatchDogProductType } from 'types/product';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 
 const WatchdogPopup = dynamic(
@@ -14,30 +15,19 @@ const WatchdogPopup = dynamic(
 );
 
 type WatchDogButtonProps = {
-    productName: string;
-    productUuid: string | undefined;
-    isInquiryType: boolean;
-    availability: TypeAvailability;
-    productIsSellingDenied: boolean | undefined;
+    product: WatchDogProductType;
+    listIndex?: number;
     buttonSize?: 'small' | 'medium' | 'large' | 'xlarge';
 };
 
-export const WatchDogButton: FC<WatchDogButtonProps> = ({
-    productName,
-    productUuid,
-    isInquiryType,
-    availability,
-    productIsSellingDenied,
-    className,
-    buttonSize = 'large',
-}) => {
+export const WatchDogButton: FC<WatchDogButtonProps> = ({ product, listIndex, className, buttonSize = 'large' }) => {
     const { t } = useTranslation();
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
 
     const showWatchdogButton =
-        productUuid &&
-        !isInquiryType &&
-        (availability.status === TypeAvailabilityStatusEnum.OutOfStock || productIsSellingDenied);
+        product.uuid &&
+        !product.isInquiryType &&
+        (product.availability.status === TypeAvailabilityStatusEnum.OutOfStock || product.isSellingDenied);
 
     if (!showWatchdogButton) {
         return null;
@@ -46,15 +36,18 @@ export const WatchDogButton: FC<WatchDogButtonProps> = ({
     const openWatchDogPopup = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         e.stopPropagation();
 
-        if (productUuid) {
-            updatePortalContent(<WatchdogPopup productUuid={productUuid} />);
+        if (product.uuid) {
+            updatePortalContent(<WatchdogPopup listIndex={listIndex} product={product} />);
         }
     };
 
     return (
         <Button
             aria-haspopup="dialog"
-            aria-label={t('Open watchdog popup for {{productName}}', { ns: 'accessibility', productName })}
+            aria-label={t('Open watchdog popup for {{productName}}', {
+                ns: 'accessibility',
+                productName: product.fullName,
+            })}
             className={twJoin('whitespace-nowrap', className)}
             size={buttonSize}
             title={t('Watchdog popup')}

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailContent.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailContent.tsx
@@ -79,14 +79,7 @@ export const ProductDetailContent: FC<ProductDetailContentProps> = ({ product, i
                                 storeAvailabilities={product.storeAvailabilities}
                             />
 
-                            <WatchDogButton
-                                availability={product.availability}
-                                className="self-start"
-                                isInquiryType={product.isInquiryType}
-                                productIsSellingDenied={product.isSellingDenied}
-                                productName={product.name}
-                                productUuid={product.uuid}
-                            />
+                            <WatchDogButton className="self-start" product={product} />
 
                             <DeferredProductDetailAddToCart product={product} />
 

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
@@ -86,13 +86,7 @@ export const ProductVariantsTable: FC<ProductVariantsTableProps> = ({ variants }
                             <ProductPrice className="lg:flex-col lg:items-end" productPrice={variant.price} />
 
                             <div className="flex flex-col gap-2">
-                                <WatchDogButton
-                                    availability={variant.availability}
-                                    isInquiryType={variant.isInquiryType}
-                                    productIsSellingDenied={variant.isSellingDenied}
-                                    productName={variant.fullName}
-                                    productUuid={variant.uuid}
-                                />
+                                <WatchDogButton listIndex={index} product={variant} />
 
                                 <ProductAction
                                     isWithSpinbox

--- a/project-base/storefront/gtm/factories/getGtmCreateWatchDogEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmCreateWatchDogEvent.ts
@@ -1,12 +1,47 @@
 import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { mapGtmProductInterface } from 'gtm/mappers/mapGtmProductInterface';
 import { GtmCreateWatchdogEventType } from 'gtm/types/events';
+import { GtmCartItemType } from 'gtm/types/objects';
+import { getGtmPriceBasedOnVisibility } from 'gtm/utils/getGtmPriceBasedOnVisibility';
 import { WatchdogFormType } from 'types/form';
+import { WatchDogProductType } from 'types/product';
+import { DomainConfigType } from 'utils/domain/domainConfig';
 
-export const getGtmCreateWatchDogEvent = (watchdogFormData: WatchdogFormType): GtmCreateWatchdogEventType => ({
+export const getGtmCreateWatchDogEvent = (
+    watchdogFormData: WatchdogFormType,
+    product: WatchDogProductType,
+    domainConfig: DomainConfigType,
+    arePricesHidden: boolean,
+    listIndex?: number,
+): GtmCreateWatchdogEventType => ({
     event: GtmEventType.create_watchdog,
     eventParameters: {
         email: watchdogFormData.email,
         productUuid: watchdogFormData.productUuid,
     },
+    ecommerce: {
+        currencyCode: domainConfig.currencyCode,
+        valueWithoutVat: getGtmPriceBasedOnVisibility(product.price.priceWithoutVat),
+        valueWithVat: getGtmPriceBasedOnVisibility(product.price.priceWithVat),
+        products: [mapGtmWatchdogProduct(product, domainConfig.url, listIndex)],
+        arePricesHidden,
+    },
     _clear: true,
 });
+
+const mapGtmWatchdogProduct = (
+    product: WatchDogProductType,
+    domainUrl: string,
+    listIndex?: number,
+): GtmCartItemType => {
+    const mappedProduct: GtmCartItemType = {
+        ...mapGtmProductInterface(product, domainUrl),
+        quantity: 1,
+    };
+
+    if (listIndex !== undefined) {
+        mappedProduct.listIndex = listIndex + 1;
+    }
+
+    return mappedProduct;
+};

--- a/project-base/storefront/gtm/handlers/onGtmCreateWatchdotEventHandler.ts
+++ b/project-base/storefront/gtm/handlers/onGtmCreateWatchdotEventHandler.ts
@@ -1,7 +1,15 @@
 import { getGtmCreateWatchDogEvent } from 'gtm/factories/getGtmCreateWatchDogEvent';
 import { gtmSafePushEvent } from 'gtm/utils/gtmSafePushEvent';
 import { WatchdogFormType } from 'types/form';
+import { WatchDogProductType } from 'types/product';
+import { DomainConfigType } from 'utils/domain/domainConfig';
 
-export const onGtmCreateWatchdotEventHandler = (watchdogFormData: WatchdogFormType): void => {
-    gtmSafePushEvent(getGtmCreateWatchDogEvent(watchdogFormData));
+export const onGtmCreateWatchdotEventHandler = (
+    watchdogFormData: WatchdogFormType,
+    product: WatchDogProductType,
+    domainConfig: DomainConfigType,
+    arePricesHidden: boolean,
+    listIndex?: number,
+): void => {
+    gtmSafePushEvent(getGtmCreateWatchDogEvent(watchdogFormData, product, domainConfig, arePricesHidden, listIndex));
 };

--- a/project-base/storefront/gtm/types/events.ts
+++ b/project-base/storefront/gtm/types/events.ts
@@ -295,5 +295,12 @@ export type GtmCreateWatchdogEventType = GtmEventInterface<
             email: string;
             productUuid: string;
         };
+        ecommerce: {
+            currencyCode: string;
+            valueWithoutVat: number | null;
+            valueWithVat: number | null;
+            products: GtmCartItemType[];
+            arePricesHidden: boolean;
+        };
     }
 >;

--- a/project-base/storefront/types/product.ts
+++ b/project-base/storefront/types/product.ts
@@ -10,3 +10,9 @@ export type ProductInterfaceType =
     | TypeCartItemFragment['product']
     | TypeListedProductFragment
     | TypeSimpleProductFragment;
+
+export type WatchDogProductType =
+    | TypeProductDetailFragment
+    | TypeMainVariantDetailFragment
+    | TypeMainVariantDetailFragment['variants'][number]
+    | TypeListedProductFragment;

--- a/project-base/storefront/vitest/gtm/getGtmCreateWatchDogEvent.test.ts
+++ b/project-base/storefront/vitest/gtm/getGtmCreateWatchDogEvent.test.ts
@@ -1,0 +1,115 @@
+import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
+import { TypeAvailabilityStatusEnum } from 'graphql/types';
+import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { getGtmCreateWatchDogEvent } from 'gtm/factories/getGtmCreateWatchDogEvent';
+import { WatchdogFormType } from 'types/form';
+import { describe, expect, test } from 'vitest';
+import { defaultTestDomainConfig } from '../helpers/mockPublicConfig';
+
+const watchdogFormData: WatchdogFormType = {
+    email: 'customer@example.com',
+    productUuid: 'd6316f87-b06a-45f1-92b4-4a6a347817db',
+    gdprAgreement: true,
+};
+
+const listedProduct = {
+    __typename: 'RegularProduct',
+    id: 12345,
+    uuid: 'd6316f87-b06a-45f1-92b4-4a6a347817db',
+    slug: '/watched-product',
+    fullName: 'Watched Product',
+    name: 'Watched Product',
+    stockQuantity: 0,
+    isAllowedNegativeStock: false,
+    isSellingDenied: false,
+    isCurrentlyOutOfStock: true,
+    availableStoresCount: null,
+    catalogNumber: 'WATCH-1',
+    isMainVariant: false,
+    isInquiryType: false,
+    unit: {
+        name: 'pcs',
+    },
+    flags: [
+        {
+            __typename: 'Flag',
+            uuid: '18cf6d4a-f243-498b-9b9d-2b989d2fae19',
+            name: 'Action',
+            rgbColor: '#ff0000',
+        },
+    ],
+    mainImage: {
+        __typename: 'Image',
+        name: 'Watched product image',
+        url: 'https://cdn.example.com/watched-product.jpg',
+    },
+    price: {
+        __typename: 'ProductPrice',
+        priceWithVat: '121.00',
+        priceWithoutVat: '100.00',
+        vatAmount: '21.00',
+        isPriceFrom: false,
+        nextPriceChange: null,
+        percentageDiscount: null,
+        basicPrice: {
+            priceWithVat: '121.00',
+            priceWithoutVat: '100.00',
+            vatAmount: '21.00',
+        },
+    },
+    availability: {
+        __typename: 'Availability',
+        name: 'Out of stock',
+        status: TypeAvailabilityStatusEnum.OutOfStock,
+    },
+    brand: {
+        __typename: 'Brand',
+        name: 'Watch Brand',
+        slug: '/watch-brand',
+    },
+    categories: [
+        {
+            __typename: 'Category',
+            name: 'Watches',
+        },
+    ],
+} satisfies TypeListedProductFragment;
+
+describe('getGtmCreateWatchDogEvent', () => {
+    test('should create watchdog event with product ecommerce data', () => {
+        const event = getGtmCreateWatchDogEvent(watchdogFormData, listedProduct, defaultTestDomainConfig, false, 1);
+
+        expect(event).toEqual({
+            event: GtmEventType.create_watchdog,
+            eventParameters: {
+                email: 'customer@example.com',
+                productUuid: 'd6316f87-b06a-45f1-92b4-4a6a347817db',
+            },
+            ecommerce: {
+                currencyCode: 'EUR',
+                valueWithoutVat: 100,
+                valueWithVat: 121,
+                products: [
+                    {
+                        id: 12345,
+                        name: 'Watched Product',
+                        availability: 'Out of stock',
+                        flags: ['Action'],
+                        priceWithoutVat: 100,
+                        priceWithVat: 121,
+                        vatAmount: 21,
+                        sku: 'WATCH-1',
+                        url: 'https://test1.example.com/watched-product',
+                        brand: 'Watch Brand',
+                        categories: ['Watches'],
+                        imageUrl: 'https://cdn.example.com/watched-product.jpg',
+                        quantity: 1,
+                        listIndex: 2,
+                    },
+                ],
+                arePricesHidden: false,
+            },
+            _clear: true,
+        });
+    });
+});

--- a/upgrade-notes/storefront_20260504_134844.md
+++ b/upgrade-notes/storefront_20260504_134844.md
@@ -1,0 +1,3 @@
+#### Add product ecommerce data to watchdog GTM event ([#4598](https://github.com/shopsys/shopsys/pull/4598))
+
+See #project-base-diff to update your project.


### PR DESCRIPTION
#### Description, the reason for the PR

This PR extends watchdog GTM tracking so the create watchdog event includes product ecommerce details in addition to the submitted email.

Analytics can now identify which product was watched, including its prices, currency, availability, category context, and list position when available. This keeps watchdog tracking aligned with other product-related GTM events such as add to cart.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4017-watchdog-gtm-event.odin.shopsys.cloud
  - https://cz.tc-ssp-4017-watchdog-gtm-event.odin.shopsys.cloud
  - https://tc-ssp-4017-watchdog-gtm-event.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1777977018.475539 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4017-watchdog-gtm-event.odin.shopsys.cloud
  - https://cz.tc-ssp-4017-watchdog-gtm-event.odin.shopsys.cloud
  - https://tc-ssp-4017-watchdog-gtm-event.odin.shopsys.cloud/sk
<!-- Replace -->
