### PR TITLE
mcp: prevent reading hidden columns via subselects

### DIFF
--- a/packages/mcp/src/Component/Database/Query/SqlQueryValidator.php
+++ b/packages/mcp/src/Component/Database/Query/SqlQueryValidator.php
@@ -452,6 +452,11 @@ class SqlQueryValidator
             );
         }
 
+        if ($wrappedNodeTag === self::NODE_TAG_RANGE_SUBSELECT) {
+            // Range subselects are validated in collectRelationsFromRangeSubselect(), before their derived alias is visible.
+            return null;
+        }
+
         if ($wrappedNodeTag === self::NODE_TAG_FUNC_CALL && !$this->isAllowedFunctionCall($wrappedNode)) {
             return self::ERROR_UNSUPPORTED_READ_WRITE_CONSTRUCT;
         }
@@ -502,6 +507,8 @@ class SqlQueryValidator
             return $this->collectRelationsFromRangeSubselect(
                 $fromNode[self::NODE_TAG_RANGE_SUBSELECT] ?? [],
                 $relationsIndexedByAliases,
+                $cteRelationsIndexedByNames,
+                $allowedColumnsSetIndexedByTableNames,
             );
         }
 
@@ -584,11 +591,32 @@ class SqlQueryValidator
     /**
      * @param array<string, mixed> $rangeSubselect
      * @param array<string, array{type: 'table'|'cte'|'derived', tableName?: string, columnNamesSet?: array<string, bool>|null}> $relationsIndexedByAliases
+     * @param array<string, array{type: 'cte', columnNamesSet: array<string, bool>|null}> $cteRelationsIndexedByNames
+     * @param array<string, array<string, bool>> $allowedColumnsSetIndexedByTableNames
      */
     protected function collectRelationsFromRangeSubselect(
         array $rangeSubselect,
         array &$relationsIndexedByAliases,
+        array $cteRelationsIndexedByNames,
+        array $allowedColumnsSetIndexedByTableNames,
     ): ?string {
+        $subquery = $rangeSubselect['subquery'] ?? null;
+
+        if (!is_array($subquery) || $this->getWrappedNodeTag($subquery) !== self::NODE_TAG_SELECT_STMT) {
+            return self::ERROR_ONLY_SELECT_SUPPORTED;
+        }
+
+        $validationErrorMessage = $this->validateSelectStatement(
+            $subquery[self::NODE_TAG_SELECT_STMT],
+            $allowedColumnsSetIndexedByTableNames,
+            false,
+            $cteRelationsIndexedByNames,
+        );
+
+        if ($validationErrorMessage !== null) {
+            return $validationErrorMessage;
+        }
+
         $aliasName = $this->getAliasName($rangeSubselect['alias'] ?? null);
 
         if ($aliasName === null) {

--- a/packages/mcp/tests/Unit/Component/Database/Query/SqlQueryValidatorTest.php
+++ b/packages/mcp/tests/Unit/Component/Database/Query/SqlQueryValidatorTest.php
@@ -120,6 +120,10 @@ class SqlQueryValidatorTest extends TestCase
             'sql' => 'SELECT sub.id2 FROM (SELECT id FROM products) AS sub(id2) LIMIT 10',
         ];
 
+        yield 'derived table with exposed column is allowed' => [
+            'sql' => 'SELECT sub.id FROM (SELECT id FROM administrators) sub LIMIT 10',
+        ];
+
         yield 'order by aggregate alias is allowed' => [
             'sql' => 'SELECT customer_id, COUNT(id) AS order_count FROM orders GROUP BY customer_id ORDER BY order_count DESC, customer_id ASC LIMIT 10',
         ];
@@ -359,8 +363,38 @@ class SqlQueryValidatorTest extends TestCase
         ];
 
         yield 'non exposed table is rejected' => [
-            'sql' => 'SELECT id FROM administrators LIMIT 10',
+            'sql' => 'SELECT id FROM administrator_mcp_tokens LIMIT 10',
             'expectedErrorMessage' => SqlQueryValidator::ERROR_TABLE_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column behind derived table is rejected' => [
+            'sql' => 'SELECT x.password FROM (SELECT password FROM administrators) x LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column behind derived table with column alias is rejected' => [
+            'sql' => 'SELECT x.password FROM (SELECT password FROM administrators) AS x(password) LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column behind derived table disguised as exposed column alias is rejected' => [
+            'sql' => 'SELECT x.id FROM (SELECT password FROM administrators) AS x(id) LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'non exposed table hidden behind derived table is rejected' => [
+            'sql' => 'SELECT x.secret_hash FROM (SELECT secret_hash FROM administrator_mcp_tokens) x LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_TABLE_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in scalar subquery select list is rejected' => [
+            'sql' => 'SELECT (SELECT username FROM administrators LIMIT 1) AS visible_username, (SELECT password FROM administrators LIMIT 1) AS hidden_password LIMIT 1',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column behind nested derived tables is rejected' => [
+            'sql' => 'SELECT x.username FROM (SELECT username FROM (SELECT username, password FROM administrators) y) x LIMIT 1',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
         ];
 
         yield 'non public schema table is rejected' => [
@@ -450,6 +484,10 @@ class SqlQueryValidatorTest extends TestCase
     private function getAllowedColumnsSetIndexedByTableNames(): array
     {
         return [
+            'administrators' => [
+                'id' => true,
+                'username' => true,
+            ],
             'currencies' => [
                 'code' => true,
                 'exchange_rate' => true,

--- a/packages/mcp/tests/Unit/Component/Database/Query/SqlQueryValidatorTest.php
+++ b/packages/mcp/tests/Unit/Component/Database/Query/SqlQueryValidatorTest.php
@@ -417,6 +417,41 @@ class SqlQueryValidatorTest extends TestCase
             'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
         ];
 
+        yield 'hidden column with output alias is rejected' => [
+            'sql' => 'SELECT password AS password_alias FROM administrators LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in cte body is rejected' => [
+            'sql' => 'WITH administrator_passwords AS (SELECT password FROM administrators) SELECT password FROM administrator_passwords LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in where clause is rejected' => [
+            'sql' => 'SELECT id FROM administrators WHERE password IS NOT NULL LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in order by clause is rejected' => [
+            'sql' => 'SELECT id FROM administrators ORDER BY password LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in allowed function argument is rejected' => [
+            'sql' => 'SELECT LENGTH(password) FROM administrators LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in union branch is rejected' => [
+            'sql' => 'SELECT username FROM administrators UNION ALL SELECT password FROM administrators LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
+        yield 'hidden column in case expression is rejected' => [
+            'sql' => 'SELECT CASE WHEN password LIKE \'$2y$%\' THEN username ELSE email END FROM administrators LIMIT 10',
+            'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,
+        ];
+
         yield 'hidden qualified column is rejected' => [
             'sql' => 'SELECT pt.secret_hash FROM products p JOIN product_translations pt ON pt.translatable_id = p.id LIMIT 10',
             'expectedErrorMessage' => SqlQueryValidator::ERROR_COLUMN_NOT_EXPOSED,


### PR DESCRIPTION
#### Description, the reason for the PR

The MCP SQL tool lets an AI assistant query the database while restricting which tables and columns it is allowed to read. The query validator enforced these restrictions on the top-level query, but did not validate columns referenced inside a derived table (a subquery in the `FROM` clause). As a result, wrapping a non-exposed column in a subquery bypassed the restriction entirely — for example, `SELECT x.password FROM (SELECT password FROM administrators) x` returned administrator password hashes that should never be reachable through MCP. Because the same gap also allowed reaching non-exposed tables, this was a data-exposure security issue.

This change makes the validator fully validate every derived table's inner query against the exposed schema before its columns become available to the outer query, so hidden columns and non-exposed tables are rejected no matter how deeply they are nested. The accompanying test suite is extended to lock down this and the related vectors that reference a hidden column from a different position — `WHERE`, `ORDER BY`, an allowed function argument, a `UNION` branch, a `CASE` expression, a CTE body, and an output alias — each of which now reliably returns a "column not exposed" error.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://rv-fix-sql-validator-subselect.odin.shopsys.cloud
  - https://cz.rv-fix-sql-validator-subselect.odin.shopsys.cloud
  - https://rv-fix-sql-validator-subselect.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1781256185.689499 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-sql-validator-subselect.odin.shopsys.cloud
  - https://cz.rv-fix-sql-validator-subselect.odin.shopsys.cloud
  - https://rv-fix-sql-validator-subselect.odin.shopsys.cloud/sk
<!-- Replace -->
