### PR TITLE
Limit GraphQL query depth

### DIFF
--- a/project-base/app/config/packages/overblog_graphql.yaml
+++ b/project-base/app/config/packages/overblog_graphql.yaml
@@ -25,6 +25,7 @@ overblog_graphql:
         enable_introspection: '%kernel.debug%'
         handle_cors: false
         query_max_complexity: 1110
+        query_max_depth: 15
     services:
         promise_adapter: "webonyx_graphql.sync_promise_adapter"
 

--- a/upgrade-notes/backend_20260618_174150.md
+++ b/upgrade-notes/backend_20260618_174150.md
@@ -1,0 +1,3 @@
+#### Limit GraphQL query depth ([#4664](https://github.com/shopsys/shopsys/pull/4664))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Frontend API already limited GraphQL query complexity, but it did not limit query depth. Recursive fields such as category children could still be nested very deeply and accepted by validation as long as their calculated complexity stayed under the configured threshold.

This PR adds a maximum GraphQL query depth of 15. Deep recursive queries are now rejected during GraphQL validation before execution, while normal storefront queries remain covered by the existing complexity guard.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-query-max-depth.odin.shopsys.cloud
  - https://cz.mg-query-max-depth.odin.shopsys.cloud
  - https://mg-query-max-depth.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782117696.861999 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-query-max-depth.odin.shopsys.cloud
  - https://cz.mg-query-max-depth.odin.shopsys.cloud
  - https://mg-query-max-depth.odin.shopsys.cloud/sk
<!-- Replace -->
