### PR TITLE
admin: relative dates in cron list are now translatable

### DIFF
--- a/packages/administration/src/Twig/Runtime/DateTimeAgoRuntime.php
+++ b/packages/administration/src/Twig/Runtime/DateTimeAgoRuntime.php
@@ -29,7 +29,7 @@ class DateTimeAgoRuntime implements RuntimeExtensionInterface
         }
 
         $today = $this->clock->now()->format('Y-m-d');
-        $yesterday = (new DatePoint('yesterday'))->format('Y-m-d');
+        $yesterday = new DatePoint('yesterday')->format('Y-m-d');
         $dateStr = $dateTime->format('Y-m-d');
 
         if ($dateStr !== $today && $dateStr !== $yesterday) {
@@ -42,8 +42,8 @@ class DateTimeAgoRuntime implements RuntimeExtensionInterface
         }
 
         $datePart = match ($dateStr) {
-            $today => 'today',
-            $yesterday => 'yesterday',
+            $today => t('today'),
+            $yesterday => t('yesterday'),
             default => throw new LogicException('Date should be either today or yesterday at this point'),
         };
 

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -2332,6 +2332,9 @@ msgstr "obchodní zástupci"
 msgid "subscribers"
 msgstr "odběratelé newsletteru"
 
+msgid "today"
+msgstr "dnes"
+
 msgid "type&nbsp;%key%&nbsp;to search"
 msgstr "stiskněte&nbsp;%key%&nbsp;pro hledání"
 
@@ -2346,4 +2349,7 @@ msgstr "použijte %keyTab% nebo %keyShiftTab%"
 
 msgid "watchdogs"
 msgstr "hlídací psi"
+
+msgid "yesterday"
+msgstr "včera"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -2332,6 +2332,9 @@ msgstr ""
 msgid "subscribers"
 msgstr ""
 
+msgid "today"
+msgstr ""
+
 msgid "type&nbsp;%key%&nbsp;to search"
 msgstr ""
 
@@ -2345,5 +2348,8 @@ msgid "use %keyTab% or %keyShiftTab%"
 msgstr ""
 
 msgid "watchdogs"
+msgstr ""
+
+msgid "yesterday"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -2332,6 +2332,9 @@ msgstr "obchodní zástupcovia"
 msgid "subscribers"
 msgstr "odberateľia"
 
+msgid "today"
+msgstr "dnes"
+
 msgid "type&nbsp;%key%&nbsp;to search"
 msgstr "stlačte&nbsp;%key%&nbsp;pre vyhľadávanie"
 
@@ -2346,4 +2349,7 @@ msgstr "použite %keyTab% alebo %keyShiftTab%"
 
 msgid "watchdogs"
 msgstr "watchdogy"
+
+msgid "yesterday"
+msgstr "včera"
 


### PR DESCRIPTION
#### Description, the reason for the PR

Relative date labels in the administration cron list are now translated according to the administration locale.

Until now, recent dates could display the English labels `today` and `yesterday` even in localized administration. This made the cron overview inconsistent for Czech and Slovak administrators. The labels now use the standard translation system, so the same date/time output stays localized together with the rest of the administration.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-fix-translation.odin.shopsys.cloud
  - https://cz.mg-fix-translation.odin.shopsys.cloud
  - https://mg-fix-translation.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778488710.555189 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-translation.odin.shopsys.cloud
  - https://cz.mg-fix-translation.odin.shopsys.cloud
  - https://mg-fix-translation.odin.shopsys.cloud/sk
<!-- Replace -->
