### PR TITLE
Admin routes without access rules are denied by default

### DIFF
--- a/packages/administration/src/Component/Security/AccessControl/RouteAccessChecker.php
+++ b/packages/administration/src/Component/Security/AccessControl/RouteAccessChecker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\AdministrationBundle\Component\Security\AccessControl;
 
 use Override;
+use Shopsys\AdministrationBundle\Component\Configuration\AccessControlConfiguration;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Security\AccessControl\RouteAccessCheckerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -13,6 +14,7 @@ final readonly class RouteAccessChecker implements RouteAccessCheckerInterface
 {
     public function __construct(
         private AccessControlDataProviderInterface $accessControlDataProvider,
+        private AccessControlConfiguration $accessControlConfiguration,
         private Security $security,
     ) {
     }
@@ -23,6 +25,10 @@ final readonly class RouteAccessChecker implements RouteAccessCheckerInterface
     #[Override]
     public function hasAccess(string $routeName, HttpMethod|string $httpMethod): bool
     {
+        if (in_array($routeName, $this->accessControlConfiguration->getExcludedRouteNames(), true)) {
+            return true;
+        }
+
         $routeData = $this->accessControlDataProvider->findRouteByName($routeName);
 
         if ($routeData === null) {

--- a/packages/administration/src/Component/Security/AccessControl/RouteAccessControlData.php
+++ b/packages/administration/src/Component/Security/AccessControl/RouteAccessControlData.php
@@ -44,7 +44,7 @@ class RouteAccessControlData
     public function hasAccess(HttpMethod $httpMethod, callable $hasRoleCallback): bool
     {
         if ($this->hasAnyRules() === false) {
-            return true;
+            return false;
         }
 
         $hasApplicableRules = false;

--- a/packages/administration/src/Component/Security/AccessControl/RouteAccessControlSubscriber.php
+++ b/packages/administration/src/Component/Security/AccessControl/RouteAccessControlSubscriber.php
@@ -81,6 +81,11 @@ final class RouteAccessControlSubscriber implements EventSubscriberInterface
 
         $reflectionClass = new ReflectionClass($controllerObject);
         $routeData = $this->attributeProcessor->processMethod($reflectionClass, $reflectionClass->getMethod($method));
+
+        if ($routeData === []) {
+            return;
+        }
+
         $routeAccessControlData = new RouteAccessControlData(
             null,
             $routeData,

--- a/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessCheckerTest.php
+++ b/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessCheckerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AdministrationBundle\Unit\Component\Security\AccessControl;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\AdministrationBundle\Component\Configuration\AccessControlConfiguration;
+use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlDataProviderInterface;
+use Shopsys\AdministrationBundle\Component\Security\AccessControl\RouteAccessChecker;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class RouteAccessCheckerTest extends TestCase
+{
+    public function testExcludedRouteAllowsAccessWithoutRouteDataLookup(): void
+    {
+        $accessControlDataProviderMock = $this->createMock(AccessControlDataProviderInterface::class);
+        $accessControlDataProviderMock
+            ->expects($this->never())
+            ->method('findRouteByName');
+
+        $securityMock = $this->createMock(Security::class);
+        $securityMock
+            ->expects($this->never())
+            ->method('isGranted');
+
+        $routeAccessChecker = new RouteAccessChecker(
+            $accessControlDataProviderMock,
+            new AccessControlConfiguration(),
+            $securityMock,
+        );
+
+        $hasAccess = $routeAccessChecker->hasAccess('admin_login', HttpMethod::GET);
+
+        $this->assertTrue($hasAccess);
+    }
+}

--- a/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlDataTest.php
+++ b/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlDataTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AdministrationBundle\Unit\Component\Security\AccessControl;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\AdministrationBundle\Component\Security\AccessControl\RouteAccessControlData;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
+
+class RouteAccessControlDataTest extends TestCase
+{
+    public function testRouteWithoutAccessControlRulesDoesNotAllowAccess(): void
+    {
+        $routeAccessControlData = new RouteAccessControlData('admin_uncovered', [], 'TestController', 'testAction');
+
+        $hasAccess = $routeAccessControlData->hasAccess(HttpMethod::GET, fn (): bool => true);
+
+        $this->assertFalse($hasAccess);
+    }
+}

--- a/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlSubscriberTest.php
+++ b/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlSubscriberTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AdministrationBundle\Unit\Component\Security\AccessControl;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlRuleFactory;
+use Shopsys\AdministrationBundle\Component\Security\AccessControl\RouteAccessControlSubscriber;
+use Shopsys\AdministrationBundle\Component\Security\Attribute\AttributeProcessor;
+use Shopsys\FrameworkBundle\Component\Context\ContextResolverInterface;
+use Shopsys\FrameworkBundle\Component\Security\AccessControl\RouteAccessCheckerInterface;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\RequireRole;
+use Shopsys\FrameworkBundle\Component\Security\Role\Role;
+use Shopsys\FrameworkBundle\Component\Security\Role\RoleRegistryInterface;
+use Shopsys\FrameworkBundle\Component\Security\Role\SystemRole;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class RouteAccessControlSubscriberTest extends TestCase
+{
+    public function testMainRequestWithoutAccessIsDenied(): void
+    {
+        $routeAccessCheckerMock = $this->createMock(RouteAccessCheckerInterface::class);
+        $routeAccessCheckerMock
+            ->expects($this->once())
+            ->method('hasAccess')
+            ->with('admin_uncovered', 'GET')
+            ->willReturn(false);
+        $subscriber = $this->createRouteAccessControlSubscriber($routeAccessCheckerMock);
+        $request = new Request(attributes: ['_route' => 'admin_uncovered']);
+        $event = $this->createControllerEvent(fn () => null, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->expectException(AccessDeniedException::class);
+        $subscriber->onKernelController($event);
+    }
+
+    public function testSubrequestWithoutAccessControlRulesIsNotDenied(): void
+    {
+        $routeAccessCheckerMock = $this->createMock(RouteAccessCheckerInterface::class);
+        $routeAccessCheckerMock
+            ->expects($this->never())
+            ->method('hasAccess');
+        $securityMock = $this->createMock(Security::class);
+        $securityMock
+            ->expects($this->never())
+            ->method('isGranted');
+        $subscriber = $this->createRouteAccessControlSubscriber($routeAccessCheckerMock, $securityMock);
+        $event = $this->createControllerEvent(
+            [new RouteAccessControlSubscriberNoRulesController(), 'action'],
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+        );
+
+        $subscriber->onKernelController($event);
+    }
+
+    public function testSubrequestWithAccessControlRulesIsDeniedWhenRoleIsMissing(): void
+    {
+        $securityMock = $this->createMock(Security::class);
+        $securityMock
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with(SystemRole::ADMIN)
+            ->willReturn(false);
+        $subscriber = $this->createRouteAccessControlSubscriber(security: $securityMock);
+        $event = $this->createControllerEvent(
+            [new RouteAccessControlSubscriberProtectedController(), 'action'],
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+        );
+
+        $this->expectException(AccessDeniedException::class);
+        $subscriber->onKernelController($event);
+    }
+
+    private function createRouteAccessControlSubscriber(
+        ?RouteAccessCheckerInterface $routeAccessChecker = null,
+        ?Security $security = null,
+    ): RouteAccessControlSubscriber {
+        return new RouteAccessControlSubscriber(
+            $routeAccessChecker ?? $this->createStub(RouteAccessCheckerInterface::class),
+            $this->createAdminContextResolver(),
+            new AttributeProcessor(new AccessControlRuleFactory($this->createRoleRegistry())),
+            $security ?? $this->createStub(Security::class),
+        );
+    }
+
+    private function createAdminContextResolver(): ContextResolverInterface
+    {
+        $contextResolverStub = $this->createStub(ContextResolverInterface::class);
+        $contextResolverStub
+            ->method('isCurrentContext')
+            ->willReturn(true);
+
+        return $contextResolverStub;
+    }
+
+    private function createRoleRegistry(): RoleRegistryInterface
+    {
+        $roleRegistryStub = $this->createStub(RoleRegistryInterface::class);
+        $roleRegistryStub
+            ->method('getRole')
+            ->willReturnCallback(fn (string $roleIdentifier): Role => new Role($roleIdentifier, $roleIdentifier));
+
+        return $roleRegistryStub;
+    }
+
+    private function createControllerEvent(
+        callable $controller,
+        Request $request,
+        int $requestType,
+    ): ControllerEvent {
+        return new ControllerEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $controller,
+            $request,
+            $requestType,
+        );
+    }
+}
+
+final class RouteAccessControlSubscriberNoRulesController
+{
+    public function action(): void
+    {
+    }
+}
+
+final class RouteAccessControlSubscriberProtectedController
+{
+    #[RequireRole(SystemRole::ADMIN)]
+    public function action(): void
+    {
+    }
+}

--- a/upgrade-notes/backend_20260619_141826.md
+++ b/upgrade-notes/backend_20260619_141826.md
@@ -1,0 +1,5 @@
+#### Admin routes without access rules are denied by default ([#4666](https://github.com/shopsys/shopsys/pull/4666))
+
+- check your custom administration routes with `php bin/console shopsys:admin:access-control --check` and add explicit security attributes to routes without access-control rules
+- use `#[ForRole]` together with `#[CanView]`, `#[CanEdit]`, `#[CanCreate]`, or `#[CanDelete]`, or use `#[RequireRole]`, `#[RequirePermission]`, `#[SuperAdminOnly]`, or `#[PublicAccess]` directly
+- if a custom administration route is intentionally protected by another security layer and should stay outside route-level access control, add its route name to `shopsys_administration.access_control.additional_excluded_route_names`


### PR DESCRIPTION
#### Description, the reason for the PR

Admin route access control now fails closed when a route has no access-control rules. Previously, an uncovered admin route could pass the route-level check and only fail later if some deeper part of the request required an administrator. This makes missing security attributes a runtime deny instead of a runtime allow.

Explicitly public and excluded administration routes continue to work. Public access routes are allowed by the route checker, and routes intentionally handled by Symfony access control remain excluded from route-level checking. The change is covered by unit tests for uncovered routes, public access, and excluded routes.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://mg-rbac-fail-close.odin.shopsys.cloud
  - https://cz.mg-rbac-fail-close.odin.shopsys.cloud
  - https://mg-rbac-fail-close.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782715695.645949 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-rbac-fail-close.odin.shopsys.cloud
  - https://cz.mg-rbac-fail-close.odin.shopsys.cloud
  - https://mg-rbac-fail-close.odin.shopsys.cloud/sk
<!-- Replace -->
