### PR TITLE
Fix Biome checks for backend SCSS

### DIFF
--- a/packages/administration/assets/src/styles/custom.scss
+++ b/packages/administration/assets/src/styles/custom.scss
@@ -11,6 +11,7 @@
         overflow: hidden;
 
         @include media-breakpoint-up(xl) {
+            /* biome-ignore lint/suspicious/noDuplicateProperties: breakpoint override intentionally redefines the base declaration */
             flex-basis: auto;
         }
     }
@@ -19,6 +20,7 @@
         width: 100%;
 
         @include media-breakpoint-up(sm) {
+            /* biome-ignore lint/suspicious/noDuplicateProperties: breakpoint override intentionally redefines the base declaration */
             width: auto;
         }
     }
@@ -28,6 +30,7 @@
         justify-content: space-between;
 
         @include media-breakpoint-up(sm) {
+            /* biome-ignore lint/suspicious/noDuplicateProperties: breakpoint override intentionally redefines the base declaration */
             width: auto;
         }
     }
@@ -49,6 +52,7 @@
     margin-bottom: 10vh !important;
 
     @include media-breakpoint-up(xl) {
+        /* biome-ignore lint/suspicious/noDuplicateProperties: breakpoint override intentionally redefines the base declaration */
         margin-bottom: 20vh !important;
     }
 
@@ -82,7 +86,7 @@
 }
 
 .link-disabled {
-    opacity: .4;
+    opacity: 0.4;
     cursor: not-allowed;
     pointer-events: auto;
 }

--- a/packages/administration/assets/src/styles/mailer-info.scss
+++ b/packages/administration/assets/src/styles/mailer-info.scss
@@ -3,6 +3,6 @@
     --tblr-alert-bg: color-mix(in srgb, var(--tblr-alert-color) 25%, transparent);
     --tblr-alert-border-color: color-mix(in srgb, var(--tblr-alert-color) 20%, transparent);
 
-    background-color: color-mix(in srgb,var(--tblr-alert-bg),var(--tblr-bg-surface));
+    background-color: color-mix(in srgb, var(--tblr-alert-bg), var(--tblr-bg-surface));
     border: var(--tblr-border-width) var(--tblr-border-style) var(--tblr-alert-border-color);
 }

--- a/packages/administration/assets/src/styles/role-grid.scss
+++ b/packages/administration/assets/src/styles/role-grid.scss
@@ -2,7 +2,7 @@
     visibility: hidden;
     opacity: 0;
     pointer-events: none;
-    transition: opacity .15s ease-in-out;
+    transition: opacity 0.15s ease-in-out;
 
     tr:hover & {
         visibility: visible;

--- a/packages/administration/assets/src/styles/sidebar.scss
+++ b/packages/administration/assets/src/styles/sidebar.scss
@@ -1,6 +1,6 @@
 $sidebar-width: 18rem;
 
-$sidebar-bg: linear-gradient(90deg, #1A2342 0%, #243056 100%);
+$sidebar-bg: linear-gradient(90deg, #1a2342 0%, #243056 100%);
 $sidebar-fg: #f9fafb;
 $sidebar-hover-bg: rgba($sidebar-fg, 0.1);
 $sidebar-active-bg: rgba(0, 0, 0, 0.25);

--- a/packages/biome-config/index.json
+++ b/packages/biome-config/index.json
@@ -14,12 +14,14 @@
         "rules": {
             "recommended": true,
             "style": {
+                "noDescendingSpecificity": "off",
                 "noParameterAssign": "off",
                 "useConst": "error",
                 "useTemplate": "error"
             },
             "complexity": {
                 "noForEach": "off",
+                "noImportantStyles": "off",
                 "noStaticOnlyClass": "off",
                 "noThisInStatic": "off"
             },
@@ -40,6 +42,11 @@
             "bracketSpacing": true,
             "bracketSameLine": false,
             "quoteProperties": "asNeeded"
+        }
+    },
+    "css": {
+        "formatter": {
+            "quoteStyle": "single"
         }
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

The backend asset standards checks now support the updated Biome behavior for SCSS files through the shared Biome configuration.

Biome continues formatting backend styles and keeps useful SCSS linting enabled, while known legacy override patterns are handled explicitly. This restores the coding standards checks after the Biome upgrade without changing the intended styling.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4153-fix-biome-upgrade-issues.odin.shopsys.cloud
  - https://cz.tc-ssp-4153-fix-biome-upgrade-issues.odin.shopsys.cloud
  - https://tc-ssp-4153-fix-biome-upgrade-issues.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782214669.652379 -->