### PR TITLE
Fix minor issues in administration

### DIFF
--- a/packages/administration/templates/content/superadmin/urlsListGrid.html.twig
+++ b/packages/administration/templates/content/superadmin/urlsListGrid.html.twig
@@ -4,5 +4,5 @@
 {% block h1 %}{{ 'URL addresses'|trans }}{% endblock %}
 
 {% block main_content %}
-    {{ 'The current list of URL addresses can be found in the project\'s repository in the "storefront/config/staticRewritePaths.js" file.'|trans }}
+    {{ 'The current list of URL addresses can be found in the project\'s repository in the "storefront/config/routes.ts" file.'|trans }}
 {% endblock%}

--- a/packages/administration/templates/form/content/PricesByPricingGroupsType.html.twig
+++ b/packages/administration/templates/form/content/PricesByPricingGroupsType.html.twig
@@ -13,7 +13,7 @@
 {% block pricing_group_price_input_row %}
     {% set domainId = form.parent.vars.domain_id %}
 
-    <div class="row align-items-center">
+    <div class="row align-items-center mb-3">
         {{ form_label(form) }}
 
         <div class="col-12 col-md-6">

--- a/packages/administration/templates/form/content/ProductVideosDataCollection.html.twig
+++ b/packages/administration/templates/form/content/ProductVideosDataCollection.html.twig
@@ -25,7 +25,7 @@
 
         <span class="js-videos-collection-add-row btn">
             {{ ux_icon('plus') }}
-            {{ 'Add another video'|trans }}
+            {{ 'Add video'|trans }}
         </span>
     </div>
 {% endblock %}

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -2188,8 +2188,8 @@ msgstr "Obchodní podmínky"
 msgid "Terms and conditions settings"
 msgstr "Nastavení obchodních podmínek"
 
-msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/staticRewritePaths.js\" file."
-msgstr "Aktuální seznam URL adres lze nalézt v repozitáři projektu v souboru \"storefront/config/staticRewritePaths.js\"."
+msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/routes.ts\" file."
+msgstr "Aktuální seznam URL adres lze nalézt v repozitáři projektu v souboru \"storefront/config/routes.ts\"."
 
 msgid "The days are used to display proper stores opening hours and to calculate order withdrawal deadline."
 msgstr "Dny se používají k zobrazení správné otevírací doby prodejen a k výpočtu lhůty pro odstoupení od smlouvy u objednávky."

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -67,9 +67,6 @@ msgstr "Přidat další parametr"
 msgid "Add another price with weight limit"
 msgstr "Přidat další cenu s váhovým limitem"
 
-msgid "Add another video"
-msgstr "Přidat další video"
-
 msgid "Add country"
 msgstr "Přidat stát"
 
@@ -108,6 +105,9 @@ msgstr "Přidejte nějaké předpisy pro e-mailový whitelist"
 
 msgid "Add some parameters"
 msgstr "Přidat parametr"
+
+msgid "Add video"
+msgstr "Přidat video"
 
 msgid "Administration"
 msgstr "Administrace"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -2188,7 +2188,7 @@ msgstr ""
 msgid "Terms and conditions settings"
 msgstr ""
 
-msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/staticRewritePaths.js\" file."
+msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/routes.ts\" file."
 msgstr ""
 
 msgid "The days are used to display proper stores opening hours and to calculate order withdrawal deadline."

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -67,9 +67,6 @@ msgstr ""
 msgid "Add another price with weight limit"
 msgstr ""
 
-msgid "Add another video"
-msgstr ""
-
 msgid "Add country"
 msgstr ""
 
@@ -107,6 +104,9 @@ msgid "Add some mail whitelist patterns"
 msgstr ""
 
 msgid "Add some parameters"
+msgstr ""
+
+msgid "Add video"
 msgstr ""
 
 msgid "Administration"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -67,9 +67,6 @@ msgstr "Pridať ďalší parameter"
 msgid "Add another price with weight limit"
 msgstr "Pridať ďalšiu cenu s hmotnostným limitom"
 
-msgid "Add another video"
-msgstr "Pridať ďalšie video"
-
 msgid "Add country"
 msgstr "Pridať krajinu"
 
@@ -108,6 +105,9 @@ msgstr "Pridať niektoré vzory bieleho zoznamu emailov"
 
 msgid "Add some parameters"
 msgstr "Pridať niektoré parametre"
+
+msgid "Add video"
+msgstr "Pridať video"
 
 msgid "Administration"
 msgstr "Administrácia"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -2188,8 +2188,8 @@ msgstr "Obchodné podmienky"
 msgid "Terms and conditions settings"
 msgstr "Nastavenia Terms and conditions"
 
-msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/staticRewritePaths.js\" file."
-msgstr "Aktuálny zoznam URL adries môže byť nájdený v repositári projektu v súbore \"storefront/config/staticRewritePaths.js\"."
+msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/routes.ts\" file."
+msgstr "Aktuálny zoznam URL adries sa nachádza v repozitári projektu v súbore \"storefront/config/routes.ts\"."
 
 msgid "The days are used to display proper stores opening hours and to calculate order withdrawal deadline."
 msgstr "Tieto dni sa používajú na zobrazenie správnych otváracích hodín obchodov a na výpočet lehoty na odstúpenie od objednávky."

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -277,6 +277,18 @@ final class ProductFormType extends AbstractType
                 'label' => 'Weight (g)',
                 'required' => false,
             ])
+            ->add('unit', ChoiceType::class, [
+                'required' => true,
+                'choices' => $this->unitFacade->getAll(),
+                'choice_label' => 'name',
+                'choice_value' => 'id',
+                'constraints' => [
+                    new Constraints\NotBlank(
+                        message: 'Please choose unit',
+                    ),
+                ],
+                'label' => 'Unit',
+            ])
             ->add('excludedTransports', ChoiceType::class, [
                 'required' => false,
                 'choices' => $this->transportFacade->getAll(),
@@ -422,20 +434,6 @@ final class ProductFormType extends AbstractType
                     ],
                 ]);
         }
-        $builderDisplayAvailabilityGroup
-            ->add('unit', ChoiceType::class, [
-                'required' => true,
-                'choices' => $this->unitFacade->getAll(),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
-                'constraints' => [
-                    new Constraints\NotBlank(
-                        message: 'Please choose unit',
-                    ),
-                ],
-                'label' => 'Unit',
-            ]);
-
         $builderDisplayAvailabilityGroup
             ->add('orderingPriorityByDomainId', MultidomainType::class, [
                 'entry_type' => TextType::class,

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -313,6 +313,7 @@ final class ProductFormType extends AbstractType
                     'entry_type' => TextareaType::class,
                     'required' => false,
                     'disabled' => $this->isProductVariant($product),
+                    'label' => false,
                 ]);
         }
 
@@ -336,6 +337,7 @@ final class ProductFormType extends AbstractType
                     'entry_type' => CKEditorType::class,
                     'required' => false,
                     'disabled' => $this->isProductVariant($product),
+                    'label' => false,
                 ]);
         }
 

--- a/project-base/app/tests/App/Smoke/NewProductTest.php
+++ b/project-base/app/tests/App/Smoke/NewProductTest.php
@@ -65,9 +65,9 @@ class NewProductTest extends ApplicationTestCase
         $form['product_form[basicInformationGroup][partno]'] = '123456';
         $form['product_form[basicInformationGroup][ean]'] = '123456';
         $form['product_form[descriptionsGroup][descriptions][1]'] = 'test description';
+        $form['product_form[basicInformationGroup][unit]']->setValue((string)$unit->getId());
         $form['product_form[displayAvailabilityGroup][sellingFrom]'] = '1.1.1990';
         $form['product_form[displayAvailabilityGroup][sellingTo]'] = '1.1.2000';
-        $form['product_form[displayAvailabilityGroup][unit]']->setValue((string)$unit->getId());
         $form['product_form[stocksGroup][productStockData][1][productQuantity]'] = '1';
         $form['product_form[stocksGroup][productStockData][2][productQuantity]'] = '2';
         $form['product_form[stocksGroup][productStockData][3][productQuantity]'] = '3';

--- a/upgrade-notes/backend_20260707_154508.md
+++ b/upgrade-notes/backend_20260707_154508.md
@@ -1,0 +1,3 @@
+#### Fix minor issues in administration ([#4681](https://github.com/shopsys/shopsys/pull/4681))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
A collection of small administration UI fixes:

- **Superadmin URL addresses page** (Settings > Superadmin > URL addresses) pointed users to `storefront/config/staticRewritePaths.js`. That file is now a `.ts` file and no longer holds the URL address list — the actual list lives in `storefront/config/routes.ts`. Updated the Twig template and en/cs/sk translations (including an improved Slovak translation).
- **Product form: "Add another video" button** renamed to "Add video" to match the wording of other add buttons.
- **Product form: duplicate untranslated labels** — the Description and Short description sections rendered an extra auto-generated label ("Descriptions" / "Short descriptions") below the section heading. These came from Symfony's field-name humanization and had no translations; they are now suppressed via `'label' => false`.
- **Product form: Unit field** moved from the Display and availability section to Basic information, where it logically belongs (next to Weight). The smoke test was updated accordingly.
- **Product form: price rows spacing** — rows in the Prices section had no bottom margin, so inputs without a calculated price preview touched each other. Added `mb-3` for uniform spacing.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://pk-fix-urls-list-grid-file-reference.odin.shopsys.cloud
  - https://cz.pk-fix-urls-list-grid-file-reference.odin.shopsys.cloud
  - https://pk-fix-urls-list-grid-file-reference.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1783625523.253699 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-fix-urls-list-grid-file-reference.odin.shopsys.cloud
  - https://cz.pk-fix-urls-list-grid-file-reference.odin.shopsys.cloud
  - https://pk-fix-urls-list-grid-file-reference.odin.shopsys.cloud/sk
<!-- Replace -->
