### PR TITLE
Allow numbered street names in address forms

### DIFF
--- a/project-base/storefront/utils/parsing/parseStreetWithHouseNumber.ts
+++ b/project-base/storefront/utils/parsing/parseStreetWithHouseNumber.ts
@@ -4,21 +4,28 @@ type ParsedStreetWithHouseNumber = {
 };
 
 export const streetWithHouseNumberRegex =
-    /^(?:[\u00C0-\u017Fa-zA-Z].*\s(\d+(?:\/\d+)?[\u00C0-\u017Fa-zA-Z]?)|(\d+(?:\/\d+)?[\u00C0-\u017Fa-zA-Z]?)\s.*[\u00C0-\u017Fa-zA-Z])$/;
+    /^(?:([\u00C0-\u017Fa-zA-Z].*)\s(\d+(?:\/\d+)?[\u00C0-\u017Fa-zA-Z]?)|(\d+(?:\/\d+)?[\u00C0-\u017Fa-zA-Z]?)\s(.*[\u00C0-\u017Fa-zA-Z])|(\d+\.\s[\u00C0-\u017Fa-zA-Z].*)\s(\d+(?:\/\d+)?[\u00C0-\u017Fa-zA-Z]?))$/;
 
 export const parseStreetWithHouseNumber = (street: string): ParsedStreetWithHouseNumber => {
     const streetWithHouseNumberMatch = street.match(streetWithHouseNumberRegex);
-    const streetNumber = streetWithHouseNumberMatch?.[1] ?? streetWithHouseNumberMatch?.[2];
+    const streetAtEnd = streetWithHouseNumberMatch?.[1] ?? streetWithHouseNumberMatch?.[5];
+    const streetNumberAtEnd = streetWithHouseNumberMatch?.[2] ?? streetWithHouseNumberMatch?.[6];
+    const streetNumberAtBeginning = streetWithHouseNumberMatch?.[3];
+    const streetNumber = streetNumberAtEnd ?? streetNumberAtBeginning;
 
     if (streetNumber === undefined) {
         return { street };
     }
 
+    if (streetNumberAtEnd !== undefined && streetAtEnd !== undefined) {
+        return {
+            street: streetAtEnd.trim(),
+            streetNumber,
+        };
+    }
+
     return {
-        street:
-            streetWithHouseNumberMatch?.[1] !== undefined
-                ? street.slice(0, -streetNumber.length).trim()
-                : street.slice(streetNumber.length).trim(),
+        street: streetWithHouseNumberMatch?.[4].trim() ?? street,
         streetNumber,
     };
 };

--- a/project-base/storefront/vitest/utils/parsing/parseStreetWithHouseNumber.test.ts
+++ b/project-base/storefront/vitest/utils/parsing/parseStreetWithHouseNumber.test.ts
@@ -1,0 +1,22 @@
+import { parseStreetWithHouseNumber } from 'utils/parsing/parseStreetWithHouseNumber';
+import { describe, expect, test } from 'vitest';
+
+describe('parseStreetWithHouseNumber', () => {
+    test.each([
+        ['Street 123', { street: 'Street', streetNumber: '123' }],
+        ['Street 123/4', { street: 'Street', streetNumber: '123/4' }],
+        ['123 Street', { street: 'Street', streetNumber: '123' }],
+        ['17. listopadu 2/2', { street: '17. listopadu', streetNumber: '2/2' }],
+        ['1. máje 5', { street: '1. máje', streetNumber: '5' }],
+    ])('parses street with house number: %s', (street, expected) => {
+        expect(parseStreetWithHouseNumber(street)).toEqual(expected);
+    });
+
+    test.each([
+        'Street',
+        '123',
+        '17. listopadu',
+    ])('keeps street without complete street and house number unchanged: %s', (street) => {
+        expect(parseStreetWithHouseNumber(street)).toEqual({ street });
+    });
+});

--- a/upgrade-notes/storefront_20260514_122911.md
+++ b/upgrade-notes/storefront_20260514_122911.md
@@ -1,0 +1,4 @@
+#### Allow numbered street names in address forms ([#4615](https://github.com/shopsys/shopsys/pull/4615))
+
+- street validation now accepts valid street names that start with ordinal numbers, such as `17. listopadu 2/2`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Address forms now accept valid street names that start with an ordinal number.

This prevents customers from being blocked when entering real street names that begin with a number while keeping the requirement that the address contains both a street name and a house number.

#### Fixes issues
...

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4045-allow-numbered-street-names.odin.shopsys.cloud
  - https://cz.tc-ssp-4045-allow-numbered-street-names.odin.shopsys.cloud
  - https://tc-ssp-4045-allow-numbered-street-names.odin.shopsys.cloud/sk
<!-- Replace -->
