### PR TITLE
Fix trusted proxies configuration

### DIFF
--- a/project-base/app/config/packages/framework.yaml
+++ b/project-base/app/config/packages/framework.yaml
@@ -25,6 +25,6 @@ framework:
         handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
         storage_factory_id: session.storage.factory.native
     trusted_hosts: ~
-    trusted_proxies: '%env(TRUSTED_PROXIES)%)'
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
     validation:
         enable_attributes: true

--- a/upgrade-notes/backend_20260618_165258.md
+++ b/upgrade-notes/backend_20260618_165258.md
@@ -1,0 +1,3 @@
+#### Fix trusted proxies configuration ([#4663](https://github.com/shopsys/shopsys/pull/4663))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Trusted proxy configuration did not use the `TRUSTED_PROXIES` environment value correctly because the env placeholder contained an extra closing parenthesis. Symfony therefore treated the configured proxy address as a different value and ignored forwarded headers from the actual reverse proxy.

This PR restores correct trusted proxy matching. As a result, the application can again detect the real client IP and HTTPS scheme behind the configured proxy, which is important for IP-based rate limiting, absolute URL generation, and secure-cookie decisions.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://mg-trusted-proxies.odin.shopsys.cloud
  - https://cz.mg-trusted-proxies.odin.shopsys.cloud
  - https://mg-trusted-proxies.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782112810.924079 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-trusted-proxies.odin.shopsys.cloud
  - https://cz.mg-trusted-proxies.odin.shopsys.cloud
  - https://mg-trusted-proxies.odin.shopsys.cloud/sk
<!-- Replace -->
