### PR TITLE
Catalog page now shows categories independently of navigation

### DIFF
--- a/project-base/storefront/components/Pages/Catalog/CatalogContent.tsx
+++ b/project-base/storefront/components/Pages/Catalog/CatalogContent.tsx
@@ -1,41 +1,23 @@
 import { CategoryCard } from 'components/Blocks/Categories/CategoryCard';
 import { SkeletonPageCatalog } from 'components/Blocks/Skeleton/SkeletonPageCatalog';
 import { Webline } from 'components/Layout/Webline/Webline';
-import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useNavigationQuery } from 'graphql/requests/navigation/queries/NavigationQuery.generated';
-import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
+import { useCatalogCategoriesQuery } from 'graphql/requests/categories/queries/CatalogCategoriesQuery.generated';
 
 export const CatalogContent: FC = () => {
-    const [{ data: navigationData, fetching: isNavigationFetching }] = useNavigationQuery();
-    const { url } = useDomainConfig();
-    const [catalogUrl] = getInternationalizedStaticUrls(['/catalog'], url);
+    const [{ data: catalogCategoriesData, fetching: areCatalogCategoriesFetching }] = useCatalogCategoriesQuery();
 
-    if (isNavigationFetching) {
+    if (areCatalogCategoriesFetching) {
         return <SkeletonPageCatalog />;
     }
 
-    if (!navigationData) {
+    if (!catalogCategoriesData) {
         return null;
     }
-
-    const catalogNavigationItem = navigationData.navigation.find(
-        (navigationItem) => navigationItem.link === catalogUrl,
-    );
-
-    if (!catalogNavigationItem) {
-        return null;
-    }
-
-    const l1Categories = catalogNavigationItem.categoriesByColumns.flatMap((column) => column.categories);
-
-    const uniqueL1Categories = l1Categories.filter(
-        (category, index, self) => index === self.findIndex((c) => c.uuid === category.uuid),
-    );
 
     return (
         <Webline>
             <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4">
-                {uniqueL1Categories.map((category) => (
+                {catalogCategoriesData.categories.map((category) => (
                     <CategoryCard key={category.uuid} showChildren category={category} variant="catalog" />
                 ))}
             </div>

--- a/project-base/storefront/graphql/requests/categories/queries/CatalogCategoriesQuery.generated.tsx
+++ b/project-base/storefront/graphql/requests/categories/queries/CatalogCategoriesQuery.generated.tsx
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import * as Types from '../../../types';
+
+import gql from 'graphql-tag';
+import { ImageFragment } from '../../images/fragments/ImageFragment.generated';
+import * as Urql from 'urql';
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type TypeCatalogCategoriesQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type TypeCatalogCategoriesQuery = { __typename?: 'Query', categories: Array<{ __typename: 'Category', uuid: string, name: string, slug: string, mainImage: { __typename: 'Image', name: string | null, url: string } | null, children: Array<{ __typename: 'Category', uuid: string, name: string, slug: string }> }> };
+
+
+export const CatalogCategoriesQueryDocument = gql`
+    query CatalogCategoriesQuery {
+  categories {
+    __typename
+    uuid
+    name
+    slug
+    mainImage {
+      ...ImageFragment
+    }
+    children {
+      __typename
+      uuid
+      name
+      slug
+    }
+  }
+}
+    ${ImageFragment}`;
+
+export function useCatalogCategoriesQuery(options?: Omit<Urql.UseQueryArgs<TypeCatalogCategoriesQueryVariables>, 'query'>) {
+  return Urql.useQuery<TypeCatalogCategoriesQuery, TypeCatalogCategoriesQueryVariables>({ query: CatalogCategoriesQueryDocument, ...options });
+};

--- a/project-base/storefront/graphql/requests/categories/queries/CatalogCategoriesQuery.graphql
+++ b/project-base/storefront/graphql/requests/categories/queries/CatalogCategoriesQuery.graphql
@@ -1,0 +1,17 @@
+query CatalogCategoriesQuery {
+    categories {
+        __typename
+        uuid
+        name
+        slug
+        mainImage {
+            ...ImageFragment
+        }
+        children {
+            __typename
+            uuid
+            name
+            slug
+        }
+    }
+}

--- a/project-base/storefront/pages/catalog.tsx
+++ b/project-base/storefront/pages/catalog.tsx
@@ -3,7 +3,7 @@ import { Webline } from 'components/Layout/Webline/Webline';
 import { CatalogContent } from 'components/Pages/Catalog/CatalogContent';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { TypeBreadcrumbFragment } from 'graphql/requests/breadcrumbs/fragments/BreadcrumbFragment.generated';
-import { NavigationQueryDocument } from 'graphql/requests/navigation/queries/NavigationQuery.generated';
+import { CatalogCategoriesQueryDocument } from 'graphql/requests/categories/queries/CatalogCategoriesQuery.generated';
 import { GtmPageType } from 'gtm/enums/GtmPageType';
 import { useGtmStaticPageReadyEvent } from 'gtm/factories/useGtmStaticPageReadyEvent';
 import { useGtmPageReadyEvent } from 'gtm/utils/pageReadyEvents/useGtmPageReadyEvent';
@@ -35,7 +35,7 @@ const CatalogPage: FC<ServerSidePropsType> = () => {
 export const getServerSideProps = getServerSidePropsWrapper(({ redisClient, domainConfig, t }) => async (context) => {
     return initServerSideProps({
         context,
-        prefetchedQueries: [{ query: NavigationQueryDocument }],
+        prefetchedQueries: [{ query: CatalogCategoriesQueryDocument }],
         redisClient,
         domainConfig,
         t,

--- a/upgrade-notes/storefront_20260507_143339.md
+++ b/upgrade-notes/storefront_20260507_143339.md
@@ -1,0 +1,5 @@
+#### Catalog page now shows categories independently of navigation ([#4606](https://github.com/shopsys/shopsys/pull/4606))
+
+- the catalog page now uses the existing categories query instead of the navigation menu query
+- the catalog page remains available with visible top-level categories even when the `/catalog` URL is not configured in the navigation menu
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The catalog page now always displays the visible category overview from the existing category data source.

Until now, the page content depended on whether the catalog URL was configured as an item in the navigation menu. That made the page empty when administrators customized the menu and did not include the catalog link there.

With this change, administrators can add the catalog URL to navigation or leave it out, and the catalog page remains available with the category tree.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4033-catalog-page-fix.odin.shopsys.cloud
  - https://cz.tc-ssp-4033-catalog-page-fix.odin.shopsys.cloud
  - https://tc-ssp-4033-catalog-page-fix.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778494425.596539 -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4033-catalog-page-fix.odin.shopsys.cloud
  - https://cz.tc-ssp-4033-catalog-page-fix.odin.shopsys.cloud
  - https://tc-ssp-4033-catalog-page-fix.odin.shopsys.cloud/sk
<!-- Replace -->
