### PR TITLE
Keep delivery addresses synced in checkout

### DIFF
--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
@@ -3,6 +3,7 @@ import { AddressList } from 'components/Blocks/AddressList/AddressList';
 import { CheckboxControlled } from 'components/Forms/Checkbox/CheckboxControlled';
 import { FormBlockWrapper, FormHeading } from 'components/Forms/Form/Form';
 import { FormLine } from 'components/Forms/Lib/FormLine';
+import { FormLineError } from 'components/Forms/Lib/FormLineError';
 import { useContactInformationFormMeta } from 'components/Pages/Order/ContactInformation/contactInformationFormMeta';
 import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
@@ -33,30 +34,54 @@ export const ContactInformationDeliveryAddress: FC = () => {
     const { canManagePersonalData } = useAuthorization();
     const { setValue } = formProviderMethods;
     const deliveryAddressUuidFieldName = formMeta.fields.deliveryAddressUuid.name;
+    const deliveryAddressUuidError = formProviderMethods.formState.errors.deliveryAddressUuid;
     const defaultDeliveryAddressUuid = user?.defaultDeliveryAddress?.uuid;
     const firstDeliveryAddressUuid = user?.deliveryAddresses[0]?.uuid;
 
     const handleChangeDeliveryAddressForOrder = (value: string) => {
-        setValue(deliveryAddressUuidFieldName, value);
+        setValue(deliveryAddressUuidFieldName, value, { shouldValidate: true });
         updateContactInformation({ deliveryAddressUuid: value });
     };
 
     useEffect(() => {
+        const deliveryAddressUuidToSelect = defaultDeliveryAddressUuid ?? firstDeliveryAddressUuid ?? '';
+
         if (deliveryAddressUuid) {
+            if (!isUserLoggedIn || pickupPlace || user === undefined || user === null) {
+                return;
+            }
+
+            const isSelectedDeliveryAddressAvailable = user.deliveryAddresses.some((deliveryAddress) => {
+                return deliveryAddress.uuid === deliveryAddressUuid;
+            });
+
+            if (isSelectedDeliveryAddressAvailable) {
+                return;
+            }
+
+            setValue(deliveryAddressUuidFieldName, deliveryAddressUuidToSelect, {
+                shouldValidate: isDeliveryAddressDifferentFromBilling,
+            });
+            updateContactInformation({ deliveryAddressUuid: deliveryAddressUuidToSelect });
+
             return;
         }
 
-        if (defaultDeliveryAddressUuid) {
-            setValue(deliveryAddressUuidFieldName, defaultDeliveryAddressUuid, { shouldValidate: true });
-        } else if (firstDeliveryAddressUuid) {
-            setValue(deliveryAddressUuidFieldName, firstDeliveryAddressUuid, { shouldValidate: true });
+        if (deliveryAddressUuidToSelect) {
+            setValue(deliveryAddressUuidFieldName, deliveryAddressUuidToSelect, { shouldValidate: true });
+            updateContactInformation({ deliveryAddressUuid: deliveryAddressUuidToSelect });
         }
     }, [
         defaultDeliveryAddressUuid,
         firstDeliveryAddressUuid,
         deliveryAddressUuid,
         deliveryAddressUuidFieldName,
+        isDeliveryAddressDifferentFromBilling,
+        isUserLoggedIn,
+        pickupPlace,
         setValue,
+        updateContactInformation,
+        user,
     ]);
 
     return (
@@ -75,9 +100,13 @@ export const ContactInformationDeliveryAddress: FC = () => {
                 checkboxProps={{
                     label: formMeta.fields.isDeliveryAddressDifferentFromBilling.label,
                 }}
-                onChange={(event) =>
-                    updateContactInformation({ isDeliveryAddressDifferentFromBilling: event.target.checked })
-                }
+                onChange={(event) => {
+                    updateContactInformation({ isDeliveryAddressDifferentFromBilling: event.target.checked });
+
+                    if (!event.target.checked) {
+                        formProviderMethods.clearErrors(deliveryAddressUuidFieldName);
+                    }
+                }}
             />
 
             <AnimatePresence initial={false}>
@@ -87,12 +116,21 @@ export const ContactInformationDeliveryAddress: FC = () => {
                             <>
                                 <p className="h4 mb-5">{t('Choose delivery address')}</p>
 
-                                <AddressList
-                                    defaultDeliveryAddress={user?.defaultDeliveryAddress}
-                                    deliveryAddresses={user?.deliveryAddresses ?? []}
-                                    orderSelectAddressHandler={handleChangeDeliveryAddressForOrder}
-                                    orderSelectedAddress={deliveryAddressUuid}
-                                />
+                                <div
+                                    className="flex flex-col gap-2"
+                                    id={`${formMeta.formName}-${deliveryAddressUuidFieldName}`}
+                                >
+                                    <AddressList
+                                        defaultDeliveryAddress={user?.defaultDeliveryAddress}
+                                        deliveryAddresses={user?.deliveryAddresses ?? []}
+                                        orderSelectAddressHandler={handleChangeDeliveryAddressForOrder}
+                                        orderSelectedAddress={deliveryAddressUuid}
+                                    />
+
+                                    {deliveryAddressUuidError?.message !== undefined && (
+                                        <FormLineError error={deliveryAddressUuidError} inputType="text-input" />
+                                    )}
+                                </div>
                             </>
                         )}
 

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
@@ -167,7 +167,12 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
                 then: () => validateCountry(t),
             }),
             newsletterSubscription: Yup.boolean(),
-            deliveryAddressUuid: Yup.string().optional(),
+            deliveryAddressUuid: Yup.string().when('isDeliveryAddressDifferentFromBilling', {
+                is: (isDeliveryAddressDifferentFromBilling: boolean) =>
+                    isUserLoggedIn && !pickupPlace && isDeliveryAddressDifferentFromBilling,
+                then: () => Yup.string().required(t('Please add or select a delivery address')),
+                otherwise: (schema) => schema.optional(),
+            }),
             note: Yup.string().optional().nullable(),
             isWithoutHeurekaAgreement: Yup.boolean(),
         }),
@@ -199,7 +204,7 @@ const shouldValidateDeliveryAddressField = (
     if (
         !isPickupPlaceSelected &&
         isDeliveryAddressDifferentFromBilling &&
-        (deliveryAddressUuid === 'new-delivery-address' || deliveryAddressUuid === '')
+        (deliveryAddressUuid === 'new-delivery-address' || (!isUserLoggedIn && deliveryAddressUuid === ''))
     ) {
         return true;
     }
@@ -213,7 +218,7 @@ const shouldValidateDeliveryAddressField = (
     }
 
     if (isUserLoggedIn) {
-        return deliveryAddressUuid === '';
+        return false;
     }
 
     return true;

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -397,6 +397,7 @@
     "Phone number (optional)": "Telefonní číslo (nepovinné)",
     "Phone prefix": "Telefonní předvolba",
     "Pickup place": "Odběrné místo",
+    "Please add or select a delivery address": "Přidejte nebo vyberte prosím doručovací adresu",
     "Please attach files": "Prosím připojte soubory",
     "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.": "Prosím, přiložte obrázky reklamovaného zboží ve formátu JPG nebo PNG s maximální velikostí souboru {{ max }}. Maximální počet souborů je {{ maxFilesCount }}.",
     "Please check inserted details": "Prosím zkontrolujte zadané údaje.",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -369,6 +369,7 @@
     "Phone number (optional)": "Phone number (optional)",
     "Phone prefix": "Phone prefix",
     "Pickup place": "Pickup place",
+    "Please add or select a delivery address": "Please add or select a delivery address",
     "Please attach files": "Please attach files",
     "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.": "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.",
     "Please check inserted details": "Please, check inserted details",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -397,6 +397,7 @@
     "Phone number (optional)": "Telefónne číslo (nepovinné)",
     "Phone prefix": "Telefónna predvoľba",
     "Pickup place": "Pickup place",
+    "Please add or select a delivery address": "Pridajte alebo vyberte prosím doručovaciu adresu",
     "Please attach files": "Prosím pripojte súbory",
     "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.": "Prosím, priložte obrázky reklamovaného tovaru vo formáte JPG alebo PNG s maximálnou veľkosťou súboru {{ max }}. Maximálny počet súborov je {{ maxFilesCount }}.",
     "Please check inserted details": "Prosím, skontrolujte zadané údaje.",

--- a/project-base/storefront/urql/cache/cacheExchange.ts
+++ b/project-base/storefront/urql/cache/cacheExchange.ts
@@ -71,6 +71,8 @@ export const cache = cacheExchange({
         Payment: keyUuid,
         PersonalData: keyNull,
         PersonalDataPage: keyNull,
+        PhoneData: keyNull,
+        PhonePrefix: keyCode,
         Price: keyNull,
         PricingSetting: keyNull,
         Product: keyUuid,

--- a/project-base/storefront/urql/cache/updates.ts
+++ b/project-base/storefront/urql/cache/updates.ts
@@ -39,9 +39,18 @@ import {
     TypeCartQueryVariables,
 } from 'graphql/requests/cart/queries/CartQuery.generated';
 import {
+    TypeCreateDeliveryAddressMutation,
+    TypeCreateDeliveryAddressMutationVariables,
+} from 'graphql/requests/customer/mutations/CreateDeliveryAddressMutation.generated';
+import {
     TypeDeleteDeliveryAddressMutation,
     TypeDeleteDeliveryAddressMutationVariables,
 } from 'graphql/requests/customer/mutations/DeleteDeliveryAddressMutation.generated';
+import {
+    CurrentCustomerUserQueryDocument,
+    TypeCurrentCustomerUserQuery,
+    TypeCurrentCustomerUserQueryVariables,
+} from 'graphql/requests/customer/queries/CurrentCustomerUserQuery.generated';
 import {
     TypeCreateOrderMutation,
     TypeCreateOrderMutationVariables,
@@ -83,17 +92,21 @@ export const cacheUpdates: UpdatesConfig = {
             cache.invalidate('ProductPrice');
         },
         DeleteDeliveryAddress(
-            _result: TypeDeleteDeliveryAddressMutation,
+            result: TypeDeleteDeliveryAddressMutation,
             _args: TypeDeleteDeliveryAddressMutationVariables,
             cache,
         ) {
-            invalidateFields(cache, ['currentCustomerUser']);
+            manuallyUpdateCurrentCustomerUserDeliveryAddresses(cache, result.DeleteDeliveryAddress);
         },
         CreateOrder(_result: TypeCreateOrderMutation, _args: TypeCreateOrderMutationVariables, cache) {
             invalidateFields(cache, ['currentCustomerUser']);
         },
-        CreateDeliveryAddress(_result: TypeCreateOrderMutation, _args: TypeCreateOrderMutationVariables, cache) {
-            invalidateFields(cache, ['currentCustomerUser']);
+        CreateDeliveryAddress(
+            result: TypeCreateDeliveryAddressMutation,
+            _args: TypeCreateDeliveryAddressMutationVariables,
+            cache,
+        ) {
+            manuallyUpdateCurrentCustomerUserDeliveryAddresses(cache, result.CreateDeliveryAddress);
         },
         AddToCart(result: TypeAddToCartMutation, _args: TypeAddToCartMutationVariables, cache) {
             manuallyUpdateCartQuery(cache, result.AddToCart.cart, result.AddToCart.cart.uuid);
@@ -191,6 +204,34 @@ const manuallyUpdateCartQuery = (cache: Cache, newCart: TypeCartFragment, cartUu
             __typename: 'Query',
             cart: newCart,
         }),
+    );
+};
+
+const manuallyUpdateCurrentCustomerUserDeliveryAddresses = (
+    cache: Cache,
+    deliveryAddresses: NonNullable<TypeCurrentCustomerUserQuery['currentCustomerUser']>['deliveryAddresses'],
+) => {
+    cache.updateQuery<TypeCurrentCustomerUserQuery, TypeCurrentCustomerUserQueryVariables>(
+        { query: CurrentCustomerUserQueryDocument },
+        (data) => {
+            if (data?.currentCustomerUser === null || data?.currentCustomerUser === undefined) {
+                return data;
+            }
+
+            const defaultDeliveryAddress =
+                deliveryAddresses.find((deliveryAddress) => {
+                    return deliveryAddress.uuid === data.currentCustomerUser?.defaultDeliveryAddress?.uuid;
+                }) ?? null;
+
+            return {
+                ...data,
+                currentCustomerUser: {
+                    ...data.currentCustomerUser,
+                    defaultDeliveryAddress,
+                    deliveryAddresses,
+                },
+            };
+        },
     );
 };
 

--- a/upgrade-notes/storefront_20260513_110609.md
+++ b/upgrade-notes/storefront_20260513_110609.md
@@ -1,0 +1,8 @@
+#### Keep delivery addresses synced in checkout ([#4612](https://github.com/shopsys/shopsys/pull/4612))
+
+- newly created delivery addresses are now added to the customer user cache immediately after the create mutation
+- deleted delivery addresses are now removed from the customer user cache immediately after the delete mutation
+- checkout now persists the automatically selected delivery address so the new address can be used for the order without reloading the page
+- checkout now validates that logged-in customers add or select a delivery address before submitting the order when sending it to another delivery address
+- phone prefix and phone data results now have explicit graphcache key configuration
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Customers who create or delete delivery addresses during checkout now see the address list update immediately without reloading the page.

Previously, the checkout could keep showing stale delivery address data after an address was created or deleted through the address popup. It was also possible to submit an order while "send to another delivery address" was selected but no delivery address existed, which only resulted in a GraphQL validation error.

This change keeps the storefront customer data synchronized with the create and delete mutation responses, clears stale default delivery address data when needed, persists the automatically selected address in the checkout state, and shows a validation message when the customer still needs to add or select a delivery address.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4043-show-first-delivery-address.odin.shopsys.cloud
  - https://cz.tc-ssp-4043-show-first-delivery-address.odin.shopsys.cloud
  - https://tc-ssp-4043-show-first-delivery-address.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1779096315.761309 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4043-show-first-delivery-address.odin.shopsys.cloud
  - https://cz.tc-ssp-4043-show-first-delivery-address.odin.shopsys.cloud
  - https://tc-ssp-4043-show-first-delivery-address.odin.shopsys.cloud/sk
<!-- Replace -->
