### PR TITLE
DB migration: remove useless column comment

### DIFF
--- a/packages/framework/src/Migrations/Version20260227164539.php
+++ b/packages/framework/src/Migrations/Version20260227164539.php
@@ -29,7 +29,6 @@ class Version20260227164539 extends AbstractMigration
             FROM blog_articles ba
             WHERE bad.blog_article_id = ba.id
         ');
-        $this->sql('COMMENT ON COLUMN blog_article_domains.publish_date IS \'(DC2Type:datetime_immutable)\'');
 
         $this->sql('ALTER TABLE blog_articles DROP COLUMN publish_date');
         $this->sql('ALTER TABLE blog_articles DROP COLUMN hidden');


### PR DESCRIPTION
#### Description, the reason for the PR
- DBAL 4 no longer stores type metadata in SQL column comments
- Version20260302120000 removes all such comments, but it is already executed on production/devel
- the migration was created in a branch that was in progress for a long time, meanwhile, all such comments were removed by `Version20260302120000`

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-migration.odin.shopsys.cloud
  - https://cz.rv-fix-migration.odin.shopsys.cloud
  - https://rv-fix-migration.odin.shopsys.cloud/sk
<!-- Replace -->
