### PR TITLE
Limit GraphQL batch request operations

### DIFF
--- a/packages/frontend-api/src/Component/HttpFoundation/GraphqlBatchRequestValidator.php
+++ b/packages/frontend-api/src/Component/HttpFoundation/GraphqlBatchRequestValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\HttpFoundation;
+
+use JsonException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GraphqlBatchRequestValidator
+{
+    protected const string CONTENT_TYPE_FORM_DATA = 'multipart/form-data';
+
+    protected const string CONTENT_TYPE_JSON = 'application/json';
+
+    public function __construct(
+        protected readonly int $maxOperations,
+    ) {
+    }
+
+    public function getLimitViolationResponse(Request $request): ?JsonResponse
+    {
+        $operationsCount = $this->getOperationsCount($request);
+
+        if ($operationsCount === null || $operationsCount <= $this->maxOperations) {
+            return null;
+        }
+
+        return new JsonResponse([
+            'errors' => [
+                [
+                    'message' => sprintf('Batch request cannot contain more than %d operations.', $this->maxOperations),
+                ],
+            ],
+        ], Response::HTTP_BAD_REQUEST);
+    }
+
+    protected function getOperationsCount(Request $request): ?int
+    {
+        $contentType = explode(';', (string)$request->headers->get('content-type'), 2)[0];
+
+        if ($contentType === static::CONTENT_TYPE_JSON) {
+            return $this->getJsonOperationsCount($request);
+        }
+
+        if ($contentType === static::CONTENT_TYPE_FORM_DATA) {
+            return $this->getFormDataOperationsCount($request);
+        }
+
+        return null;
+    }
+
+    protected function getJsonOperationsCount(Request $request): ?int
+    {
+        try {
+            $requestData = json_decode($request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        return $this->getListCount($requestData);
+    }
+
+    protected function getFormDataOperationsCount(Request $request): ?int
+    {
+        $requestData = $request->request->all();
+
+        if (isset($requestData['operations']) && is_string($requestData['operations'])) {
+            try {
+                $requestData = json_decode($requestData['operations'], true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                return null;
+            }
+        } elseif (isset($requestData['operations']) && is_array($requestData['operations'])) {
+            $requestData = $requestData['operations'];
+        }
+
+        return $this->getListCount($requestData);
+    }
+
+    protected function getListCount(mixed $requestData): ?int
+    {
+        if (!is_array($requestData) || !array_is_list($requestData)) {
+            return null;
+        }
+
+        return count($requestData);
+    }
+}

--- a/packages/frontend-api/src/Controller/FrontendApiController.php
+++ b/packages/frontend-api/src/Controller/FrontendApiController.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrontendApiBundle\Controller;
 
 use Overblog\GraphQLBundle\Controller\GraphController;
 use Shopsys\FrameworkBundle\Component\EntityLog\Detection\DetectionFacade;
+use Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlBatchRequestValidator;
 use Shopsys\FrontendApiBundle\Model\GraphqlConfigurator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,6 +17,7 @@ class FrontendApiController
         protected readonly GraphController $graphController,
         protected readonly GraphqlConfigurator $graphqlConfigurator,
         protected readonly DetectionFacade $detectionFacade,
+        protected readonly GraphqlBatchRequestValidator $graphqlBatchRequestValidator,
     ) {
     }
 
@@ -30,6 +32,12 @@ class FrontendApiController
 
     public function batchEndpointAction(Request $request, ?string $schemaName = null): Response
     {
+        $limitViolationResponse = $this->graphqlBatchRequestValidator->getLimitViolationResponse($request);
+
+        if ($limitViolationResponse !== null) {
+            return $limitViolationResponse;
+        }
+
         $this->detectionFacade->setFrontendApiSourceAndUserIdentifier();
 
         $this->graphqlConfigurator->applyExtraConfiguration();

--- a/packages/frontend-api/src/Resources/config/parameters.yaml
+++ b/packages/frontend-api/src/Resources/config/parameters.yaml
@@ -1,2 +1,3 @@
 parameters:
+    shopsys.frontend_api.max_batch_operations: 20
     shopsys.frontend_api.validation_logged_as_error: false

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -24,6 +24,10 @@ services:
 
     Shopsys\FrontendApiBundle\Component\GqlContext\GqlContextInitializer: ~
 
+    Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlBatchRequestValidator:
+        arguments:
+            $maxOperations: '%shopsys.frontend_api.max_batch_operations%'
+
     Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlMutationErrorRollbackSubscriber: ~
 
     Shopsys\FrontendApiBundle\Component\HttpFoundation\GraphqlOperationTypeResolver: ~

--- a/project-base/app/config/packages/frontend_api.yaml
+++ b/project-base/app/config/packages/frontend_api.yaml
@@ -1,2 +1,8 @@
 parameters:
     shopsys.frontend_api.keys_filepath: '%kernel.project_dir%/config/frontend-api'
+
+    # Maximum number of operations allowed in a single GraphQL batch request
+    shopsys.frontend_api.max_batch_operations: 20
+
+    # Set to true to log validation errors with log level ERROR instead of INFO
+    shopsys.frontend_api.validation_logged_as_error: false

--- a/project-base/app/config/packages/overblog_graphql.yaml
+++ b/project-base/app/config/packages/overblog_graphql.yaml
@@ -27,3 +27,5 @@ overblog_graphql:
         query_max_complexity: 1110
     services:
         promise_adapter: "webonyx_graphql.sync_promise_adapter"
+
+# Frontend API-specific parameters are configured in frontend_api.yaml

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -13,9 +13,6 @@ parameters:
     shopsys.allowed_admin_locales: ['en', 'cs', 'sk']
     shopsys.cron_timezone: Europe/Prague
 
-    # Set to true to log validation errors with log level ERROR instead of INFO
-    shopsys.frontend_api.validation_logged_as_error: false
-
     shopsys.mail_template.display_price: 'selling_price'
 
     # Performance test parameters

--- a/project-base/app/config/shopsys-routing/routing_friendly_url.php
+++ b/project-base/app/config/shopsys-routing/routing_friendly_url.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Component\FriendlyUrl\FriendlyUrlRouteEnum;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;

--- a/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/GraphqlBatchLimitTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/GraphqlBatchLimitTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\HttpFoundation;
+
+use Nette\Utils\Json;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+final class GraphqlBatchLimitTest extends GraphQlTestCase
+{
+    private const int MAX_BATCH_OPERATIONS = 20;
+
+    public function testBatchRequestWithLimitOperationsIsAccepted(): void
+    {
+        $this->sendBatchRequest(static::MAX_BATCH_OPERATIONS);
+
+        $response = Json::decode((string)self::$client->getResponse()->getContent(), true);
+
+        $this->assertSame(Response::HTTP_OK, self::$client->getResponse()->getStatusCode());
+        $this->assertCount(static::MAX_BATCH_OPERATIONS, $response);
+    }
+
+    public function testBatchRequestAboveLimitIsRejected(): void
+    {
+        $this->sendBatchRequest(static::MAX_BATCH_OPERATIONS + 1);
+
+        $response = Json::decode((string)self::$client->getResponse()->getContent(), true);
+
+        $this->assertSame(Response::HTTP_BAD_REQUEST, self::$client->getResponse()->getStatusCode());
+        $this->assertSame(
+            'Batch request cannot contain more than 20 operations.',
+            $response['errors'][0]['message'],
+        );
+    }
+
+    private function sendBatchRequest(int $operationsCount): void
+    {
+        $path = $this->getLocalizedPathOnFirstDomainByRouteName('overblog_graphql_batch_endpoint');
+        $query = file_get_contents(__DIR__ . '/graphql/TypenameQuery.graphql');
+
+        if ($query === false) {
+            $this->fail('Unable to load GraphQL query fixture.');
+        }
+
+        self::$client->request(
+            'POST',
+            $path,
+            content: Json::encode($this->createBatchRequestData($operationsCount, $query)),
+        );
+    }
+
+    /**
+     * @return array<int, array{id: int, query: string}>
+     */
+    private function createBatchRequestData(int $operationsCount, string $query): array
+    {
+        $batchRequestData = [];
+
+        for ($operationId = 1; $operationId <= $operationsCount; $operationId++) {
+            $batchRequestData[] = [
+                'id' => $operationId,
+                'query' => $query,
+            ];
+        }
+
+        return $batchRequestData;
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/graphql/TypenameQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/HttpFoundation/graphql/TypenameQuery.graphql
@@ -1,0 +1,3 @@
+query TypenameQuery {
+    __typename
+}

--- a/upgrade-notes/backend_20260615_134026.md
+++ b/upgrade-notes/backend_20260615_134026.md
@@ -1,0 +1,3 @@
+#### Limit GraphQL batch request operations ([#4656](https://github.com/shopsys/shopsys/pull/4656))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

This PR limits how many operations can be sent in a single GraphQL batch request to the Frontend API.

Without this limit, clients could send oversized batch payloads that would all be passed to GraphQL execution at once. The new behavior rejects batch requests above the configured limit with a clear `400 Bad Request` response, while requests within the limit continue to work normally.

The default limit is 20 operations and can be adjusted through configuration when a project needs a different threshold.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://mg-limit-batch-query.odin.shopsys.cloud
  - https://cz.mg-limit-batch-query.odin.shopsys.cloud
  - https://mg-limit-batch-query.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1781702768.481089 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-limit-batch-query.odin.shopsys.cloud
  - https://cz.mg-limit-batch-query.odin.shopsys.cloud
  - https://mg-limit-batch-query.odin.shopsys.cloud/sk
<!-- Replace -->
