### PR TITLE
Update administrator activity once per request

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -237,7 +237,9 @@ If generated files are part of a larger change (e.g., you added a new GraphQL fi
 
 ## Upgrade Notes
 
-When changes include upgrade note files (typically in `upgrade/` directory or files matching `*UPGRADE*` patterns), always group them into their own separate commit.
+When changes include upgrade note files (typically in `upgrade/` directory or files matching `*UPGRADE*` patterns), group them into their own separate commit by default.
+
+If the user explicitly asks for a single commit, one commit, or to include all changes in the same commit, obey that request and include upgrade notes in the same commit as the related changes.
 
 **Commit message:** `added upgrade notes` — no body needed.
 
@@ -245,7 +247,7 @@ When changes include upgrade note files (typically in `upgrade/` directory or fi
 added upgrade notes
 ```
 
-Never combine upgrade note files with other changes. Always split them out into their own group.
+Unless the user explicitly requests a single commit, never combine upgrade note files with other changes. Split them out into their own group.
 
 ## Interaction Pattern
 

--- a/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFacade.php
+++ b/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFacade.php
@@ -30,8 +30,9 @@ class AdministratorActivityFacade
         return $administratorActivity;
     }
 
-    public function updateCurrentActivityLastActionTime(Administrator $administrator): void
+    public function updateCurrentActivity(Administrator $administrator): void
     {
+        $administrator->setLastActivity($this->clock->now());
         $currentAdministratorActivity = $this->administratorActivityRepository->getCurrent($administrator);
         $currentAdministratorActivity->updateLastActionTime();
         $this->em->flush();

--- a/packages/framework/src/Model/Administrator/Activity/AdministratorActivityRequestSubscriber.php
+++ b/packages/framework/src/Model/Administrator/Activity/AdministratorActivityRequestSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Activity;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\CurrentAdministrator;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\AdministratorIsNotLoggedException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AdministratorActivityRequestSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        protected readonly ContextResolverInterface $contextResolver,
+        protected readonly CurrentAdministrator $currentAdministrator,
+        protected readonly AdministratorActivityFacade $administratorActivityFacade,
+    ) {
+    }
+
+    public function updateAdministratorActivity(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest() || !$this->contextResolver->isCurrentContext(AdminContext::class)) {
+            return;
+        }
+
+        try {
+            $administrator = $this->currentAdministrator->getCurrentlyLoggedAdministrator();
+        } catch (AdministratorIsNotLoggedException) {
+            return;
+        }
+
+        $this->administratorActivityFacade->updateCurrentActivity($administrator);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'updateAdministratorActivity',
+        ];
+    }
+}

--- a/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
@@ -6,7 +6,6 @@ namespace Shopsys\FrameworkBundle\Model\Administrator\Security;
 
 use Override;
 use Psr\Clock\ClockInterface;
-use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade;
 use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository;
 use Shopsys\FrameworkBundle\Model\Security\TimelimitLoginInterface;
@@ -21,7 +20,6 @@ class AdministratorUserProvider implements UserProviderInterface
 {
     public function __construct(
         protected readonly AdministratorRepository $administratorRepository,
-        protected readonly AdministratorActivityFacade $administratorActivityFacade,
         protected readonly AdministratorRolesChangedSubscriber $administratorRolesChangedSubscriber,
         protected readonly ClockInterface $clock,
     ) {
@@ -82,17 +80,11 @@ class AdministratorUserProvider implements UserProviderInterface
             if ($this->clock->now()->getTimestamp() - $administrator->getLastActivity()->getTimestamp() > 3600 * 5) {
                 throw new AuthenticationExpiredException('Admin was too long inactive.');
             }
-
-            if ($freshAdministrator !== null) {
-                $freshAdministrator->setLastActivity($this->clock->now());
-            }
         }
 
         if ($freshAdministrator === null) {
             throw new UserNotFoundException('Unable to find an active admin');
         }
-
-        $this->administratorActivityFacade->updateCurrentActivityLastActionTime($freshAdministrator);
 
         if ($freshAdministrator->getRolesChangedAt() > $administrator->getRolesChangedAt()) {
             //In this step token does not exist, so we are not able to update user roles.

--- a/packages/framework/tests/Unit/Model/Administrator/Activity/AdministratorActivityFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Administrator/Activity/AdministratorActivityFacadeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Administrator\Activity;
+
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivity;
+use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactory;
+use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityRepository;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+
+class AdministratorActivityFacadeTest extends TestCase
+{
+    public function testUpdateCurrentActivityUpdatesAdministratorActivityAndFlushes(): void
+    {
+        $mockedNow = new DateTimeImmutable('2026-05-13 10:00:00');
+        $administratorMock = $this->createMock(Administrator::class);
+        $administratorMock->expects($this->once())->method('setLastActivity')->with($mockedNow);
+
+        $administratorActivityMock = $this->createMock(AdministratorActivity::class);
+        $administratorActivityMock->expects($this->once())->method('updateLastActionTime');
+
+        $administratorActivityRepositoryMock = $this->createMock(AdministratorActivityRepository::class);
+        $administratorActivityRepositoryMock
+            ->expects($this->once())
+            ->method('getCurrent')
+            ->with($administratorMock)
+            ->willReturn($administratorActivityMock);
+
+        $emMock = $this->createMock(EntityManagerInterface::class);
+        $emMock->expects($this->once())->method('flush');
+
+        $clockStub = $this->createStub(ClockInterface::class);
+        $clockStub->method('now')->willReturn($mockedNow);
+
+        $administratorActivityFacade = new AdministratorActivityFacade(
+            $emMock,
+            $administratorActivityRepositoryMock,
+            $this->createStub(AdministratorActivityFactory::class),
+            $clockStub,
+        );
+
+        $administratorActivityFacade->updateCurrentActivity($administratorMock);
+    }
+}

--- a/packages/framework/tests/Unit/Model/Administrator/Activity/AdministratorActivityRequestSubscriberTest.php
+++ b/packages/framework/tests/Unit/Model/Administrator/Activity/AdministratorActivityRequestSubscriberTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Administrator\Activity;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Context\AdminContext;
+use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityRequestSubscriber;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+use Shopsys\FrameworkBundle\Model\Administrator\CurrentAdministrator;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\AdministratorIsNotLoggedException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class AdministratorActivityRequestSubscriberTest extends TestCase
+{
+    public function testUpdateAdministratorActivityUpdatesLoggedAdministratorOnMainAdminRequest(): void
+    {
+        $administratorStub = $this->createStub(Administrator::class);
+
+        $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
+        $administratorActivityFacadeMock->expects($this->once())->method('updateCurrentActivity')->with($administratorStub);
+
+        $subscriber = $this->createSubscriber(
+            true,
+            $administratorStub,
+            $administratorActivityFacadeMock,
+        );
+
+        $subscriber->updateAdministratorActivity($this->createRequestEvent(HttpKernelInterface::MAIN_REQUEST));
+    }
+
+    public function testUpdateAdministratorActivityDoesNothingOnSubRequest(): void
+    {
+        $contextResolverMock = $this->createMock(ContextResolverInterface::class);
+        $contextResolverMock->expects($this->never())->method('isCurrentContext');
+
+        $currentAdministratorMock = $this->createMock(CurrentAdministrator::class);
+        $currentAdministratorMock->expects($this->never())->method('getCurrentlyLoggedAdministrator');
+
+        $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
+        $administratorActivityFacadeMock->expects($this->never())->method('updateCurrentActivity');
+
+        $subscriber = new AdministratorActivityRequestSubscriber(
+            $contextResolverMock,
+            $currentAdministratorMock,
+            $administratorActivityFacadeMock,
+        );
+
+        $subscriber->updateAdministratorActivity($this->createRequestEvent(HttpKernelInterface::SUB_REQUEST));
+    }
+
+    public function testUpdateAdministratorActivityDoesNothingOutsideAdminContext(): void
+    {
+        $currentAdministratorMock = $this->createMock(CurrentAdministrator::class);
+        $currentAdministratorMock->expects($this->never())->method('getCurrentlyLoggedAdministrator');
+
+        $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
+        $administratorActivityFacadeMock->expects($this->never())->method('updateCurrentActivity');
+
+        $subscriber = $this->createSubscriber(
+            false,
+            null,
+            $administratorActivityFacadeMock,
+            $currentAdministratorMock,
+        );
+
+        $subscriber->updateAdministratorActivity($this->createRequestEvent(HttpKernelInterface::MAIN_REQUEST));
+    }
+
+    public function testUpdateAdministratorActivityDoesNothingWhenAdministratorIsNotLogged(): void
+    {
+        $currentAdministratorMock = $this->createMock(CurrentAdministrator::class);
+        $currentAdministratorMock
+            ->expects($this->once())
+            ->method('getCurrentlyLoggedAdministrator')
+            ->willThrowException(new AdministratorIsNotLoggedException('Administrator is not logged.'));
+
+        $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
+        $administratorActivityFacadeMock->expects($this->never())->method('updateCurrentActivity');
+
+        $subscriber = $this->createSubscriber(
+            true,
+            null,
+            $administratorActivityFacadeMock,
+            $currentAdministratorMock,
+        );
+
+        $subscriber->updateAdministratorActivity($this->createRequestEvent(HttpKernelInterface::MAIN_REQUEST));
+    }
+
+    private function createSubscriber(
+        bool $isAdminContext,
+        ?Administrator $administrator,
+        AdministratorActivityFacade $administratorActivityFacade,
+        ?CurrentAdministrator $currentAdministrator = null,
+    ): AdministratorActivityRequestSubscriber {
+        $contextResolverMock = $this->createMock(ContextResolverInterface::class);
+        $contextResolverMock
+            ->expects($this->once())
+            ->method('isCurrentContext')
+            ->with(AdminContext::class)
+            ->willReturn($isAdminContext);
+
+        if ($currentAdministrator === null) {
+            $currentAdministrator = $this->createStub(CurrentAdministrator::class);
+
+            if ($administrator !== null) {
+                $currentAdministrator->method('getCurrentlyLoggedAdministrator')->willReturn($administrator);
+            }
+        }
+
+        return new AdministratorActivityRequestSubscriber(
+            $contextResolverMock,
+            $currentAdministrator,
+            $administratorActivityFacade,
+        );
+    }
+
+    private function createRequestEvent(int $requestType): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            $requestType,
+        );
+    }
+}

--- a/upgrade-notes/backend_20260513_111033.md
+++ b/upgrade-notes/backend_20260513_111033.md
@@ -1,0 +1,5 @@
+#### admin: move administrator activity updates out of the user provider ([#4613](https://github.com/shopsys/shopsys/pull/4613))
+
+- `Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade::updateCurrentActivityLastActionTime()` was renamed to `updateCurrentActivity()`
+    - the method now updates both the administrator's `lastActivity` and the current administrator activity's last action time in a single flush
+    - update your custom calls or overrides to use `updateCurrentActivity()` instead


### PR DESCRIPTION
#### Description, the reason for the PR

This PR reduces unnecessary administrator activity updates during a single administration request.

Previously, administrator activity was updated from the user refresh flow, which can be executed multiple times during one request-response lifecycle. This caused repeated database writes for the same request. Administrator inactivity validation still happens during user refresh, but the activity timestamp is now updated once for the main administration request.

As a result, administrator sessions still expire correctly after inactivity, while the current activity record is kept up to date with fewer redundant writes.

This PR also adjusts the local commit workflow instructions so that upgrade notes are kept separate by default, but can be included in the same commit when a user explicitly asks for a single commit.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-admin-last-action.odin.shopsys.cloud
  - https://cz.mg-admin-last-action.odin.shopsys.cloud
  - https://mg-admin-last-action.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1779084381.092439 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-admin-last-action.odin.shopsys.cloud
  - https://cz.mg-admin-last-action.odin.shopsys.cloud
  - https://mg-admin-last-action.odin.shopsys.cloud/sk
<!-- Replace -->
