### PR TITLE
Add make targets to switch the whole application between dev and production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help: ## Displays list of available commands
 	run-specific-test-regression run-specific-test-base \
 	open-acceptance-tests-base open-acceptance-tests-regression run-smoke-tests \
 	generate-snapshots-info-table prepare-data-for-acceptance-tests cypress-prepare cypress-cleanup \
-	check-licenses
+	check-licenses environment-prod environment-dev
 
 # ------------------------------------------------------------------------------
 # 🐳 Docker Compose (macOS with Mutagen)
@@ -67,6 +67,33 @@ generate-schema-native: ## Generates GraphQL schema and frontend types (natively
 	find project-base/storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;
 	cd project-base/storefront; pnpm run gql
 	rm -rf project-base/storefront/schema.graphql
+
+# ------------------------------------------------------------------------------
+# 🔁 Switching application environment (backend + storefront)
+# ------------------------------------------------------------------------------
+
+# Switches the whole application to the given environment.
+# $(1) = backend environment passed to phing (dev|prod)
+# $(2) = storefront run command (dev|build)
+# The storefront run command lives in the STOREFRONT_RUN_COMMAND env variable in docker-compose.yml
+# (read by the storefront entrypoint). The target rewrites that value and recreates the container to apply it.
+define switch_environment
+	@echo "🔁 Switching whole application to '$(1)' environment..."
+	@echo "🐘 Switching backend..."
+	docker compose exec php-fpm php phing -D production.confirm.action=y -D change.environment=$(1) environment-change
+	@echo "🛍️  Setting STOREFRONT_RUN_COMMAND=$(2) in docker-compose.yml and recreating the storefront container..."
+	sed -i.bak -E 's@^([[:space:]]*- STOREFRONT_RUN_COMMAND=)(dev|build)[[:space:]]*$$@\1$(2)@' docker-compose.yml && rm -f docker-compose.yml.bak
+	@grep -qE '^[[:space:]]*- STOREFRONT_RUN_COMMAND=$(2)$$' docker-compose.yml || { echo "❌ Failed to set STOREFRONT_RUN_COMMAND=$(2) in docker-compose.yml"; exit 1; }
+	docker compose up -d --force-recreate storefront
+	@echo "✅ Application switched to '$(1)' environment (storefront running '$(2)')."
+	@if [ "$(2)" = "build" ]; then echo "ℹ️  Storefront is building the production bundle in the background; follow it with 'docker compose logs -f storefront'."; fi
+endef
+
+environment-prod: ## Switches the whole application (backend + storefront) to the production environment
+	$(call switch_environment,prod,build)
+
+environment-dev: ## Switches the whole application (backend + storefront) to the development environment
+	$(call switch_environment,dev,dev)
 
 # ------------------------------------------------------------------------------
 # ✅ Code Checks and Fixes (PHP and JS/TS)

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -48,8 +48,9 @@ services:
             dockerfile: ./docker/dev.Dockerfile
             target: development
         container_name: shopsys-framework-storefront
-        command: # Optional
-            - dev # change to `- build` if you want to test application build
+        environment:
+            # toggled by `make environment-dev` / `make environment-prod`; recreate the container to apply (dev = dev server, build = production build)
+            - STOREFRONT_RUN_COMMAND=dev
         volumes:
             - storefront:/home/node/app
         ports:

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -50,8 +50,9 @@ services:
             args:
                 node_uid: 1000
         container_name: shopsys-framework-storefront
-        command: # Optional
-            - dev # change to `- build` if you want to test application build
+        environment:
+            # toggled by `make environment-dev` / `make environment-prod`; recreate the container to apply (dev = dev server, build = production build)
+            - STOREFRONT_RUN_COMMAND=dev
         volumes:
             - ./project-base/storefront:/home/node/app
         ports:

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -25,7 +25,7 @@ help: ## Displays list of available commands
 	run-specific-test-regression run-specific-test-base \
 	open-acceptance-tests-base open-acceptance-tests-regression run-smoke-tests \
 	generate-snapshots-info-table prepare-data-for-acceptance-tests cypress-prepare cypress-cleanup \
-	check-licenses
+	check-licenses environment-prod environment-dev
 
 # ------------------------------------------------------------------------------
 # 🐳 Docker Compose (macOS with Mutagen)
@@ -67,6 +67,33 @@ generate-schema-native: ## Generates GraphQL schema and frontend types (natively
 	find storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;
 	cd storefront; pnpm run gql
 	rm -rf storefront/schema.graphql
+
+# ------------------------------------------------------------------------------
+# 🔁 Switching application environment (backend + storefront)
+# ------------------------------------------------------------------------------
+
+# Switches the whole application to the given environment.
+# $(1) = backend environment passed to phing (dev|prod)
+# $(2) = storefront run command (dev|build)
+# The storefront run command lives in the STOREFRONT_RUN_COMMAND env variable in docker-compose.yml
+# (read by the storefront entrypoint). The target rewrites that value and recreates the container to apply it.
+define switch_environment
+	@echo "🔁 Switching whole application to '$(1)' environment..."
+	@echo "🐘 Switching backend..."
+	docker compose exec php-fpm php phing -D production.confirm.action=y -D change.environment=$(1) environment-change
+	@echo "🛍️  Setting STOREFRONT_RUN_COMMAND=$(2) in docker-compose.yml and recreating the storefront container..."
+	sed -i.bak -E 's@^([[:space:]]*- STOREFRONT_RUN_COMMAND=)(dev|build)[[:space:]]*$$@\1$(2)@' docker-compose.yml && rm -f docker-compose.yml.bak
+	@grep -qE '^[[:space:]]*- STOREFRONT_RUN_COMMAND=$(2)$$' docker-compose.yml || { echo "❌ Failed to set STOREFRONT_RUN_COMMAND=$(2) in docker-compose.yml"; exit 1; }
+	docker compose up -d --force-recreate storefront
+	@echo "✅ Application switched to '$(1)' environment (storefront running '$(2)')."
+	@if [ "$(2)" = "build" ]; then echo "ℹ️  Storefront is building the production bundle in the background; follow it with 'docker compose logs -f storefront'."; fi
+endef
+
+environment-prod: ## Switches the whole application (backend + storefront) to the production environment
+	$(call switch_environment,prod,build)
+
+environment-dev: ## Switches the whole application (backend + storefront) to the development environment
+	$(call switch_environment,dev,dev)
 
 # ------------------------------------------------------------------------------
 # ✅ Code Checks and Fixes (PHP and JS/TS)

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -51,8 +51,9 @@ services:
             dockerfile: ./docker/dev.Dockerfile
             target: development
         container_name: shopsys-framework-storefront
-        command: # Optional
-            - dev # change to `- build` if you want to test application build
+        environment:
+            # toggled by `make environment-dev` / `make environment-prod`; recreate the container to apply (dev = dev server, build = production build)
+            - STOREFRONT_RUN_COMMAND=dev
         volumes:
             - storefront:/home/node/app
         ports:

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -53,8 +53,9 @@ services:
             args:
                 node_uid: 1000
         container_name: shopsys-framework-storefront
-        command: # Optional
-            - dev # change to `- build` if you want to test application build
+        environment:
+            # toggled by `make environment-dev` / `make environment-prod`; recreate the container to apply (dev = dev server, build = production build)
+            - STOREFRONT_RUN_COMMAND=dev
         volumes:
             - ./storefront:/home/node/app
         ports:

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -20,6 +20,5 @@ ENV APP_ENV=development
 ENV NEXT_TELEMETRY_DISABLED=1
 
 COPY docker/entrypoint.sh /
+# entrypoint.sh selects the run command (dev|build) from the STOREFRONT_RUN_COMMAND env variable (set in docker-compose.yml), defaulting to `dev`.
 ENTRYPOINT ["/entrypoint.sh"]
-
-CMD ["dev"]

--- a/project-base/storefront/docker/entrypoint.sh
+++ b/project-base/storefront/docker/entrypoint.sh
@@ -19,7 +19,12 @@ install_with_retry() {
   done
 }
 
-case "$1" in
+# The run command is taken from the STOREFRONT_RUN_COMMAND env variable (set in docker-compose.yml
+# and toggled by `make environment-dev` / `make environment-prod`), falling back to the container
+# command argument and then to `dev`.
+RUN_COMMAND="${STOREFRONT_RUN_COMMAND:-${1:-dev}}"
+
+case "$RUN_COMMAND" in
   "dev")
     install_with_retry
     exec pnpm run dev ;;

--- a/upgrade-notes/backend_20260620_155902.md
+++ b/upgrade-notes/backend_20260620_155902.md
@@ -1,0 +1,4 @@
+#### Add make targets to switch the whole application between dev and production ([#4667](https://github.com/shopsys/shopsys/pull/4667))
+
+- update your local `docker-compose` file from the corresponding `dist` file
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Switching the whole application between development and production used to be a two-part, partly manual chore: on the backend we have `phing environment-change`, but the storefront had to be switched by hand — editing its run command in `docker-compose.yml` from `dev` to `build` and recreating the container.

This PR adds two make targets that handle both sides in a single command (available both in the monorepo `Makefile` and in `project-base/Makefile`):

- `make environment-prod` — switches the backend to `prod` (via `phing environment-change`) and recreates the storefront container running `build` (production build: `next build` + `next start`)
- `make environment-dev` — switches everything back to development (storefront running `next dev`)

How the storefront switch works: the storefront run command is now driven by a `STOREFRONT_RUN_COMMAND` environment variable in the (gitignored, generated) `docker-compose.yml`, read by the storefront entrypoint (defaulting to `dev`). The make target rewrites that value between `dev` and `build` and recreates the container to apply it. A self-documenting comment is added to all `docker-compose*.yml.dist` templates so freshly generated compose files work out of the box.

> Note: after `make environment-prod` the container comes up while `next build` runs in the background, so the storefront is served only once the build finishes (`docker compose logs -f storefront`).

#### Fixes issues

<!-- none -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)













----
:globe_with_meridians: Live Preview:
  - https://rv-switch-app-env.odin.shopsys.cloud
  - https://cz.rv-switch-app-env.odin.shopsys.cloud
  - https://rv-switch-app-env.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782386123.424459 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-switch-app-env.odin.shopsys.cloud
  - https://cz.rv-switch-app-env.odin.shopsys.cloud
  - https://rv-switch-app-env.odin.shopsys.cloud/sk
<!-- Replace -->
