### PR TITLE
github actions: set `persist-credentials` to false and remove redundant git config unsetting steps

### DIFF
--- a/.github/workflows/clean-up-after-branch-merge.yaml
+++ b/.github/workflows/clean-up-after-branch-merge.yaml
@@ -24,6 +24,7 @@ jobs:
                 with:
                     ref: 'refs/heads/${{ github.event.repository.default_branch }}'
                     path: cancel-review-after-branch-merge
+                    persist-credentials: false
             -   name: Cancel review
                 working-directory: cancel-review-after-branch-merge
                 run: |
@@ -37,10 +38,10 @@ jobs:
                 uses: actions/checkout@v6
                 with:
                     ref: 'refs/heads/${{ github.event.repository.default_branch }}'
+                    persist-credentials: false
             -   name: Prepare variables for removing split branches from packages
                 run: |
                     echo "REMOTE_TEMPLATE=https://${{ secrets.ACTIONS_GIT_PUSH_TOKEN }}@github.com/shopsys/" >> $GITHUB_ENV
             -   name: Remove split branches from packages
                 run: |
-                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -r -L1 git config --unset-all
                     bash ./.github/monorepo/remove_branch.sh "${{ needs.variables.outputs.BRANCH_NAME }}" "${REMOTE_TEMPLATE}"

--- a/.github/workflows/monorepo-force-split-branch.yaml
+++ b/.github/workflows/monorepo-force-split-branch.yaml
@@ -19,6 +19,7 @@ jobs:
                 with:
                     ref: refs/heads/${{ inputs.branch_name }}
                     fetch-depth: 0
+                    persist-credentials: false
             -   name: Prepare variables and files to be used for splitting
                 run: |
                     echo "REMOTE_TEMPLATE=https://${{ secrets.ACTIONS_GIT_PUSH_TOKEN }}@github.com/shopsys/" >> $GITHUB_ENV
@@ -28,5 +29,4 @@ jobs:
                     sudo apt-get install -y git-filter-repo
             -   name: Split repositories
                 run: |
-                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -r -L1 git config --unset-all
                     bash ./.github/monorepo/split-repositories.sh "${{ inputs.branch_name }}" "${REMOTE_TEMPLATE}" true

--- a/.github/workflows/monorepo-split.yaml
+++ b/.github/workflows/monorepo-split.yaml
@@ -17,6 +17,7 @@ jobs:
                 with:
                     ref: ${{ github.ref }}
                     fetch-depth: 0
+                    persist-credentials: false
             -   name: Prepare variables and files to be used for splitting
                 run: |
                     echo "REMOTE_TEMPLATE=https://${{ secrets.ACTIONS_GIT_PUSH_TOKEN }}@github.com/shopsys/" >> $GITHUB_ENV
@@ -26,5 +27,4 @@ jobs:
                     sudo apt-get install -y git-filter-repo
             -   name: Split repositories
                 run: |
-                    git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -r -L1 git config --unset-all
                     bash ./.github/monorepo/split-repositories.sh "${{ github.ref_name }}" "${REMOTE_TEMPLATE}"


### PR DESCRIPTION
#### Description, the reason for the PR

The monorepo-split workflows push the split package repositories using a dedicated push token (`ACTIONS_GIT_PUSH_TOKEN`). By default, `actions/checkout` persists the workflow `GITHUB_TOKEN` into the local git config as an auth header, which collides with that push token. Until now the workflows worked around this by scrubbing the persisted credentials from the git config at runtime before every push.

A previous attempt (#4643) hardened that workaround by adding `xargs -r` so the scrubbing step would not fail on empty input — but that was the wrong direction, fixing a symptom of the workaround instead of its cause.

This sets `persist-credentials: false` on the checkout step instead, so the conflicting credentials are never written in the first place. The runtime config-unsetting steps then become redundant and are removed, leaving the split and branch-cleanup workflows simpler and less fragile.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://rv-fix-monorepo-split-credentials.odin.shopsys.cloud
  - https://cz.rv-fix-monorepo-split-credentials.odin.shopsys.cloud
  - https://rv-fix-monorepo-split-credentials.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1780990787.494879 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-monorepo-split-credentials.odin.shopsys.cloud
  - https://cz.rv-fix-monorepo-split-credentials.odin.shopsys.cloud
  - https://rv-fix-monorepo-split-credentials.odin.shopsys.cloud/sk
<!-- Replace -->
