### PR TITLE
Unify CRUD page titles and add datagrid drag-and-drop reordering

### DIFF
--- a/docs/administration/crud-controller/getting-started/creating-a-new-crud-controller.md
+++ b/docs/administration/crud-controller/getting-started/creating-a-new-crud-controller.md
@@ -39,7 +39,7 @@ use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 public function configure(CrudConfig $config): void
 {
     $config
-        ->setTitle(ActionType::LIST, t('Orders management')) // Set the custom title of the list page
+        ->setEntityNamePlural(t('Orders')) // Override the auto-derived plural entity name (used in the list title and menu)
         ->setMenuSection('customers') // Set the menu section where the controller will be placed
     ;
 }

--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -46,7 +46,8 @@ Configure general behavior of the controller. Customizable options are available
 protected function configure(CrudConfig $config): void
 {
     $config
-        ->setTitle(ActionType::LIST, t('All products'))
+        ->setEntityNameSingular(t('Product'))
+        ->setEntityNamePlural(t('Products'))
         ->setMenuTitle(t('Products management'))
         ->setMenuSection('products');
 }
@@ -143,21 +144,35 @@ protected function configureForm(CrudFormConfigurator $formConfigurator, ?object
 
 The `CrudConfig` class is used to configure the behavior of the Crud Controller. It is used in the `configure` method of the Crud Controller.
 
-### Default titles
+### Titles, breadcrumbs and pretitle
 
-Page titles and the menu label are generated automatically from the entity class name using English singular/plural inflection. For example, entity `OrderItem` produces menu title "Order items", etc.
+All page labels are derived from a single source — the **singular** and **plural** entity name — which are generated automatically from the entity class name using English singular/plural inflection. For example, entity `OrderItem` produces singular "Order item" and plural "Order items". These generated names are registered as translation keys automatically — no manual `t()` wrapping is needed for defaults.
 
-These generated names are registered as translation keys automatically — no manual `t()` wrapping is needed for defaults.
+The action and the entity name are never concatenated into a single declined phrase (such as "Editing Order item"), because that is grammatically broken in inflected languages (e.g. Czech "Editace Sklad"). Instead each label keeps the entity name in the nominative case and conveys the action separately:
+
+| Page   | Pretitle (above the heading) | Heading & browser tab title    | Breadcrumb                            |
+|--------|------------------------------|--------------------------------|---------------------------------------|
+| list   | `Overview`                   | plural (e.g. "Orders")         | plural (menu label)                   |
+| create | `New record`                 | singular (e.g. "Order")        | `New record`                          |
+| edit   | `Editing`                    | singular `·` record name       | `Editing a record - {record name}`    |
+| detail | `Detail`                     | singular `·` record name       | `Record detail - {record name}`       |
+
+- The **pretitle** is a static, action-specific label rendered in the page templates.
+- The **heading** (and browser tab title) is the entity name; for edit/detail the concrete record's human-readable name is appended after a `·` separator.
+- The **breadcrumb** uses a generic, entity-independent phrase (using the word "record") so it stays grammatically correct; for edit/detail it is overridden at runtime with the record name.
+
+For the record name to be shown, the entity returned by the handler's `getById()` must implement [`Presentable`]({{github.link}}/packages/framework/src/Component/Utils/Presentable.php) (`toHumanReadable()`); this is required by the `ReadHandlerInterface` contract.
 
 ### Methods
 
-#### `setTitle(ActionType $actionType, string $title)`
+#### `setEntityNameSingular(string $entityNameSingular)` and `setEntityNamePlural(string $entityNamePlural)`
 
-Sets a custom title for a specific page type. The title is displayed in the page header. Overrides the auto-generated default for the given action.
+Override the automatically derived singular/plural entity name. Wrap the value in `t()` so it gets picked up for translation. Set these only when the automatic English inflection is wrong (e.g. irregular plurals) or you want a different label than the entity class name.
 
 ```php
-$config->setTitle(ActionType::LIST, t('All orders'));
-$config->setTitle(ActionType::CREATE, t('New order'));
+$config
+    ->setEntityNameSingular(t('Order'))
+    ->setEntityNamePlural(t('Orders'));
 ```
 
 #### `setMenuTitle(string $menuTitle)`

--- a/docs/administration/datagrid/configuration.md
+++ b/docs/administration/datagrid/configuration.md
@@ -17,7 +17,7 @@ All methods are chainable, so you can call them one after another.
 
 ```php
 // ...
-use Shopsys\AdministrationBundle\Component\Action\RowAction
+use Shopsys\AdministrationBundle\Component\Action\RowAction;
 
 //...
 
@@ -51,6 +51,32 @@ $datagrid->remove('name');
 $actions = $datagrid->rowActions();
 
 ```
+
+## Drag-and-drop ordering
+
+If the listed entity has a position that the user should be able to change by dragging rows, enable drag-and-drop ordering with `enableDragAndDrop()`. Pass the name of the field the listing is ordered by (typically the position field):
+
+```php
+// The ordering field has to be defined; it can be hidden if you do not want to display it
+$datagrid->add('position', [
+    'visible' => false,
+]);
+
+// Orders ascending by default
+$datagrid->enableDragAndDrop('position');
+
+// Drag-and-drop can be turned off again (e.g. in an extension)
+$datagrid->disableDragAndDrop();
+```
+
+Requirements and behavior:
+
+- the ordering field must be defined via `add()` beforehand, otherwise an exception is thrown,
+- the managed entity must implement `Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface` (its `setPosition()` is used to persist the new order),
+- the adapter must be entity-class-aware (e.g. the default ORM adapter); array-backed datagrids are not supported,
+- the listing is always ordered by the given field, so a manual `setDefaultOrder()` cannot be combined with drag-and-drop (and removing the ordering field is blocked until `disableDragAndDrop()` is called),
+- ordering by any other column is disabled and pagination is turned off, so the whole list can be reordered at once,
+- saving the new order is handled automatically; it is available only to administrators with the edit permission.
 
 More information about configuration-specific sections can be found in the following sections:
 

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -12,10 +12,9 @@ use Webmozart\Assert\Assert;
 
 final class CrudConfig
 {
-    /**
-     * @var array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, string>
-     */
-    private array $customPageTitles;
+    private ?string $entityNameSingular = null;
+
+    private ?string $entityNamePlural = null;
 
     private ?string $menuTitle = null;
 
@@ -51,21 +50,31 @@ final class CrudConfig
 
     public function __construct(private readonly string $entityName)
     {
-        $this->customPageTitles = [];
-
         $this->enabledActions = new ArrayCollection([
             ActionType::LIST,
         ]);
     }
 
     /**
-     * Sets a custom title for a given action type.
+     * Overrides the automatically derived singular entity name. Wrap the value in `t()`.
      *
      * @return $this
      */
-    public function setTitle(ActionType $actionType, string $title): self
+    public function setEntityNameSingular(string $entityNameSingular): self
     {
-        $this->customPageTitles[$actionType->value] = $title;
+        $this->entityNameSingular = $entityNameSingular;
+
+        return $this;
+    }
+
+    /**
+     * Overrides the automatically derived plural entity name. Wrap the value in `t()`.
+     *
+     * @return $this
+     */
+    public function setEntityNamePlural(string $entityNamePlural): self
+    {
+        $this->entityNamePlural = $entityNamePlural;
 
         return $this;
     }
@@ -294,7 +303,8 @@ final class CrudConfig
     public function getConfig(): CrudConfigData
     {
         return new CrudConfigData(
-            $this->customPageTitles,
+            $this->entityNameSingular,
+            $this->entityNamePlural,
             $this->menuTitle,
             $this->entityName,
             $this->fullDisabled,

--- a/packages/administration/src/Component/Config/CrudConfigData.php
+++ b/packages/administration/src/Component/Config/CrudConfigData.php
@@ -11,12 +11,12 @@ use Shopsys\FrameworkBundle\Component\Translation\Translator;
 final readonly class CrudConfigData
 {
     /**
-     * @param array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, string> $customPageTitles
      * @param \Shopsys\AdministrationBundle\Component\Config\ActionType[] $enabledActions
      * @param array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, null|class-string<\Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface>> $handlerClasses
      */
     public function __construct(
-        private array $customPageTitles,
+        private ?string $entityNameSingular,
+        private ?string $entityNamePlural,
         private ?string $menuTitle,
         private string $entityName,
         private bool $fullDisabled,
@@ -40,20 +40,25 @@ final readonly class CrudConfigData
         }
     }
 
-    public function getTitle(ActionType $pageType): string
+    public function getTitle(ActionType $pageType, ?string $recordName = null): string
     {
-        if (isset($this->customPageTitles[$pageType->value])) {
-            return $this->customPageTitles[$pageType->value];
-        }
-
-        $singularEntityName = Translator::staticTrans(CrudTransformationHelper::toSingularEntityName($this->entityName));
-        $pluralEntityName = Translator::staticTrans(CrudTransformationHelper::toPluralEntityName($this->entityName));
-
         return match ($pageType) {
-            ActionType::CREATE => t('Creating new %entity_name%', ['%entity_name%' => $singularEntityName]),
-            ActionType::EDIT => t('Editing %entity_name%', ['%entity_name%' => $singularEntityName]),
-            ActionType::LIST => $pluralEntityName,
-            ActionType::DETAIL => $singularEntityName,
+            ActionType::LIST => $this->getPluralEntityName(),
+            ActionType::CREATE => $this->getSingularEntityName(),
+            ActionType::EDIT, ActionType::DETAIL => implode(' · ', array_filter([
+                $this->getSingularEntityName(),
+                $recordName,
+            ])),
+            default => '',
+        };
+    }
+
+    public function getBreadcrumbTitle(ActionType $pageType): string
+    {
+        return match ($pageType) {
+            ActionType::CREATE => t('New record'),
+            ActionType::EDIT => t('Editing a record'),
+            ActionType::DETAIL => t('Record detail'),
             default => '',
         };
     }
@@ -62,6 +67,24 @@ final readonly class CrudConfigData
     {
         if ($this->menuTitle !== null) {
             return $this->menuTitle;
+        }
+
+        return $this->getPluralEntityName();
+    }
+
+    private function getSingularEntityName(): string
+    {
+        if ($this->entityNameSingular !== null) {
+            return $this->entityNameSingular;
+        }
+
+        return Translator::staticTrans(CrudTransformationHelper::toSingularEntityName($this->entityName));
+    }
+
+    private function getPluralEntityName(): string
+    {
+        if ($this->entityNamePlural !== null) {
+            return $this->entityNamePlural;
         }
 
         return Translator::staticTrans(CrudTransformationHelper::toPluralEntityName($this->entityName));

--- a/packages/administration/src/Component/Datagrid/Adapter/EntityClassAwareAdapterInterface.php
+++ b/packages/administration/src/Component/Datagrid/Adapter/EntityClassAwareAdapterInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Datagrid\Adapter;
+
+/**
+ * Implemented by datagrid adapters that are backed by a known entity class.
+ *
+ * Features that need to work with the entity itself (e.g. drag-and-drop reordering, which persists
+ * the new positions on the entity) depend on this, so they can obtain the entity class directly
+ * from the adapter instead of relying on the CRUD definition.
+ */
+interface EntityClassAwareAdapterInterface extends AdapterInterface
+{
+    /**
+     * @return class-string
+     */
+    public function getEntityClass(): string;
+}

--- a/packages/administration/src/Component/Datagrid/Adapter/Orm/OrmAdapter.php
+++ b/packages/administration/src/Component/Datagrid/Adapter/Orm/OrmAdapter.php
@@ -8,12 +8,12 @@ use Closure;
 use Doctrine\Persistence\ManagerRegistry;
 use Override;
 use RuntimeException;
-use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\AdapterInterface;
+use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\EntityClassAwareAdapterInterface;
 use Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface;
 use Shopsys\FrameworkBundle\Component\Grid\HintsHelper;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
-final class OrmAdapter implements AdapterInterface
+final class OrmAdapter implements EntityClassAwareAdapterInterface
 {
     private ProxyQuery $proxyQuery;
 
@@ -22,7 +22,7 @@ final class OrmAdapter implements AdapterInterface
      * @param null|\Closure(\Doctrine\ORM\QueryBuilder $configureQuery): void $configureQuery
      */
     public function __construct(
-        string $entityClass,
+        private readonly string $entityClass,
         private readonly ManagerRegistry $managerRegistry,
         private readonly Localization $localization,
         private readonly HintsHelper $hintsHelper,
@@ -33,6 +33,15 @@ final class OrmAdapter implements AdapterInterface
         if ($configureQuery !== null) {
             $configureQuery($this->proxyQuery->getQueryBuilder());
         }
+    }
+
+    /**
+     * @return class-string
+     */
+    #[Override]
+    public function getEntityClass(): string
+    {
+        return $this->entityClass;
     }
 
     /**

--- a/packages/administration/src/Component/Datagrid/Datagrid.php
+++ b/packages/administration/src/Component/Datagrid/Datagrid.php
@@ -11,9 +11,12 @@ use Shopsys\AdministrationBundle\Component\Action\RowAction;
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
 use Shopsys\AdministrationBundle\Component\Crud\Definition;
 use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\AdapterInterface;
+use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\EntityClassAwareAdapterInterface;
 use Shopsys\AdministrationBundle\Component\Datagrid\Field\FieldDescriptor;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\GridView;
+use Shopsys\FrameworkBundle\Component\Grid\Ordering\Exception\EntityIsNotOrderableException;
+use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -45,6 +48,11 @@ final class Datagrid
      * @var array{field: string, order: \Shopsys\AdministrationBundle\Component\Datagrid\OrderingEnum}|null
      */
     private ?array $defaultOrder = null;
+
+    /**
+     * @var class-string|null
+     */
+    private ?string $dragAndDropEntityClass = null;
 
     /**
      * @param DatagridOptions $options
@@ -110,10 +118,66 @@ final class Datagrid
      */
     public function setDefaultOrder(string $field, OrderingEnum $order): self
     {
+        if ($this->dragAndDropEntityClass !== null) {
+            throw new InvalidArgumentException(
+                'Cannot set the default order while drag-and-drop is enabled, because in that mode the listing is always ordered by the field passed to "enableDragAndDrop()". Call "disableDragAndDrop()" first if you need a different default order.',
+            );
+        }
+
         $this->defaultOrder = [
             'field' => $field,
             'order' => $order,
         ];
+
+        return $this;
+    }
+
+    /**
+     * Enable drag-and-drop reordering of the rows, ordering the listing by the given field.
+     */
+    public function enableDragAndDrop(string $field): self
+    {
+        if (!$this->fields->containsKey($field)) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot enable drag-and-drop ordering by field "%s" because no such field is defined. Define it with "add()" before calling "enableDragAndDrop()" (it can be hidden using \'visible\' => false).',
+                $field,
+            ));
+        }
+
+        if ($this->adapter instanceof EntityClassAwareAdapterInterface === false) {
+            throw new InvalidArgumentException(sprintf(
+                'Drag-and-drop ordering requires an adapter that knows its entity class (implementing "%s"), but "%s" was used.',
+                EntityClassAwareAdapterInterface::class,
+                $this->adapter::class,
+            ));
+        }
+
+        $entityClass = $this->adapter->getEntityClass();
+
+        if (is_subclass_of($entityClass, OrderableEntityInterface::class) === false) {
+            throw new EntityIsNotOrderableException(sprintf(
+                'Entity "%s" must implement "%s" to provide the "setPosition()" method used to persist the new order set by drag-and-drop.',
+                $entityClass,
+                OrderableEntityInterface::class,
+            ));
+        }
+
+        $this->dragAndDropEntityClass = $entityClass;
+        $this->defaultOrder = [
+            'field' => $field,
+            'order' => OrderingEnum::ASC,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Disable drag-and-drop reordering of the rows.
+     */
+    public function disableDragAndDrop(): self
+    {
+        $this->dragAndDropEntityClass = null;
+        $this->defaultOrder = null;
 
         return $this;
     }
@@ -191,6 +255,13 @@ final class Datagrid
             throw new InvalidArgumentException(sprintf('Field with name "%s" does not exist.', $name));
         }
 
+        if ($this->dragAndDropEntityClass !== null && $this->defaultOrder !== null && $this->defaultOrder['field'] === $name) {
+            throw new InvalidArgumentException(sprintf(
+                'Field "%s" cannot be removed because it is used as the ordering field for drag-and-drop. Call "disableDragAndDrop()" before removing it.',
+                $name,
+            ));
+        }
+
         $this->fields->remove($name);
 
         return $this;
@@ -218,17 +289,21 @@ final class Datagrid
                 continue;
             }
 
-            $grid->addColumn($field->getName(), $field->getMappingProperty() ?? $this->identificationName, $field->getLabel(), $field->isSortable(), [
+            $grid->addColumn($field->getName(), $field->getMappingProperty() ?? $this->identificationName, $field->getLabel(), $this->dragAndDropEntityClass !== null ? false : $field->isSortable(), [
                 'template' => $field->getTemplate(),
                 'help' => $field->getHelp(),
             ]);
         }
 
-        if ($this->options['pagination'] === true) {
+        if ($this->dragAndDropEntityClass !== null && $this->defaultOrder !== null) {
+            // Pagination is intentionally left disabled - reordering and saving positions must work
+            // over the whole list, not just the current page.
+            $grid->enableDragAndDrop($this->dragAndDropEntityClass, $this->defaultOrder['field']);
+        } elseif ($this->options['pagination'] === true) {
             $grid->enablePaging();
         }
 
-        if ($this->defaultOrder !== null) {
+        if ($this->dragAndDropEntityClass === null && $this->defaultOrder !== null) {
             $grid->setDefaultOrder($this->defaultOrder['field'], $this->defaultOrder['order']->value);
         }
 

--- a/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
+++ b/packages/administration/src/Component/Menu/CrudMenuSubscriber.php
@@ -77,7 +77,7 @@ final class CrudMenuSubscriber implements EventSubscriberInterface
                 $parent->addChild($route->getRouteName(), [
                     'route' => $route->getRouteName(),
                     'display' => false,
-                    'label' => $config->getTitle($action),
+                    'label' => $config->getBreadcrumbTitle($action),
                 ]);
             }
         }

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -22,6 +22,7 @@ use Shopsys\AdministrationBundle\Component\Datagrid\DatagridFactory;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -50,6 +51,9 @@ abstract class AbstractCrudController extends AdminBaseController
 
     #[Required]
     public FormFactoryInterface $formFactory;
+
+    #[Required]
+    public BreadcrumbOverrider $breadcrumbOverrider;
 
     public function setDefinition(Definition $definition): void
     {
@@ -171,8 +175,12 @@ abstract class AbstractCrudController extends AdminBaseController
             $this->addErrorFlashTwig(t('Please check the correctness of all data filled.'));
         }
 
+        $config = $this->definition->getConfig();
+        $recordName = $entity->toHumanReadable();
+        $this->breadcrumbOverrider->overrideLastItem($config->getBreadcrumbTitle(ActionType::EDIT) . ' - ' . $recordName);
+
         return $this->render('@ShopsysAdministration/crud/edit.html.twig', [
-            'title' => $this->definition->getConfig()->getTitle(ActionType::EDIT),
+            'title' => $config->getTitle(ActionType::EDIT, $recordName),
             'topActions' => $this->getConfiguredActions(ActionType::EDIT),
             'form' => $form->createView(),
         ]);

--- a/packages/administration/templates/crud/detail.html.twig
+++ b/packages/administration/templates/crud/detail.html.twig
@@ -2,6 +2,8 @@
 {% import '@ShopsysAdministration/crud/inline/actions.html.twig' as actions %}
 
 {% block title %}- {{ title }}{% endblock %}
+
+{% block pre_title %}{{ 'Detail'|trans }}{% endblock %}
 {% block h1 %}{{ title }}{% endblock %}
 
 {% block btn %}

--- a/packages/administration/templates/crud/edit.html.twig
+++ b/packages/administration/templates/crud/edit.html.twig
@@ -2,6 +2,8 @@
 {% import '@ShopsysAdministration/crud/inline/actions.html.twig' as actions %}
 
 {% block title %}- {{ title }}{% endblock %}
+
+{% block pre_title %}{{ 'Editing'|trans }}{% endblock %}
 {% block h1 %}{{ title }}{% endblock %}
 
 {% block btn %}

--- a/packages/administration/templates/crud/inline/action.html.twig
+++ b/packages/administration/templates/crud/inline/action.html.twig
@@ -1,7 +1,5 @@
-{% set url = action_url(actionRoute, data) %}
-
-{% if url is not null %}
-    <a href="{{ url }}"
+{% if action_has_access(actionRoute) %}
+    <a href="{{ action_url(actionRoute, data) }}"
         {{ attributes|raw }}
     >
         {% if icon is not null %}

--- a/packages/administration/templates/crud/new.html.twig
+++ b/packages/administration/templates/crud/new.html.twig
@@ -2,6 +2,8 @@
 {% import '@ShopsysAdministration/crud/inline/actions.html.twig' as actions %}
 
 {% block title %}- {{ title }}{% endblock %}
+
+{% block pre_title %}{{ 'New record'|trans }}{% endblock %}
 {% block h1 %}{{ title }}{% endblock %}
 
 {% block btn %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -589,9 +589,6 @@ msgstr "Vytvořena"
 msgid "Created on"
 msgstr "Vytvořeno dne"
 
-msgid "Creating new %entity_name%"
-msgstr "Vytvoření nové %entity_name%"
-
 msgid "Cron detail"
 msgstr "Detail cronu"
 
@@ -675,6 +672,9 @@ msgstr "Zrušit výběr všech oprávnění pro tuto roli"
 
 msgid "Deselect all permissions in section"
 msgstr "Zrušit výběr všech oprávnění v sekci"
+
+msgid "Detail"
+msgstr "Detail"
 
 msgid "Disable"
 msgstr "Vypnout"
@@ -802,11 +802,14 @@ msgstr "Upravit sledování zásilky"
 msgid "Edit withdrawal request"
 msgstr "Upravit žádost o odstoupení"
 
-msgid "Editing %entity_name%"
-msgstr "Editace %entity_name%"
+msgid "Editing"
+msgstr "Editace"
 
 msgid "Editing SEO page"
 msgstr "Editace SEO stránky"
+
+msgid "Editing a record"
+msgstr "Editace položky"
 
 msgid "Editing administrator"
 msgstr "Editace administrátora"
@@ -1372,6 +1375,9 @@ msgstr "Nové zboží"
 msgid "New promo code"
 msgstr "Nový slevový kupón"
 
+msgid "New record"
+msgstr "Nový záznam"
+
 msgid "New registered customers"
 msgstr "Nově registrovaní zákazníci"
 
@@ -1800,6 +1806,9 @@ msgstr "Rychlé hledání"
 
 msgid "Rate can't be modified. It is necessary to create new rate, remove existing one and replace it with new one."
 msgstr "Výši sazby nelze upravit. Je třeba vytvořit novou sazbu a starou odstranit s nahrazením za novou."
+
+msgid "Record detail"
+msgstr "Detail položky"
 
 msgid "Record is not present in the Elasticsearch for the selected entity and domain."
 msgstr "Záznam není uložen v Elasticsearch pro zvolenou entitu a doménu."

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -589,9 +589,6 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
-msgid "Creating new %entity_name%"
-msgstr ""
-
 msgid "Cron detail"
 msgstr ""
 
@@ -674,6 +671,9 @@ msgid "Deselect all permissions for this role"
 msgstr ""
 
 msgid "Deselect all permissions in section"
+msgstr ""
+
+msgid "Detail"
 msgstr ""
 
 msgid "Disable"
@@ -802,10 +802,13 @@ msgstr ""
 msgid "Edit withdrawal request"
 msgstr ""
 
-msgid "Editing %entity_name%"
+msgid "Editing"
 msgstr ""
 
 msgid "Editing SEO page"
+msgstr ""
+
+msgid "Editing a record"
 msgstr ""
 
 msgid "Editing administrator"
@@ -1372,6 +1375,9 @@ msgstr ""
 msgid "New promo code"
 msgstr ""
 
+msgid "New record"
+msgstr ""
+
 msgid "New registered customers"
 msgstr ""
 
@@ -1799,6 +1805,9 @@ msgid "Quick search"
 msgstr ""
 
 msgid "Rate can't be modified. It is necessary to create new rate, remove existing one and replace it with new one."
+msgstr ""
+
+msgid "Record detail"
 msgstr ""
 
 msgid "Record is not present in the Elasticsearch for the selected entity and domain."

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -589,9 +589,6 @@ msgstr "Vytvorené"
 msgid "Created on"
 msgstr "Vytvorené v"
 
-msgid "Creating new %entity_name%"
-msgstr "Vytváranie nového %entity_name%"
-
 msgid "Cron detail"
 msgstr "Detail cronu"
 
@@ -675,6 +672,9 @@ msgstr "Zrušiť výber všetkých oprávnení pre túto rolu"
 
 msgid "Deselect all permissions in section"
 msgstr "Zrušiť výber všetkých povolení v sekcii"
+
+msgid "Detail"
+msgstr "Detail"
 
 msgid "Disable"
 msgstr "Zakázať"
@@ -802,11 +802,14 @@ msgstr "Upraviť sledovanie zásielky"
 msgid "Edit withdrawal request"
 msgstr "Upraviť žiadosť o odstúpenie"
 
-msgid "Editing %entity_name%"
-msgstr "Úprava %entity_name%"
+msgid "Editing"
+msgstr "Úprava"
 
 msgid "Editing SEO page"
 msgstr "Upravovanie SEO stránky"
+
+msgid "Editing a record"
+msgstr "Upravovanie položky"
 
 msgid "Editing administrator"
 msgstr "Upravovanie administrátora"
@@ -1372,6 +1375,9 @@ msgstr "Nový produkt"
 msgid "New promo code"
 msgstr "Nový promo kód"
 
+msgid "New record"
+msgstr "Nový záznam"
+
 msgid "New registered customers"
 msgstr "Novoregistrovaní zákazníci"
 
@@ -1800,6 +1806,9 @@ msgstr "Rýchle hľadanie"
 
 msgid "Rate can't be modified. It is necessary to create new rate, remove existing one and replace it with new one."
 msgstr "Výšku sadzby nemôže byť upravená. Je potrebné vytvoriť novú sadzbu a starú odstrániť s nahradením za novú."
+
+msgid "Record detail"
+msgstr "Detail položky"
 
 msgid "Record is not present in the Elasticsearch for the selected entity and domain."
 msgstr "Záznam nie je uložený v Elasticsearch pre zvolenú entitu a doménu."

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -67,6 +67,8 @@ class Grid
 
     protected ?string $orderingEntityClass = null;
 
+    protected ?string $dragAndDropOrderSourceColumnName = null;
+
     protected PaginationResult $paginationResults;
 
     /**
@@ -461,7 +463,7 @@ class Grid
             }
         }
 
-        if ($this->getOrderSourceColumnName() !== null) {
+        if (!$this->isDragAndDrop() && $this->getOrderSourceColumnName() !== null) {
             $gridParameters['order'] = $this->getOrderSourceColumnNameWithDirection();
         }
 
@@ -512,8 +514,8 @@ class Grid
         $orderDirection = $this->orderDirection;
 
         if ($this->isDragAndDrop()) {
-            $orderSourceColumnName = null;
-            $orderDirection = DataSourceInterface::ORDER_DESC;
+            $orderSourceColumnName = $this->dragAndDropOrderSourceColumnName;
+            $orderDirection = DataSourceInterface::ORDER_ASC;
         }
 
         $this->paginationResults = $this->dataSource->getPaginatedRows(
@@ -567,9 +569,15 @@ class Grid
         return $row[$sourceColumnName];
     }
 
-    public function enableDragAndDrop(string $entityClass): void
+    /**
+     * When drag-and-drop is enabled the listing is always ordered by $orderSourceColumnName ascending,
+     * regardless of any ordering coming from the request, so the persisted positions are never mixed up.
+     * Pass null when the ordering is already baked into the data source query builder (legacy grids).
+     */
+    public function enableDragAndDrop(string $entityClass, ?string $orderSourceColumnName = null): void
     {
         $this->orderingEntityClass = $entityClass;
+        $this->dragAndDropOrderSourceColumnName = $orderSourceColumnName;
     }
 
     public function enableMultipleDragAndDrop(): void

--- a/packages/framework/tests/Unit/Component/Grid/GridTest.php
+++ b/packages/framework/tests/Unit/Component/Grid/GridTest.php
@@ -337,6 +337,47 @@ class GridTest extends TestCase
         $this->assertTrue($grid->isDragAndDrop());
     }
 
+    public function testDragAndDropIgnoresRequestOrderToPreventOrderByInjection(): void
+    {
+        $getParameters = [
+            Grid::GET_PARAMETER => [
+                'gridId' => [
+                    'order' => 'maliciousColumn',
+                ],
+            ],
+        ];
+
+        $request = new Request($getParameters);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $twigStub = $this->createStub(Environment::class);
+        $routerStub = $this->createStub(Router::class);
+        $routeCsrfProtectorStub = $this->createStub(RouteCsrfProtector::class);
+        $dataSourceMock = $this->getMockBuilder(DataSourceInterface::class)->getMock();
+        $dataSourceMock->expects($this->once())->method('getPaginatedRows')
+            ->with(null, 1, 'position', DataSourceInterface::ORDER_ASC)
+            ->willReturn(new PaginationResult(1, 1, 0, []));
+        $accessCheckerStub = $this->createStub(AccessCheckerInterface::class);
+        $accessCheckerStub
+            ->method('canEdit')
+            ->willReturn(true);
+
+        $grid = new Grid(
+            'gridId',
+            SystemRole::ALL,
+            $dataSourceMock,
+            $requestStack,
+            $routerStub,
+            $routeCsrfProtectorStub,
+            $twigStub,
+            $accessCheckerStub,
+        );
+
+        $grid->enableDragAndDrop('Path\To\Entity\Class', 'position');
+        $grid->createView();
+    }
+
     public function testReorderColumns(): void
     {
         $request = new Request();

--- a/upgrade-notes/backend_20260624_205033.md
+++ b/upgrade-notes/backend_20260624_205033.md
@@ -1,0 +1,8 @@
+#### Unify CRUD controller page titles, breadcrumbs and pretitles ([#4672](https://github.com/shopsys/shopsys/pull/4672))
+
+- `Shopsys\AdministrationBundle\Component\Config\CrudConfig::setTitle()` was removed. CRUD page titles, breadcrumbs and pretitles are now composed automatically from the entity name (and the concrete record name on edit/detail pages), so per-action custom titles are no longer configurable this way. Remove your `setTitle()` calls; to override the auto-derived entity name, use the new `CrudConfig::setEntityNameSingular()` / `CrudConfig::setEntityNamePlural()` methods and wrap the value in `t()`:
+    ```diff
+    - $config->setTitle(ActionType::LIST, t('All orders'));
+    + $config->setEntityNamePlural(t('Orders'));
+    ```
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

This PR improves the administration CRUD controllers in two ways.

**Consistent, grammatically correct page titles.** Until now, CRUD page titles, breadcrumbs and the small pretitle above the heading were built by gluing an action word together with the entity name (e.g. "Editing Stock"). In inflected languages such as Czech this produced grammatically broken labels like "Editace Sklad". Titles are now composed so that each part stays in its base form: the heading shows the entity name — and the concrete record name on edit/detail pages (e.g. "Stock · Main warehouse") — the action is conveyed by a generic, always-correct breadcrumb ("Editing a record - Main warehouse") and a static pretitle. The result reads correctly across all CRUD controllers and languages. Custom per-action titles via `CrudConfig::setTitle()` were replaced by `setEntityNameSingular()` / `setEntityNamePlural()` for overriding the auto-derived entity name (see upgrade notes).

**Drag-and-drop reordering in datagrids.** Datagrids — and therefore CRUD list pages — can now enable drag-and-drop row reordering with a single `Datagrid::enableDragAndDrop('position')` call. The listing is automatically ordered by the given field, sorting by other columns and pagination are turned off so the whole list can be rearranged at once, and the new order is saved automatically. It is available only to administrators with the edit permission.

Additionally, the create button on CRUD list pages is now shown only to administrators who have the create permission.

#### Fixes issues

N/A

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-crud-enchantments.odin.shopsys.cloud
  - https://cz.jg-crud-enchantments.odin.shopsys.cloud
  - https://jg-crud-enchantments.odin.shopsys.cloud/sk
<!-- Replace -->
