### PR TITLE
Make Zbozi tests independent of domain configuration

### DIFF
--- a/project-base/app/tests/FrontendApiBundle/Functional/Zbozi/CategoryZboziCategoryTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Zbozi/CategoryZboziCategoryTest.php
@@ -6,16 +6,19 @@ namespace Tests\FrontendApiBundle\Functional\Zbozi;
 
 use App\DataFixtures\Demo\CategoryDataFixture;
 use App\Model\Category\Category;
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 final class CategoryZboziCategoryTest extends GraphQlTestCase
 {
-    public function testCategoryZboziCategoryIsNullOnFirstDomain(): void
+    public function testCategoryZboziCategoryIsNullOnNonCsDomain(): void
     {
-        if ($this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale() === 'cs') {
-            $this->markTestSkipped('First domain has cs locale where zbozi mappings exist; this test expects no mapping.');
+        $domainId = ZboziDomainTestHelper::findFirstNonCsDomainId($this->domain);
+
+        if ($domainId === null) {
+            $this->markTestSkipped('There is no non-cs domain where zbozi mappings are expected to be missing.');
         }
+
+        $this->domain->switchDomainById($domainId);
 
         $electronics = $this->getReference(CategoryDataFixture::CATEGORY_ELECTRONICS, Category::class);
 
@@ -30,11 +33,13 @@ final class CategoryZboziCategoryTest extends GraphQlTestCase
 
     public function testCategoryZboziCategoryReturnsFullNameOnCsDomain(): void
     {
-        if ($this->domain->getDomainConfigById(Domain::SECOND_DOMAIN_ID)->getLocale() !== 'cs') {
-            $this->markTestSkipped('Second domain is not in cs locale; zbozi mappings are seeded only for cs.');
+        $domainId = ZboziDomainTestHelper::findFirstCsDomainId($this->domain);
+
+        if ($domainId === null) {
+            $this->markTestSkipped('There is no cs domain where zbozi mappings are seeded.');
         }
 
-        $this->domain->switchDomainById(Domain::SECOND_DOMAIN_ID);
+        $this->domain->switchDomainById($domainId);
 
         $electronics = $this->getReference(CategoryDataFixture::CATEGORY_ELECTRONICS, Category::class);
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Zbozi/ProductZboziCategoryTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Zbozi/ProductZboziCategoryTest.php
@@ -12,7 +12,7 @@ final class ProductZboziCategoryTest extends GraphQlTestCase
 {
     public function testProductZboziCategoryIsNullOnNonCsDomain(): void
     {
-        $domainId = $this->findFirstNonCsDomainId();
+        $domainId = ZboziDomainTestHelper::findFirstNonCsDomainId($this->domain);
 
         if ($domainId === null) {
             $this->markTestSkipped('There is no non-cs domain where zbozi mappings are expected to be missing.');
@@ -33,7 +33,7 @@ final class ProductZboziCategoryTest extends GraphQlTestCase
 
     public function testProductZboziCategoryReturnsFullNameOnCsDomain(): void
     {
-        $domainId = $this->findFirstCsDomainId();
+        $domainId = ZboziDomainTestHelper::findFirstCsDomainId($this->domain);
 
         if ($domainId === null) {
             $this->markTestSkipped('There is no cs domain where zbozi mappings are seeded.');
@@ -50,27 +50,5 @@ final class ProductZboziCategoryTest extends GraphQlTestCase
         $data = $this->getResponseDataForGraphQlType($response, 'product');
 
         $this->assertSame('Foto | Foto doplňky a příslušenství | Objektivy', $data['zboziCategory']);
-    }
-
-    private function findFirstNonCsDomainId(): ?int
-    {
-        foreach ($this->domain->getAll() as $domainConfig) {
-            if ($domainConfig->getLocale() !== 'cs') {
-                return $domainConfig->getId();
-            }
-        }
-
-        return null;
-    }
-
-    private function findFirstCsDomainId(): ?int
-    {
-        foreach ($this->domain->getAll() as $domainConfig) {
-            if ($domainConfig->getLocale() === 'cs') {
-                return $domainConfig->getId();
-            }
-        }
-
-        return null;
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Zbozi/ZboziDomainTestHelper.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Zbozi/ZboziDomainTestHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Zbozi;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Locale\LocaleHelper;
+
+final class ZboziDomainTestHelper
+{
+    public static function findFirstNonCsDomainId(Domain $domain): ?int
+    {
+        foreach ($domain->getAll() as $domainConfig) {
+            if ($domainConfig->getLocale() !== LocaleHelper::LOCALE_CS) {
+                return $domainConfig->getId();
+            }
+        }
+
+        return null;
+    }
+
+    public static function findFirstCsDomainId(Domain $domain): ?int
+    {
+        foreach ($domain->getAll() as $domainConfig) {
+            if ($domainConfig->getLocale() === LocaleHelper::LOCALE_CS) {
+                return $domainConfig->getId();
+            }
+        }
+
+        return null;
+    }
+}

--- a/upgrade-notes/backend_20260626_065901.md
+++ b/upgrade-notes/backend_20260626_065901.md
@@ -1,0 +1,3 @@
+#### zbozi tests now select domains by locale ([#4677](https://github.com/shopsys/shopsys/pull/4677))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Zbozi Frontend API tests now work independently of the configured domain IDs and domain count.

Previously, the category Zbozi test expected the Czech domain to be the second domain. That caused false failures in projects with a different setup, including single-domain Czech shops. The tests now select Czech and non-Czech domains by locale, so they verify Zbozi category mapping without depending on a specific domain configuration.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-zbozi-category-test.odin.shopsys.cloud
  - https://cz.mg-fix-zbozi-category-test.odin.shopsys.cloud
  - https://mg-fix-zbozi-category-test.odin.shopsys.cloud/sk
<!-- Replace -->
