### PR TITLE
mcp: make schema cache warmer non-optional

### DIFF
--- a/packages/mcp/src/Component/Database/Schema/McpSchemaCacheWarmer.php
+++ b/packages/mcp/src/Component/Database/Schema/McpSchemaCacheWarmer.php
@@ -47,6 +47,6 @@ class McpSchemaCacheWarmer implements CacheWarmerInterface
     #[Override]
     public function isOptional(): bool
     {
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

Keeps the MCP server consistently available after any cache-wiping operation (deploys, migrations, container restarts, manual cache cleanup). Until now those operations could leave MCP broken with *"Generated MCP schema file is missing"* until somebody manually ran `cache:warmup` or `shopsys:mcp:generate-schema` on the live environment. We have observed exactly that failure on the dev review server.

The MCP schema artifact is produced by a Symfony cache warmer that lives in `%kernel.cache_dir%`. Marking the warmer as *optional* meant Symfony skipped it during the implicit container compilation that follows a cache wipe — only an explicit `cache:warmup` would run it. Switching it to non-optional regenerates the artifact transparently on the first request after the cache directory is recreated, so no manual intervention is needed.

The existing availability guard and exception handling already make the warmer safe to run unconditionally: it skips silently when MCP credentials are not configured, and only logs a warning if database introspection fails during a transient build state.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://rv-mcp-cache-warmer.odin.shopsys.cloud
  - https://cz.rv-mcp-cache-warmer.odin.shopsys.cloud
  - https://rv-mcp-cache-warmer.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1779952216.918339 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-mcp-cache-warmer.odin.shopsys.cloud
  - https://cz.rv-mcp-cache-warmer.odin.shopsys.cloud
  - https://rv-mcp-cache-warmer.odin.shopsys.cloud/sk
<!-- Replace -->
