### PR TITLE
Add order withdrawal GTM event

### DIFF
--- a/docs/storefront/gtm/events.md
+++ b/docs/storefront/gtm/events.md
@@ -399,6 +399,21 @@ export type GtmPaymentFailEventType = GtmEventInterface<
 >;
 ```
 
+## GtmWithdrawalEventType
+
+This type is used for tracking when a user submits an order withdrawal request.
+
+```ts
+export type GtmWithdrawalEventType = GtmEventInterface<
+  GtmEventType.withdrawal, // the type of the event
+  {
+    ecommerce: {
+      id: string; // the number of the order for which the withdrawal was requested
+    };
+  }
+>;
+```
+
 ## GtmCreateOrderEventOrderPartType
 
 This type represents the order part of the GtmCreateOrderEventType. It is stored in local storage before redirecting to the payment gate if the user has chosen to pay using a payment that requires a redirect.

--- a/project-base/storefront/components/Pages/OrderWithdrawal/OrderWithdrawalContent.tsx
+++ b/project-base/storefront/components/Pages/OrderWithdrawal/OrderWithdrawalContent.tsx
@@ -11,6 +11,7 @@ import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { TIDs } from 'cypress/tids';
 import { TypeOrderWithdrawalDataFragment } from 'graphql/requests/orders/fragments/OrderWithdrawalDataFragment.generated';
 import { useOrderWithdrawalRequestMutation } from 'graphql/requests/orders/mutations/OrderWithdrawalRequestMutation.generated';
+import { onGtmWithdrawalEventHandler } from 'gtm/handlers/onGtmWithdrawalEventHandler';
 import { useRouter } from 'next/router';
 import { FormProvider, SubmitHandler } from 'react-hook-form';
 import { useSessionStore } from 'store/useSessionStore';
@@ -52,6 +53,8 @@ export const OrderWithdrawalContent: FC<OrderWithdrawalContentProps> = ({ order 
         });
 
         if (result.data?.OrderWithdrawalRequest) {
+            onGtmWithdrawalEventHandler(order.number);
+
             const [orderWithdrawalSuccessUrl] = getInternationalizedStaticUrls(
                 [{ url: '/order-withdrawal-success/:orderUrlHash', param: order.urlHash }],
                 url,

--- a/project-base/storefront/gtm/enums/GtmEventType.ts
+++ b/project-base/storefront/gtm/enums/GtmEventType.ts
@@ -25,4 +25,5 @@ export enum GtmEventType {
     login = 'ec.login',
     registration = 'ec.registration',
     create_watchdog = 'ec.create_watchdog',
+    withdrawal = 'ec.withdrawal',
 }

--- a/project-base/storefront/gtm/factories/getGtmWithdrawalEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmWithdrawalEvent.ts
@@ -1,0 +1,10 @@
+import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { GtmWithdrawalEventType } from 'gtm/types/events';
+
+export const getGtmWithdrawalEvent = (orderNumber: string): GtmWithdrawalEventType => ({
+    event: GtmEventType.withdrawal,
+    ecommerce: {
+        id: orderNumber,
+    },
+    _clear: true,
+});

--- a/project-base/storefront/gtm/handlers/onGtmWithdrawalEventHandler.ts
+++ b/project-base/storefront/gtm/handlers/onGtmWithdrawalEventHandler.ts
@@ -1,0 +1,6 @@
+import { getGtmWithdrawalEvent } from 'gtm/factories/getGtmWithdrawalEvent';
+import { gtmSafePushEvent } from 'gtm/utils/gtmSafePushEvent';
+
+export const onGtmWithdrawalEventHandler = (orderNumber: string): void => {
+    gtmSafePushEvent(getGtmWithdrawalEvent(orderNumber));
+};

--- a/project-base/storefront/gtm/types/events.ts
+++ b/project-base/storefront/gtm/types/events.ts
@@ -368,3 +368,12 @@ export type GtmCreateWatchdogEventType = GtmEventInterface<
         };
     }
 >;
+
+export type GtmWithdrawalEventType = GtmEventInterface<
+    GtmEventType.withdrawal,
+    {
+        ecommerce: {
+            id: string;
+        };
+    }
+>;

--- a/project-base/storefront/vitest/gtm/getGtmWithdrawalEvent.test.ts
+++ b/project-base/storefront/vitest/gtm/getGtmWithdrawalEvent.test.ts
@@ -1,0 +1,15 @@
+import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { getGtmWithdrawalEvent } from 'gtm/factories/getGtmWithdrawalEvent';
+import { describe, expect, test } from 'vitest';
+
+describe('getGtmWithdrawalEvent', () => {
+    test('should create withdrawal event with order number as ecommerce id', () => {
+        expect(getGtmWithdrawalEvent('T12345')).toStrictEqual({
+            event: GtmEventType.withdrawal,
+            ecommerce: {
+                id: 'T12345',
+            },
+            _clear: true,
+        });
+    });
+});

--- a/upgrade-notes/storefront_20260505_100353.md
+++ b/upgrade-notes/storefront_20260505_100353.md
@@ -1,0 +1,5 @@
+#### Add order withdrawal GTM event ([#4603](https://github.com/shopsys/shopsys/pull/4603))
+
+- Storefront now pushes the GTM `ec.withdrawal` event after an order withdrawal request is submitted successfully
+- the event contains the order number in `ecommerce.id`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The storefront now sends a dedicated GTM event when a customer successfully submits an order withdrawal request.

This gives analytics integrations a clear signal for withdrawal submissions and includes the order number in `ecommerce.id`, matching the expected GTM payload for this event.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4027-add-withdrawal-event.odin.shopsys.cloud
  - https://cz.tc-ssp-4027-add-withdrawal-event.odin.shopsys.cloud
  - https://tc-ssp-4027-add-withdrawal-event.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778157559.048769 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4027-add-withdrawal-event.odin.shopsys.cloud
  - https://cz.tc-ssp-4027-add-withdrawal-event.odin.shopsys.cloud
  - https://tc-ssp-4027-add-withdrawal-event.odin.shopsys.cloud/sk
<!-- Replace -->
