### PR TITLE
package manifests now resolve internal dev dependencies

### DIFF
--- a/packages/administration/composer.json
+++ b/packages/administration/composer.json
@@ -31,9 +31,7 @@
         "php": "^8.5",
         "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
-        "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/form": "^7.4",
@@ -54,6 +52,8 @@
         "shopsys/biome-config": "20.0.x-dev",
         "shopsys/coding-standards": "20.0.x-dev"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "symfony": {
             "require": "^7.4",

--- a/packages/article-feed-luigis-box/composer.json
+++ b/packages/article-feed-luigis-box/composer.json
@@ -36,10 +36,8 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/orm": "^3.6",
         "doctrine/persistence": "^4.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/form": "^7.4",
@@ -50,6 +48,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/brand-feed-luigis-box/composer.json
+++ b/packages/brand-feed-luigis-box/composer.json
@@ -36,10 +36,8 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/orm": "^3.6",
         "doctrine/persistence": "^4.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/form": "^7.4",
@@ -50,6 +48,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/category-feed-luigis-box/composer.json
+++ b/packages/category-feed-luigis-box/composer.json
@@ -36,10 +36,8 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/orm": "^3.6",
         "doctrine/persistence": "^4.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/form": "^7.4",
@@ -50,6 +48,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -141,6 +141,8 @@
         "symfony/var-dumper": "^7.4",
         "symfony/yaml": "^7.4"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "symfony": {
             "require": "^7.4",

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -33,7 +33,6 @@
         "overblog/graphql-bundle": "^1.9",
         "overblog/graphiql-bundle": "^1.0",
         "overblog/dataloader-bundle": "^1.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
@@ -56,6 +55,8 @@
         "phpunit/phpunit": "^12.5",
         "shopsys/coding-standards": "20.0.x-dev"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true,

--- a/packages/google-cloud-bundle/composer.json
+++ b/packages/google-cloud-bundle/composer.json
@@ -23,16 +23,15 @@
         "php": "^8.5",
         "google/cloud-storage": "^1.10",
         "league/flysystem-google-cloud-storage": "^3.0",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
-        "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/framework-bundle": "^7.4",
         "symfony/http-kernel": "^7.4",
         "symfony/options-resolver": "^7.4"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "ocramius/package-versions": true,

--- a/packages/luigis-box/composer.json
+++ b/packages/luigis-box/composer.json
@@ -28,11 +28,8 @@
     },
     "require": {
         "php": "^8.5",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/frontend-api": "20.0.x-dev",
-        "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "shopsys/article-feed-luigis-box": "20.0.x-dev",
         "shopsys/brand-feed-luigis-box": "20.0.x-dev",
         "shopsys/category-feed-luigis-box": "20.0.x-dev",
@@ -47,6 +44,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/maker/composer.json
+++ b/packages/maker/composer.json
@@ -34,10 +34,8 @@
         "doctrine/persistence": "^4.1",
         "prezent/doctrine-translatable": "^5.0",
         "ramsey/uuid": "^4.3.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/console": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/filesystem": "^7.4",
@@ -56,6 +54,8 @@
         "phpunit/phpunit": "^12.5",
         "shopsys/coding-standards": "20.0.x-dev"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "symfony": {
             "require": "^7.4",

--- a/packages/mcp-attributes/composer.json
+++ b/packages/mcp-attributes/composer.json
@@ -33,6 +33,8 @@
         "phpunit/phpunit": "^12.5",
         "shopsys/coding-standards": "20.0.x-dev"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true,

--- a/packages/mcp/composer.json
+++ b/packages/mcp/composer.json
@@ -28,12 +28,10 @@
         "php": "^8.5",
         "ext-pg_query": "*",
         "shopsys/administration": "20.0.x-dev",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/mcp-attributes": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "symfony/clock": "^7.4",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/http-foundation": "^7.4",
@@ -52,6 +50,8 @@
         "phpunit/phpunit": "^12.5",
         "shopsys/coding-standards": "20.0.x-dev"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "symfony": {
             "require": "^7.4",

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -50,6 +50,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -30,10 +30,7 @@
     "require": {
         "php": "^8.5",
         "doctrine/orm": "^3.6",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
-        "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/framework-bundle": "^7.4",
@@ -43,6 +40,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -54,6 +54,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/product-feed-luigis-box/composer.json
+++ b/packages/product-feed-luigis-box/composer.json
@@ -35,7 +35,6 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/orm": "^3.6",
         "doctrine/persistence": "^4.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
         "shopsys/plugin-interface": "20.0.x-dev",
@@ -49,6 +48,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/product-feed-mergado/composer.json
+++ b/packages/product-feed-mergado/composer.json
@@ -35,10 +35,8 @@
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/orm": "^3.6",
         "doctrine/persistence": "^4.1",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
         "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/form": "^7.4",
@@ -49,6 +47,8 @@
     "require-dev": {
         "phpunit/phpunit": "^12.5"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -51,6 +51,8 @@
         "phpunit/phpunit": "^12.5",
         "shopsys/frontend-api": "20.0.x-dev"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "suggest": {
         "shopsys/frontend-api": "Required only when you want to extend the Frontend API Category type with additional Zbozi.cz related fields."
     },

--- a/packages/s3-bridge/composer.json
+++ b/packages/s3-bridge/composer.json
@@ -25,10 +25,7 @@
         "aws/aws-sdk-php": "^3.220.0",
         "league/flysystem": "^3.11",
         "league/flysystem-aws-s3-v3": "^3.12.2",
-        "shopsys/form-types-bundle": "20.0.x-dev",
         "shopsys/framework": "20.0.x-dev",
-        "shopsys/migrations": "20.0.x-dev",
-        "shopsys/plugin-interface": "20.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/http-kernel": "^7.4"
@@ -36,6 +33,8 @@
     "require-dev": {
         "phpstan/phpstan": "^2.1.16"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "symfony/flex": true


### PR DESCRIPTION
#### Description, the reason for the PR

This PR makes split package Composer manifests usable as standalone root packages when they contain internal Shopsys `20.0.x-dev` constraints.

Composer treats `minimum-stability` and `prefer-stable` as root-only settings. That means these settings only affect dependency resolution when the given `composer.json` is the root package, for example when a split package is validated, tested, or installed independently. They do not change dependency resolution for downstream applications that require these packages; the downstream application's root `composer.json` remains in control.

The PR also removes direct Shopsys package requirements that are only transitive and unused by the package itself. Dependencies that are part of a package's own contract remain direct, such as migrations for bundles that prepend Doctrine migrations configuration.

#### Fixes issues

closes #4678 

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://mg-transitive.odin.shopsys.cloud
  - https://cz.mg-transitive.odin.shopsys.cloud
  - https://mg-transitive.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1782722180.554449 -->