### PR TITLE
Keep Next cache writable in production storefront image

### DIFF
--- a/project-base/storefront/docker/Dockerfile
+++ b/project-base/storefront/docker/Dockerfile
@@ -46,7 +46,10 @@ ENV APP_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY --from=dependencies /tmp/build $APP_DIR
-RUN chown -R root:root $APP_DIR && chmod -R a-w $APP_DIR
+RUN chown -R root:root $APP_DIR \
+    && chmod -R a-w $APP_DIR \
+    && mkdir -p $APP_DIR/.next/cache \
+    && chown -R node:node $APP_DIR/.next/cache
 
 USER node
 

--- a/upgrade-notes/storefront_20260521_101010.md
+++ b/upgrade-notes/storefront_20260521_101010.md
@@ -1,0 +1,6 @@
+#### Keep Next cache writable in production storefront image ([#4629](https://github.com/shopsys/shopsys/pull/4629))
+
+- production storefront image keeps application files owned by `root:root` and read-only, but Next.js needs writable `.next/cache` at runtime for image cache files
+- if you override production storefront Docker image setup, create `$APP_DIR/.next/cache` after hardening application files and make it writable for the runtime user (`node` by default)
+- keep the writable exception limited to `.next/cache`; do not make the whole `$APP_DIR` writable, so the immutable application directory hardening from #4481 stays preserved
+- this follows from investigation of `EACCES: permission denied, mkdir '/home/node/app/.next/cache'` in production storefront runtime


### PR DESCRIPTION
#### Description, the reason for the PR
Production storefront images keep application files owned by `root:root` and read-only while the runtime process runs as the non-root `node` user. Next.js still needs to create runtime cache files under `.next/cache`, so the hardened image could fail when the cache directory did not exist.

This PR keeps the immutable application directory setup, but explicitly creates `.next/cache` and gives ownership of that directory to the runtime user. The storefront can now write its runtime cache without making the rest of the application writable.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4046-fix-next-cache-permissions.odin.shopsys.cloud
  - https://cz.tc-ssp-4046-fix-next-cache-permissions.odin.shopsys.cloud
  - https://tc-ssp-4046-fix-next-cache-permissions.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1780465937.418749 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4046-fix-next-cache-permissions.odin.shopsys.cloud
  - https://cz.tc-ssp-4046-fix-next-cache-permissions.odin.shopsys.cloud
  - https://tc-ssp-4046-fix-next-cache-permissions.odin.shopsys.cloud/sk
<!-- Replace -->
