### PR TITLE
create order GTM now reports submitted order data

### DIFF
--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
@@ -266,7 +266,7 @@ export const useContactInformationFormMeta = (): ContactInformationFormMetaType 
             newsletterSubscription: t('I want to subscribe to the newsletter'),
             note: t('Note'),
             isWithoutHeurekaAgreement: t(
-                'I do not agree to send satisfaction questionnaires within the Verified by Customers program',
+                'I do not want to receive any satisfaction questionnaire (Heureka, Zbozi, Google)',
             ),
         }),
     };

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
@@ -33,7 +33,6 @@ import { isPacketeryTransport } from 'utils/packetery';
 import { StoreOrPacketeryPoint } from 'utils/packetery/types';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
 import { dispatchBroadcastChannel } from 'utils/useBroadcastChannel';
-import { useCurrentUserContactInformation } from 'utils/user/useCurrentUserContactInformation';
 import { ContactInformationFormMetaType } from './contactInformationFormMeta';
 import {
     getDeliveryInfoFromFormValues,
@@ -188,7 +187,7 @@ const useHandleCreateOrderResult = (
                     orderConfirmationUrl,
                 )
                 .then(() => {
-                    handleEventsAfterOrderCreation(createdOrder.number);
+                    handleEventsAfterOrderCreation(createdOrder.number, formValues);
                 });
 
             return;
@@ -209,23 +208,22 @@ const useHandleEventsAfterOrderCreation = () => {
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const user = useCurrentCustomerData();
     const domainConfig = useDomainConfig();
-    const userContactInformation = useCurrentUserContactInformation();
     const { cart, payment, promoCodes } = useCurrentCart();
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
     const resetContactInformation = usePersistStore((store) => store.resetContactInformation);
     const { canSeePrices } = useAuthorization();
 
-    const handleEventsAfterOrderCreation = (orderNumber: string) => {
+    const handleEventsAfterOrderCreation = (orderNumber: string, formValues: ContactInformation) => {
         if (cart && payment) {
             const gtmCreateOrderEventOrderPart = getGtmCreateOrderEventOrderPart(
                 cart,
                 payment,
                 promoCodes,
                 orderNumber,
-                getGtmReviewConsents(),
+                getGtmReviewConsents(!formValues.isWithoutHeurekaAgreement),
                 domainConfig,
             );
-            const gtmCreateOrderEventUserPart = getGtmCreateOrderEventUserPart(user, userContactInformation);
+            const gtmCreateOrderEventUserPart = getGtmCreateOrderEventUserPart(user, formValues);
             const gtmPaymentEvent = getGtmPaymentEvent(orderNumber, payment.name, false, -1);
             const isPaymentWithPaymentGate = getIsPaymentWithPaymentGate(payment.type);
             const isPaymentSuccessful = isPaymentWithPaymentGate ? undefined : true;

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
@@ -7,6 +7,7 @@ import {
     TypeCreateOrderMutationVariables,
     useCreateOrderMutation,
 } from 'graphql/requests/orders/mutations/CreateOrderMutation.generated';
+import { useSettingsQuery } from 'graphql/requests/settings/queries/SettingsQuery.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { getGtmCreateOrderEventOrderPart, getGtmCreateOrderEventUserPart } from 'gtm/factories/getGtmCreateOrderEvent';
 import { getGtmPaymentEvent } from 'gtm/factories/getGtmPaymentEvent';
@@ -209,18 +210,22 @@ const useHandleEventsAfterOrderCreation = () => {
     const user = useCurrentCustomerData();
     const domainConfig = useDomainConfig();
     const { cart, payment, promoCodes } = useCurrentCart();
+    const [{ data: settingsData }] = useSettingsQuery();
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
     const resetContactInformation = usePersistStore((store) => store.resetContactInformation);
     const { canSeePrices } = useAuthorization();
 
     const handleEventsAfterOrderCreation = (orderNumber: string, formValues: ContactInformation) => {
         if (cart && payment) {
+            const reviewConsents = settingsData?.settings?.heurekaEnabled
+                ? getGtmReviewConsents(!formValues.isWithoutHeurekaAgreement)
+                : undefined;
             const gtmCreateOrderEventOrderPart = getGtmCreateOrderEventOrderPart(
                 cart,
                 payment,
                 promoCodes,
                 orderNumber,
-                getGtmReviewConsents(!formValues.isWithoutHeurekaAgreement),
+                reviewConsents,
                 domainConfig,
             );
             const gtmCreateOrderEventUserPart = getGtmCreateOrderEventUserPart(user, formValues);

--- a/project-base/storefront/gtm/factories/getGtmCreateOrderEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmCreateOrderEvent.ts
@@ -42,6 +42,12 @@ export const getGtmCreateOrderEventOrderPart = (
     vatAmount: parseFloat(cart.totalPrice.vatAmount),
     paymentPriceWithoutVat: getGtmPriceBasedOnVisibility(payment.price.priceWithoutVat),
     paymentPriceWithVat: getGtmPriceBasedOnVisibility(payment.price.priceWithVat),
+    transportPriceWithoutVat: cart.transport
+        ? getGtmPriceBasedOnVisibility(cart.transport.price.priceWithoutVat)
+        : null,
+    transportPriceWithVat: cart.transport ? getGtmPriceBasedOnVisibility(cart.transport.price.priceWithVat) : null,
+    transportType: cart.transport?.name ?? '',
+    discountAmount: getGtmPriceBasedOnVisibility(cart.totalDiscountPrice.priceWithVat),
     promoCodes: promoCodes.map(({ code }) => code),
     paymentType: payment.name,
     reviewConsents,

--- a/project-base/storefront/gtm/factories/getGtmCreateOrderEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmCreateOrderEvent.ts
@@ -32,7 +32,7 @@ export const getGtmCreateOrderEventOrderPart = (
     payment: TypeSimplePaymentFragment,
     promoCodes: TypePromoCode[],
     orderNumber: string,
-    reviewConsents: GtmReviewConsentsType,
+    reviewConsents: GtmReviewConsentsType | undefined,
     domainConfig: DomainConfigType,
 ): GtmCreateOrderEventOrderPartType => ({
     currencyCode: domainConfig.currencyCode,
@@ -50,7 +50,7 @@ export const getGtmCreateOrderEventOrderPart = (
     discountAmount: getGtmPriceBasedOnVisibility(cart.totalDiscountPrice.priceWithVat),
     promoCodes: promoCodes.map(({ code }) => code),
     paymentType: payment.name,
-    reviewConsents,
+    ...(reviewConsents !== undefined && { reviewConsents }),
     products: cart.items.map((cartItem, index) => mapGtmCartItemType(cartItem, domainConfig.url, index)),
 });
 

--- a/project-base/storefront/gtm/types/events.ts
+++ b/project-base/storefront/gtm/types/events.ts
@@ -308,7 +308,7 @@ export type GtmCreateOrderEventOrderPartType = {
     promoCodes?: string[];
     discountAmount: number | null;
     paymentType: string;
-    reviewConsents: GtmReviewConsentsType;
+    reviewConsents?: GtmReviewConsentsType;
     products: GtmCartItemType[] | undefined;
 };
 

--- a/project-base/storefront/gtm/types/events.ts
+++ b/project-base/storefront/gtm/types/events.ts
@@ -302,8 +302,11 @@ export type GtmCreateOrderEventOrderPartType = {
     vatAmount: number;
     paymentPriceWithoutVat: number | null;
     paymentPriceWithVat: number | null;
+    transportPriceWithoutVat: number | null;
+    transportPriceWithVat: number | null;
+    transportType: string;
     promoCodes?: string[];
-    discountAmount?: number;
+    discountAmount: number | null;
     paymentType: string;
     reviewConsents: GtmReviewConsentsType;
     products: GtmCartItemType[] | undefined;

--- a/project-base/storefront/gtm/utils/getGtmReviewConsents.ts
+++ b/project-base/storefront/gtm/utils/getGtmReviewConsents.ts
@@ -1,7 +1,7 @@
 import { GtmReviewConsentsType } from 'gtm/types/objects';
 
-export const getGtmReviewConsents = (): GtmReviewConsentsType => ({
-    google: true,
-    seznam: true,
-    heureka: true,
+export const getGtmReviewConsents = (areReviewConsentsGranted: boolean): GtmReviewConsentsType => ({
+    google: areReviewConsentsGranted,
+    seznam: areReviewConsentsGranted,
+    heureka: areReviewConsentsGranted,
 });

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -251,7 +251,7 @@
     "hrs count_other": "hod",
     "I agree to receive the newsletter": "Souhlasím se zasíláním newsletteru",
     "I agree with terms and conditions and privacy policy": "Souhlasím s <lnk1>obchodními podmínkami</lnk1> a zpracovaním osobních údajů",
-    "I do not agree to send satisfaction questionnaires within the Verified by Customers program": "Nesouhlasím se zasíláním dotazníků spokojenosti v rámci programu Ověřeno zákazníky",
+    "I do not want to receive any satisfaction questionnaire (Heureka, Zbozi, Google)": "Nechci zasílat žádný dotazník spokojenosti (Heureka, Zboží, Google)",
     "I have a discount coupon": "Mám slevový kupón",
     "I want to subscribe to the newsletter": "Chci se přihlásit k odběru newsletteru",
     "I will shop as": "Chci nakupovat jako",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -235,7 +235,7 @@
     "hrs count_other": "hrs",
     "I agree to receive the newsletter": "I agree to receive the newsletter",
     "I agree with terms and conditions and privacy policy": "I agree with <lnk1>terms and conditions</lnk1> and privacy policy",
-    "I do not agree to send satisfaction questionnaires within the Verified by Customers program": "I do not agree to send satisfaction questionnaires within the Verified by Customers program",
+    "I do not want to receive any satisfaction questionnaire (Heureka, Zbozi, Google)": "I do not want to receive any satisfaction questionnaire (Heureka, Zboží, Google)",
     "I have a discount coupon": "I have a discount coupon",
     "I want to subscribe to the newsletter": "I want to subscribe to the newsletter",
     "I will shop as": "I will shop as",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -251,7 +251,7 @@
     "hrs count_other": "hod",
     "I agree to receive the newsletter": "Súhlasím so zasielaním newsletter",
     "I agree with terms and conditions and privacy policy": "Súhlasím s <lnk1>obchodnými podmienkami</lnk1> a spracovaním osobných údajov",
-    "I do not agree to send satisfaction questionnaires within the Verified by Customers program": "Nesúhlasím so zasielaním dotazníkov spokojnosti v rámci programu Overené zákazníkmi",
+    "I do not want to receive any satisfaction questionnaire (Heureka, Zbozi, Google)": "Nechcem zasielať žiadny dotazník spokojnosti (Heureka, Zboží, Google)",
     "I have a discount coupon": "Mám zľavový kupón",
     "I want to subscribe to the newsletter": "Chcem sa prihlásiť k odberu newsletteru",
     "I will shop as": "Budem nakupovat ako",

--- a/project-base/storefront/vitest/gtm/getGtmCreateOrderEvent.test.ts
+++ b/project-base/storefront/vitest/gtm/getGtmCreateOrderEvent.test.ts
@@ -1,0 +1,116 @@
+import { getGtmCreateOrderEventOrderPart } from 'gtm/factories/getGtmCreateOrderEvent';
+import { getGtmReviewConsents } from 'gtm/utils/getGtmReviewConsents';
+import { describe, expect, test } from 'vitest';
+
+const domainConfig = {
+    currencyCode: 'EUR',
+    url: 'https://example.com',
+} as any;
+
+const payment = {
+    name: 'Credit card',
+    price: {
+        priceWithoutVat: '10.00',
+        priceWithVat: '12.10',
+    },
+} as any;
+
+const cart = {
+    totalPrice: {
+        priceWithoutVat: '100.00',
+        priceWithVat: '121.00',
+        vatAmount: '21.00',
+    },
+    totalDiscountPrice: {
+        priceWithVat: '5.00',
+    },
+    transport: {
+        name: 'Packetery',
+        price: {
+            priceWithoutVat: '4.00',
+            priceWithVat: '4.84',
+        },
+    },
+    items: [],
+} as any;
+
+describe('getGtmCreateOrderEventOrderPart', () => {
+    test('should include payment, transport and discount order values', () => {
+        const result = getGtmCreateOrderEventOrderPart(
+            cart,
+            payment,
+            [{ code: 'PROMO' }] as any,
+            '202600001',
+            getGtmReviewConsents(true),
+            domainConfig,
+        );
+
+        expect(result).toMatchObject({
+            currencyCode: 'EUR',
+            id: '202600001',
+            valueWithoutVat: 100,
+            valueWithVat: 121,
+            vatAmount: 21,
+            paymentPriceWithoutVat: 10,
+            paymentPriceWithVat: 12.1,
+            transportPriceWithoutVat: 4,
+            transportPriceWithVat: 4.84,
+            transportType: 'Packetery',
+            discountAmount: 5,
+            promoCodes: ['PROMO'],
+            paymentType: 'Credit card',
+            reviewConsents: {
+                google: true,
+                seznam: true,
+                heureka: true,
+            },
+        });
+    });
+
+    test('should hide price-related values when prices are hidden', () => {
+        const result = getGtmCreateOrderEventOrderPart(
+            {
+                ...cart,
+                totalPrice: {
+                    priceWithoutVat: '***',
+                    priceWithVat: '***',
+                    vatAmount: '0',
+                },
+                totalDiscountPrice: {
+                    priceWithVat: '***',
+                },
+                transport: {
+                    ...cart.transport,
+                    price: {
+                        priceWithoutVat: '***',
+                        priceWithVat: '***',
+                    },
+                },
+            },
+            {
+                ...payment,
+                price: {
+                    priceWithoutVat: '***',
+                    priceWithVat: '***',
+                },
+            },
+            [],
+            '202600001',
+            getGtmReviewConsents(false),
+            domainConfig,
+        );
+
+        expect(result.valueWithoutVat).toBeNull();
+        expect(result.valueWithVat).toBeNull();
+        expect(result.paymentPriceWithoutVat).toBeNull();
+        expect(result.paymentPriceWithVat).toBeNull();
+        expect(result.transportPriceWithoutVat).toBeNull();
+        expect(result.transportPriceWithVat).toBeNull();
+        expect(result.discountAmount).toBeNull();
+        expect(result.reviewConsents).toEqual({
+            google: false,
+            seznam: false,
+            heureka: false,
+        });
+    });
+});

--- a/project-base/storefront/vitest/gtm/getGtmCreateOrderEvent.test.ts
+++ b/project-base/storefront/vitest/gtm/getGtmCreateOrderEvent.test.ts
@@ -113,4 +113,10 @@ describe('getGtmCreateOrderEventOrderPart', () => {
             heureka: false,
         });
     });
+
+    test('should omit review consents when they are not available on the current domain', () => {
+        const result = getGtmCreateOrderEventOrderPart(cart, payment, [], '202600001', undefined, domainConfig);
+
+        expect(result).not.toHaveProperty('reviewConsents');
+    });
 });

--- a/project-base/storefront/vitest/gtm/getGtmUserInfo.test.ts
+++ b/project-base/storefront/vitest/gtm/getGtmUserInfo.test.ts
@@ -1,0 +1,43 @@
+import { getGtmUserInfo } from 'gtm/utils/getGtmUserInfo';
+import { CustomerTypeEnum } from 'types/customer';
+import { describe, expect, test } from 'vitest';
+
+const contactInformation = {
+    city: 'Prague',
+    country: { value: 'CZ', label: 'Czech Republic' },
+    customer: CustomerTypeEnum.CommonCustomer,
+    email: 'customer@example.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    postcode: '10000',
+    street: 'Main street 1',
+    telephone: '123456789',
+    newsletterSubscription: false,
+} as any;
+
+const currentCustomer = {
+    uuid: 'customer-uuid',
+    city: 'Prague',
+    country: { code: 'CZ' },
+    email: 'customer@example.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    postcode: '10000',
+    street: 'Main street 1',
+    telephone: '123456789',
+    newsletterSubscription: true,
+    pricingGroup: 'Default',
+    loginInfo: {
+        loginType: 'web',
+        externalId: null,
+    },
+    companyCustomer: false,
+} as any;
+
+describe('getGtmUserInfo', () => {
+    test('should use newsletter subscription value from submitted contact information', () => {
+        const result = getGtmUserInfo(currentCustomer, contactInformation);
+
+        expect(result.newsletterSubscription).toBe(false);
+    });
+});

--- a/upgrade-notes/storefront_20260505_082450.md
+++ b/upgrade-notes/storefront_20260505_082450.md
@@ -1,0 +1,7 @@
+#### create order GTM now reports submitted order data ([#4602](https://github.com/shopsys/shopsys/pull/4602))
+
+- `ec.create_order` GTM event now includes transport price without VAT, transport price with VAT, transport type, discount amount, and promo codes
+- `reviewConsents` in the `ec.create_order` GTM event are now derived from the satisfaction questionnaire checkbox in the checkout contact information step
+- `newsletterSubscription` in the `ec.create_order` GTM event now reflects the value submitted in the checkout form instead of the stored customer profile value
+- the satisfaction questionnaire checkbox text was updated to mention Heureka, Zboží, and Google while keeping the existing Heureka agreement behavior
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The storefront create order GTM event now reports submitted checkout values consistently. It includes transport price/type, discount amount and promo codes, and derives review consents and newsletter subscription from the order form.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4009-gtm-create-order-fields.odin.shopsys.cloud
  - https://cz.tc-ssp-4009-gtm-create-order-fields.odin.shopsys.cloud
  - https://tc-ssp-4009-gtm-create-order-fields.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778073019.047469 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4009-gtm-create-order-fields.odin.shopsys.cloud
  - https://cz.tc-ssp-4009-gtm-create-order-fields.odin.shopsys.cloud
  - https://tc-ssp-4009-gtm-create-order-fields.odin.shopsys.cloud/sk
<!-- Replace -->
