### PR TITLE
Domain URL replacement now skips mapped superclasses

### DIFF
--- a/packages/framework/src/Component/Doctrine/StringColumnsFinder.php
+++ b/packages/framework/src/Component/Doctrine/StringColumnsFinder.php
@@ -23,6 +23,11 @@ class StringColumnsFinder
 
                 throw new UnexpectedTypeException($message);
             }
+
+            if ($classMetadata->isMappedSuperclass) {
+                continue;
+            }
+
             $stringColumnNames = $this->getStringColumnNames($classMetadata);
 
             if (count($stringColumnNames) > 0) {

--- a/packages/framework/tests/Unit/Component/Doctrine/StringColumnsFinderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/StringColumnsFinderTest.php
@@ -59,6 +59,52 @@ class StringColumnsFinderTest extends TestCase
         $this->assertSame($expectedResult, $actualResult);
     }
 
+    public function testGetAllStringColumnNamesIndexedByTableNameSkipsMappedSuperclasses(): void
+    {
+        $mappedSuperclassMetadataStub = $this->createStub(ClassMetadata::class);
+        $mappedSuperclassMetadataStub->isMappedSuperclass = true;
+        $mappedSuperclassMetadataStub
+            ->method('getTableName')
+            ->willReturn('MappedSuperclass');
+        $mappedSuperclassMetadataStub
+            ->method('getFieldNames')
+            ->willReturn(['mappedSuperclassStringField']);
+        $mappedSuperclassMetadataStub
+            ->method('getTypeOfField')
+            ->willReturn('string');
+        $mappedSuperclassMetadataStub
+            ->method('getColumnName')
+            ->willReturn('mapped_superclass_string_field');
+
+        $classMetadataInfoStub = $this->createStub(ClassMetadata::class);
+        $classMetadataInfoStub
+            ->method('getTableName')
+            ->willReturn('EntityName');
+        $classMetadataInfoStub
+            ->method('getFieldNames')
+            ->willReturn(['entityStringField']);
+        $classMetadataInfoStub
+            ->method('getTypeOfField')
+            ->willReturn('string');
+        $classMetadataInfoStub
+            ->method('getColumnName')
+            ->willReturn('entity_string_field');
+
+        $expectedResult = [
+            'EntityName' => [
+                'entity_string_field',
+            ],
+        ];
+
+        $stringColumnsFinder = new StringColumnsFinder();
+        $actualResult = $stringColumnsFinder->getAllStringColumnNamesIndexedByTableName([
+            $mappedSuperclassMetadataStub,
+            $classMetadataInfoStub,
+        ]);
+
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
     public function testGetAllStringColumnNamesIndexedByTableNameException(): void
     {
         $classMetadataStub = $this->createStub(PersistenceClassMetadata::class);


### PR DESCRIPTION
#### Description, the reason for the PR

CDN domain URL replacement could fail when Doctrine metadata contained mapped superclasses with string columns. These metadata entries describe inherited mapping only and do not have their own database tables, so replacement SQL must not be generated for them.

This PR makes domain URL replacement skip mapped superclasses while continuing to process regular entity tables. As a result, changing domain or CDN URLs works reliably even when mapped-superclass metadata, such as uploaded file metadata, is present.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://mg-fix-domain-url-replace.odin.shopsys.cloud
  - https://cz.mg-fix-domain-url-replace.odin.shopsys.cloud
  - https://mg-fix-domain-url-replace.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1781590442.572509 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-domain-url-replace.odin.shopsys.cloud
  - https://cz.mg-fix-domain-url-replace.odin.shopsys.cloud
  - https://mg-fix-domain-url-replace.odin.shopsys.cloud/sk
<!-- Replace -->
