### PR TITLE
Clarify VAT labels in promo code limits

### DIFF
--- a/packages/administration/templates/form/content/PromoCodeLimitCollectionType.html.twig
+++ b/packages/administration/templates/form/content/PromoCodeLimitCollectionType.html.twig
@@ -1,7 +1,7 @@
 {% macro limitRow(limit, index) %}
     <div class="js-limits-item js-form-group row align-items-center mb-3 pb-3 border-bottom" data-index="{{ index }}">
         <div class="col-11 col-md-5 mb-2 mb-md-0">
-            <label class="d-md-none col-form-label" for="{{ limit.fromPrice.vars.id }}">{{ 'From'|trans }} {{ priceVatLabel() }}</label>
+            <label class="d-md-none col-form-label" for="{{ limit.fromPrice.vars.id }}">{{ 'From (with VAT)'|trans }}</label>
             {{ form_widget(limit.fromPrice) }}
             {{ form_errors(limit.fromPrice) }}
         </div>
@@ -9,7 +9,7 @@
             {{ ux_icon('arrow-simple') }}
         </div>
         <div class="col-11 col-md-5">
-            <label class="d-md-none col-form-label" for="{{ limit.discount.vars.id }}">{{ 'Discount'|trans }} {{ priceVatLabel() }}</label>
+            <label class="d-md-none col-form-label" for="{{ limit.discount.vars.id }}">{{ 'Discount'|trans }}</label>
             {{ form_widget(limit.discount) }}
             {{ form_errors(limit.discount) }}
         </div>
@@ -25,10 +25,10 @@
         <div id="promo_code_limits">
             <div class="row mb-3 text-uppercase fs-5 bg-surface-tertiary text-secondary p-2 border-bottom d-none d-md-flex">
                 <div class="col-6">
-                    <strong>{{ 'From'|trans }} {{ priceVatLabel() }}</strong>
+                    <strong>{{ 'From (with VAT)'|trans }}</strong>
                 </div>
                 <div class="col-6">
-                    <strong>{{ 'Discount'|trans }} {{ priceVatLabel() }}</strong>
+                    <strong>{{ 'Discount'|trans }}</strong>
                 </div>
             </div>
             <div class="js-limits" data-prototype="{{ self.limitRow(form.vars.prototype)|escape }}" data-index="{{ form|length }}">

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -958,8 +958,8 @@ msgstr "Doprava a platba zdarma"
 msgid "Friday"
 msgstr "Pátek"
 
-msgid "From"
-msgstr "Od"
+msgid "From (with VAT)"
+msgstr "Od (s DPH)"
 
 msgid "Future"
 msgstr "Budoucí"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Friday"
 msgstr ""
 
-msgid "From"
+msgid "From (with VAT)"
 msgstr ""
 
 msgid "Future"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -958,8 +958,8 @@ msgstr "Doprava a platba zadarmo"
 msgid "Friday"
 msgstr "Piatok"
 
-msgid "From"
-msgstr "Od"
+msgid "From (with VAT)"
+msgstr "Od (s DPH)"
 
 msgid "Future"
 msgstr "Budúcnosť"


### PR DESCRIPTION
#### Description, the reason for the PR

Promo code limit settings now make it clearer which value includes VAT. The "From" price is explicitly labeled as including VAT, while the discount field no longer shows a VAT label because it does not represent a VAT-included price.

This avoids misleading administrators when configuring promo code limits and makes the form labels consistent in desktop and mobile layouts.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-promo-code-price-text.odin.shopsys.cloud
  - https://cz.mg-promo-code-price-text.odin.shopsys.cloud
  - https://mg-promo-code-price-text.odin.shopsys.cloud/sk
<!-- Replace -->
