### PR TITLE
Set Corepack cache path in storefront Docker images

### DIFF
--- a/project-base/storefront/docker/Dockerfile
+++ b/project-base/storefront/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:24.14.0-alpine3.22 AS base
 
+ENV COREPACK_HOME=/usr/local/share/corepack
 RUN apk add --no-cache icu-data-full libc6-compat
 RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
 

--- a/project-base/storefront/docker/ci.Dockerfile
+++ b/project-base/storefront/docker/ci.Dockerfile
@@ -1,5 +1,6 @@
 FROM node:24.14.0-alpine3.22 AS development
 
+ENV COREPACK_HOME=/usr/local/share/corepack
 RUN apk add --no-cache icu-data-full libc6-compat
 RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
 

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -1,5 +1,6 @@
 FROM node:24.14.0-alpine3.22 AS development
 
+ENV COREPACK_HOME=/usr/local/share/corepack
 RUN apk add --no-cache icu-data-full libc6-compat
 RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
 

--- a/upgrade-notes/storefront_20260520_132907.md
+++ b/upgrade-notes/storefront_20260520_132907.md
@@ -1,0 +1,8 @@
+#### Set Corepack cache path in storefront Docker images ([#4625](https://github.com/shopsys/shopsys/pull/4625))
+
+- storefront Dockerfiles now set `COREPACK_HOME=/usr/local/share/corepack`
+- if you override storefront Dockerfiles in your project, add the same `COREPACK_HOME` value before running `corepack enable && corepack prepare pnpm@10.30.3 --activate`
+- this makes Corepack use the same cache location during image build and container runtime
+- without an explicit cache path, pnpm prepared during Docker image build can be stored in the root user's Corepack cache, while the running storefront container executes as the `node` user and uses a different cache
+- keeping the cache shared prevents unnecessary runtime pnpm downloads and makes the storefront Docker image startup more deterministic
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

This PR makes storefront Docker images use a shared Corepack cache location for the prepared pnpm binary.

Without an explicit cache path, Corepack can prepare pnpm during image build under the root user's cache, while the running storefront container executes as the node user and looks in a different cache. Using a shared location keeps the package manager available from the image itself and avoids unnecessary runtime Corepack downloads during container startup.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4061-update-dockerfiles.odin.shopsys.cloud
  - https://cz.tc-ssp-4061-update-dockerfiles.odin.shopsys.cloud
  - https://tc-ssp-4061-update-dockerfiles.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1779451911.113499 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4061-update-dockerfiles.odin.shopsys.cloud
  - https://cz.tc-ssp-4061-update-dockerfiles.odin.shopsys.cloud
  - https://tc-ssp-4061-update-dockerfiles.odin.shopsys.cloud/sk
<!-- Replace -->
