### PR TITLE
Hide admin pages requiring parameters from autocomplete search

### DIFF
--- a/docs/administration/administration-menu.md
+++ b/docs/administration/administration-menu.md
@@ -57,6 +57,19 @@ To avoid throwing the `MissingMandatoryParametersException`, we have replaced th
 It simply doesn't generate a URI when the exception is thrown.
 The route is still used to resolve the current menu item.
 
+## Autocomplete search
+
+The admin autocomplete search also uses menu items as its source.
+An item is included in search results when:
+
+- it has a label
+- it has a generated URI
+
+This means hidden menu items (`display => false`) are searchable by default.
+That is useful for pages like "new" actions, which are intentionally hidden from the side menu but are still valid standalone admin pages.
+
+Routes with mandatory route parameters but without concrete values usually have no generated URI because of the custom routing extension above, so they do not appear in the autocomplete.
+
 ## Breadcrumb overriding
 
 A `BreadcrumbOverrider::overrideLastItem(string $label)` call can be used in a controller to override the last breadcrumb item.

--- a/packages/framework/src/Controller/Admin/BestsellingProductController.php
+++ b/packages/framework/src/Controller/Admin/BestsellingProductController.php
@@ -53,14 +53,15 @@ class BestsellingProductController extends AdminBaseController
         ]);
     }
 
-    #[Route(path: '/product/bestselling-product/detail/')]
+    #[Route(path: '/product/bestselling-product/detail/domain/{domainId}/category/{categoryId}/', requirements: [
+        'domainId' => '\d+',
+        'categoryId' => '\d+',
+    ])]
     #[CanEdit(methods: [HttpMethod::POST])]
     #[CanView(methods: [HttpMethod::GET])]
-    public function detailAction(Request $request): Response
+    public function detailAction(Request $request, int $domainId, int $categoryId): Response
     {
-        $categoryId = $request->query->getInt('categoryId');
         $category = $this->categoryFacade->getById($categoryId);
-        $domainId = $request->query->getInt('domainId');
 
         $products = $this->manualBestsellingProductFacade->getProductsIndexedByPosition(
             $category,

--- a/packages/framework/src/Controller/Admin/LanguageConstantController.php
+++ b/packages/framework/src/Controller/Admin/LanguageConstantController.php
@@ -57,13 +57,18 @@ class LanguageConstantController extends AdminBaseController
         ]);
     }
 
-    #[Route(path: '/constant/edit/')]
+    #[Route(
+        path: '/constant/edit/{namespace}/{key}/',
+        requirements: ['key' => '.+'],
+        defaults: ['namespace' => LanguageConstant::NAMESPACE_COMMON],
+    )]
     #[CanEdit(methods: [HttpMethod::POST])]
     #[CanView(methods: [HttpMethod::GET])]
-    public function editAction(Request $request): Response
-    {
-        $key = $request->query->get('key');
-        $namespace = $request->query->get('namespace', LanguageConstant::NAMESPACE_COMMON);
+    public function editAction(
+        Request $request,
+        string $key,
+        string $namespace = LanguageConstant::NAMESPACE_COMMON,
+    ): Response {
         $locale = $this->getSelectedLocale();
         $translation = $this->languageConstantFacade->getOriginalTranslationsByLocaleIndexedByKey($locale, $namespace)[$key] ?? null;
 

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -248,6 +248,7 @@ class RouteConfigCustomization
             })
             ->customizeByRouteName('admin_bestsellingproduct_detail', function (RouteConfig $config): void {
                 $config->changeDefaultRequestDataSet('Category with ID 1 is the root, use ID 2 instead.')
+                    ->setParameter('domainId', 1)
                     ->setParameter('categoryId', 2);
             })
             ->customizeByRouteName('admin_pricinggroup_delete', function (RouteConfig $config): void {

--- a/upgrade-notes/backend_20260512_113155.md
+++ b/upgrade-notes/backend_20260512_113155.md
@@ -1,0 +1,9 @@
+#### admin: replace query parameters with path variables in selected admin routes ([#4608](https://github.com/shopsys/shopsys/pull/4608))
+
+- route `admin_bestsellingproduct_detail` (`Shopsys\FrameworkBundle\Controller\Admin\BestsellingProductController::detailAction`) changed its URI and method signature
+    - URI changed from `/product/bestselling-product/detail/` (with query params `domainId` and `categoryId`) to `/product/bestselling-product/detail/domain/{domainId}/category/{categoryId}/`
+    - update all URL generations for this route to pass `domainId` and `categoryId` as path parameters
+- route `admin_languageconstant_edit` (`Shopsys\FrameworkBundle\Controller\Admin\LanguageConstantController::editAction`) changed its URI and method signature
+    - URI changed from `/constant/edit/` (with query params `key` and `namespace`) to `/constant/edit/{namespace}/{key}/`
+    - update all URL generations for this route to pass `key`, and pass `namespace` when you need a non-default namespace
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Two admin pages — bestselling product detail and language constant edit — appeared in the administration autocomplete search even though they cannot be opened without a concrete category/domain or translation key/namespace. Picking such a result led to a broken page because the required values were missing.

The actions used query string parameters with implicit defaults, so the routes looked parameter-less to the routing layer. This PR makes the parameters explicit by moving them into the path. URI generation now fails when concrete values are missing, the custom routing extension turns the failure into an empty URI, and the autocomplete filter excludes the route automatically — the same mechanism that already hides other parameterized admin routes.

The administration menu documentation was also extended with an explanation of when an item shows up in the autocomplete results.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://rv-admin-menu-search-tweak.odin.shopsys.cloud
  - https://cz.rv-admin-menu-search-tweak.odin.shopsys.cloud
  - https://rv-admin-menu-search-tweak.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1778659104.560929 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-admin-menu-search-tweak.odin.shopsys.cloud
  - https://cz.rv-admin-menu-search-tweak.odin.shopsys.cloud
  - https://rv-admin-menu-search-tweak.odin.shopsys.cloud/sk
<!-- Replace -->
