### PR TITLE
Fix skeletons during browser history navigation

### DIFF
--- a/project-base/storefront/utils/app/usePageLoader.ts
+++ b/project-base/storefront/utils/app/usePageLoader.ts
@@ -1,14 +1,26 @@
 import { useRouter } from 'next/router';
 import Nprogress from 'nprogress';
-import { useEffect, useEffectEvent } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { PageType } from 'store/slices/createPageLoadingStateSlice';
 import { useSessionStore } from 'store/useSessionStore';
+import { getSkeletonTypeFromRouteUrl } from 'utils/skeleton/getSkeletonTypeFromRouteUrl';
+import {
+    getSkeletonTypeFromRouteState,
+    updateCurrentHistoryStateSkeletonType,
+} from 'utils/skeleton/routeStateSkeletonType';
 
 export const usePageLoader = () => {
     const router = useRouter();
     const updatePageLoadingState = useSessionStore((s) => s.updatePageLoadingState);
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
+    const pendingNavigationSkeletonType = useRef<PageType | undefined>(undefined);
 
-    const onRouteChangeStart = useEffectEvent((_targetUrl: string, { shallow }: { shallow: boolean }) => {
+    const onRouteChangeStart = useEffectEvent((targetUrl: string, { shallow }: { shallow: boolean }) => {
+        const currentPageLoadingState = useSessionStore.getState();
+        pendingNavigationSkeletonType.current =
+            getSkeletonTypeFromRouteUrl(targetUrl) ??
+            (currentPageLoadingState.isPageLoading ? currentPageLoadingState.redirectPageType : undefined);
+
         updatePortalContent(null);
         updatePageLoadingState({ hadClientSideNavigation: true });
         if (!shallow) {
@@ -16,7 +28,11 @@ export const usePageLoader = () => {
         }
     });
 
-    const onRouteChangeStop = useEffectEvent((_targetUrl: string, { shallow }: { shallow: boolean }) => {
+    const onRouteChangeStop = useEffectEvent((targetUrl: string, { shallow }: { shallow: boolean }) => {
+        const redirectPageType = pendingNavigationSkeletonType.current ?? getSkeletonTypeFromRouteUrl(targetUrl);
+
+        updateCurrentHistoryStateSkeletonType(redirectPageType);
+        pendingNavigationSkeletonType.current = undefined;
         updatePageLoadingState({ isPageLoading: false });
 
         if (!shallow) {
@@ -24,15 +40,51 @@ export const usePageLoader = () => {
         }
     });
 
+    const onRouteChangeError = useEffectEvent(
+        (_error: Error, _targetUrl: string, { shallow }: { shallow: boolean }) => {
+            pendingNavigationSkeletonType.current = undefined;
+
+            if (!shallow) {
+                Nprogress.done();
+            }
+        },
+    );
+
+    const onBeforePopState = useEffectEvent(
+        (routeState: { as: string; url: string; options?: { shallow?: boolean } }) => {
+            if (routeState.options?.shallow && getRoutePathWithoutQuery(routeState.url) === router.pathname) {
+                return true;
+            }
+
+            updatePageLoadingState({
+                isPageLoading: true,
+                redirectPageType: getSkeletonTypeFromRouteState(routeState),
+            });
+
+            return true;
+        },
+    );
+
     useEffect(() => {
         Nprogress.configure({ showSpinner: false, minimum: 0.2 });
+        updateCurrentHistoryStateSkeletonType(
+            useSessionStore.getState().redirectPageType ??
+                getSkeletonTypeFromRouteUrl(router.pathname) ??
+                getSkeletonTypeFromRouteUrl(router.asPath),
+        );
+        router.beforePopState(onBeforePopState);
 
         router.events.on('routeChangeStart', onRouteChangeStart);
         router.events.on('routeChangeComplete', onRouteChangeStop);
+        router.events.on('routeChangeError', onRouteChangeError);
 
         return () => {
+            router.beforePopState(() => true);
             router.events.off('routeChangeStart', onRouteChangeStart);
             router.events.off('routeChangeComplete', onRouteChangeStop);
+            router.events.off('routeChangeError', onRouteChangeError);
         };
-    }, [router.events]);
+    }, [router, router.events]);
 };
+
+const getRoutePathWithoutQuery = (routeUrl: string): string => routeUrl.split('?')[0];

--- a/project-base/storefront/utils/skeleton/getSkeletonTypeFromRouteUrl.ts
+++ b/project-base/storefront/utils/skeleton/getSkeletonTypeFromRouteUrl.ts
@@ -1,0 +1,70 @@
+import type { PageType } from 'store/slices/createPageLoadingStateSlice';
+import { FriendlyPagesDestinations, type FriendlyPageTypesValue } from 'types/friendlyUrl';
+import { SkeletonEnum } from 'types/skeletons';
+import { getPageTypeKey } from 'utils/page/getPageTypeKey';
+import { SLUG_TYPE_QUERY_PARAMETER_NAME } from 'utils/queryParamNames';
+
+const RELATIVE_URL_PARSE_BASE = 'https://shopsys.example';
+
+const FRIENDLY_ROUTE_SKELETON_PATTERNS = Object.entries(FriendlyPagesDestinations).map(([pageType, destination]) => ({
+    matcher: createRouteMatcher(destination),
+    skeletonType: pageType as PageType,
+}));
+
+export const getSkeletonTypeFromRouteUrl = (routeUrl: string | undefined): PageType | undefined => {
+    if (!routeUrl) {
+        return undefined;
+    }
+
+    const parsedRouteUrl = getParsedRouteUrl(routeUrl);
+
+    if (!parsedRouteUrl) {
+        return undefined;
+    }
+
+    const slugType = parsedRouteUrl.searchParams.get(SLUG_TYPE_QUERY_PARAMETER_NAME);
+    const friendlyPageType = slugType ? getPageTypeKey(slugType as FriendlyPageTypesValue) : undefined;
+
+    if (friendlyPageType) {
+        return friendlyPageType;
+    }
+
+    const pathname = normalizePathname(parsedRouteUrl.pathname);
+
+    if (pathname === '/') {
+        return SkeletonEnum.Homepage;
+    }
+
+    const routePattern = FRIENDLY_ROUTE_SKELETON_PATTERNS.find((pattern) => pattern.matcher.test(pathname));
+
+    return routePattern?.skeletonType;
+};
+
+function getParsedRouteUrl(routeUrl: string): URL | undefined {
+    try {
+        return new URL(routeUrl, RELATIVE_URL_PARSE_BASE);
+    } catch {
+        return undefined;
+    }
+}
+
+function normalizePathname(pathname: string): string {
+    if (pathname !== '/' && pathname.endsWith('/')) {
+        return pathname.slice(0, -1);
+    }
+
+    return pathname;
+}
+
+function createRouteMatcher(route: string): RegExp {
+    const routeRegex = escapeRegExp(route)
+        .replaceAll(/\\\[.*?\\\]/g, '[^/]+')
+        .replaceAll(/:[^/]+/g, '[^/]+')
+        .replaceAll('/', '\\/');
+
+    return new RegExp(`^${routeRegex}$`);
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/project-base/storefront/utils/skeleton/routeStateSkeletonType.ts
+++ b/project-base/storefront/utils/skeleton/routeStateSkeletonType.ts
@@ -1,0 +1,36 @@
+import type { PageType } from 'store/slices/createPageLoadingStateSlice';
+import { getSkeletonTypeFromRouteUrl } from './getSkeletonTypeFromRouteUrl';
+
+const HISTORY_STATE_SKELETON_TYPE_KEY = 'shopsysSkeletonType';
+
+type RouteStateWithSkeletonType = {
+    as?: string;
+    url?: string;
+    [HISTORY_STATE_SKELETON_TYPE_KEY]?: PageType;
+};
+
+export const getSkeletonTypeFromRouteState = (routeState: RouteStateWithSkeletonType): PageType | undefined => {
+    return (
+        routeState[HISTORY_STATE_SKELETON_TYPE_KEY] ??
+        getSkeletonTypeFromRouteUrl(routeState.url) ??
+        getSkeletonTypeFromRouteUrl(routeState.as)
+    );
+};
+
+export const updateCurrentHistoryStateSkeletonType = (skeletonType: PageType | undefined): void => {
+    const currentState = window.history.state;
+
+    if (!currentState) {
+        return;
+    }
+
+    const newState = { ...currentState };
+
+    if (skeletonType) {
+        newState[HISTORY_STATE_SKELETON_TYPE_KEY] = skeletonType;
+    } else {
+        delete newState[HISTORY_STATE_SKELETON_TYPE_KEY];
+    }
+
+    window.history.replaceState(newState, '', window.location.href);
+};

--- a/project-base/storefront/vitest/utils/skeleton/getSkeletonTypeFromRouteUrl.test.ts
+++ b/project-base/storefront/vitest/utils/skeleton/getSkeletonTypeFromRouteUrl.test.ts
@@ -1,0 +1,25 @@
+import { getSkeletonTypeFromRouteUrl } from 'utils/skeleton/getSkeletonTypeFromRouteUrl';
+import { describe, expect, test } from 'vitest';
+
+describe('getSkeletonTypeFromRouteUrl test', () => {
+    test('returns skeleton type from friendly URL slug type query parameter', () => {
+        expect(getSkeletonTypeFromRouteUrl('/products/[productSlug]?slugType=front_product_detail')).toBe('product');
+        expect(getSkeletonTypeFromRouteUrl('/categories/[categorySlug]?slugType=front_product_list')).toBe('category');
+    });
+
+    test('returns skeleton type from internal friendly route', () => {
+        expect(getSkeletonTypeFromRouteUrl('/products/test-product')).toBe('product');
+        expect(getSkeletonTypeFromRouteUrl('/categories/test-category')).toBe('category');
+        expect(getSkeletonTypeFromRouteUrl('/catalog')).toBe('catalog');
+    });
+
+    test('returns undefined for unknown route', () => {
+        expect(getSkeletonTypeFromRouteUrl('/unknown-route')).toBeUndefined();
+        expect(getSkeletonTypeFromRouteUrl('/cart')).toBeUndefined();
+        expect(getSkeletonTypeFromRouteUrl('/kosik')).toBeUndefined();
+    });
+
+    test('returns homepage skeleton type from root route', () => {
+        expect(getSkeletonTypeFromRouteUrl('/')).toBe('homepage');
+    });
+});

--- a/project-base/storefront/vitest/utils/skeleton/routeStateSkeletonType.test.ts
+++ b/project-base/storefront/vitest/utils/skeleton/routeStateSkeletonType.test.ts
@@ -1,0 +1,18 @@
+import { getSkeletonTypeFromRouteState } from 'utils/skeleton/routeStateSkeletonType';
+import { describe, expect, test } from 'vitest';
+
+describe('getSkeletonTypeFromRouteState test', () => {
+    test('returns skeleton type stored in route state', () => {
+        expect(getSkeletonTypeFromRouteState({ shopsysSkeletonType: 'cart', url: '/unknown-route' })).toBe('cart');
+    });
+
+    test('falls back to skeleton type from route url', () => {
+        expect(getSkeletonTypeFromRouteState({ url: '/products/[productSlug]?slugType=front_product_detail' })).toBe(
+            'product',
+        );
+    });
+
+    test('falls back to skeleton type from displayed route url', () => {
+        expect(getSkeletonTypeFromRouteState({ as: '/' })).toBe('homepage');
+    });
+});

--- a/upgrade-notes/storefront_20260514_135610.md
+++ b/upgrade-notes/storefront_20260514_135610.md
@@ -1,0 +1,6 @@
+#### Fix skeletons during browser history navigation ([#4616](https://github.com/shopsys/shopsys/pull/4616))
+
+- The storefront page loading state now keeps the intended skeleton type in browser history entries and restores it when users navigate with browser back and forward buttons.
+- This prevents showing a skeleton for the previously visited page, for example a product detail skeleton while returning to a category or homepage.
+- The change also avoids showing a full-page skeleton for shallow same-route history changes, such as category filtering, sorting, or pagination.
+- If your project customizes storefront navigation, page loading, or skeleton handling, review #project-base-diff and port the changes from `usePageLoader()` and the related skeleton route state helpers.


### PR DESCRIPTION
#### Description, the reason for the PR

Storefront users now see a loading skeleton that matches the page they are navigating to when using browser back and forward buttons. Previously, the skeleton could stay tied to the last clicked page, so returning from a product detail to a category or homepage could briefly show the wrong page structure.

The navigation state now keeps the intended skeleton type with browser history entries and restores it during history navigation. This keeps normal link navigation unchanged while making browser controls feel consistent with the destination page.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4035-correct-skeleton-for-browser-history-navigation.odin.shopsys.cloud
  - https://cz.tc-ssp-4035-correct-skeleton-for-browser-history-navigation.odin.shopsys.cloud
  - https://tc-ssp-4035-correct-skeleton-for-browser-history-navigation.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1779345912.863639 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4035-correct-skeleton-for-browser-history-navigation.odin.shopsys.cloud
  - https://cz.tc-ssp-4035-correct-skeleton-for-browser-history-navigation.odin.shopsys.cloud
  - https://tc-ssp-4035-correct-skeleton-for-browser-history-navigation.odin.shopsys.cloud/sk
<!-- Replace -->
