### PR TITLE
nginx: uploaded files now download as attachments

### DIFF
--- a/packages/framework/src/Component/FileUpload/Exception/MissingFileConfigByFileClassException.php
+++ b/packages/framework/src/Component/FileUpload/Exception/MissingFileConfigByFileClassException.php
@@ -6,7 +6,7 @@ namespace Shopsys\FrameworkBundle\Component\FileUpload\Exception;
 
 use Exception;
 
-class MissingFileClassDirectoryMappingException extends Exception
+class MissingFileConfigByFileClassException extends Exception
 {
     public function __construct(string $message = '', ?Exception $previous = null)
     {

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\FileUpload;
 
 use InvalidArgumentException;
+use League\Flysystem\Config;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
 use League\Flysystem\StorageAttributes;
+use League\Flysystem\Visibility;
 use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFile;
 use Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFileRepository;
 use Shopsys\FrameworkBundle\Component\Doctrine\Exception\UnexpectedTypeException;
-use Shopsys\FrameworkBundle\Component\FileUpload\Exception\MissingFileClassDirectoryMappingException;
+use Shopsys\FrameworkBundle\Component\FileUpload\Exception\MissingFileConfigByFileClassException;
 use Shopsys\FrameworkBundle\Component\FileUpload\Exception\MoveToEntityFailedException;
 use Shopsys\FrameworkBundle\Component\FileUpload\Exception\UploadFailedException;
 use Shopsys\FrameworkBundle\Component\Image\Image;
@@ -30,9 +32,15 @@ class FileUpload
     protected const int DELETE_OLD_FILES_SECONDS = 86400;
     protected const string POSITION_BY_ENTITY_AND_TYPE_CACHE_NAMESPACE = 'positionByEntityAndType';
 
+    /**
+     * @param array<class-string<\Shopsys\FrameworkBundle\Component\FileUpload\EntityFileUploadInterface>, array{
+     *      directory: non-empty-string,
+     *      visibility: 'public'|'private',
+     *  }> $filesConfigByFileClass
+     */
     public function __construct(
         protected readonly string $temporaryDir,
-        protected array $directoriesByFileClass,
+        protected array $filesConfigByFileClass,
         protected readonly FileNamingConvention $fileNamingConvention,
         protected readonly MountManager $mountManager,
         protected readonly FilesystemOperator $filesystem,
@@ -54,6 +62,9 @@ class FileUpload
         $this->mountManager->move(
             'local://' . $file->getRealPath(),
             'main://' . $this->getTemporaryDirectory() . '/' . $temporaryFilename,
+            [
+                Config::OPTION_VISIBILITY => Visibility::PRIVATE,
+            ],
         );
 
         return $temporaryFilename;
@@ -174,7 +185,13 @@ class FileUpload
                     $this->filesystem->delete($targetFilename);
                 }
 
-                $this->mountManager->move('main://' . $sourceFilepath, 'main://' . $targetFilename);
+                $this->mountManager->move(
+                    'main://' . $sourceFilepath,
+                    'main://' . $targetFilename,
+                    [
+                        Config::OPTION_VISIBILITY => $this->getVisibilityByFileClass($fileForUpload->getFileClass()),
+                    ],
+                );
                 $entity->setFileKeyAsUploaded($key);
             } catch (IOException $ex) {
                 $message = 'Failed to rename file from temporary directory to entity';
@@ -266,20 +283,36 @@ class FileUpload
         return $uploadEntityType;
     }
 
-    protected function getDirectoryByFileClass(string $fileClass): string
+    /**
+     * @return array{
+     *      directory: non-empty-string,
+     *      visibility: 'public'|'private',
+     *  }
+     */
+    protected function getFileConfigByFileClass(string $fileClass): array
     {
-        if (array_key_exists($fileClass, $this->directoriesByFileClass)) {
-            return $this->directoriesByFileClass[$fileClass];
+        if (array_key_exists($fileClass, $this->filesConfigByFileClass)) {
+            return $this->filesConfigByFileClass[$fileClass];
         }
 
-        foreach ($this->directoriesByFileClass as $class => $dir) {
+        foreach ($this->filesConfigByFileClass as $class => $config) {
             if (is_subclass_of($fileClass, $class)) {
-                return $dir;
+                return $config;
             }
         }
 
-        throw new MissingFileClassDirectoryMappingException(
-            sprintf('Missing directory mapping for file class "%s"', $fileClass),
+        throw new MissingFileConfigByFileClassException(
+            sprintf('Missing file config mapping for file class "%s"', $fileClass),
         );
+    }
+
+    protected function getDirectoryByFileClass(string $fileClass): string
+    {
+        return $this->getFileConfigByFileClass($fileClass)['directory'];
+    }
+
+    protected function getVisibilityByFileClass(string $fileClass): string
+    {
+        return $this->getFileConfigByFileClass($fileClass)['visibility'];
     }
 }

--- a/packages/framework/src/Component/PostDeploy/Task/SetCustomerUploadedFilesPrivateVisibilityTask.php
+++ b/packages/framework/src/Component/PostDeploy/Task/SetCustomerUploadedFilesPrivateVisibilityTask.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\PostDeploy\Task;
+
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Visibility;
+use Override;
+use Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFile;
+use Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFileLocator;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class SetCustomerUploadedFilesPrivateVisibilityTask implements PostDeployTaskInterface
+{
+    protected const int BATCH_SIZE = 100;
+
+    public function __construct(
+        protected readonly EntityManagerInterface $entityManager,
+        protected readonly FilesystemOperator $filesystem,
+        protected readonly CustomerUploadedFileLocator $customerUploadedFileLocator,
+    ) {
+    }
+
+    #[Override]
+    public function run(SymfonyStyle $style): void
+    {
+        $style->section('Customer uploaded files visibility');
+
+        $processedCount = $this->setCustomerUploadedFilesPrivateVisibility($style);
+
+        if ($processedCount === 0) {
+            $style->success('No customer uploaded files found.');
+
+            return;
+        }
+
+        $style->success(sprintf('Set private visibility for %d customer uploaded files.', $processedCount));
+    }
+
+    protected function setCustomerUploadedFilesPrivateVisibility(SymfonyStyle $style): int
+    {
+        $tableName = $this->getCustomerUploadedFilesTableName();
+        $totalCount = (int)$this->entityManager->getConnection()->fetchOne(
+            sprintf('SELECT COUNT(id) FROM %s', $tableName),
+        );
+
+        if ($totalCount === 0) {
+            return 0;
+        }
+
+        $style->progressStart($totalCount);
+
+        $processedCount = 0;
+        $lastProcessedId = 0;
+
+        while (true) {
+            $rows = $this->getCustomerUploadedFileRows($tableName, $lastProcessedId);
+
+            if ($rows === []) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $this->filesystem->setVisibility(
+                    $this->getCustomerUploadedFilepath($row),
+                    Visibility::PRIVATE,
+                );
+
+                $lastProcessedId = (int)$row['id'];
+                $processedCount++;
+                $style->progressAdvance();
+            }
+        }
+
+        $style->progressFinish();
+
+        return $processedCount;
+    }
+
+    protected function getCustomerUploadedFilesTableName(): string
+    {
+        return $this->entityManager->getClassMetadata(CustomerUploadedFile::class)->getTableName();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function getCustomerUploadedFileRows(string $tableName, int $lastProcessedId): array
+    {
+        return $this->entityManager->getConnection()->fetchAllAssociative(
+            sprintf(
+                'SELECT id, entity_name, extension FROM %s WHERE id > :lastProcessedId ORDER BY id ASC LIMIT %d',
+                $tableName,
+                static::BATCH_SIZE,
+            ),
+            ['lastProcessedId' => $lastProcessedId],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    protected function getCustomerUploadedFilepath(array $row): string
+    {
+        return $this->customerUploadedFileLocator->getAbsoluteFilePath(
+            sprintf('%s/%d.%s', (string)$row['entity_name'], (int)$row['id'], (string)$row['extension']),
+        );
+    }
+}

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskConfig;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskDescriptor;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskRunEnum;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\RecalculateFileSizesTask;
+use Shopsys\FrameworkBundle\Component\PostDeploy\Task\SetCustomerUploadedFilesPrivateVisibilityTask;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataProviderInterface;
 use Shopsys\FrameworkBundle\Model\Category\AutomatedFilter\CategoryAutomatedFilterInterface;
 use Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender\MailTemplateSenderInterface;
@@ -128,6 +129,11 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
                         'run' => PostDeployTaskRunEnum::ONE_TIME,
                         'priority' => 100,
                         'service' => RecalculateFileSizesTask::class,
+                    ],
+                    'set_customer_uploaded_files_private_visibility' => [
+                        'run' => PostDeployTaskRunEnum::ONE_TIME,
+                        'priority' => 90,
+                        'service' => SetCustomerUploadedFilesPrivateVisibilityTask::class,
                     ],
                 ],
             ],

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -297,10 +297,16 @@ services:
     Shopsys\FrameworkBundle\Component\FileUpload\FileUpload:
         arguments:
             $temporaryDir: '%shopsys.var_dir%'
-            $directoriesByFileClass:
-                Shopsys\FrameworkBundle\Component\Image\Image: '%shopsys.image_dir%'
-                Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile: '%shopsys.uploaded_file_dir%'
-                Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFile: '%shopsys.customer_uploaded_file_dir%'
+            $filesConfigByFileClass:
+                Shopsys\FrameworkBundle\Component\Image\Image:
+                    directory: '%shopsys.image_dir%'
+                    visibility: !php/const League\Flysystem\Visibility::PUBLIC
+                Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile:
+                    directory: '%shopsys.uploaded_file_dir%'
+                    visibility: !php/const League\Flysystem\Visibility::PUBLIC
+                Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFile:
+                    directory: '%shopsys.customer_uploaded_file_dir%'
+                    visibility: !php/const League\Flysystem\Visibility::PRIVATE
 
     Shopsys\FrameworkBundle\Component\Filesystem\MainFilesystemFactory:
         arguments:

--- a/packages/framework/tests/Unit/Component/Image/ImageFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Image/ImageFactoryTest.php
@@ -6,6 +6,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Image;
 
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
+use League\Flysystem\Visibility;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFileRepository;
@@ -73,7 +74,7 @@ class ImageFactoryTest extends TestCase
 
         return new FileUpload(
             'temporaryDir',
-            [Image::class => 'imageDir'],
+            [Image::class => ['directory' => 'imageDir', 'visibility' => Visibility::PUBLIC]],
             $fileNamingConvention,
             $mountManager,
             $abstractFilesystem,

--- a/packages/framework/tests/Unit/DependencyInjection/ShopsysFrameworkExtensionTest.php
+++ b/packages/framework/tests/Unit/DependencyInjection/ShopsysFrameworkExtensionTest.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskConfig;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskDescriptor;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskRunEnum;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\RecalculateFileSizesTask;
+use Shopsys\FrameworkBundle\Component\PostDeploy\Task\SetCustomerUploadedFilesPrivateVisibilityTask;
 use Shopsys\FrameworkBundle\DependencyInjection\Configuration;
 use Shopsys\FrameworkBundle\DependencyInjection\ShopsysFrameworkExtension;
 use Symfony\Component\Config\Definition\Processor;
@@ -83,9 +84,16 @@ class ShopsysFrameworkExtensionTest extends TestCase
             ->getDefinition(PostDeployTaskConfig::class)
             ->getArgument('$descriptors');
 
-        $this->assertCount(2, $descriptorDefinitions);
+        $this->assertCount(3, $descriptorDefinitions);
         $this->assertDescriptorDefinition($descriptorDefinitions[0], 'recalculate_file_sizes', PostDeployTaskRunEnum::ONE_TIME, 100, RecalculateFileSizesTask::class);
         $this->assertDescriptorDefinition($descriptorDefinitions[1], 'project_task', PostDeployTaskRunEnum::ALWAYS, 100, 'project_service');
+        $this->assertDescriptorDefinition(
+            $descriptorDefinitions[2],
+            'set_customer_uploaded_files_private_visibility',
+            PostDeployTaskRunEnum::ONE_TIME,
+            90,
+            SetCustomerUploadedFilesPrivateVisibilityTask::class,
+        );
     }
 
     private function assertDescriptorDefinition(

--- a/project-base/app/orchestration/kubernetes/configmap/nginx.yaml
+++ b/project-base/app/orchestration/kubernetes/configmap/nginx.yaml
@@ -73,6 +73,11 @@ data:
             ~^/_next/static/ "*";
         }
 
+        map $uri $uploaded_file_content_disposition {
+            default "";
+            ~^/(?:[^/]+/)?content(?:-test)?/uploadedFiles/ "attachment";
+        }
+
         server {
             listen 80;
             root /var/www/html/web;
@@ -139,6 +144,7 @@ data:
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "0" always;
             add_header Permissions-Policy "camera=(), geolocation=(self), microphone=(), payment=(), usb=()" always;
+            add_header Content-Disposition $uploaded_file_content_disposition always;
 
             set $request_host $http_host;
             if ($http_originalhost) {
@@ -275,6 +281,7 @@ data:
                 proxy_buffering         off;
                 proxy_hide_header       Access-Control-Allow-Origin;
                 proxy_hide_header       Access-Control-Allow-Credentials;
+                proxy_hide_header       Content-Disposition;
 
                 proxy_pass              {{S3_ENDPOINT}}/{{PROJECT_NAME}}/web$request_uri;
             }

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -25,6 +25,11 @@ map $request_uri $static_cors {
     ~^/_next/static/ "*";
 }
 
+map $uri $uploaded_file_content_disposition {
+    default "";
+    ~^/(?:[^/]+/)?content(?:-test)?/uploadedFiles/ "attachment";
+}
+
 server {
     listen 8081;
 
@@ -59,6 +64,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "0" always;
     add_header Permissions-Policy "camera=(), geolocation=(self), microphone=(), payment=(), usb=()" always;
+    add_header Content-Disposition $uploaded_file_content_disposition always;
 
     # define code to be used to redirect to the proper upstream
     error_page 470 = @app;

--- a/upgrade-notes/backend_20260618_095103.md
+++ b/upgrade-notes/backend_20260618_095103.md
@@ -1,0 +1,3 @@
+#### Force download uploaded files as attachments ([#4660](https://github.com/shopsys/shopsys/pull/4660))
+
+- see #project-base-diff to update your project

--- a/upgrade-notes/backend_20260618_095103.md
+++ b/upgrade-notes/backend_20260618_095103.md
@@ -1,3 +1,10 @@
-#### Force download uploaded files as attachments ([#4660](https://github.com/shopsys/shopsys/pull/4660))
+#### nginx: uploaded files now download as attachments ([#4660](https://github.com/shopsys/shopsys/pull/4660))
 
+- if your project overrides the `Shopsys\FrameworkBundle\Component\FileUpload\FileUpload` service argument or registers custom file classes, replace `$directoriesByFileClass` with `$filesConfigByFileClass`
+    - each file class config now requires `directory` and `visibility` keys
+    - use `League\Flysystem\Visibility::PUBLIC` for `Shopsys\FrameworkBundle\Component\Image\Image` and `Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile`
+    - use `League\Flysystem\Visibility::PRIVATE` for `Shopsys\FrameworkBundle\Component\CustomerUploadedFile\CustomerUploadedFile`
+- if your custom file class uses `League\Flysystem\Visibility::PRIVATE`, add a one-time post-deploy task based on `Shopsys\FrameworkBundle\Component\PostDeploy\Task\SetCustomerUploadedFilesPrivateVisibilityTask` to update the visibility of its existing files
+- if you instantiate `Shopsys\FrameworkBundle\Component\FileUpload\FileUpload` manually, update the second constructor argument to the new `$filesConfigByFileClass` shape
+- replace references to `Shopsys\FrameworkBundle\Component\FileUpload\Exception\MissingFileClassDirectoryMappingException` with `Shopsys\FrameworkBundle\Component\FileUpload\Exception\MissingFileConfigByFileClassException`
 - see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Uploaded files served from `/content/uploadedFiles/` are now delivered as downloadable attachments instead of being rendered directly in the browser.

This prevents uploaded HTML or SVG files from executing active content when someone opens the raw uploaded-file URL. Legitimate file access remains available, but browsers are instructed to download these files consistently in both Docker and Kubernetes nginx configurations.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)






















----
:globe_with_meridians: Live Preview:
  - https://mg-svg-attachment.odin.shopsys.cloud
  - https://cz.mg-svg-attachment.odin.shopsys.cloud
  - https://mg-svg-attachment.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1784731221.861989 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-svg-attachment.odin.shopsys.cloud
  - https://cz.mg-svg-attachment.odin.shopsys.cloud
  - https://mg-svg-attachment.odin.shopsys.cloud/sk
<!-- Replace -->
