### PR TITLE
Prevent simplified review deployment volume race

### DIFF
--- a/docker/conf/docker-compose.github-actions.review.simplified.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.simplified.yml.dist
@@ -103,6 +103,8 @@ services:
         image: php-fpm-image
         volumes:
             - web-volume:/var/www/html/project-base/app/web
+        depends_on:
+            - php-fpm
         environment:
             IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK: 1
             DATABASE_NAME: "${BRANCH_NAME_ESCAPED}"


### PR DESCRIPTION
#### Description, the reason for the PR

Simplified review deployments can occasionally fail while Docker is creating the fresh shared web volume for the review environment. When `php-fpm` and `php-consumer` start at the same time, both containers may try to initialize the same mounted web directory, which can make the GitHub Actions review job fail before the environment is available.

This PR makes the simplified review setup start the consumer only after `php-fpm`, matching the regular review compose setup. Review environments should become more reliable and require fewer manual reruns of failed review jobs.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-review.odin.shopsys.cloud
  - https://cz.mg-fix-review.odin.shopsys.cloud
  - https://mg-fix-review.odin.shopsys.cloud/sk
<!-- Replace -->
