### PR TITLE
cron monitoring

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1280,7 +1280,7 @@ jobs:
                     chmod +x set-urls-for-review.sh
                     chmod +x 12-set-env-variables.envsh
                     ./set-urls-for-review.sh setDomainsToDockerCompose
-                    docker compose down -v --remove-orphans || true
+                    docker compose down -v --remove-orphans
                     HASH_DEC=$((16#$(printf '%s' "${BRANCH_NAME_ESCAPED}" | sha1sum | head -c 8)))
                     export CRON_OFFSET_MIN=$((HASH_DEC % 5))
                     export CRON_OFFSET_MIN_10=$((HASH_DEC % 10))

--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -80,3 +80,44 @@ Set it to `false` for instances whose modules are independent of each other so t
 !!! note
 
     Crons implementing `Shopsys\Plugin\Cron\IteratedCronModuleInterface` with the correct implementation of iterate, wakeUp, and sleep methods will be checked during every iteration if their memory limit is not approaching and if so, they will be stopped and started again in the next iteration.
+
+## Sentry Cron Monitoring
+
+Cron modules can opt into [Sentry Cron Monitoring](https://docs.sentry.io/product/crons/) so that missed runs, failures, and overrunning jobs are reported to Sentry (and from there to alert channels like Slack):
+
+```yaml
+Shopsys\FrameworkBundle\Model\Sitemap\SitemapCronModule:
+    tags:
+        - {
+              name: shopsys.cron,
+              cron: '0 4 * * *',
+              instanceName: export,
+              readableName: 'Generate Sitemap',
+              sentryMonitoring: true,
+              sentryCheckinMargin: 5,
+              sentryFailureThreshold: 3,
+          }
+```
+
+When `sentryMonitoring` is enabled, an `in_progress` check-in is sent when the module starts and an `ok`/`error` check-in when it finishes.
+The Sentry monitor is created and updated automatically with a schedule matching the module's cron expression, so no manual setup in Sentry is needed.
+
+The `shopsys.cron` tag supports these monitoring attributes:
+
+| Attribute                 | Meaning                                                                                                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sentryMonitoring`        | enables monitoring for the module (default `false`)                                                                                                                                                    |
+| `sentryMaxRuntime`        | minutes a single run may take before Sentry marks the check-in as timed out; defaults to `timeout_iterated_cron_sec` (rounded up to whole minutes) for iterated modules and to `30` for simple modules |
+| `sentryCheckinMargin`     | minutes Sentry waits for the start check-in after the scheduled time before reporting a missed run; defaults to the instance's `run_every_min`                                                         |
+| `sentryFailureThreshold`  | number of consecutive failed or missed check-ins before Sentry creates an issue                                                                                                                        |
+| `sentryRecoveryThreshold` | number of consecutive successful check-ins before Sentry resolves the issue                                                                                                                            |
+
+Things to be aware of:
+
+- check-ins are only sent when Sentry is configured via the `SENTRY_DSN` environment variable; without a DSN, they are no-ops
+- the monitor schedule is evaluated in the `shopsys.cron_timezone` timezone (the server timezone when the parameter is not set), the same timezone used for evaluating cron expressions
+- modules within one instance run sequentially, so a module can start several minutes after its scheduled time when earlier modules run long — set `sentryCheckinMargin` generously for modules with a fixed schedule time
+- the minute field of a monitored module's cron expression must align with the instance's `run_every_min` grid — for example, `7 * * * *` never runs with `run_every_min: 5`, yet Sentry would expect a check-in every hour and report it as missed
+- a disabled monitored module reports a healthy run whenever its schedule fires, so intentionally disabling a module does not trigger false "missed run" alerts
+- an iterated module that is suspended and resumed reports each chunk as a separate successful check-in
+- when you remove `sentryMonitoring` from a module, the existing monitor stays in Sentry and keeps alerting about missed check-ins — delete or mute it in the Sentry UI

--- a/packages/framework/src/Component/Cron/Config/CronConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronConfig.php
@@ -6,12 +6,16 @@ namespace Shopsys\FrameworkBundle\Component\Cron\Config;
 
 use DateTimeInterface;
 use Shopsys\FrameworkBundle\Component\Cron\Config\Exception\CronModuleConfigNotFoundException;
+use Shopsys\FrameworkBundle\Component\Cron\Config\Exception\SentryMonitoringNotEnabledException;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
+use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 
 class CronConfig
 {
+    protected const int MAX_SENTRY_SLUG_LENGTH = 50;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig[]
      */
@@ -19,6 +23,7 @@ class CronConfig
 
     public function __construct(
         protected readonly CronTimeResolver $cronTimeResolver,
+        protected readonly TransformStringHelper $transformStringHelper,
     ) {
         $this->cronModuleConfigs = [];
     }
@@ -32,6 +37,11 @@ class CronConfig
         ?string $readableFrequency = null,
         int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
         int $timeoutIteratedCronSec = CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+        bool $sentryMonitoring = false,
+        ?int $sentryMaxRuntime = null,
+        ?int $sentryCheckinMargin = null,
+        ?int $sentryFailureThreshold = null,
+        ?int $sentryRecoveryThreshold = null,
     ): void {
         $this->cronTimeResolver->validateCronExpression($cronExpression);
 
@@ -43,10 +53,59 @@ class CronConfig
             $readableFrequency,
             $runEveryMin,
             $timeoutIteratedCronSec,
+            $this->createSentryMonitorConfig(
+                $serviceId,
+                $sentryMonitoring,
+                $sentryMaxRuntime,
+                $sentryCheckinMargin,
+                $sentryFailureThreshold,
+                $sentryRecoveryThreshold,
+            ),
         );
         $cronModuleConfig->assignToInstance($instanceName);
 
         $this->cronModuleConfigs[] = $cronModuleConfig;
+    }
+
+    protected function createSentryMonitorConfig(
+        string $serviceId,
+        bool $sentryMonitoring,
+        ?int $sentryMaxRuntime,
+        ?int $sentryCheckinMargin,
+        ?int $sentryFailureThreshold,
+        ?int $sentryRecoveryThreshold,
+    ): ?SentryMonitorConfig {
+        if (!$sentryMonitoring) {
+            $hasSentryOptions = $sentryMaxRuntime !== null
+                || $sentryCheckinMargin !== null
+                || $sentryFailureThreshold !== null
+                || $sentryRecoveryThreshold !== null;
+
+            if ($hasSentryOptions) {
+                throw new SentryMonitoringNotEnabledException($serviceId);
+            }
+
+            return null;
+        }
+
+        return new SentryMonitorConfig(
+            $this->buildSentryMonitorSlug($serviceId),
+            $sentryMaxRuntime,
+            $sentryCheckinMargin,
+            $sentryFailureThreshold,
+            $sentryRecoveryThreshold,
+        );
+    }
+
+    protected function buildSentryMonitorSlug(string $serviceId): string
+    {
+        $className = basename(str_replace('\\', '/', $serviceId));
+        $className = $this->transformStringHelper->removeStringFromEnd($className, 'CronModule');
+        $classSlug = $this->transformStringHelper->stringToFriendlyUrlSlug($className);
+
+        $suffix = '-' . substr(md5($serviceId), 0, 6);
+
+        return rtrim(substr($classSlug, 0, self::MAX_SENTRY_SLUG_LENGTH - strlen($suffix)), '-') . $suffix;
     }
 
     /**

--- a/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
@@ -27,6 +27,7 @@ class CronModuleConfig implements CronTimeInterface
         protected readonly ?string $readableFrequency = null,
         protected readonly int $runEveryMin = self::RUN_EVERY_MIN_DEFAULT,
         protected readonly int $timeoutIteratedCronSec = self::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+        protected readonly ?SentryMonitorConfig $sentryMonitorConfig = null,
     ) {
         $this->assignToInstance(self::DEFAULT_INSTANCE_NAME);
     }
@@ -81,7 +82,7 @@ class CronModuleConfig implements CronTimeInterface
      * Replaces wildcard minute field with the actual run interval so that
      * the translated frequency reflects reality (e.g. "every 5 minutes" instead of "every minute").
      */
-    protected function getEffectiveCronExpression(): string
+    public function getEffectiveCronExpression(): string
     {
         $parts = explode(' ', $this->cronExpression);
 
@@ -100,5 +101,10 @@ class CronModuleConfig implements CronTimeInterface
     public function getTimeoutIteratedCronSec(): int
     {
         return $this->timeoutIteratedCronSec;
+    }
+
+    public function getSentryMonitorConfig(): ?SentryMonitorConfig
+    {
+        return $this->sentryMonitorConfig;
     }
 }

--- a/packages/framework/src/Component/Cron/Config/Exception/SentryMonitoringNotEnabledException.php
+++ b/packages/framework/src/Component/Cron/Config/Exception/SentryMonitoringNotEnabledException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron\Config\Exception;
+
+use Exception;
+use Throwable;
+
+class SentryMonitoringNotEnabledException extends Exception
+{
+    public function __construct(string $serviceId, ?Throwable $previous = null)
+    {
+        parent::__construct(
+            'Cron module "' . $serviceId . '" sets Sentry monitoring options but "sentryMonitoring" is not enabled. Enable it or remove the option(s).',
+            0,
+            $previous,
+        );
+    }
+}

--- a/packages/framework/src/Component/Cron/Config/SentryMonitorConfig.php
+++ b/packages/framework/src/Component/Cron/Config/SentryMonitorConfig.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron\Config;
+
+class SentryMonitorConfig
+{
+    public function __construct(
+        protected readonly string $slug,
+        protected readonly ?int $maxRuntime = null,
+        protected readonly ?int $checkinMargin = null,
+        protected readonly ?int $failureThreshold = null,
+        protected readonly ?int $recoveryThreshold = null,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getMaxRuntime(): ?int
+    {
+        return $this->maxRuntime;
+    }
+
+    public function getCheckinMargin(): ?int
+    {
+        return $this->checkinMargin;
+    }
+
+    public function getFailureThreshold(): ?int
+    {
+        return $this->failureThreshold;
+    }
+
+    public function getRecoveryThreshold(): ?int
+    {
+        return $this->recoveryThreshold;
+    }
+}

--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -18,6 +18,7 @@ class CronFacade
         protected readonly CronModuleFacade $cronModuleFacade,
         protected readonly ParameterBagInterface $parameterBag,
         protected readonly CronModuleProcessRunner $cronModuleProcessRunner,
+        protected readonly SentryCronMonitorFacade $sentryCronMonitorFacade,
     ) {
     }
 
@@ -70,6 +71,7 @@ class CronFacade
             foreach ($cronModuleConfigs as $cronModuleConfig) {
                 if ($this->cronModuleFacade->isModuleDisabled($cronModuleConfig)) {
                     $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
+                    $this->sentryCronMonitorFacade->reportDisabledRunAsHealthy($cronModuleConfig);
 
                     continue;
                 }

--- a/packages/framework/src/Component/Cron/CronModuleFacade.php
+++ b/packages/framework/src/Component/Cron/CronModuleFacade.php
@@ -23,6 +23,7 @@ class CronModuleFacade
         protected readonly CronModuleRunFactory $cronModuleRunFactory,
         protected readonly InMemoryCache $inMemoryCache,
         protected readonly ClockInterface $clock,
+        protected readonly SentryCronMonitorFacade $sentryCronMonitorFacade,
     ) {
     }
 
@@ -88,6 +89,8 @@ class CronModuleFacade
         $cronModule->updateLastStartedAt();
 
         $this->em->flush();
+
+        $this->sentryCronMonitorFacade->reportStart($cronModuleConfig);
     }
 
     public function markCronAsEnded(CronModuleConfig $cronModuleConfig): void
@@ -105,10 +108,14 @@ class CronModuleFacade
         $this->em->persist($cronModuleRun);
 
         $this->em->flush();
+
+        $this->sentryCronMonitorFacade->reportSuccess($cronModuleConfig);
     }
 
     public function markCronAsFailed(CronModuleConfig $cronModuleConfig): void
     {
+        $this->sentryCronMonitorFacade->reportFailure($cronModuleConfig);
+
         $cronModule = $this->cronModuleRepository->getCronModuleByServiceId($cronModuleConfig->getServiceId());
         $startedAt = $cronModule->getLastStartedAt() ?? $this->clock->now();
         $finishedAt = $this->clock->now();

--- a/packages/framework/src/Component/Cron/CronModuleRunnerFacade.php
+++ b/packages/framework/src/Component/Cron/CronModuleRunnerFacade.php
@@ -17,6 +17,7 @@ class CronModuleRunnerFacade
         protected readonly CronConfig $cronConfig,
         protected readonly CronModuleFacade $cronModuleFacade,
         protected readonly CronModuleExecutor $cronModuleExecutor,
+        protected readonly SentryCronMonitorFacade $sentryCronMonitorFacade,
     ) {
     }
 
@@ -50,6 +51,7 @@ class CronModuleRunnerFacade
     {
         if ($this->cronModuleFacade->isModuleDisabled($cronModuleConfig) === true) {
             $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
+            $this->sentryCronMonitorFacade->reportDisabledRunAsHealthy($cronModuleConfig);
 
             return CronModuleExecutor::RUN_STATUS_OK;
         }

--- a/packages/framework/src/Component/Cron/MonitorConfigFactory.php
+++ b/packages/framework/src/Component/Cron/MonitorConfigFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron;
+
+use Sentry\MonitorConfig;
+use Sentry\MonitorSchedule;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
+
+class MonitorConfigFactory
+{
+    protected const int DEFAULT_MAX_RUNTIME_MIN = 30;
+
+    public function __construct(
+        protected readonly ?string $cronTimeZone = null,
+    ) {
+    }
+
+    public function create(CronModuleConfig $cronModuleConfig): MonitorConfig
+    {
+        $sentryMonitorConfig = $cronModuleConfig->getSentryMonitorConfig();
+
+        $maxRuntime = $sentryMonitorConfig?->getMaxRuntime();
+
+        if ($maxRuntime === null && $cronModuleConfig->getService() instanceof IteratedCronModuleInterface) {
+            $maxRuntime = (int)ceil($cronModuleConfig->getTimeoutIteratedCronSec() / 60);
+        }
+
+        $maxRuntime = $maxRuntime ?? self::DEFAULT_MAX_RUNTIME_MIN;
+
+        $checkinMargin = $sentryMonitorConfig?->getCheckinMargin() ?? $cronModuleConfig->getRunEveryMin();
+
+        return new MonitorConfig(
+            MonitorSchedule::crontab($cronModuleConfig->getEffectiveCronExpression()),
+            checkinMargin: $checkinMargin > 0 ? $checkinMargin : null,
+            maxRuntime: $maxRuntime > 0 ? $maxRuntime : null,
+            timezone: $this->cronTimeZone ?? date_default_timezone_get(),
+            failureIssueThreshold: $sentryMonitorConfig?->getFailureThreshold(),
+            recoveryThreshold: $sentryMonitorConfig?->getRecoveryThreshold(),
+        );
+    }
+}

--- a/packages/framework/src/Component/Cron/SentryCronMonitorFacade.php
+++ b/packages/framework/src/Component/Cron/SentryCronMonitorFacade.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron;
+
+use Psr\Log\LoggerInterface;
+use Sentry\CheckInStatus;
+use Sentry\MonitorConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Throwable;
+use function Sentry\captureCheckIn;
+
+class SentryCronMonitorFacade
+{
+    /**
+     * @var array<string, string|null>
+     */
+    protected array $checkInIds = [];
+
+    public function __construct(
+        protected readonly LoggerInterface $logger,
+        protected readonly MonitorConfigFactory $monitorConfigFactory,
+    ) {
+    }
+
+    public function reportStart(CronModuleConfig $cronModuleConfig): void
+    {
+        $this->runCheckIn(
+            $cronModuleConfig,
+            'start',
+            function (string $slug, MonitorConfig $monitorConfig) use ($cronModuleConfig): void {
+                $this->checkInIds[$cronModuleConfig->getServiceId()] = $this->captureCheckIn(
+                    $slug,
+                    CheckInStatus::inProgress(),
+                    $monitorConfig,
+                );
+            },
+        );
+    }
+
+    public function reportSuccess(CronModuleConfig $cronModuleConfig): void
+    {
+        $this->runCheckIn(
+            $cronModuleConfig,
+            'success',
+            function (string $slug, MonitorConfig $monitorConfig) use ($cronModuleConfig): void {
+                $this->captureCheckIn($slug, CheckInStatus::ok(), $monitorConfig, $this->pullCheckInId($cronModuleConfig));
+            },
+        );
+    }
+
+    public function reportFailure(CronModuleConfig $cronModuleConfig): void
+    {
+        $this->runCheckIn(
+            $cronModuleConfig,
+            'failure',
+            function (string $slug, MonitorConfig $monitorConfig) use ($cronModuleConfig): void {
+                $this->captureCheckIn($slug, CheckInStatus::error(), $monitorConfig, $this->pullCheckInId($cronModuleConfig));
+            },
+        );
+    }
+
+    /**
+     * A disabled module sends no real check-ins, so Sentry would report its scheduled runs as missed.
+     * Sending a paired start/success check-in keeps the monitor healthy while the module is intentionally disabled.
+     */
+    public function reportDisabledRunAsHealthy(CronModuleConfig $cronModuleConfig): void
+    {
+        $this->runCheckIn($cronModuleConfig, 'disabled-module success', function (string $slug, MonitorConfig $monitorConfig): void {
+            $checkInId = $this->captureCheckIn($slug, CheckInStatus::inProgress(), $monitorConfig);
+            $this->captureCheckIn($slug, CheckInStatus::ok(), $monitorConfig, $checkInId);
+        });
+    }
+
+    /**
+     * Runs the given check-in only when monitoring is enabled, swallowing and logging any Sentry transport error
+     * so that a monitoring outage can never break cron execution.
+     *
+     * The monitor configuration is passed to the callback so that every check-in (including the closing ones)
+     * carries it, letting Sentry upsert the monitor regardless of the order in which check-ins are ingested.
+     *
+     * @param callable(string, \Sentry\MonitorConfig): void $checkIn
+     */
+    protected function runCheckIn(CronModuleConfig $cronModuleConfig, string $checkInType, callable $checkIn): void
+    {
+        $sentryMonitorConfig = $cronModuleConfig->getSentryMonitorConfig();
+
+        if ($sentryMonitorConfig === null) {
+            return;
+        }
+
+        try {
+            $checkIn($sentryMonitorConfig->getSlug(), $this->monitorConfigFactory->create($cronModuleConfig));
+        } catch (Throwable $exception) {
+            $this->logCheckInFailure($checkInType, $cronModuleConfig, $exception);
+        }
+    }
+
+    protected function captureCheckIn(
+        string $slug,
+        CheckInStatus $status,
+        ?MonitorConfig $monitorConfig = null,
+        ?string $checkInId = null,
+    ): ?string {
+        return captureCheckIn(
+            slug: $slug,
+            status: $status,
+            monitorConfig: $monitorConfig,
+            checkInId: $checkInId,
+        );
+    }
+
+    protected function pullCheckInId(CronModuleConfig $cronModuleConfig): ?string
+    {
+        $serviceId = $cronModuleConfig->getServiceId();
+        $checkInId = $this->checkInIds[$serviceId] ?? null;
+        unset($this->checkInIds[$serviceId]);
+
+        return $checkInId;
+    }
+
+    protected function logCheckInFailure(
+        string $checkInType,
+        CronModuleConfig $cronModuleConfig,
+        Throwable $exception,
+    ): void {
+        $this->logger->error(sprintf('Failed to send Sentry check-in (%s)', $checkInType), [
+            'serviceId' => $cronModuleConfig->getServiceId(),
+            'exception' => $exception,
+        ]);
+    }
+}

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
@@ -38,6 +38,11 @@ final class RegisterCronModulesCompilerPass implements CompilerPassInterface
                         $tag['readableFrequency'] ?? null,
                         $instanceConfig['run_every_min'],
                         $instanceConfig['timeout_iterated_cron_sec'],
+                        $tag['sentryMonitoring'] ?? false,
+                        $tag['sentryMaxRuntime'] ?? null,
+                        $tag['sentryCheckinMargin'] ?? null,
+                        $tag['sentryFailureThreshold'] ?? null,
+                        $tag['sentryRecoveryThreshold'] ?? null,
                     ],
                 );
             }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -146,6 +146,14 @@ services:
         arguments:
             - '@monolog.logger.cron'
 
+    Shopsys\FrameworkBundle\Component\Cron\MonitorConfigFactory:
+        arguments:
+            $cronTimeZone: '%shopsys.cron_timezone%'
+
+    Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade:
+        arguments:
+            $logger: '@monolog.logger.cron'
+
     Shopsys\FrameworkBundle\Component\CustomerUploadedFile\Config\CustomerUploadedFileConfig:
         arguments:
             - '%shopsys.customer_uploaded_file_config_filepath%'

--- a/packages/framework/tests/Unit/Component/Cron/CronConfigTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronConfigTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\Exception\SentryMonitoringNotEnabledException;
+use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
+use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+
+class CronConfigTest extends TestCase
+{
+    public function testSentryMonitorConfigIsCreatedWithGivenOptions(): void
+    {
+        $cronConfig = $this->createCronConfig();
+        $cronConfig->registerCronModuleInstance(
+            $this->createStub(SimpleCronModuleInterface::class),
+            'App\Cron\FooCronModule',
+            '* * * * *',
+            CronModuleConfig::DEFAULT_INSTANCE_NAME,
+            sentryMonitoring: true,
+            sentryMaxRuntime: 5,
+            sentryCheckinMargin: 10,
+            sentryFailureThreshold: 3,
+            sentryRecoveryThreshold: 2,
+        );
+
+        $sentryMonitorConfig = $cronConfig->getCronModuleConfigByServiceId('App\Cron\FooCronModule')
+            ->getSentryMonitorConfig();
+
+        $this->assertNotNull($sentryMonitorConfig);
+        $this->assertSame(5, $sentryMonitorConfig->getMaxRuntime());
+        $this->assertSame(10, $sentryMonitorConfig->getCheckinMargin());
+        $this->assertSame(3, $sentryMonitorConfig->getFailureThreshold());
+        $this->assertSame(2, $sentryMonitorConfig->getRecoveryThreshold());
+    }
+
+    public function testSentryMonitorConfigIsNullWhenMonitoringIsNotEnabled(): void
+    {
+        $cronConfig = $this->createCronConfig();
+        $cronConfig->registerCronModuleInstance(
+            $this->createStub(SimpleCronModuleInterface::class),
+            'App\Cron\FooCronModule',
+            '* * * * *',
+            CronModuleConfig::DEFAULT_INSTANCE_NAME,
+        );
+
+        $this->assertNull(
+            $cronConfig->getCronModuleConfigByServiceId('App\Cron\FooCronModule')->getSentryMonitorConfig(),
+        );
+    }
+
+    public function testSentryOptionsWithoutEnabledMonitoringThrowException(): void
+    {
+        $cronConfig = $this->createCronConfig();
+
+        $this->expectException(SentryMonitoringNotEnabledException::class);
+
+        $cronConfig->registerCronModuleInstance(
+            $this->createStub(SimpleCronModuleInterface::class),
+            'App\Cron\FooCronModule',
+            '* * * * *',
+            CronModuleConfig::DEFAULT_INSTANCE_NAME,
+            sentryMaxRuntime: 5,
+        );
+    }
+
+    public function testSlugStripsCronModuleSuffixAndLowercasesClassName(): void
+    {
+        $slug = $this->registerAndGetSlug('Shopsys\FrameworkBundle\Model\Sitemap\SitemapCronModule');
+
+        $this->assertMatchesRegularExpression('/^sitemap-[0-9a-f]{6}$/', $slug);
+    }
+
+    public function testSlugLowercasesMultiWordClassNameIntoSingleToken(): void
+    {
+        $slug = $this->registerAndGetSlug('App\Model\Product\Elasticsearch\ProductRecalculationCronModule');
+
+        $this->assertMatchesRegularExpression('/^productrecalculation-[0-9a-f]{6}$/', $slug);
+    }
+
+    public function testSlugIsDeterministicForSameServiceId(): void
+    {
+        $this->assertSame(
+            $this->registerAndGetSlug('App\Cron\FooCronModule'),
+            $this->registerAndGetSlug('App\Cron\FooCronModule'),
+        );
+    }
+
+    public function testSlugDiffersForDifferentServiceIdsWithSameClassName(): void
+    {
+        $this->assertNotSame(
+            $this->registerAndGetSlug('App\Cron\FooCronModule'),
+            $this->registerAndGetSlug('App\Other\FooCronModule'),
+        );
+    }
+
+    public function testSlugNeverExceedsMaxLength(): void
+    {
+        $slug = $this->registerAndGetSlug(
+            'App\Model\Stock\SynchronizeAvailabilityAndStockQuantitiesFromExternalSystemCronModule',
+        );
+
+        $this->assertLessThanOrEqual(50, strlen($slug));
+        $this->assertMatchesRegularExpression('/-[0-9a-f]{6}$/', $slug);
+    }
+
+    public function testSlugContainsOnlyAllowedCharactersForNonClassNameServiceId(): void
+    {
+        $slug = $this->registerAndGetSlug('app.cron.foo_module');
+
+        $this->assertMatchesRegularExpression('/^app-cron-foo_module-[0-9a-f]{6}$/', $slug);
+    }
+
+    public function testSlugHasNoDoubleDashWhenTruncationLandsOnSeparator(): void
+    {
+        $slug = $this->registerAndGetSlug(str_repeat('a', 42) . '.tail');
+
+        $this->assertStringNotContainsString('--', $slug);
+        $this->assertMatchesRegularExpression('/^a{42}-[0-9a-f]{6}$/', $slug);
+    }
+
+    private function registerAndGetSlug(string $serviceId): string
+    {
+        $cronConfig = $this->createCronConfig();
+        $cronConfig->registerCronModuleInstance(
+            $this->createStub(SimpleCronModuleInterface::class),
+            $serviceId,
+            '* * * * *',
+            CronModuleConfig::DEFAULT_INSTANCE_NAME,
+            sentryMonitoring: true,
+        );
+
+        $sentryMonitorConfig = $cronConfig->getCronModuleConfigByServiceId($serviceId)->getSentryMonitorConfig();
+        $this->assertNotNull($sentryMonitorConfig);
+
+        return $sentryMonitorConfig->getSlug();
+    }
+
+    private function createCronConfig(): CronConfig
+    {
+        return new CronConfig(new CronTimeResolver(), new TransformStringHelper());
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -14,6 +14,8 @@ use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleFacade;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleProcessRunner;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
+use Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade;
+use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 use Symfony\Component\Clock\DatePoint;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -103,6 +105,35 @@ class CronFacadeTest extends TestCase
             ->runScheduledModulesForInstance(CronModuleConfig::DEFAULT_INSTANCE_NAME, static function (): void {}, false);
     }
 
+    public function testRunScheduledModulesReportsDisabledModulesAsHealthy(): void
+    {
+        $moduleStub = $this->createStub(SimpleCronModuleInterface::class);
+
+        $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
+        $cronModuleFacadeStub->method('getOnlyScheduledCronModuleConfigs')
+            ->willReturnArgument(0);
+        $cronModuleFacadeStub->method('isModuleDisabled')->willReturn(true);
+
+        $cronModuleProcessRunnerMock = $this->createMock(CronModuleProcessRunner::class);
+        $cronModuleProcessRunnerMock->expects($this->never())->method('runModule');
+
+        $sentryCronMonitorFacadeMock = $this->createMock(SentryCronMonitorFacade::class);
+        $sentryCronMonitorFacadeMock->expects($this->exactly(2))->method('reportDisabledRunAsHealthy');
+
+        $parameterBagStub = $this->createStub(ParameterBagInterface::class);
+        $parameterBagStub->method('get')->willReturn([]);
+
+        $cronConfig = $this->createCronConfigWithRegisteredServices(['first' => $moduleStub, 'second' => $moduleStub]);
+
+        $this->createCronFacade(
+            $cronConfig,
+            $cronModuleFacadeStub,
+            $parameterBagStub,
+            $cronModuleProcessRunnerMock,
+            $sentryCronMonitorFacadeMock,
+        )->runScheduledModulesForInstance(CronModuleConfig::DEFAULT_INSTANCE_NAME, static function (): void {}, false);
+    }
+
     public function testRunSingleModuleDelegatesToProcessRunner(): void
     {
         $cronModuleFacadeStub = $this->createStub(CronModuleFacade::class);
@@ -141,6 +172,7 @@ class CronFacadeTest extends TestCase
         CronModuleFacade $cronModuleFacade,
         ?ParameterBagInterface $parameterBag = null,
         ?CronModuleProcessRunner $cronModuleProcessRunner = null,
+        ?SentryCronMonitorFacade $sentryCronMonitorFacade = null,
     ): CronFacade {
         $loggerMock = $this->createStub(Logger::class);
 
@@ -150,6 +182,7 @@ class CronFacadeTest extends TestCase
             $cronModuleFacade,
             $parameterBag ?? $this->createStub(ParameterBagInterface::class),
             $cronModuleProcessRunner ?? $this->createStub(CronModuleProcessRunner::class),
+            $sentryCronMonitorFacade ?? $this->createStub(SentryCronMonitorFacade::class),
         );
     }
 
@@ -158,7 +191,7 @@ class CronFacadeTest extends TestCase
         ?CronTimeResolver $cronTimeResolverMock = null,
     ): CronConfig {
         $cronTimeResolver = $cronTimeResolverMock ?? new CronTimeResolver();
-        $cronConfig = new CronConfig($cronTimeResolver);
+        $cronConfig = new CronConfig($cronTimeResolver, new TransformStringHelper());
 
         foreach ($servicesIndexedById as $serviceId => $service) {
             $cronConfig->registerCronModuleInstance(

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleExecutorTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleExecutorTest.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
+use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
 use Symfony\Component\Clock\Clock;
 
@@ -84,7 +85,7 @@ class CronModuleExecutorTest extends TestCase
     private function getCronModuleExecutor(array $servicesIndexedById): CronModuleExecutor
     {
         $cronTimeResolver = new CronTimeResolver();
-        $cronConfig = new CronConfig($cronTimeResolver);
+        $cronConfig = new CronConfig($cronTimeResolver, new TransformStringHelper());
 
         $loggerStub = $this->createStub(Logger::class);
         $bytesHelper = new BytesHelper();

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleFacadeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Cron\CronFilter;
+use Shopsys\FrameworkBundle\Component\Cron\CronModule;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleFacade;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleRepository;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleRun;
+use Shopsys\FrameworkBundle\Component\Cron\CronModuleRunFactory;
+use Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+use Symfony\Component\Clock\DatePoint;
+
+class CronModuleFacadeTest extends TestCase
+{
+    private const string SERVICE_ID = 'App\Cron\FooCronModule';
+
+    public function testMarkCronAsStartedReportsStartToSentryMonitor(): void
+    {
+        $cronModuleConfig = $this->createCronModuleConfig();
+
+        $sentryCronMonitorFacadeMock = $this->createMock(SentryCronMonitorFacade::class);
+        $sentryCronMonitorFacadeMock->expects($this->once())
+            ->method('reportStart')
+            ->with($cronModuleConfig);
+
+        $this->createCronModuleFacade($sentryCronMonitorFacadeMock)->markCronAsStarted($cronModuleConfig);
+    }
+
+    public function testMarkCronAsEndedReportsSuccessToSentryMonitor(): void
+    {
+        $cronModuleConfig = $this->createCronModuleConfig();
+
+        $sentryCronMonitorFacadeMock = $this->createMock(SentryCronMonitorFacade::class);
+        $sentryCronMonitorFacadeMock->expects($this->once())
+            ->method('reportSuccess')
+            ->with($cronModuleConfig);
+
+        $this->createCronModuleFacade($sentryCronMonitorFacadeMock)->markCronAsEnded($cronModuleConfig);
+    }
+
+    public function testMarkCronAsFailedReportsFailureToSentryMonitorEvenWithoutDatabaseConnection(): void
+    {
+        $cronModuleConfig = $this->createCronModuleConfig();
+
+        $sentryCronMonitorFacadeMock = $this->createMock(SentryCronMonitorFacade::class);
+        $sentryCronMonitorFacadeMock->expects($this->once())
+            ->method('reportFailure')
+            ->with($cronModuleConfig);
+
+        $this->createCronModuleFacade($sentryCronMonitorFacadeMock)->markCronAsFailed($cronModuleConfig);
+    }
+
+    private function createCronModuleFacade(SentryCronMonitorFacade $sentryCronMonitorFacade): CronModuleFacade
+    {
+        $cronModuleRepositoryStub = $this->createStub(CronModuleRepository::class);
+        $cronModuleRepositoryStub->method('getCronModuleByServiceId')
+            ->willReturn(new CronModule(self::SERVICE_ID));
+
+        $cronModuleRunFactoryStub = $this->createStub(CronModuleRunFactory::class);
+        $cronModuleRunFactoryStub->method('createFromFinishedCronModule')
+            ->willReturn($this->createStub(CronModuleRun::class));
+
+        $connectionStub = $this->createStub(Connection::class);
+        $connectionStub->method('isConnected')->willReturn(false);
+
+        $entityManagerStub = $this->createStub(EntityManagerInterface::class);
+        $entityManagerStub->method('getConnection')->willReturn($connectionStub);
+
+        $clockStub = $this->createStub(ClockInterface::class);
+        $clockStub->method('now')->willReturn(new DatePoint());
+
+        return new CronModuleFacade(
+            $entityManagerStub,
+            $cronModuleRepositoryStub,
+            $this->createStub(CronFilter::class),
+            $cronModuleRunFactoryStub,
+            $this->createStub(InMemoryCache::class),
+            $clockStub,
+            $sentryCronMonitorFacade,
+        );
+    }
+
+    private function createCronModuleConfig(): CronModuleConfig
+    {
+        return new CronModuleConfig(
+            $this->createStub(SimpleCronModuleInterface::class),
+            self::SERVICE_ID,
+            '* * * * *',
+        );
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleRunnerFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleRunnerFacadeTest.php
@@ -14,6 +14,8 @@ use Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleFacade;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleRunnerFacade;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
+use Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade;
+use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 
 class CronModuleRunnerFacadeTest extends TestCase
@@ -30,7 +32,7 @@ class CronModuleRunnerFacadeTest extends TestCase
         $cronModuleService = $this->createStub(SimpleCronModuleInterface::class);
         $this->serviceId = get_class($cronModuleService);
 
-        $this->cronConfig = new CronConfig(new CronTimeResolver());
+        $this->cronConfig = new CronConfig(new CronTimeResolver(), new TransformStringHelper());
         $this->cronConfig->registerCronModuleInstance(
             $cronModuleService,
             $this->serviceId,
@@ -39,14 +41,17 @@ class CronModuleRunnerFacadeTest extends TestCase
         );
     }
 
-    public function testRunDisabledModuleReturnsOkAndUnschedulesIt(): void
+    public function testRunDisabledModuleReturnsOkUnschedulesItAndReportsHealthyRun(): void
     {
         $cronModuleFacadeMock = $this->createMock(CronModuleFacade::class);
         $cronModuleFacadeMock->method('isModuleDisabled')->willReturn(true);
         $cronModuleFacadeMock->expects($this->once())->method('unscheduleModule');
         $cronModuleFacadeMock->expects($this->never())->method('markCronAsStarted');
 
-        $result = $this->createCronModuleRunnerFacade($cronModuleFacadeMock)
+        $sentryCronMonitorFacadeMock = $this->createMock(SentryCronMonitorFacade::class);
+        $sentryCronMonitorFacadeMock->expects($this->once())->method('reportDisabledRunAsHealthy');
+
+        $result = $this->createCronModuleRunnerFacade($cronModuleFacadeMock, sentryCronMonitorFacade: $sentryCronMonitorFacadeMock)
             ->runModuleByServiceIdInContext($this->serviceId);
 
         $this->assertSame(CronModuleExecutor::RUN_STATUS_OK, $result);
@@ -109,12 +114,14 @@ class CronModuleRunnerFacadeTest extends TestCase
     private function createCronModuleRunnerFacade(
         CronModuleFacade $cronModuleFacade,
         ?CronModuleExecutor $cronModuleExecutor = null,
+        ?SentryCronMonitorFacade $sentryCronMonitorFacade = null,
     ): CronModuleRunnerFacade {
         return new CronModuleRunnerFacade(
             $this->createStub(Logger::class),
             $this->cronConfig,
             $cronModuleFacade,
             $cronModuleExecutor ?? $this->createStub(CronModuleExecutor::class),
+            $sentryCronMonitorFacade ?? $this->createStub(SentryCronMonitorFacade::class),
         );
     }
 }

--- a/packages/framework/tests/Unit/Component/Cron/MonitorConfigFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/MonitorConfigFactoryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\MonitorConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\SentryMonitorConfig;
+use Shopsys\FrameworkBundle\Component\Cron\MonitorConfigFactory;
+use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+
+class MonitorConfigFactoryTest extends TestCase
+{
+    private const string SERVICE_ID = 'App\Cron\FooCronModule';
+    private const string SLUG = 'foo-slug';
+
+    public function testUsesExplicitMaxRuntimeAndThresholds(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(SimpleCronModuleInterface::class),
+            '0 4 * * *',
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            new SentryMonitorConfig(self::SLUG, maxRuntime: 5, checkinMargin: null, failureThreshold: 3, recoveryThreshold: 2),
+        );
+
+        $this->assertSame('0 4 * * *', $monitorConfig->getSchedule()->getValue());
+        $this->assertSame(5, $monitorConfig->getMaxRuntime());
+        $this->assertSame(3, $monitorConfig->getFailureRecoveryThreshold());
+        $this->assertSame(2, $monitorConfig->getRecoveryThreshold());
+        $this->assertSame('Europe/Prague', $monitorConfig->getTimezone());
+    }
+
+    public function testFallsBackCheckinMarginToRunEveryMin(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(SimpleCronModuleInterface::class),
+            '* * * * *',
+            10,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            new SentryMonitorConfig(self::SLUG, maxRuntime: 5),
+        );
+
+        $this->assertSame(10, $monitorConfig->getCheckinMargin());
+    }
+
+    public function testDisablesCheckinMarginWhenZero(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(SimpleCronModuleInterface::class),
+            '* * * * *',
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            new SentryMonitorConfig(self::SLUG, checkinMargin: 0),
+        );
+
+        $this->assertNull($monitorConfig->getCheckinMargin());
+    }
+
+    public function testDerivesMaxRuntimeFromTimeoutForIteratedModule(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(IteratedCronModuleInterface::class),
+            '* * * * *',
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            240,
+            new SentryMonitorConfig(self::SLUG),
+        );
+
+        $this->assertSame(4, $monitorConfig->getMaxRuntime());
+    }
+
+    public function testDefaultsMaxRuntimeToThirtyMinutesForSimpleModule(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(SimpleCronModuleInterface::class),
+            '* * * * *',
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            new SentryMonitorConfig(self::SLUG),
+        );
+
+        $this->assertSame(30, $monitorConfig->getMaxRuntime());
+    }
+
+    public function testUsesEffectiveCronExpressionForWildcardMinute(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(SimpleCronModuleInterface::class),
+            '* * * * *',
+            5,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            new SentryMonitorConfig(self::SLUG),
+        );
+
+        $this->assertSame('*/5 * * * *', $monitorConfig->getSchedule()->getValue());
+    }
+
+    public function testFallsBackToDefaultTimezoneWhenCronTimeZoneNotSet(): void
+    {
+        $monitorConfig = $this->create(
+            $this->createStub(SimpleCronModuleInterface::class),
+            '* * * * *',
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            new SentryMonitorConfig(self::SLUG),
+            cronTimeZone: null,
+        );
+
+        $this->assertSame(date_default_timezone_get(), $monitorConfig->getTimezone());
+    }
+
+    private function create(
+        SimpleCronModuleInterface|IteratedCronModuleInterface $service,
+        string $cronExpression,
+        int $runEveryMin,
+        int $timeoutIteratedCronSec,
+        SentryMonitorConfig $sentryMonitorConfig,
+        ?string $cronTimeZone = 'Europe/Prague',
+    ): MonitorConfig {
+        $cronModuleConfig = new CronModuleConfig(
+            $service,
+            self::SERVICE_ID,
+            $cronExpression,
+            null,
+            null,
+            $runEveryMin,
+            $timeoutIteratedCronSec,
+            $sentryMonitorConfig,
+        );
+
+        return (new MonitorConfigFactory($cronTimeZone))->create($cronModuleConfig);
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/SentryCronMonitorFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/SentryCronMonitorFacadeTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\SentryMonitorConfig;
+use Shopsys\FrameworkBundle\Component\Cron\MonitorConfigFactory;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+
+class SentryCronMonitorFacadeTest extends TestCase
+{
+    private const string SERVICE_ID = 'App\Cron\FooCronModule';
+    private const string SLUG = 'foo-slug';
+
+    public function testReportStartAndSuccessSendPairedCheckIns(): void
+    {
+        $facade = $this->createFacade();
+        $cronModuleConfig = $this->createMonitoredCronModuleConfig();
+
+        $facade->reportStart($cronModuleConfig);
+        $facade->reportSuccess($cronModuleConfig);
+
+        $this->assertCount(2, $facade->capturedCheckIns);
+        $this->assertSame('in_progress', $facade->capturedCheckIns[0]['status']);
+        $this->assertSame('ok', $facade->capturedCheckIns[1]['status']);
+        $this->assertSame(self::SLUG, $facade->capturedCheckIns[0]['slug']);
+        $this->assertSame(self::SLUG, $facade->capturedCheckIns[1]['slug']);
+        $this->assertSame($facade->capturedCheckIns[0]['checkInId'], $facade->capturedCheckIns[1]['checkInId']);
+    }
+
+    public function testReportStartAndFailureSendPairedCheckIns(): void
+    {
+        $facade = $this->createFacade();
+        $cronModuleConfig = $this->createMonitoredCronModuleConfig();
+
+        $facade->reportStart($cronModuleConfig);
+        $facade->reportFailure($cronModuleConfig);
+
+        $this->assertCount(2, $facade->capturedCheckIns);
+        $this->assertSame('in_progress', $facade->capturedCheckIns[0]['status']);
+        $this->assertSame('error', $facade->capturedCheckIns[1]['status']);
+        $this->assertSame($facade->capturedCheckIns[0]['checkInId'], $facade->capturedCheckIns[1]['checkInId']);
+    }
+
+    public function testEveryCheckInCarriesMonitorConfigSoSentryCanUpsertTheMonitor(): void
+    {
+        $facade = $this->createFacade();
+        $cronModuleConfig = $this->createMonitoredCronModuleConfig();
+
+        $facade->reportStart($cronModuleConfig);
+        $facade->reportSuccess($cronModuleConfig);
+        $facade->reportFailure($cronModuleConfig);
+        $facade->reportDisabledRunAsHealthy($cronModuleConfig);
+
+        foreach ($facade->capturedCheckIns as $capturedCheckIn) {
+            $this->assertTrue($capturedCheckIn['hasMonitorConfig']);
+        }
+    }
+
+    public function testReportSuccessWithoutPreviousStartUpsertsMonitorWithoutId(): void
+    {
+        $facade = $this->createFacade();
+
+        $facade->reportSuccess($this->createMonitoredCronModuleConfig());
+
+        $this->assertCount(1, $facade->capturedCheckIns);
+        $this->assertSame('ok', $facade->capturedCheckIns[0]['status']);
+        $this->assertNull($facade->capturedCheckIns[0]['checkInId']);
+        $this->assertTrue($facade->capturedCheckIns[0]['hasMonitorConfig']);
+    }
+
+    public function testReportFailureWithoutPreviousStartUpsertsMonitorWithoutId(): void
+    {
+        $facade = $this->createFacade();
+
+        $facade->reportFailure($this->createMonitoredCronModuleConfig());
+
+        $this->assertCount(1, $facade->capturedCheckIns);
+        $this->assertSame('error', $facade->capturedCheckIns[0]['status']);
+        $this->assertNull($facade->capturedCheckIns[0]['checkInId']);
+        $this->assertTrue($facade->capturedCheckIns[0]['hasMonitorConfig']);
+    }
+
+    public function testReportDisabledRunAsHealthySendsPairedCheckIns(): void
+    {
+        $facade = $this->createFacade();
+
+        $facade->reportDisabledRunAsHealthy($this->createMonitoredCronModuleConfig());
+
+        $this->assertCount(2, $facade->capturedCheckIns);
+        $this->assertSame('in_progress', $facade->capturedCheckIns[0]['status']);
+        $this->assertSame('ok', $facade->capturedCheckIns[1]['status']);
+        $this->assertSame($facade->capturedCheckIns[0]['checkInId'], $facade->capturedCheckIns[1]['checkInId']);
+    }
+
+    public function testNoCheckInsWhenMonitoringDisabled(): void
+    {
+        $facade = $this->createFacade();
+        $cronModuleConfig = $this->createUnmonitoredCronModuleConfig();
+
+        $facade->reportStart($cronModuleConfig);
+        $facade->reportSuccess($cronModuleConfig);
+        $facade->reportFailure($cronModuleConfig);
+        $facade->reportDisabledRunAsHealthy($cronModuleConfig);
+
+        $this->assertSame([], $facade->capturedCheckIns);
+    }
+
+    public function testCheckInErrorIsSwallowedAndLogged(): void
+    {
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())->method('error');
+
+        $facade = $this->createFacade($loggerMock);
+        $facade->throwOnCapture = new RuntimeException('Sentry is down');
+
+        $facade->reportStart($this->createMonitoredCronModuleConfig());
+
+        $this->assertSame([], $facade->capturedCheckIns);
+    }
+
+    private function createFacade(?LoggerInterface $logger = null): TestSentryCronMonitorFacade
+    {
+        return new TestSentryCronMonitorFacade(
+            $logger ?? $this->createStub(LoggerInterface::class),
+            new MonitorConfigFactory(),
+        );
+    }
+
+    private function createMonitoredCronModuleConfig(): CronModuleConfig
+    {
+        return $this->createCronModuleConfig(new SentryMonitorConfig(self::SLUG));
+    }
+
+    private function createUnmonitoredCronModuleConfig(): CronModuleConfig
+    {
+        return $this->createCronModuleConfig(null);
+    }
+
+    private function createCronModuleConfig(?SentryMonitorConfig $sentryMonitorConfig): CronModuleConfig
+    {
+        return new CronModuleConfig(
+            $this->createStub(SimpleCronModuleInterface::class),
+            self::SERVICE_ID,
+            '* * * * *',
+            null,
+            null,
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            $sentryMonitorConfig,
+        );
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/TestSentryCronMonitorFacade.php
+++ b/packages/framework/tests/Unit/Component/Cron/TestSentryCronMonitorFacade.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use Override;
+use Sentry\CheckInStatus;
+use Sentry\MonitorConfig;
+use Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade;
+use Throwable;
+
+class TestSentryCronMonitorFacade extends SentryCronMonitorFacade
+{
+    /**
+     * @var array<int, array{status: string, slug: string, checkInId: string|null, hasMonitorConfig: bool}>
+     */
+    public array $capturedCheckIns = [];
+
+    public ?Throwable $throwOnCapture = null;
+
+    protected int $checkInIdSequence = 0;
+
+    #[Override]
+    protected function captureCheckIn(
+        string $slug,
+        CheckInStatus $status,
+        ?MonitorConfig $monitorConfig = null,
+        ?string $checkInId = null,
+    ): ?string {
+        if ($this->throwOnCapture !== null) {
+            throw $this->throwOnCapture;
+        }
+
+        if ($status === CheckInStatus::inProgress()) {
+            $checkInId = 'check-in-' . ++$this->checkInIdSequence;
+        }
+
+        $this->capturedCheckIns[] = [
+            'status' => (string)$status,
+            'slug' => $slug,
+            'checkInId' => $checkInId,
+            'hasMonitorConfig' => $monitorConfig !== null,
+        ];
+
+        return $checkInId;
+    }
+}

--- a/project-base/app/config/cron.yaml
+++ b/project-base/app/config/cron.yaml
@@ -21,108 +21,108 @@ services:
 
     Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule:
         tags:
-            - { name: shopsys.cron, cron: '* * * * *', instanceName: service, readableName: 'Delete vats' }
+            - { name: shopsys.cron, cron: '* * * * *', instanceName: service, readableName: 'Delete vats', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Component\Cron\DeleteOldCronModuleRunsCronModule:
         tags:
-            - { name: shopsys.cron, cron: '* * * * *', instanceName: service, readableName: 'Delete old cron module runs' }
+            - { name: shopsys.cron, cron: '* * * * *', instanceName: service, readableName: 'Delete old cron module runs', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Cart\Item\DeleteOldCartsCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 0 * * *', instanceName: service, readableName: 'Delete old customer carts' }
+            - { name: shopsys.cron, cron: '0 0 * * *', instanceName: service, readableName: 'Delete old customer carts', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrontendApiBundle\Model\Security\DeleteExpiredExchangeTokensCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 3 * * *', instanceName: service, readableName: 'Remove expired login as user exchange tokens' }
+            - { name: shopsys.cron, cron: '0 3 * * *', instanceName: service, readableName: 'Remove expired login as user exchange tokens', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Payment\ReturnHash\DeleteExpiredPaymentReturnHashesCronModule:
         tags:
-            - { name: shopsys.cron, cron: '5 3 * * *', instanceName: service, readableName: 'Remove expired payment return hashes' }
+            - { name: shopsys.cron, cron: '5 3 * * *', instanceName: service, readableName: 'Remove expired payment return hashes', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Customer\User\RemoveOldCustomerUserRefreshTokenChainsCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 4 * * *', instanceName: service, readableName: 'Remove old customer user refresh token chains' }
+            - { name: shopsys.cron, cron: '0 4 * * *', instanceName: service, readableName: 'Remove old customer user refresh token chains', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Component\FileUpload\DeleteOldUploadedFilesCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 5 * * *', instanceName: service, readableName: 'Delete old temporary uploaded files' }
+            - { name: shopsys.cron, cron: '0 5 * * *', instanceName: service, readableName: 'Delete old temporary uploaded files', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Transfer\Issue\TransferIssueLogCleanerCronModule:
         tags:
-            - { name: shopsys.cron, cron: '10 23 * * *', instanceName: service, readableName: 'Delete old transfer issues' }
+            - { name: shopsys.cron, cron: '10 23 * * *', instanceName: service, readableName: 'Delete old transfer issues', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 3 * * *', instanceName: service, readableName: 'Download Heureka categories' }
+            - { name: shopsys.cron, cron: '0 3 * * *', instanceName: service, readableName: 'Download Heureka categories', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\ProductFeed\ZboziBundle\Model\ZboziCategory\ZboziCategoryCronModule:
         tags:
-            - { name: shopsys.cron, cron: '15 3 * * *', instanceName: service, readableName: 'Download Zbozi.cz categories' }
+            - { name: shopsys.cron, cron: '15 3 * * *', instanceName: service, readableName: 'Download Zbozi.cz categories', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Product\List\RemoveOldProductListsCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 3 * * *', instanceName: service, readableName: 'Delete old product lists' }
+            - { name: shopsys.cron, cron: '0 3 * * *', instanceName: service, readableName: 'Delete old product lists', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Product\GiftPlan\RecalculateGiftFlagsCronModule:
         tags:
-            - { name: shopsys.cron, cron: '15 0 * * *', instanceName: service, readableName: 'Recalculate gift flags by active plans' }
+            - { name: shopsys.cron, cron: '15 0 * * *', instanceName: service, readableName: 'Recalculate gift flags by active plans', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     # Export
 
     Shopsys\FrameworkBundle\Model\Feed\FeedCronModule:
         tags:
-            - { name: shopsys.cron, cron: '* * * * *', instanceName: export, readableName: 'Generate feeds' }
+            - { name: shopsys.cron, cron: '* * * * *', instanceName: export, readableName: 'Generate feeds', sentryMonitoring: true, sentryMaxRuntime: 5, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Sitemap\SitemapCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 4 * * *', instanceName: export, readableName: 'Generate Sitemap' }
+            - { name: shopsys.cron, cron: '0 4 * * *', instanceName: export, readableName: 'Generate Sitemap', sentryMonitoring: true, sentryCheckinMargin: 5, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapCronModule:
         tags:
-            - { name: shopsys.cron, cron: '10 4 * * *', instanceName: export, readableName: 'Generate image sitemap' }
+            - { name: shopsys.cron, cron: '10 4 * * *', instanceName: export, readableName: 'Generate image sitemap', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleExportCronModule:
         tags:
-            - { name: shopsys.cron, cron: '10 3 * * *', instanceName: export, readableName: "Export articles to Elasticsearch" }
+            - { name: shopsys.cron, cron: '10 3 * * *', instanceName: export, readableName: "Export articles to Elasticsearch", sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Blog\Article\Elasticsearch\BlogArticleExportCronModule:
         tags:
-            - { name: shopsys.cron, cron: '10 3 * * *', instanceName: export, readableName: "Export blog articles to Elasticsearch" }
+            - { name: shopsys.cron, cron: '10 3 * * *', instanceName: export, readableName: "Export blog articles to Elasticsearch", sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\Blog\Article\Elasticsearch\BlogArticleExportChangedCronModule:
         tags:
-            - { name: shopsys.cron, cron: '5 * * * *', instanceName: export, readableName: "Export changed blog articles to Elasticsearch" }
+            - { name: shopsys.cron, cron: '5 * * * *', instanceName: export, readableName: "Export changed blog articles to Elasticsearch", sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     # Products
 
     Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductRecalculationCronModule:
         tags:
-            - { name: shopsys.cron, cron: '0 0 * * *', instanceName: products, readableName: "Dispatches all products to be recalculated and exported" }
+            - { name: shopsys.cron, cron: '0 0 * * *', instanceName: products, readableName: "Dispatches all products to be recalculated and exported", sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     # GoPay
 
     Shopsys\FrameworkBundle\Model\GoPay\GoPayAvailablePaymentsCronModule:
         tags:
-            - { name: shopsys.cron, cron: '50 3 * * *', instanceName: gopay, readableName: 'Import available payment methods from GoPay' }
+            - { name: shopsys.cron, cron: '50 3 * * *', instanceName: gopay, readableName: 'Import available payment methods from GoPay', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     Shopsys\FrameworkBundle\Model\GoPay\OrderGoPayStatusUpdateCronModule:
         tags:
-            - { name: shopsys.cron, cron: '15 * * * *', instanceName: gopay, readableName: 'Import order payment status from GoPay' }
+            - { name: shopsys.cron, cron: '15 * * * *', instanceName: gopay, readableName: 'Import order payment status from GoPay', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     # Data bridge import
 
     App\Component\DataBridge\DummyCronModule:
         tags:
-            - { name: shopsys.cron, cron: '* * * * *', instanceName: dataBridgeImport, readableName: 'Dummy data bridge import' }
+            - { name: shopsys.cron, cron: '* * * * *', instanceName: dataBridgeImport, readableName: 'Dummy data bridge import', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     # Packetery
 
     Shopsys\FrameworkBundle\Component\Packetery\PacketeryCronModule:
         tags:
-            - { name: shopsys.cron, cron: '* * * * *', instanceName: packetery, readableName: 'Sending parcels to the packetery' }
+            - { name: shopsys.cron, cron: '* * * * *', instanceName: packetery, readableName: 'Sending parcels to the packetery', sentryMonitoring: true, sentryFailureThreshold: 3 }
 
     # Watchdog
 
     Shopsys\FrameworkBundle\Model\Watchdog\WatchdogCronModule:
         tags:
-            - { name: shopsys.cron, cron: '*/10 * * * *', instanceName: watchdog, readableName: 'Sending watchdog emails' }
+            - { name: shopsys.cron, cron: '*/10 * * * *', instanceName: watchdog, readableName: 'Sending watchdog emails', sentryMonitoring: true, sentryFailureThreshold: 3 }

--- a/upgrade-notes/backend_20260609_120000.md
+++ b/upgrade-notes/backend_20260609_120000.md
@@ -1,0 +1,10 @@
+#### Add optional Sentry cron monitoring (check-ins) for cron modules ([#4654](https://github.com/shopsys/shopsys/pull/4654))
+
+- cron modules can opt into [Sentry Cron Monitoring](https://docs.sentry.io/product/crons/) per module via new `shopsys.cron` tag attributes; see the [cron documentation](https://docs.shopsys.com/en/latest/introduction/cron/) for details and configuration
+- `Shopsys\FrameworkBundle\Component\Cron\CronFacade::__construct()` now expects `Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade $sentryCronMonitorFacade` as the last parameter
+- `Shopsys\FrameworkBundle\Component\Cron\CronModuleFacade::__construct()` now expects `Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade $sentryCronMonitorFacade` as the last parameter
+- `Shopsys\FrameworkBundle\Component\Cron\CronModuleRunnerFacade::__construct()` now expects `Shopsys\FrameworkBundle\Component\Cron\SentryCronMonitorFacade $sentryCronMonitorFacade` as the last parameter
+- `Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig::__construct()` now expects `Shopsys\FrameworkBundle\Component\String\TransformStringHelper $transformStringHelper` as the last parameter
+- `Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig::registerCronModuleInstance()` accepts new optional Sentry monitoring parameters (`bool $sentryMonitoring`, `?int $sentryMaxRuntime`, `?int $sentryCheckinMargin`, `?int $sentryFailureThreshold`, `?int $sentryRecoveryThreshold`)
+- `Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig::__construct()` accepts a new optional `?Shopsys\FrameworkBundle\Component\Cron\Config\SentryMonitorConfig $sentryMonitorConfig = null` as the last parameter
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
  
  This PR adds optional [Sentry Cron Monitoring](https://docs.sentry.io/product/crons/) for the platform's cron modules, so teams get notified when a scheduled job stops running or repeatedly fails — instead of
  discovering it only when something downstream breaks (stale product feeds, an outdated sitemap, unprocessed payments).

  When monitoring is enabled for a cron module, the application reports a check-in to Sentry when the job starts and again when it finishes (success or failure). Sentry then knows each job's expected schedule and
  raises an alert — which can notify Slack — when a run is missed, overruns its expected duration, or fails several times in a row. Monitoring is opt-in per module through new `shopsys.cron` tag attributes
  (`sentryMonitoring`, plus optional `sentryMaxRuntime`, `sentryCheckinMargin`, `sentryFailureThreshold`, and `sentryRecoveryThreshold`), and it ships enabled for feed and sitemap generation as ready-to-use
  examples. With no `SENTRY_DSN` configured everything is a no-op, so local and CI environments are unaffected.

  Each monitor's schedule is evaluated in the project's configured cron timezone, and intentionally disabled cron modules keep reporting healthy so they don't raise false "missed run" alerts. The new tag
  attributes and their caveats are documented in the cron guide.

  #### Fixes issues

  Implements SSP-3975.

  #### License Agreement for contributions

  - [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

  














----
:globe_with_meridians: Live Preview:
  - https://tl-cron-monitoring.odin.shopsys.cloud
  - https://cz.tl-cron-monitoring.odin.shopsys.cloud
  - https://tl-cron-monitoring.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782285737.570329 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-cron-monitoring.odin.shopsys.cloud
  - https://cz.tl-cron-monitoring.odin.shopsys.cloud
  - https://tl-cron-monitoring.odin.shopsys.cloud/sk
<!-- Replace -->
