### PR TITLE
github actions: use `xargs -r` to safely handle empty input in workflows

### DIFF
--- a/.github/workflows/clean-up-after-branch-merge.yaml
+++ b/.github/workflows/clean-up-after-branch-merge.yaml
@@ -42,5 +42,5 @@ jobs:
                     echo "REMOTE_TEMPLATE=https://${{ secrets.ACTIONS_GIT_PUSH_TOKEN }}@github.com/shopsys/" >> $GITHUB_ENV
             -   name: Remove split branches from packages
                 run: |
-                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
+                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -r -L1 git config --unset-all
                     bash ./.github/monorepo/remove_branch.sh "${{ needs.variables.outputs.BRANCH_NAME }}" "${REMOTE_TEMPLATE}"

--- a/.github/workflows/monorepo-force-split-branch.yaml
+++ b/.github/workflows/monorepo-force-split-branch.yaml
@@ -28,5 +28,5 @@ jobs:
                     sudo apt-get install -y git-filter-repo
             -   name: Split repositories
                 run: |
-                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all || true
+                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -r -L1 git config --unset-all
                     bash ./.github/monorepo/split-repositories.sh "${{ inputs.branch_name }}" "${REMOTE_TEMPLATE}" true

--- a/.github/workflows/monorepo-split.yaml
+++ b/.github/workflows/monorepo-split.yaml
@@ -26,5 +26,5 @@ jobs:
                     sudo apt-get install -y git-filter-repo
             -   name: Split repositories
                 run: |
-                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all || true
+                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -r -L1 git config --unset-all
                     bash ./.github/monorepo/split-repositories.sh "${{ github.ref_name }}" "${REMOTE_TEMPLATE}"


### PR DESCRIPTION
#### Description, the reason for the PR

The "Clean up after branch merge" workflow started failing with exit code 123 after the recent `actions/checkout` upgrade to v6 (https://github.com/shopsys/shopsys/pull/4535). The cleanup step strips the checkout's auth header before pushing branch deletions to the split package repositories, using `git config | grep | xargs git config --unset-all`. Under v6 the checkout no longer leaves a matching `extraheader` config entry, so `grep` produced no output — and because `xargs` was running without `--no-run-if-empty`, it still invoked `git config --unset-all` once with no argument, which fails and aborts the whole step before the branch removal could run.

Adding `-r` (`--no-run-if-empty`) makes `xargs` a no-op when there is nothing to unset, so the workflow proceeds correctly. The same robustness fix is applied to the two monorepo split workflows that share the pattern; they were already guarded with `|| true`, but the flag avoids needlessly spawning a failing command.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-gh-actions.odin.shopsys.cloud
  - https://cz.rv-fix-gh-actions.odin.shopsys.cloud
  - https://rv-fix-gh-actions.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1780904467.201009 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-gh-actions.odin.shopsys.cloud
  - https://cz.rv-fix-gh-actions.odin.shopsys.cloud
  - https://rv-fix-gh-actions.odin.shopsys.cloud/sk
<!-- Replace -->
