### PR TITLE
Fix language constants with boundary spaces

### DIFF
--- a/packages/administration/templates/content/languageConstant/edit.html.twig
+++ b/packages/administration/templates/content/languageConstant/edit.html.twig
@@ -1,8 +1,22 @@
 {% extends '@ShopsysAdministration/layout/layout_with_panel.html.twig' %}
+{% form_theme form _self %}
+{% import '@ShopsysAdministration/content/languageConstant/renderValueWithWhitespace.html.twig' as renderValueWithWhitespace %}
 
 {% block title %}- {{ 'Language constant translation'|trans }}{% endblock %}
 {% block h1 %}{{ 'Language constant translation'|trans }}{% endblock %}
 
 {% block main_content %}
     {{ form(form) }}
+{% endblock %}
+
+{% block _language_constant_form_key_widget %}
+    {% set data = renderValueWithWhitespace.renderValueWithWhitespace(data) %}
+
+    {{ block('display_only_widget') }}
+{% endblock %}
+
+{% block _language_constant_form_originalTranslation_widget %}
+    {% set data = renderValueWithWhitespace.renderValueWithWhitespace(data) %}
+
+    {{ block('display_only_widget') }}
 {% endblock %}

--- a/packages/administration/templates/content/languageConstant/listGrid.html.twig
+++ b/packages/administration/templates/content/languageConstant/listGrid.html.twig
@@ -1,5 +1,20 @@
 {% extends '@ShopsysAdministration/datagrid/grid.html.twig' %}
 
+{% block grid_value_cell_id_key %}
+    {% import '@ShopsysAdministration/content/languageConstant/renderValueWithWhitespace.html.twig' as renderValueWithWhitespace %}
+    {{ renderValueWithWhitespace.renderValueWithWhitespace(value) }}
+{% endblock %}
+
+{% block grid_value_cell_id_originalTranslation %}
+    {% import '@ShopsysAdministration/content/languageConstant/renderValueWithWhitespace.html.twig' as renderValueWithWhitespace %}
+    {{ renderValueWithWhitespace.renderValueWithWhitespace(value) }}
+{% endblock %}
+
+{% block grid_value_cell_id_userTranslation %}
+    {% import '@ShopsysAdministration/content/languageConstant/renderValueWithWhitespace.html.twig' as renderValueWithWhitespace %}
+    {{ renderValueWithWhitespace.renderValueWithWhitespace(value) }}
+{% endblock %}
+
 {% block grid_action_cell_type_delete %}
     {% if row.userTranslation is not empty %}
         {{ gridView.renderBlock('grid_action_cell', { actionColumn: actionColumn, row: row}) }}

--- a/packages/administration/templates/content/languageConstant/renderValueWithWhitespace.html.twig
+++ b/packages/administration/templates/content/languageConstant/renderValueWithWhitespace.html.twig
@@ -1,0 +1,19 @@
+{% macro renderValueWithWhitespace(value) %}
+    {% if value starts with ' ' or value ends with ' ' %}
+        {% set trimmedValue = value|trim(' ') %}
+
+        {%- if trimmedValue is empty -%}
+            {{- value|replace({' ': '&middot;'})|raw -}}
+        {%- else -%}
+            {%- if value starts with ' ' -%}&middot;{%- endif -%}
+            {{- trimmedValue -}}
+            {%- if value ends with ' ' -%}&middot;{%- endif -%}
+        {%- endif -%}
+
+        <span>
+            {{ info_icon('String contains leading/trailing spaces represented by &middot; sign'|trans) }}
+        </span>
+    {% else %}
+        {{ value }}
+    {% endif %}
+{% endmacro %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -1891,6 +1891,9 @@ msgstr "Prodejny"
 msgid "Street"
 msgstr "Ulice"
 
+msgid "String contains leading/trailing spaces represented by &middot; sign"
+msgstr "Řetězec obsahuje úvodní/koncové mezery (reprezentované znakem &middot;)"
+
 msgid "Strong"
 msgstr "Silné"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -1891,6 +1891,9 @@ msgstr ""
 msgid "Street"
 msgstr ""
 
+msgid "String contains leading/trailing spaces represented by &middot; sign"
+msgstr ""
+
 msgid "Strong"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -1891,6 +1891,9 @@ msgstr "Obchody"
 msgid "Street"
 msgstr "Ulica"
 
+msgid "String contains leading/trailing spaces represented by &middot; sign"
+msgstr "Reťazec obsahuje úvodné/koncové medzery (reprezentované znakom &middot;)"
+
 msgid "Strong"
 msgstr "Silné"
 

--- a/packages/framework/src/Form/Admin/LanguageConstant/LanguageConstantFormType.php
+++ b/packages/framework/src/Form/Admin/LanguageConstant/LanguageConstantFormType.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Form\Admin\LanguageConstant;
 
 use Override;
 use Shopsys\FormTypesBundle\ActionBarType;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Form\DisplayOnlyType;
 use Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantData;
 use Symfony\Component\Form\AbstractType;
@@ -13,6 +14,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class LanguageConstantFormType extends AbstractType
 {
@@ -37,8 +39,15 @@ final class LanguageConstantFormType extends AbstractType
             ->add('userTranslation', TextType::class, [
                 'required' => true,
                 'label' => 'User translation',
+                'trim' => false,
                 'constraints' => [
                     new Constraints\NotBlank(),
+                    new Constraints\Callback(static function ($value, ExecutionContextInterface $context): void {
+                        if (is_string($value) && preg_match('/[^\S ]/u', $value) === 1) {
+                            $context->buildViolation(t('Only regular spaces are allowed as whitespace characters.', domain: Translator::VALIDATOR_TRANSLATION_DOMAIN))
+                                ->addViolation();
+                        }
+                    }),
                 ],
             ])
             ->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -160,6 +160,9 @@ msgstr "Odkaz musí být validní URL adresa"
 msgid "Name cannot be longer than {{ limit }} characters"
 msgstr "Název nesmí být delší než {{ limit }} znaků"
 
+msgid "Only regular spaces are allowed as whitespace characters."
+msgstr "Pouze běžné mezery jsou povoleny jako bílé znaky."
+
 msgid "Opacity must be between {{ min }} and {{ max }}"
 msgstr "Průhlednost musí být mezi {{ min }} a {{ max }}"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -160,6 +160,9 @@ msgstr ""
 msgid "Name cannot be longer than {{ limit }} characters"
 msgstr ""
 
+msgid "Only regular spaces are allowed as whitespace characters."
+msgstr ""
+
 msgid "Opacity must be between {{ min }} and {{ max }}"
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/validators.sk.po
+++ b/packages/framework/src/Resources/translations/validators.sk.po
@@ -160,6 +160,9 @@ msgstr "Odkaz musí byť platná URL adresa"
 msgid "Name cannot be longer than {{ limit }} characters"
 msgstr "Názov nemôže byť dlhší ako {{ limit }} znakov"
 
+msgid "Only regular spaces are allowed as whitespace characters."
+msgstr "Ako biele znaky sú povolené iba bežné medzery."
+
 msgid "Opacity must be between {{ min }} and {{ max }}"
 msgstr "Priehľadnosť musí byť medzi {{ min }} a {{ max }}"
 

--- a/packages/framework/tests/Unit/Form/Admin/LanguageConstant/LanguageConstantFormTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/LanguageConstant/LanguageConstantFormTypeTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form\Admin\LanguageConstant;
+
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Shopsys\FormTypesBundle\ActionBarType;
+use Shopsys\FormTypesBundle\LinkType;
+use Shopsys\FrameworkBundle\Form\Admin\LanguageConstant\LanguageConstantFormType;
+use Shopsys\FrameworkBundle\Form\DisplayOnlyType;
+use Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstant;
+use Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantData;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Validation;
+use Tests\FrameworkBundle\Test\DomainConfigHelper;
+use Tests\FrameworkBundle\Test\SetTranslatorTrait;
+
+final class LanguageConstantFormTypeTest extends TypeTestCase
+{
+    use SetTranslatorTrait;
+
+    private UrlGeneratorInterface $urlGenerator;
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function getValidUserTranslationsData(): iterable
+    {
+        yield 'starts with space' => [' user translation', ' user translation'];
+
+        yield 'ends with space' => ['user translation ', 'user translation '];
+
+        yield 'contains only space' => [' ', ' '];
+    }
+
+    #[DataProvider('getValidUserTranslationsData')]
+    public function testUserTranslationAllowsRegularSpaces(
+        string $userTranslation,
+        string $expectedUserTranslation,
+    ): void {
+        $languageConstantFormData = $this->getFullLanguageConstantFormData();
+        $languageConstantFormData['userTranslation'] = $userTranslation;
+
+        $languageConstantForm = $this->createLanguageConstantForm();
+        $languageConstantForm->submit($languageConstantFormData);
+
+        $this->assertTrue($languageConstantForm->isValid(), 'Valid form');
+        $this->assertSame($expectedUserTranslation, $languageConstantForm->getData()->userTranslation);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function getInvalidUserTranslationsData(): iterable
+    {
+        yield 'contains tab' => ["user\ttranslation"];
+
+        yield 'contains newline' => ["user\ntranslation"];
+
+        yield 'contains carriage return' => ["user\rtranslation"];
+
+        yield 'contains non-breaking space' => ["user\u{00A0}translation"];
+    }
+
+    #[DataProvider('getInvalidUserTranslationsData')]
+    public function testUserTranslationRejectsWhitespaceCharactersOtherThanRegularSpace(string $userTranslation): void
+    {
+        $languageConstantFormData = $this->getFullLanguageConstantFormData();
+        $languageConstantFormData['userTranslation'] = $userTranslation;
+
+        $languageConstantForm = $this->createLanguageConstantForm();
+        $languageConstantForm->submit($languageConstantFormData);
+
+        $this->assertFalse($languageConstantForm->isValid(), 'Invalid form');
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+        $this->setTranslator();
+
+        $this->urlGenerator = $this->createStub(UrlGeneratorInterface::class);
+        $this->urlGenerator->method('generate')->willReturn(DomainConfigHelper::DEFAULT_EXAMPLE_COM_BASE_URL);
+
+        parent::setUp();
+    }
+
+    #[Override]
+    protected function getExtensions(): array
+    {
+        return [
+            new ValidatorExtension(Validation::createValidator()),
+            new PreloadedExtension(
+                [
+                    new LanguageConstantFormType(),
+                    new DisplayOnlyType(),
+                    new ActionBarType($this->urlGenerator),
+                    new LinkType(),
+                ],
+                [],
+            ),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     actionBar: array{save: string},
+     *     userTranslation: string,
+     * }
+     */
+    private function getFullLanguageConstantFormData(): array
+    {
+        return [
+            'actionBar' => [
+                'save' => '',
+            ],
+            'userTranslation' => 'user translation',
+        ];
+    }
+
+    private function createLanguageConstantForm(): FormInterface
+    {
+        $languageConstantData = new LanguageConstantData();
+        $languageConstantData->key = 'language constant key';
+        $languageConstantData->namespace = LanguageConstant::NAMESPACE_COMMON;
+        $languageConstantData->locale = 'en';
+        $languageConstantData->originalTranslation = 'original translation';
+        $languageConstantData->userTranslation = 'user translation';
+
+        return $this->factory->create(LanguageConstantFormType::class, $languageConstantData);
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

Administrators can now work with language constant translations that intentionally start or end with a regular space.

Previously, boundary spaces were hard to notice in the language constant list and detail views, and translations with leading or trailing spaces could not be saved because the form trimmed the value before validation. This was problematic for translations where the surrounding space is part of the intended output.

This change keeps regular leading and trailing spaces in the submitted translation, rejects other whitespace characters such as tabs and newlines, and makes boundary spaces visible in administration using dot markers with an explanatory tooltip.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://mg-fix-language-constant-space.odin.shopsys.cloud
  - https://cz.mg-fix-language-constant-space.odin.shopsys.cloud
  - https://mg-fix-language-constant-space.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1779184527.346629 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-language-constant-space.odin.shopsys.cloud
  - https://cz.mg-fix-language-constant-space.odin.shopsys.cloud
  - https://mg-fix-language-constant-space.odin.shopsys.cloud/sk
<!-- Replace -->
