### PR TITLE
releaser: add major/minor branch checklist step

### DIFF
--- a/utils/releaser/config/after-release.php
+++ b/utils/releaser/config/after-release.php
@@ -8,6 +8,7 @@ use Shopsys\Releaser\ReleaseWorker\AfterRelease\CheckPackagesGithubActionsBuilds
 use Shopsys\Releaser\ReleaseWorker\AfterRelease\CheckPackagesOnPackagistReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\AfterRelease\CheckShopsysInstallReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\AfterRelease\EnableMergingReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\AfterRelease\EnsureMajorMinorBranchExistsReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\AfterRelease\EnsureReleaseHighlightsPostIsReleasedReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\AfterRelease\EnsureRoadmapIsUpdatedReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\AfterRelease\PostInfoToSlackReleaseWorker;
@@ -36,6 +37,7 @@ return [
     EnsureReleaseHighlightsPostIsReleasedReleaseWorker::class,
     PostInfoToSlackReleaseWorker::class,
     CheckDocsReleaseWorker::class,
+    EnsureMajorMinorBranchExistsReleaseWorker::class,
     EnsureRoadmapIsUpdatedReleaseWorker::class,
     BeHappyReleaseWorker::class,
 ];

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/EnsureMajorMinorBranchExistsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/EnsureMajorMinorBranchExistsReleaseWorker.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\AfterRelease;
+
+use Override;
+use PharIo\Version\Version;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+
+final class EnsureMajorMinorBranchExistsReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    #[Override]
+    public function getDescription(
+        Version $version,
+        string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME,
+    ): string {
+        return '[Manually] Check whether a new major/minor branch needs to be created';
+    }
+
+    #[Override]
+    public function work(
+        Version $version,
+        string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME,
+    ): void {
+        $this->symfonyStyle->note('For a new major or minor release, make sure the corresponding major/minor branch exists. If it does not exist and is needed, create it according to the checklist in Confluence.');
+
+        $this->confirm('Confirm that the required major/minor branch exists or that no new branch is needed.');
+    }
+
+    /**
+     * @return string[]
+     */
+    #[Override]
+    protected function getAllowedStages(): array
+    {
+        return [Stage::AFTER_RELEASE];
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

The release process now reminds releasers to check whether a new major/minor branch is needed after publishing a release.

This prevents the branch creation step from being missed during major and minor releases. When the corresponding branch does not exist but is required, the releaser is directed to follow the Confluence checklist, so the post-release process stays consistent.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
<!-- SLACK_TIMESTAMP: 1784877438.944959 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-releaser-branch.odin.shopsys.cloud
  - https://cz.mg-releaser-branch.odin.shopsys.cloud
  - https://mg-releaser-branch.odin.shopsys.cloud/sk
<!-- Replace -->
