### PR TITLE
Link Sentry storefront traces with backend requests

### DIFF
--- a/docs/project/working-with-sentry-and-mcp.md
+++ b/docs/project/working-with-sentry-and-mcp.md
@@ -12,6 +12,18 @@ breadcrumbs, suspect commits, and Jira context in a single flow.
 This document explains how to enable the MCP servers and walks through two real workflows:
 investigating a production bug and reviewing performance / Web Vitals issues.
 
+## Storefront distributed tracing
+
+The storefront and backend use the same `0.1` tracing sample rate. Frontend GraphQL requests
+propagate Sentry tracing headers only to configured GraphQL endpoints:
+
+- Browser requests match the public GraphQL endpoint host from the domain configuration.
+- Server-side storefront requests match `INTERNAL_ENDPOINT`, which is used for internal GraphQL
+  communication.
+
+This keeps frontend and backend spans in one Sentry trace without sending `sentry-trace` and
+`baggage` headers to unrelated third-party services.
+
 ## MCP server setup
 
 ### Sentry MCP

--- a/project-base/storefront/buildPublicEnvConfig.ts
+++ b/project-base/storefront/buildPublicEnvConfig.ts
@@ -25,6 +25,7 @@ export function buildPublicConfig(): PublicRuntimeConfig {
         cdnDomain: process.env.CDN_DOMAIN ?? '',
         sentryDsn,
         sentryEnvironment: process.env.SENTRY_ENVIRONMENT ?? '',
+        sentryRelease: process.env.SENTRY_RELEASE ?? '',
         sentryFeedbackEnable: process.env.SENTRY_FEEDBACK_ENABLE === '1',
         sentryReplaysEnable: process.env.SENTRY_REPLAYS_ENABLE === '1',
         errorDebuggingLevel: process.env.ERROR_DEBUGGING_LEVEL ?? '',

--- a/project-base/storefront/envConfig.ts
+++ b/project-base/storefront/envConfig.ts
@@ -28,6 +28,7 @@ export type PublicRuntimeConfig = {
     readonly showSymfonyToolbar: string;
     readonly sentryDsn: string;
     readonly sentryEnvironment: string;
+    readonly sentryRelease: string;
     readonly sentryFeedbackEnable: boolean;
     readonly sentryReplaysEnable: boolean;
 };

--- a/project-base/storefront/instrumentation-client.ts
+++ b/project-base/storefront/instrumentation-client.ts
@@ -1,18 +1,25 @@
 import { getPublicConfigProperty } from 'envConfig';
 import * as Sentry from '@sentry/nextjs';
+import { getTracePropagationTargetsFromPublicGraphqlEndpoints as getPublicGraphqlTracePropagationTargets } from 'utils/sentry/tracePropagationTargets';
 
 const dsn = getPublicConfigProperty('sentryDsn');
 const environment = getPublicConfigProperty('sentryEnvironment');
+const release = getPublicConfigProperty('sentryRelease');
 const enableFeedback = getPublicConfigProperty('sentryFeedbackEnable');
 const enableReplays = getPublicConfigProperty('sentryReplaysEnable');
 const isSentryEnabled = dsn.trim() !== '';
+const tracePropagationTargets = getPublicGraphqlTracePropagationTargets(
+    getPublicConfigProperty('domains').map((domain) => domain.publicGraphqlEndpoint),
+);
 
 if (isSentryEnabled) {
     Sentry.init({
         dsn: dsn,
         environment: environment,
+        release: release,
         tracesSampleRate: 0.1,
-        integrations: [],
+        integrations: [Sentry.browserTracingIntegration()],
+        tracePropagationTargets: tracePropagationTargets,
         replaysSessionSampleRate: enableReplays ? 0.1 : 0,
         replaysOnErrorSampleRate: enableReplays ? 1.0 : 0,
     });

--- a/project-base/storefront/instrumentation.ts
+++ b/project-base/storefront/instrumentation.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { getTracePropagationTargetsFromInternalEndpoint } from 'utils/sentry/tracePropagationTargets';
 
 export function register() {
     const sentryDsn = process.env.SENTRY_DSN?.trim();
@@ -7,24 +8,23 @@ export function register() {
         return;
     }
 
+    const tracePropagationTargets = getTracePropagationTargetsFromInternalEndpoint(process.env.INTERNAL_ENDPOINT);
+    const sentryConfig = {
+        dsn: sentryDsn,
+        environment: process.env.SENTRY_ENVIRONMENT,
+        release: process.env.SENTRY_RELEASE,
+        tracesSampleRate: 0.1,
+        ...(tracePropagationTargets.length > 0 ? { tracePropagationTargets: tracePropagationTargets } : {}),
+    };
+
     if (process.env.NEXT_RUNTIME === 'nodejs') {
         // this is your Sentry.init call from `sentry.server.config.js|ts`
-        Sentry.init({
-            dsn: sentryDsn,
-            environment: process.env.SENTRY_ENVIRONMENT,
-            release: process.env.SENTRY_RELEASE,
-            tracesSampleRate: 0.1,
-        });
+        Sentry.init(sentryConfig);
     }
 
     // This is your Sentry.init call from `sentry.edge.config.js|ts`
     if (process.env.NEXT_RUNTIME === 'edge') {
-        Sentry.init({
-            dsn: sentryDsn,
-            environment: process.env.SENTRY_ENVIRONMENT,
-            release: process.env.SENTRY_RELEASE,
-            tracesSampleRate: 0.1,
-        });
+        Sentry.init(sentryConfig);
     }
 }
 

--- a/project-base/storefront/utils/sentry/tracePropagationTargets.ts
+++ b/project-base/storefront/utils/sentry/tracePropagationTargets.ts
@@ -1,0 +1,70 @@
+const sameOriginGraphqlPathPattern = /^\/graphql(?:[/?#]|$)/;
+
+export function getTracePropagationTargetsFromPublicGraphqlEndpoints(
+    publicGraphqlEndpoints: readonly string[],
+): Array<string | RegExp> {
+    const publicGraphqlEndpointTargets = publicGraphqlEndpoints
+        .map((publicGraphqlEndpoint) => getTracePropagationTargetFromGraphqlEndpoint(publicGraphqlEndpoint))
+        .filter((target): target is RegExp => target !== null);
+    const uniquePublicGraphqlEndpointTargets = publicGraphqlEndpointTargets.filter(
+        (target, index, targets) =>
+            targets.findIndex((existingTarget) => existingTarget.source === target.source) === index,
+    );
+
+    return [sameOriginGraphqlPathPattern, ...uniquePublicGraphqlEndpointTargets];
+}
+
+export function getTracePropagationTargetsFromInternalEndpoint(internalEndpoint: string | undefined): RegExp[] {
+    const tracePropagationTarget = getTracePropagationTargetFromInternalEndpoint(internalEndpoint);
+
+    return tracePropagationTarget !== null ? [tracePropagationTarget] : [];
+}
+
+export function getTracePropagationTargetFromGraphqlEndpoint(graphqlEndpoint: string): RegExp | null {
+    const normalizedGraphqlEndpoint = normalizeUrlWithoutTrailingSlash(graphqlEndpoint);
+
+    if (normalizedGraphqlEndpoint === null) {
+        return null;
+    }
+
+    return new RegExp(`^${escapeRegExp(normalizedGraphqlEndpoint)}(?:[/?#]|$)`);
+}
+
+export function getTracePropagationTargetFromInternalEndpoint(internalEndpoint: string | undefined): RegExp | null {
+    if (!internalEndpoint) {
+        return null;
+    }
+
+    const normalizedInternalEndpoint = normalizeBaseUrlWithTrailingSlash(internalEndpoint);
+
+    if (normalizedInternalEndpoint === null) {
+        return null;
+    }
+
+    return new RegExp(`^${escapeRegExp(normalizedInternalEndpoint)}(?:[^/]+/)?graphql(?:[/?#]|$)`);
+}
+
+function normalizeUrlWithoutTrailingSlash(url: string): string | null {
+    try {
+        const urlObject = new URL(url);
+
+        return urlObject.href.replace(/\/$/, '');
+    } catch {
+        return null;
+    }
+}
+
+function normalizeBaseUrlWithTrailingSlash(url: string): string | null {
+    try {
+        const urlObject = new URL(url);
+        const urlHrefWithoutTrailingSlash = urlObject.href.replace(/\/$/, '');
+
+        return `${urlHrefWithoutTrailingSlash}/`;
+    } catch {
+        return null;
+    }
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/project-base/storefront/vitest/helpers/mockPublicConfig.ts
+++ b/project-base/storefront/vitest/helpers/mockPublicConfig.ts
@@ -67,6 +67,7 @@ export const defaultTestConfig: PublicRuntimeConfig = {
     showSymfonyToolbar: '',
     sentryDsn: '',
     sentryEnvironment: '',
+    sentryRelease: '',
     sentryFeedbackEnable: false,
     sentryReplaysEnable: false,
 };

--- a/project-base/storefront/vitest/utils/config/buildPublicConfig.test.ts
+++ b/project-base/storefront/vitest/utils/config/buildPublicConfig.test.ts
@@ -142,6 +142,7 @@ describe('buildPublicConfig', () => {
             delete process.env.CDN_DOMAIN;
             delete process.env.SENTRY_DSN;
             delete process.env.SENTRY_ENVIRONMENT;
+            delete process.env.SENTRY_RELEASE;
             delete process.env.ERROR_DEBUGGING_LEVEL;
             delete process.env.SHOW_SYMFONY_TOOLBAR;
             delete process.env.USERSNAP_PROJECT_API_KEY;
@@ -153,6 +154,7 @@ describe('buildPublicConfig', () => {
             expect(config.cdnDomain).toBe('');
             expect(config.sentryDsn).toBe('');
             expect(config.sentryEnvironment).toBe('');
+            expect(config.sentryRelease).toBe('');
             expect(config.errorDebuggingLevel).toBe('');
             expect(config.showSymfonyToolbar).toBe('');
             expect(config.userSnapApiKey).toBe('');
@@ -179,6 +181,22 @@ describe('buildPublicConfig', () => {
             const config = buildPublicConfig();
 
             expect(config.sentryDsn).toBe('');
+        });
+    });
+
+    describe('sentry release', () => {
+        it('exposes SENTRY_RELEASE to public runtime config', () => {
+            process.env.SENTRY_RELEASE = 'abc123';
+            const config = buildPublicConfig();
+
+            expect(config.sentryRelease).toBe('abc123');
+        });
+
+        it('produces empty string when SENTRY_RELEASE is missing', () => {
+            delete process.env.SENTRY_RELEASE;
+            const config = buildPublicConfig();
+
+            expect(config.sentryRelease).toBe('');
         });
     });
 

--- a/project-base/storefront/vitest/utils/sentry/tracePropagationTargets.test.ts
+++ b/project-base/storefront/vitest/utils/sentry/tracePropagationTargets.test.ts
@@ -1,0 +1,56 @@
+import {
+    getTracePropagationTargetFromGraphqlEndpoint,
+    getTracePropagationTargetFromInternalEndpoint,
+    getTracePropagationTargetsFromPublicGraphqlEndpoints,
+} from 'utils/sentry/tracePropagationTargets';
+import { describe, expect, it } from 'vitest';
+
+describe('tracePropagationTargets', () => {
+    it('returns same-origin GraphQL path target and deduplicated public endpoint targets', () => {
+        const targets = getTracePropagationTargetsFromPublicGraphqlEndpoints([
+            'https://example.com/graphql/',
+            'https://example.com/graphql',
+            'not-a-url',
+            'https://example.com/sk/graphql/',
+        ]);
+
+        expect(targets).toHaveLength(3);
+        expect(targets[0]).toBeInstanceOf(RegExp);
+        expect((targets[0] as RegExp).test('/graphql/CartQuery')).toBe(true);
+        expect((targets[0] as RegExp).test('/sgtm/g/collect')).toBe(false);
+        expect(targets.slice(1).map((target) => (target as RegExp).source)).toEqual([
+            '^https:\\/\\/example\\.com\\/graphql(?:[/?#]|$)',
+            '^https:\\/\\/example\\.com\\/sk\\/graphql(?:[/?#]|$)',
+        ]);
+    });
+
+    it('matches public GraphQL endpoint variants and rejects unrelated URLs', () => {
+        const target = getTracePropagationTargetFromGraphqlEndpoint('https://example.com/graphql/');
+
+        expect(target?.test('https://example.com/graphql/CartQuery')).toBe(true);
+        expect(target?.test('https://example.com/graphql?operationName=CartQuery')).toBe(true);
+        expect(target?.test('https://example.com/graphql#fragment')).toBe(true);
+        expect(target?.test('https://example.com/graphql-other')).toBe(false);
+        expect(target?.test('https://example.com/sgtm/g/collect')).toBe(false);
+        expect(target?.test('https://piskoviste.shopsys.cz/sgtm/g/collect')).toBe(false);
+    });
+
+    it('returns null for invalid public GraphQL endpoint URL', () => {
+        expect(getTracePropagationTargetFromGraphqlEndpoint('not-a-url')).toBeNull();
+    });
+
+    it('matches default and localized internal GraphQL endpoint URLs', () => {
+        const target = getTracePropagationTargetFromInternalEndpoint('http://internal:8000/');
+
+        expect(target?.test('http://internal:8000/graphql/CartQuery')).toBe(true);
+        expect(target?.test('http://internal:8000/sk/graphql/CartQuery')).toBe(true);
+        expect(target?.test('http://internal:8000/cs/graphql?operationName=CartQuery')).toBe(true);
+        expect(target?.test('http://internal:8000/api/log-exception')).toBe(false);
+        expect(target?.test('http://internal:8000/sgtm/g/collect')).toBe(false);
+    });
+
+    it('returns null for invalid or missing internal endpoint URL', () => {
+        expect(getTracePropagationTargetFromInternalEndpoint(undefined)).toBeNull();
+        expect(getTracePropagationTargetFromInternalEndpoint('not-a-url')).toBeNull();
+    });
+});

--- a/upgrade-notes/storefront_20260519_085737.md
+++ b/upgrade-notes/storefront_20260519_085737.md
@@ -1,0 +1,6 @@
+#### Link Sentry storefront traces with backend requests ([#4621](https://github.com/shopsys/shopsys/pull/4621))
+
+- if your project overrides storefront Sentry initialization, update it to enable `Sentry.browserTracingIntegration()` and configure `tracePropagationTargets` for your GraphQL endpoints so frontend requests propagate `sentry-trace` and `baggage` headers to the backend
+- keep the storefront and backend tracing sample rate aligned (project-base uses `0.1` on both sides) to make frontend and backend spans appear in the same Sentry trace consistently
+- ensure `SENTRY_RELEASE` is available for the storefront runtime if you rely on release-based Sentry filtering or trace investigation
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Storefront Sentry tracing now propagates tracing headers to GraphQL requests, so frontend storefront work and the corresponding backend GraphQL processing can be correlated in one Sentry trace.

The propagation is intentionally scoped only to configured GraphQL endpoints. This keeps trace linking available for storefront-to-backend communication without sending `sentry-trace` and `baggage` headers to unrelated third-party services. The shared tracing sample rate is documented as well.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4001-sentry-distributed-tracing-request-linking.odin.shopsys.cloud
  - https://cz.tc-ssp-4001-sentry-distributed-tracing-request-linking.odin.shopsys.cloud
  - https://tc-ssp-4001-sentry-distributed-tracing-request-linking.odin.shopsys.cloud/sk
<!-- Replace -->
