### PR TITLE
stop reporting 405 MethodNotAllowedHttpException to Sentry

### DIFF
--- a/project-base/app/config/packages/sentry.yaml
+++ b/project-base/app/config/packages/sentry.yaml
@@ -8,6 +8,7 @@ sentry:
         environment: '%env(SENTRY_ENVIRONMENT)%'
         ignore_exceptions:
             - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+            - Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
         release: '%env(SENTRY_RELEASE)%'
         traces_sample_rate: 0.1
     register_error_handler: false

--- a/upgrade-notes/backend_20260610_092731.md
+++ b/upgrade-notes/backend_20260610_092731.md
@@ -1,0 +1,3 @@
+#### stop reporting 405 MethodNotAllowedHttpException to Sentry ([#4646](https://github.com/shopsys/shopsys/pull/4646))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Automated scanners regularly probe production sites for leaked secrets by requesting paths like `GET /graphql/.env`. Because the GraphQL endpoint route accepts only `POST`, these requests raised a
  `MethodNotAllowedHttpException` (HTTP 405) that was reported to Sentry, flooding the error tracker with noise from bot traffic (e.g. SSP-4056).

 A 405 is a client-side error — the same category as the 404 `NotFoundHttpException` that is already ignored — and does not indicate any fault in the application. This change adds
  `MethodNotAllowedHttpException` to Sentry's `ignore_exceptions` list so these requests no longer create alerts, keeping Sentry focused on genuine application errors. Application behavior is unchanged; only
  error reporting is affected.

 #### License Agreement for contributions

 - [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)



----
:globe_with_meridians: Live Preview:
  - https://tl-ignore-405-sentry.odin.shopsys.cloud
  - https://cz.tl-ignore-405-sentry.odin.shopsys.cloud
  - https://tl-ignore-405-sentry.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1781076900.940759 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-ignore-405-sentry.odin.shopsys.cloud
  - https://cz.tl-ignore-405-sentry.odin.shopsys.cloud
  - https://tl-ignore-405-sentry.odin.shopsys.cloud/sk
<!-- Replace -->
