### PR TITLE
Enforce direct requires for transitive dev dependencies in packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /.env.local.php
 /.env.*.local
 /utils/releaser/.phpunit.cache
+/utils/monorepo-tools/.phpunit.cache
 /packages/frontend-api/.phpunit.cache
 
 /phing.phar

--- a/build.xml
+++ b/build.xml
@@ -85,6 +85,21 @@
         </exec>
     </target>
 
+    <target name="mutual-dependencies-check" description="Checks that every package directly requires all of its transitive dev-version shopsys dependencies." hidden="true">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="monorepo:validate-mutual-dependencies"/>
+        </exec>
+    </target>
+
+    <target name="mutual-dependencies-fix" description="Adds the missing direct requires for transitive dev-version shopsys dependencies." hidden="true">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="monorepo:validate-mutual-dependencies"/>
+            <arg value="--fix"/>
+        </exec>
+    </target>
+
     <target name="npm-translations-dump" description="Dumped translations from javascript's files." hidden="true">
         <exec executable="${path.npm.executable}" dir="${path.root}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="run"/>
@@ -177,11 +192,11 @@
         </if>
     </target>
 
-    <target name="standards" depends="shopsys_administration.standards,phing-config-check" description="Checks coding standards."/>
+    <target name="standards" depends="shopsys_administration.standards,phing-config-check,mutual-dependencies-check" description="Checks coding standards."/>
 
     <target name="standards-diff" depends="shopsys_administration.standards-diff,phing-config-check" description="Checks coding standards in changed files."/>
 
-    <target name="standards-fix" depends="shopsys_administration.standards-fix,phing-config-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix" depends="shopsys_administration.standards-fix,phing-config-fix,mutual-dependencies-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
 
     <target name="standards-fix-diff" depends="shopsys_administration.standards-fix-diff,phing-config-fix" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
 
@@ -300,6 +315,12 @@
             <arg value="--configuration"/>
             <arg value="${path.utils}/releaser/phpunit.xml"/>
             <arg value="${path.utils}/releaser/tests/"/>
+        </exec>
+        <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.utils}/monorepo-tools/phpunit.xml"/>
+            <arg value="${path.utils}/monorepo-tools/tests/"/>
         </exec>
         <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
@@ -470,6 +491,15 @@
                     <arg value="--configuration"/>
                     <arg value="${path.utils}/releaser/phpunit.xml"/>
                     <arg value="${path.utils}/releaser/tests/"/>
+                    <arg value="--do-not-fail-on-empty-test-suite"/>
+                    <arg value="--filter"/>
+                    <arg value="${test.name}"/>
+                </exec>
+                <exec executable="${path.bin}/phpunit" logoutput="true" passthru="true" checkreturn="true">
+                    <arg value="--colors=always"/>
+                    <arg value="--configuration"/>
+                    <arg value="${path.utils}/monorepo-tools/phpunit.xml"/>
+                    <arg value="${path.utils}/monorepo-tools/tests/"/>
                     <arg value="--do-not-fail-on-empty-test-suite"/>
                     <arg value="--filter"/>
                     <arg value="${test.name}"/>

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,9 @@
             "Tests\\ProductFeed\\LuigisBoxBundle\\": "packages/product-feed-luigis-box/tests/",
             "Tests\\LuigisBoxBundle\\": "packages/luigis-box/tests/",
             "Shopsys\\Releaser\\": "utils/releaser/src/",
-            "Shopsys\\Releaser\\Tests\\": "utils/releaser/tests"
+            "Shopsys\\Releaser\\Tests\\": "utils/releaser/tests",
+            "Shopsys\\MonorepoTools\\": "utils/monorepo-tools/src/",
+            "Shopsys\\MonorepoTools\\Tests\\": "utils/monorepo-tools/tests"
         }
     },
     "require": {

--- a/packages/article-feed-luigis-box/composer.json
+++ b/packages/article-feed-luigis-box/composer.json
@@ -38,6 +38,7 @@
         "doctrine/persistence": "^4.1",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/brand-feed-luigis-box/composer.json
+++ b/packages/brand-feed-luigis-box/composer.json
@@ -38,6 +38,7 @@
         "doctrine/persistence": "^4.1",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/category-feed-luigis-box/composer.json
+++ b/packages/category-feed-luigis-box/composer.json
@@ -38,6 +38,7 @@
         "doctrine/persistence": "^4.1",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/google-cloud-bundle/composer.json
+++ b/packages/google-cloud-bundle/composer.json
@@ -25,6 +25,7 @@
         "league/flysystem-google-cloud-storage": "^3.0",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/luigis-box/composer.json
+++ b/packages/luigis-box/composer.json
@@ -31,6 +31,7 @@
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/frontend-api": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "shopsys/article-feed-luigis-box": "20.0.x-dev",

--- a/packages/maker/composer.json
+++ b/packages/maker/composer.json
@@ -36,6 +36,7 @@
         "ramsey/uuid": "^4.3.1",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/console": "^7.4",

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -32,6 +32,7 @@
         "doctrine/orm": "^3.6",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/product-feed-luigis-box/composer.json
+++ b/packages/product-feed-luigis-box/composer.json
@@ -37,6 +37,7 @@
         "doctrine/persistence": "^4.1",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/product-feed-mergado/composer.json
+++ b/packages/product-feed-mergado/composer.json
@@ -37,6 +37,7 @@
         "doctrine/persistence": "^4.1",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/packages/s3-bridge/composer.json
+++ b/packages/s3-bridge/composer.json
@@ -27,6 +27,7 @@
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
+        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",

--- a/parameters_monorepo.yaml
+++ b/parameters_monorepo.yaml
@@ -1,5 +1,6 @@
 imports:
     - { resource: 'utils/releaser/config/services.php', ignore_errors: true }
+    - { resource: 'utils/monorepo-tools/config/services.php', ignore_errors: true }
 
 parameters:
     shopsys.framework.root_dir: '%kernel.project_dir%/../../packages/framework'

--- a/utils/monorepo-tools/config/services.php
+++ b/utils/monorepo-tools/config/services.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/**
+ * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('Shopsys\\MonorepoTools\\', __DIR__ . '/../src')
+        ->exclude([__DIR__ . '/../src/MutualDependency/MissingMutualDependencies.php']);
+};

--- a/utils/monorepo-tools/phpunit.xml
+++ b/utils/monorepo-tools/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    backupGlobals="false"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    failOnNotice="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    failOnPhpunitNotice="true"
+    displayDetailsOnPhpunitNotices="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+>
+  <source/>
+</phpunit>

--- a/utils/monorepo-tools/src/Command/ValidateMutualDependenciesCommand.php
+++ b/utils/monorepo-tools/src/Command/ValidateMutualDependenciesCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\MonorepoTools\Command;
+
+use Override;
+use Shopsys\MonorepoTools\MutualDependency\MutualDependencyChecker;
+use Shopsys\Releaser\FileManipulator\ComposerJsonFileManipulator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'monorepo:validate-mutual-dependencies',
+    description: 'Validate that every package directly requires all of its transitive dev-version shopsys dependencies.',
+)]
+final class ValidateMutualDependenciesCommand extends Command
+{
+    private const string OPTION_FIX = 'fix';
+
+    public function __construct(
+        private readonly MutualDependencyChecker $mutualDependencyChecker,
+        private readonly ComposerJsonFileManipulator $composerJsonFileManipulator,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this->addOption(
+            self::OPTION_FIX,
+            null,
+            InputOption::VALUE_NONE,
+            'Add the missing requires into the composer.json files instead of only reporting them',
+        );
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $symfonyStyle = new SymfonyStyle($input, $output);
+        $missingMutualDependencies = $this->mutualDependencyChecker->check();
+
+        if ($missingMutualDependencies === []) {
+            $symfonyStyle->success(
+                'All packages directly require their transitive dev-version shopsys dependencies.',
+            );
+
+            return Command::SUCCESS;
+        }
+
+        $isFix = (bool)$input->getOption(self::OPTION_FIX);
+
+        foreach ($missingMutualDependencies as $missingMutualDependency) {
+            $symfonyStyle->section($missingMutualDependency->packageName);
+
+            $missingRequires = [];
+
+            foreach ($missingMutualDependency->missingRequiresByVersion as $packageName => $versionConstraint) {
+                $missingRequires[] = sprintf('"%s": "%s"', $packageName, $versionConstraint);
+            }
+
+            $symfonyStyle->listing($missingRequires);
+
+            if ($isFix) {
+                $this->composerJsonFileManipulator->addRequires(
+                    $missingMutualDependency->composerJsonFileInfo,
+                    $missingMutualDependency->missingRequiresByVersion,
+                );
+            }
+        }
+
+        if ($isFix) {
+            $symfonyStyle->success(
+                sprintf('Added missing requires into %d package(s).', count($missingMutualDependencies)),
+            );
+
+            return Command::SUCCESS;
+        }
+
+        $symfonyStyle->error(sprintf(
+            '%d package(s) do not directly require all of their transitive dev-version shopsys dependencies.'
+                . ' Run the command with --fix to add them.',
+            count($missingMutualDependencies),
+        ));
+
+        return Command::FAILURE;
+    }
+}

--- a/utils/monorepo-tools/src/MutualDependency/MissingMutualDependencies.php
+++ b/utils/monorepo-tools/src/MutualDependency/MissingMutualDependencies.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\MonorepoTools\MutualDependency;
+
+use Symfony\Component\Finder\SplFileInfo;
+
+final class MissingMutualDependencies
+{
+    /**
+     * @param string $packageName name of the package whose composer.json is incomplete (e.g. "shopsys/product-feed-mergado")
+     * @param \Symfony\Component\Finder\SplFileInfo $composerJsonFileInfo composer.json of the incomplete package
+     * @param array<string, string> $missingRequiresByVersion map of the missing direct require to the development
+     *      version constraint that should be used (e.g. ["shopsys/mcp-attributes" => "20.0.x-dev"])
+     */
+    public function __construct(
+        public readonly string $packageName,
+        public readonly SplFileInfo $composerJsonFileInfo,
+        public readonly array $missingRequiresByVersion,
+    ) {
+    }
+}

--- a/utils/monorepo-tools/src/MutualDependency/MutualDependencyChecker.php
+++ b/utils/monorepo-tools/src/MutualDependency/MutualDependencyChecker.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\MonorepoTools\MutualDependency;
+
+use Nette\Utils\Json;
+use Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider;
+
+/**
+ * Verifies that every package directly requires all of its transitive shopsys dependencies that are required in a
+ * development version (e.g. "20.0.x-dev").
+ *
+ * Composer derives a per-package stability flag from a direct dev-version require in the root composer.json, but it
+ * does not derive it for a dev-version dependency that is only reachable transitively. Therefore a split package
+ * tested standalone fails to install (the transitive dev dependency "does not match your minimum-stability") unless
+ * it lists that dependency directly.
+ */
+class MutualDependencyChecker
+{
+    public function __construct(
+        private readonly ComposerJsonFilesProvider $composerJsonFilesProvider,
+    ) {
+    }
+
+    /**
+     * @return \Shopsys\MonorepoTools\MutualDependency\MissingMutualDependencies[]
+     */
+    public function check(): array
+    {
+        $fileInfoByName = [];
+        $requiresByName = [];
+
+        foreach ($this->composerJsonFilesProvider->provideExcludingMonorepoComposerJson() as $composerJsonFileInfo) {
+            $jsonContent = Json::decode($composerJsonFileInfo->getContents(), true);
+            $packageName = $jsonContent['name'];
+
+            $fileInfoByName[$packageName] = $composerJsonFileInfo;
+            $requiresByName[$packageName] = $jsonContent['require'] ?? [];
+        }
+
+        $internalPackageNames = array_keys($requiresByName);
+
+        $missingMutualDependencies = [];
+
+        foreach ($internalPackageNames as $packageName) {
+            $missingRequiresByVersion = $this->resolveMissingRequires(
+                $packageName,
+                $requiresByName,
+                $internalPackageNames,
+            );
+
+            if ($missingRequiresByVersion === []) {
+                continue;
+            }
+
+            ksort($missingRequiresByVersion);
+
+            $missingMutualDependencies[] = new MissingMutualDependencies(
+                $packageName,
+                $fileInfoByName[$packageName],
+                $missingRequiresByVersion,
+            );
+        }
+
+        return $missingMutualDependencies;
+    }
+
+    /**
+     * @param string $packageName
+     * @param array<string, array<string, string>> $requiresByName
+     * @param string[] $internalPackageNames
+     * @return array<string, string>
+     */
+    private function resolveMissingRequires(
+        string $packageName,
+        array $requiresByName,
+        array $internalPackageNames,
+    ): array {
+        $directRequires = $requiresByName[$packageName];
+        $transitiveDevRequires = $this->resolveTransitiveDevRequires(
+            $packageName,
+            $requiresByName,
+            $internalPackageNames,
+        );
+
+        $missingRequiresByVersion = [];
+
+        foreach ($transitiveDevRequires as $dependencyName => $developmentVersion) {
+            if (array_key_exists($dependencyName, $directRequires)) {
+                continue;
+            }
+
+            $missingRequiresByVersion[$dependencyName] = $developmentVersion;
+        }
+
+        return $missingRequiresByVersion;
+    }
+
+    /**
+     * Walks the production "require" graph (never "require-dev", mirroring how Composer propagates stability flags) and
+     * collects every internal shopsys package reachable through dev-version edges.
+     *
+     * @param string $rootPackageName
+     * @param array<string, array<string, string>> $requiresByName
+     * @param string[] $internalPackageNames
+     * @return array<string, string> map of reachable package name to the development version constraint seen on its edge
+     */
+    private function resolveTransitiveDevRequires(
+        string $rootPackageName,
+        array $requiresByName,
+        array $internalPackageNames,
+    ): array {
+        $reachableDevRequires = [];
+        $visitedPackageNames = [];
+        $packageNamesToVisit = [$rootPackageName];
+
+        while ($packageNamesToVisit !== []) {
+            $currentPackageName = array_pop($packageNamesToVisit);
+
+            if (array_key_exists($currentPackageName, $visitedPackageNames)) {
+                continue;
+            }
+
+            $visitedPackageNames[$currentPackageName] = true;
+
+            foreach ($requiresByName[$currentPackageName] ?? [] as $requiredName => $versionConstraint) {
+                if (!in_array($requiredName, $internalPackageNames, true)) {
+                    continue;
+                }
+
+                if (!$this->isDevelopmentVersion($versionConstraint)) {
+                    continue;
+                }
+
+                if ($requiredName !== $rootPackageName) {
+                    $reachableDevRequires[$requiredName] = $versionConstraint;
+                }
+
+                $packageNamesToVisit[] = $requiredName;
+            }
+        }
+
+        return $reachableDevRequires;
+    }
+
+    private function isDevelopmentVersion(string $versionConstraint): bool
+    {
+        $versionConstraint = trim($versionConstraint);
+
+        return str_contains($versionConstraint, 'x-dev') || str_starts_with($versionConstraint, 'dev-');
+    }
+}

--- a/utils/monorepo-tools/tests/Fixtures/packages/intermediate/composer.json
+++ b/utils/monorepo-tools/tests/Fixtures/packages/intermediate/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "fixture/intermediate",
+    "require": {
+        "php": "^8.5",
+        "fixture/leaf-a": "1.0.x-dev",
+        "fixture/leaf-b": "1.0.x-dev"
+    }
+}

--- a/utils/monorepo-tools/tests/Fixtures/packages/leaf-a/composer.json
+++ b/utils/monorepo-tools/tests/Fixtures/packages/leaf-a/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "fixture/leaf-a",
+    "require": {
+        "php": "^8.5"
+    }
+}

--- a/utils/monorepo-tools/tests/Fixtures/packages/leaf-b/composer.json
+++ b/utils/monorepo-tools/tests/Fixtures/packages/leaf-b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "fixture/leaf-b",
+    "require": {
+        "php": "^8.5"
+    }
+}

--- a/utils/monorepo-tools/tests/Fixtures/packages/root-with-all-dependencies/composer.json
+++ b/utils/monorepo-tools/tests/Fixtures/packages/root-with-all-dependencies/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "fixture/root-with-all-dependencies",
+    "require": {
+        "php": "^8.5",
+        "fixture/intermediate": "1.0.x-dev",
+        "fixture/leaf-a": "1.0.x-dev",
+        "fixture/leaf-b": "1.0.x-dev"
+    }
+}

--- a/utils/monorepo-tools/tests/Fixtures/packages/root-with-missing-dependencies/composer.json
+++ b/utils/monorepo-tools/tests/Fixtures/packages/root-with-missing-dependencies/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "fixture/root-with-missing-dependencies",
+    "require": {
+        "php": "^8.5",
+        "fixture/intermediate": "1.0.x-dev"
+    }
+}

--- a/utils/monorepo-tools/tests/Fixtures/packages/root-with-stable-dependency/composer.json
+++ b/utils/monorepo-tools/tests/Fixtures/packages/root-with-stable-dependency/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "fixture/root-with-stable-dependency",
+    "require": {
+        "php": "^8.5",
+        "fixture/intermediate": "^1.0"
+    }
+}

--- a/utils/monorepo-tools/tests/MutualDependency/MutualDependencyCheckerTest.php
+++ b/utils/monorepo-tools/tests/MutualDependency/MutualDependencyCheckerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\MonorepoTools\Tests\MutualDependency;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\MonorepoTools\MutualDependency\MutualDependencyChecker;
+use Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider;
+
+final class MutualDependencyCheckerTest extends TestCase
+{
+    private function createChecker(): MutualDependencyChecker
+    {
+        return new MutualDependencyChecker(
+            new ComposerJsonFilesProvider([__DIR__ . '/../Fixtures/packages']),
+        );
+    }
+
+    public function testReportsTransitiveDevDependenciesMissingFromDirectRequires(): void
+    {
+        $results = $this->createChecker()->check();
+
+        $missingByPackageName = [];
+
+        foreach ($results as $result) {
+            $missingByPackageName[$result->packageName] = $result->missingRequiresByVersion;
+        }
+
+        // "root-with-missing-dependencies" directly requires only "intermediate"; through it, the dev-version
+        // "leaf-a" and "leaf-b" are reachable transitively but not declared directly, so both must be reported
+        $this->assertArrayHasKey('fixture/root-with-missing-dependencies', $missingByPackageName);
+        $this->assertSame(
+            [
+                'fixture/leaf-a' => '1.0.x-dev',
+                'fixture/leaf-b' => '1.0.x-dev',
+            ],
+            $missingByPackageName['fixture/root-with-missing-dependencies'],
+        );
+    }
+
+    public function testDoesNotReportPackageThatAlreadyDeclaresAllTransitiveDevDependencies(): void
+    {
+        $results = $this->createChecker()->check();
+
+        $reportedPackageNames = array_map(static fn ($result) => $result->packageName, $results);
+
+        $this->assertNotContains('fixture/root-with-all-dependencies', $reportedPackageNames);
+    }
+
+    public function testDoesNotReportTransitiveDependencyReachableOnlyThroughStableVersionEdge(): void
+    {
+        $results = $this->createChecker()->check();
+
+        $reportedPackageNames = array_map(static fn ($result) => $result->packageName, $results);
+
+        // "root-with-stable-dependency" requires "intermediate" in a stable constraint ("^1.0"), so the rule does
+        // not apply (this is the released state, where stability flags are irrelevant)
+        $this->assertNotContains('fixture/root-with-stable-dependency', $reportedPackageNames);
+    }
+}

--- a/utils/releaser/src/FileManipulator/ComposerJsonFileManipulator.php
+++ b/utils/releaser/src/FileManipulator/ComposerJsonFileManipulator.php
@@ -6,9 +6,84 @@ namespace Shopsys\Releaser\FileManipulator;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
+use Symfony\Component\Finder\SplFileInfo;
 
 class ComposerJsonFileManipulator
 {
+    /**
+     * Adds missing entries into the "require" section, keeping the keys of the same vendor alphabetically ordered.
+     *
+     * @param array<string, string> $requiresByVersion map of package name to version constraint to add
+     */
+    public function addRequires(SplFileInfo $fileInfo, array $requiresByVersion): void
+    {
+        $jsonContent = Json::decode($fileInfo->getContents(), true);
+        $require = $jsonContent['require'] ?? [];
+
+        foreach ($requiresByVersion as $packageName => $versionConstraint) {
+            $require = $this->insertRequireWithinVendor($require, $packageName, $versionConstraint);
+        }
+
+        $jsonContent['require'] = $require;
+
+        $fileContent = Json::encode($jsonContent, pretty: true) . PHP_EOL;
+        FileSystem::write($fileInfo->getRealPath(), $fileContent);
+    }
+
+    /**
+     * @param array<string, string> $require
+     * @return array<string, string>
+     */
+    private function insertRequireWithinVendor(
+        array $require,
+        string $newPackageName,
+        string $versionConstraint,
+    ): array {
+        if (array_key_exists($newPackageName, $require)) {
+            return $require;
+        }
+
+        $vendorPrefix = explode('/', $newPackageName, 2)[0] . '/';
+        $sameVendorPackageNames = array_filter(
+            array_keys($require),
+            static fn (string $packageName): bool => str_starts_with($packageName, $vendorPrefix),
+        );
+
+        $insertBeforePackageName = null;
+
+        foreach ($sameVendorPackageNames as $sameVendorPackageName) {
+            if (strcmp($sameVendorPackageName, $newPackageName) > 0) {
+                $insertBeforePackageName = $sameVendorPackageName;
+
+                break;
+            }
+        }
+
+        // the new package sorts after all of its vendor siblings (or there are none yet),
+        // so it is appended right after the last sibling, keeping the vendor block together
+        $insertAfterPackageName = $sameVendorPackageNames === [] ? null : end($sameVendorPackageNames);
+
+        $result = [];
+
+        foreach ($require as $packageName => $existingVersionConstraint) {
+            if ($packageName === $insertBeforePackageName) {
+                $result[$newPackageName] = $versionConstraint;
+            }
+
+            $result[$packageName] = $existingVersionConstraint;
+
+            if ($insertBeforePackageName === null && $packageName === $insertAfterPackageName) {
+                $result[$newPackageName] = $versionConstraint;
+            }
+        }
+
+        if (!array_key_exists($newPackageName, $result)) {
+            $result[$newPackageName] = $versionConstraint;
+        }
+
+        return $result;
+    }
+
     /**
      * @param \Symfony\Component\Finder\SplFileInfo[] $fileInfos
      * @param string[] $packageNames

--- a/utils/releaser/tests/FileManipulator/ComposerJsonFileManipulatorTest.php
+++ b/utils/releaser/tests/FileManipulator/ComposerJsonFileManipulatorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\Tests\FileManipulator;
+
+use Nette\Utils\Json;
+use Override;
+use PHPUnit\Framework\TestCase;
+use Shopsys\Releaser\FileManipulator\ComposerJsonFileManipulator;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class ComposerJsonFileManipulatorTest extends TestCase
+{
+    private ComposerJsonFileManipulator $composerJsonFileManipulator;
+
+    private string $temporaryFilePath;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->composerJsonFileManipulator = new ComposerJsonFileManipulator();
+
+        $temporaryFilePath = tempnam(sys_get_temp_dir(), 'composer-json-manipulator-test-');
+
+        if ($temporaryFilePath === false) {
+            $this->fail('Unable to create a temporary file.');
+        }
+
+        $this->temporaryFilePath = $temporaryFilePath;
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        if (file_exists($this->temporaryFilePath)) {
+            unlink($this->temporaryFilePath);
+        }
+    }
+
+    public function testAddRequireIsInsertedAlphabeticallyWithinSameVendor(): void
+    {
+        $fileInfo = $this->writeComposerJson([
+            'require' => [
+                'php' => '^8.5',
+                'fixture-vendor/alpha' => '1.0.x-dev',
+                'fixture-vendor/bravo' => '1.0.x-dev',
+                'fixture-vendor/delta' => '1.0.x-dev',
+                'other-vendor/library' => '^1.0',
+            ],
+        ]);
+
+        $this->composerJsonFileManipulator->addRequires($fileInfo, ['fixture-vendor/charlie' => '1.0.x-dev']);
+
+        $this->assertSame(
+            [
+                'php',
+                'fixture-vendor/alpha',
+                'fixture-vendor/bravo',
+                'fixture-vendor/charlie',
+                'fixture-vendor/delta',
+                'other-vendor/library',
+            ],
+            $this->readRequireKeys(),
+        );
+        $this->assertSame('1.0.x-dev', $this->readRequire()['fixture-vendor/charlie']);
+    }
+
+    public function testAddRequireThatSortsAfterAllVendorSiblingsIsInsertedRightAfterTheLastSibling(): void
+    {
+        $fileInfo = $this->writeComposerJson([
+            'require' => [
+                'php' => '^8.5',
+                'fixture-vendor/alpha' => '1.0.x-dev',
+                'fixture-vendor/bravo' => '1.0.x-dev',
+                'other-vendor/library' => '^1.0',
+            ],
+        ]);
+
+        $this->composerJsonFileManipulator->addRequires($fileInfo, ['fixture-vendor/zulu' => '1.0.x-dev']);
+
+        $this->assertSame(
+            [
+                'php',
+                'fixture-vendor/alpha',
+                'fixture-vendor/bravo',
+                'fixture-vendor/zulu',
+                'other-vendor/library',
+            ],
+            $this->readRequireKeys(),
+        );
+    }
+
+    public function testAddRequireAppendsToTheEndWhenThereIsNoVendorSibling(): void
+    {
+        $fileInfo = $this->writeComposerJson([
+            'require' => [
+                'php' => '^8.5',
+                'other-vendor/library' => '^1.0',
+            ],
+        ]);
+
+        $this->composerJsonFileManipulator->addRequires($fileInfo, ['fixture-vendor/alpha' => '1.0.x-dev']);
+
+        $this->assertSame(['php', 'other-vendor/library', 'fixture-vendor/alpha'], $this->readRequireKeys());
+    }
+
+    public function testAddRequireLeavesAnAlreadyPresentRequireUntouched(): void
+    {
+        $fileInfo = $this->writeComposerJson([
+            'require' => [
+                'php' => '^8.5',
+                'fixture-vendor/alpha' => '1.0.x-dev',
+            ],
+        ]);
+
+        $this->composerJsonFileManipulator->addRequires($fileInfo, ['fixture-vendor/alpha' => 'dev-some-branch']);
+
+        $this->assertSame(['php', 'fixture-vendor/alpha'], $this->readRequireKeys());
+        $this->assertSame('1.0.x-dev', $this->readRequire()['fixture-vendor/alpha']);
+    }
+
+    /**
+     * @param array<string, mixed> $jsonContent
+     */
+    private function writeComposerJson(array $jsonContent): SplFileInfo
+    {
+        file_put_contents($this->temporaryFilePath, Json::encode($jsonContent, pretty: true) . PHP_EOL);
+
+        return new SplFileInfo($this->temporaryFilePath, '', '');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function readRequire(): array
+    {
+        return Json::decode((string)file_get_contents($this->temporaryFilePath), true)['require'];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function readRequireKeys(): array
+    {
+        return array_keys($this->readRequire());
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

In the split-package monorepo, every package is published and must be installable on its own. Composer only derives a minimum-stability flag from a dev-version requirement (e.g. `20.0.x-dev`) when that requirement is listed *directly*; it does not derive one for a dev-version dependency reachable only transitively. As a result, a split package tested standalone fails to install, reporting that a transitive dev dependency "does not match your minimum-stability", unless the package requires that dependency directly.

This PR fixes the current occurrence by adding `shopsys/mcp-attributes` as a direct requirement to every package that already reaches it transitively, so those packages install cleanly when used on their own.

To prevent this class of problem from recurring, it also adds a `monorepo:validate-mutual-dependencies` command that checks every package directly requires all of its transitive dev-version shopsys dependencies, and adds the missing ones with `--fix`. The check is wired into the `standards` build target (so CI fails when a package is incomplete) and the fix into `standards-fix`, so the requirement is enforced automatically going forward rather than relying on developers to remember it.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-dev-dependencies.odin.shopsys.cloud
  - https://cz.rv-fix-dev-dependencies.odin.shopsys.cloud
  - https://rv-fix-dev-dependencies.odin.shopsys.cloud/sk
<!-- Replace -->
