### PR TITLE
Frontend API now accepts slug queries with a leading slash

### DIFF
--- a/packages/frontend-api/src/Model/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/frontend-api/src/Model/FriendlyUrl/FriendlyUrlFacade.php
@@ -18,6 +18,8 @@ class FriendlyUrlFacade
 
     public function getFriendlyUrlByRouteNameAndSlug(int $domainId, string $routeName, string $slug): FriendlyUrl
     {
+        $slug = ltrim($slug, '/');
+
         $friendlyUrl = $this->friendlyUrlRepository->findFriendlyUrlBySlugAndRouteName($domainId, $routeName, $slug);
 
         if ($friendlyUrl === null) {

--- a/packages/frontend-api/src/Model/Resolver/Article/ArticleQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticleQuery.php
@@ -28,7 +28,7 @@ class ArticleQuery extends AbstractQuery
             if ($uuid !== null) {
                 $articleData = $this->articleElasticsearchFacade->getByUuid($uuid);
             } elseif ($urlSlug !== null) {
-                $articleData = $this->articleElasticsearchFacade->getBySlug($urlSlug);
+                $articleData = $this->articleElasticsearchFacade->getBySlug(ltrim($urlSlug, '/'));
             } else {
                 throw new InvalidArgumentUserError('You need to provide argument \'uuid\' or \'urlSlug\'.');
             }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Slug/SlugWithLeadingSlashTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Slug/SlugWithLeadingSlashTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Slug;
+
+use App\DataFixtures\Demo\ArticleDataFixture;
+use App\DataFixtures\Demo\BlogArticleDataFixture;
+use App\DataFixtures\Demo\BrandDataFixture;
+use App\DataFixtures\Demo\CategoryDataFixture;
+use App\DataFixtures\Demo\FlagDataFixture;
+use App\DataFixtures\Demo\ProductDataFixture;
+use App\DataFixtures\Demo\SeoPageDataFixture;
+use App\DataFixtures\Demo\StoreDataFixture;
+use App\Model\Article\Article;
+use App\Model\Category\Category;
+use App\Model\Product\Brand\Brand;
+use App\Model\Product\Flag\Flag;
+use App\Model\Product\Product;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticle;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory;
+use Shopsys\FrameworkBundle\Model\Store\Store;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class SlugWithLeadingSlashTest extends GraphQlTestCase
+{
+    /**
+     * @inject
+     */
+    private FriendlyUrlFacade $friendlyUrlFacade;
+
+    /**
+     * Every query that resolves an entity by its URL slug must accept the slug both with and without a leading slash,
+     * because the API itself returns slugs with a leading slash (e.g. `/canon`).
+     */
+    public function testSlugQueriesAcceptSlugWithAndWithoutLeadingSlash(): void
+    {
+        $bareSlugsByField = [
+            'product' => $this->getMainSlug('front_product_detail', $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1', Product::class)->getId()),
+            'brand' => $this->getMainSlug('front_brand_detail', $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId()),
+            'flag' => $this->getMainSlug('front_flag_detail', $this->getReference(FlagDataFixture::FLAG_PRODUCT_MADEIN_DE, Flag::class)->getId()),
+            'category' => $this->getMainSlug('front_product_list', $this->getReference(CategoryDataFixture::CATEGORY_ELECTRONICS, Category::class)->getId()),
+            'store' => $this->getMainSlug('front_stores_detail', $this->getReference(StoreDataFixture::STORE_PREFIX . '1', Store::class)->getId()),
+            'article' => $this->getMainSlug('front_article_detail', $this->getReferenceForDomain(ArticleDataFixture::ARTICLE_PRIVACY_POLICY, Domain::FIRST_DOMAIN_ID, Article::class)->getId()),
+            'blogArticle' => $this->getMainSlug('front_blogarticle_detail', $this->getReference(BlogArticleDataFixture::FIRST_DEMO_BLOG_ARTICLE, BlogArticle::class)->getId()),
+            'blogCategory' => $this->getMainSlug('front_blogcategory_detail', $this->getReference(BlogArticleDataFixture::FIRST_DEMO_BLOG_SUBCATEGORY, BlogCategory::class)->getId()),
+        ];
+
+        foreach ($bareSlugsByField as $field => $bareSlug) {
+            $nameWithoutLeadingSlash = $this->getEntityNameByUrlSlug($field, $bareSlug);
+            $nameWithLeadingSlash = $this->getEntityNameByUrlSlug($field, '/' . $bareSlug);
+
+            $this->assertSame(
+                $nameWithoutLeadingSlash,
+                $nameWithLeadingSlash,
+                sprintf('Query "%s" must resolve the same entity for slug with and without a leading slash.', $field),
+            );
+        }
+    }
+
+    public function testSeoPageQueryAcceptsSlugWithAndWithoutLeadingSlash(): void
+    {
+        $pageSlug = SeoPageDataFixture::FIRST_DEMO_SEO_PAGE;
+
+        $titleWithoutLeadingSlash = $this->getSeoPageTitleByPageSlug($pageSlug);
+        $titleWithLeadingSlash = $this->getSeoPageTitleByPageSlug('/' . $pageSlug);
+
+        $this->assertSame($titleWithoutLeadingSlash, $titleWithLeadingSlash);
+    }
+
+    private function getMainSlug(string $routeName, int $entityId): string
+    {
+        return $this->friendlyUrlFacade->getMainFriendlyUrlSlug(Domain::FIRST_DOMAIN_ID, $routeName, $entityId);
+    }
+
+    private function getEntityNameByUrlSlug(string $field, string $urlSlug): string
+    {
+        $response = $this->getResponseContentForQuery(sprintf('{ %s(urlSlug: "%s") { name } }', $field, $urlSlug));
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $field);
+
+        return $this->getResponseDataForGraphQlType($response, $field)['name'];
+    }
+
+    private function getSeoPageTitleByPageSlug(string $pageSlug): string
+    {
+        $response = $this->getResponseContentForQuery(sprintf('{ seoPage(pageSlug: "%s") { title } }', $pageSlug));
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, 'seoPage');
+
+        return $this->getResponseDataForGraphQlType($response, 'seoPage')['title'];
+    }
+}

--- a/upgrade-notes/backend_20260609_111610.md
+++ b/upgrade-notes/backend_20260609_111610.md
@@ -1,0 +1,3 @@
+#### Frontend API now accepts slug queries with a leading slash ([#4649](https://github.com/shopsys/shopsys/pull/4649))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
- the API returns URL slugs with a leading slash (e.g. `/canon`), but slug queries rejected that format and returned not-found
- getFriendlyUrlByRouteNameAndSlug() now strips it for product, brand, flag, store, blogCategory and readyCategorySeoMix; the article Elasticsearch lookup strips it too#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://tl-fix-slugs.odin.shopsys.cloud
  - https://cz.tl-fix-slugs.odin.shopsys.cloud
  - https://tl-fix-slugs.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1781695540.520419 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-slugs.odin.shopsys.cloud
  - https://cz.tl-fix-slugs.odin.shopsys.cloud
  - https://tl-fix-slugs.odin.shopsys.cloud/sk
<!-- Replace -->
