### PR TITLE
Fix coding standard violations

### DIFF
--- a/packages/administration/src/Component/Datagrid/Adapter/Orm/DatagridDataSource.php
+++ b/packages/administration/src/Component/Datagrid/Adapter/Orm/DatagridDataSource.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\QueryBuilder;
 use Override;
 use Shopsys\AdministrationBundle\Component\Doctrine\DatagridHydrator;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;
-use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult as PaginationResult;
+use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 
 final class DatagridDataSource extends QueryBuilderWithRowManipulatorDataSource

--- a/packages/administration/src/Component/Security/Role/AdminRoleSectionsProvider.php
+++ b/packages/administration/src/Component/Security/Role/AdminRoleSectionsProvider.php
@@ -36,7 +36,7 @@ class AdminRoleSectionsProvider extends AbstractRoleSectionProvider
     }
 
     /**
-     * @{inheritDoc}
+     * {@inheritdoc}
      */
     #[Override]
     public static function getTargetContext(): string

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -128,6 +128,7 @@ use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff;
+use Symplify\CodingStandard\Fixer\Annotation\RemovePropertyVariableNameDescriptionFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -363,4 +364,5 @@ return ECSConfig::configure()
         ReturnTypeHintSniff::class . '.' . ReturnTypeHintSniff::CODE_MISSING_TRAVERSABLE_TYPE_HINT_SPECIFICATION,
         ReturnTypeHintSniff::class . '.' . ReturnTypeHintSniff::CODE_USELESS_SUPPRESS,
         ReturnTypeHintSniff::class . '.' . ReturnTypeHintSniff::CODE_LESS_SPECIFIC_NATIVE_TYPE_HINT,
+        RemovePropertyVariableNameDescriptionFixer::class => null,
     ]);

--- a/packages/form-types-bundle/src/MultidomainType.php
+++ b/packages/form-types-bundle/src/MultidomainType.php
@@ -30,7 +30,7 @@ final class MultidomainType extends AbstractType
     {
         $entryOptions = $options['entry_options'];
         $entryOptions['required'] = ($options['required'] ?? false) || ($entryOptions['required'] ?? false);
-        $entryOptions['constraints'] = $entryOptions['constraints'] ?? [];
+        $entryOptions['constraints'] ??= [];
 
         $domainIds = $this->domainIdsProvider->getAdminEnabledDomainIds();
 

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -282,7 +282,7 @@ class CronCommand extends Command
     {
         /** @var string|null $cronTimezone */
         $cronTimezone = $this->parameterBag->get('shopsys.cron_timezone');
-        $cronTimezone = $cronTimezone ?? date_default_timezone_get();
+        $cronTimezone ??= date_default_timezone_get();
 
         return new DateTimeZone($cronTimezone);
     }

--- a/packages/framework/src/Component/Cron/MonitorConfigFactory.php
+++ b/packages/framework/src/Component/Cron/MonitorConfigFactory.php
@@ -28,7 +28,7 @@ class MonitorConfigFactory
             $maxRuntime = (int)ceil($cronModuleConfig->getTimeoutIteratedCronSec() / 60);
         }
 
-        $maxRuntime = $maxRuntime ?? self::DEFAULT_MAX_RUNTIME_MIN;
+        $maxRuntime ??= self::DEFAULT_MAX_RUNTIME_MIN;
 
         $checkinMargin = $sentryMonitorConfig?->getCheckinMargin() ?? $cronModuleConfig->getRunEveryMin();
 

--- a/packages/framework/src/Component/EntityLog/ChangeSet/ChangeSetResolver.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/ChangeSetResolver.php
@@ -40,7 +40,7 @@ class ChangeSetResolver
             $dataTypeResolversArray[] = $dataTypeResolver;
         }
 
-        //sort data type resolvers from higher to lower priority
+        // sort data type resolvers from higher to lower priority
         usort($dataTypeResolversArray, function (DataTypeResolverInterface $a, DataTypeResolverInterface $b) {
             return $b->getPriority() - $a->getPriority();
         });

--- a/packages/framework/src/Component/EntityLog/EventListener/EntityLogEventListener.php
+++ b/packages/framework/src/Component/EntityLog/EventListener/EntityLogEventListener.php
@@ -126,7 +126,7 @@ class EntityLogEventListener implements ResetInterface
 
         foreach ($changeSet as $key => $value) {
             if ($value instanceof PersistentCollection) {
-                unset($changeSet[$key]); //collection is logged in resolveChangesOnCollectionForEntity method
+                unset($changeSet[$key]); // collection is logged in resolveChangesOnCollectionForEntity method
             }
         }
 

--- a/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
+++ b/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
@@ -8,7 +8,7 @@ use LogicException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
-use Symfony\Component\HttpFoundation\Session\Session as Session;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * @property \Psr\Container\ContainerInterface $container

--- a/packages/framework/src/Migrations/Version20241205144230.php
+++ b/packages/framework/src/Migrations/Version20241205144230.php
@@ -13,17 +13,17 @@ final class Version20241205144230 extends AbstractMigration
     #[Override]
     public function up(Schema $schema): void
     {
-        //product indexes
+        // product indexes
         $this->sql('CREATE INDEX products_catnum_trgm_idx ON products USING gin (normalized(catnum) gin_trgm_ops);');
         $this->sql('CREATE INDEX products_partno_trgm_idx ON products USING gin (normalized(partno) gin_trgm_ops);');
         $this->sql('CREATE INDEX product_translations_name_trgm_idx ON product_translations USING gin (normalized(name) gin_trgm_ops);');
 
-        //order indexes
+        // order indexes
         $this->sql('CREATE INDEX orders_email_trgm_idx ON orders USING gin (normalized(email) gin_trgm_ops);');
         $this->sql('CREATE INDEX orders_last_name_trgm_idx ON orders USING gin (normalized(last_name) gin_trgm_ops);');
         $this->sql('CREATE INDEX orders_company_name_trgm_idx ON orders USING gin (normalized(company_name) gin_trgm_ops);');
 
-        //user indexes
+        // user indexes
         $this->sql('CREATE INDEX customer_users_email_trgm_idx ON customer_users USING gin (normalized(email) gin_trgm_ops);');
         $this->sql('CREATE INDEX customer_users_last_name_trgm_idx ON customer_users USING gin (normalized(last_name) gin_trgm_ops);');
         $this->sql('CREATE INDEX customer_users_telephone_trgm_idx ON customer_users USING gin (normalized(telephone) gin_trgm_ops);');

--- a/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
@@ -87,8 +87,8 @@ class AdministratorUserProvider implements UserProviderInterface
         }
 
         if ($freshAdministrator->getRolesChangedAt() > $administrator->getRolesChangedAt()) {
-            //In this step token does not exist, so we are not able to update user roles.
-            //We notify RolesChangedListener for roles updating
+            // In this step token does not exist, so we are not able to update user roles.
+            // We notify RolesChangedListener for roles updating
             $this->administratorRolesChangedSubscriber->updateRoles();
         }
 

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -466,7 +466,7 @@ class CategoryRepository extends NestedTreeRepository
     ): array {
         $queryBuilder = $this->getAllQueryBuilder();
         $domainId = $domainConfig->getId();
-        $locale = $locale ?? $domainConfig->getLocale();
+        $locale ??= $domainConfig->getLocale();
         $mainCategory = $this->getProductMainCategoryOnDomain($product, $domainId);
 
         $this->addTranslation($queryBuilder, $locale);

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleSectionProvider.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleSectionProvider.php
@@ -22,7 +22,7 @@ class CustomerUserRoleSectionProvider extends AbstractRoleSectionProvider
     }
 
     /**
-     * @{inheritDoc}
+     * {@inheritdoc}
      */
     #[Override]
     public static function getTargetContext(): string

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/PersonalPickupPointMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/PersonalPickupPointMiddleware.php
@@ -64,10 +64,10 @@ class PersonalPickupPointMiddleware implements OrderProcessorMiddlewareInterface
         $orderData->personalPickupStore = $store;
         $orderData->deliveryAddressSameAsBillingAddress = false;
 
-        $orderData->deliveryFirstName = $orderData->deliveryFirstName ?? $orderData->firstName;
-        $orderData->deliveryLastName = $orderData->deliveryLastName ?? $orderData->lastName;
-        $orderData->deliveryCompanyName = $orderData->deliveryCompanyName ?? $orderData->companyName;
-        $orderData->deliveryTelephone = $orderData->deliveryTelephone ?? $orderData->telephone;
+        $orderData->deliveryFirstName ??= $orderData->firstName;
+        $orderData->deliveryLastName ??= $orderData->lastName;
+        $orderData->deliveryCompanyName ??= $orderData->companyName;
+        $orderData->deliveryTelephone ??= $orderData->telephone;
 
         $orderData->deliveryStreet = $store->getStreet();
         $orderData->deliveryCity = $store->getCity();

--- a/packages/framework/src/Model/Product/ProductCachedAttributesFacade.php
+++ b/packages/framework/src/Model/Product/ProductCachedAttributesFacade.php
@@ -47,7 +47,7 @@ class ProductCachedAttributesFacade
         return $this->inMemoryCache->getOrSaveValue(
             static::PARAMETER_VALUES_CACHE_NAMESPACE,
             function () use ($product, $locale): array {
-                $locale = $locale ?? $this->localization->getCurrentLocaleForTranslatableEntities();
+                $locale ??= $this->localization->getCurrentLocaleForTranslatableEntities();
 
                 $productParameterValues = $this->parameterRepository->getProductParameterValuesByProductSortedByOrderingPriorityAndName(
                     $product,

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -59,7 +59,7 @@ class ProductOnCurrentDomainElasticFacade
         ?string $searchText,
         ProductFilterData $productFilterData,
     ): ProductFilterCountData {
-        $searchText = $searchText ?? '';
+        $searchText ??= '';
 
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInSearch(
             $productFilterData,

--- a/packages/framework/src/Twig/FileUploadExtension.php
+++ b/packages/framework/src/Twig/FileUploadExtension.php
@@ -32,7 +32,7 @@ class FileUploadExtension extends AbstractExtension
         $filepath = $this->fileUpload->getTemporaryDirectory() . '/' . $temporaryFilename;
 
         if (file_exists($filepath) && is_file($filepath) && is_writable($filepath)) {
-            $fileSize = round((int)filesize($filepath) / 1000 / 1000, 2); //https://en.wikipedia.org/wiki/Binary_prefix
+            $fileSize = round((int)filesize($filepath) / 1000 / 1000, 2); // https://en.wikipedia.org/wiki/Binary_prefix
 
             return $filename . ' (' . $fileSize . ' MB)';
         }

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/StaleAnnotationsRemoverTest/ProjectChildWithNonAnnotationComment.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/StaleAnnotationsRemoverTest/ProjectChildWithNonAnnotationComment.php
@@ -7,7 +7,6 @@ namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\StaleAnnota
 /**
  * This is a description of the class.
  *
- * @author John Doe
  * @method void staleMethod()
  * @property string $validProperty
  */

--- a/packages/framework/tests/Unit/Component/Constraints/FileExtensionMaxLengthValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/FileExtensionMaxLengthValidatorTest.php
@@ -24,7 +24,7 @@ class FileExtensionMaxLengthValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidateValidLength(): void
     {
-        $file = new File(__DIR__ . '/' . 'non-existent.file', false);
+        $file = new File(__DIR__ . '/non-existent.file', false);
 
         $constraint = new FileExtensionMaxLength(
             limit: 4,
@@ -37,7 +37,7 @@ class FileExtensionMaxLengthValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidateInvalidLength(): void
     {
-        $file = new File(__DIR__ . '/' . 'non-existent.file', false);
+        $file = new File(__DIR__ . '/non-existent.file', false);
 
         $constraint = new FileExtensionMaxLength(
             limit: 3,

--- a/packages/frontend-api/src/Model/Complaint/ComplaintItemDataApiFactory.php
+++ b/packages/frontend-api/src/Model/Complaint/ComplaintItemDataApiFactory.php
@@ -30,8 +30,8 @@ class ComplaintItemDataApiFactory
         $catnum = $orderItem?->getCatnum() ?? $manualComplaintItemCatnum;
 
         if ($product) {
-            $productName = $productName ?? $product->getName();
-            $catnum = $catnum ?? $product->getCatnum();
+            $productName ??= $product->getName();
+            $catnum ??= $product->getCatnum();
         }
 
         $complaintItemData = $this->complaintItemDataFactory->create();

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceQuery.php
@@ -41,7 +41,7 @@ class PriceQuery extends AbstractQuery
         ?string $cartUuid = null,
         ?ArrayObject $context = null,
     ): PriceInterface {
-        $cartUuid = $cartUuid ?? $this->gqlContextHelper->getCartUuid($context);
+        $cartUuid ??= $this->gqlContextHelper->getCartUuid($context);
         $orderUuid = $this->gqlContextHelper->getOrderUuid($context);
 
         if ($cartUuid === null && $orderUuid !== null) {
@@ -89,7 +89,7 @@ class PriceQuery extends AbstractQuery
         ?string $cartUuid = null,
         ?ArrayObject $context = null,
     ): PriceInterface {
-        $cartUuid = $cartUuid ?? $this->gqlContextHelper->getCartUuid($context);
+        $cartUuid ??= $this->gqlContextHelper->getCartUuid($context);
 
         $customerUser = $this->currentCustomerUser->findCurrentCustomerUser();
 

--- a/packages/luigis-box/src/Model/Product/Connection/ProductConnectionFactory.php
+++ b/packages/luigis-box/src/Model/Product/Connection/ProductConnectionFactory.php
@@ -39,7 +39,7 @@ class ProductConnectionFactory
 
             return $this->luigisBoxFacetsToProductFilterConfigMapper->map($batchLoadResult?->getFacets() ?? [], $productFilterData);
         };
-        $orderingMode = $orderingMode ?? $this->productOrderingModeProvider->getDefaultOrderingModeForSearch();
+        $orderingMode ??= $this->productOrderingModeProvider->getDefaultOrderingModeForSearch();
 
         return $this->getConnectionPromise(
             $retrieveProductClosure,

--- a/project-base/app/src/DataFixtures/Demo/BlogArticleDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/BlogArticleDataFixture.php
@@ -67,7 +67,7 @@ class BlogArticleDataFixture extends AbstractReferenceFixture implements Depende
 
         $this->addReference(self::FIRST_DEMO_BLOG_CATEGORY, $mainPageBlogCategory);
 
-        //only in main category
+        // only in main category
         for ($i = 0; $i < self::PAGES_IN_CATEGORY; $i++) {
             $blogArticleData = $this->createArticle([$mainPageBlogCategory]);
             $this->applyStatusDiversity($blogArticleData, $i);
@@ -90,7 +90,7 @@ class BlogArticleDataFixture extends AbstractReferenceFixture implements Depende
         $firstSubcategory = $this->blogCategoryFacade->create($firstSubcategoryData);
         $this->addReference(self::FIRST_DEMO_BLOG_SUBCATEGORY, $firstSubcategory);
 
-        //in first subcategory
+        // in first subcategory
         for ($i = 0; $i < self::PAGES_IN_CATEGORY; $i++) {
             $blogArticleData = $this->createArticle([$mainPageBlogCategory, $firstSubcategory]);
             $this->applyStatusDiversity($blogArticleData, $i);
@@ -105,7 +105,7 @@ class BlogArticleDataFixture extends AbstractReferenceFixture implements Depende
         $secondSubcategory = $this->blogCategoryFacade->create($secondSubcategoryData);
         $this->addReference(self::SECOND_DEMO_BLOG_SUBCATEGORY, $secondSubcategory);
 
-        //in second subcategory
+        // in second subcategory
         for ($i = 0; $i < self::PAGES_IN_CATEGORY; $i++) {
             $blogArticleData = $this->createArticle([$mainPageBlogCategory, $secondSubcategory]);
             $this->applyStatusDiversity($blogArticleData, $i);

--- a/project-base/app/src/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ImageDataFixture.php
@@ -263,7 +263,7 @@ class ImageDataFixture extends AbstractFileFixture implements DependentFixtureIn
             $this->saveImageIntoDb($sliderItemId, 'sliderItem', $imageId, $names, SliderItemFacade::IMAGE_TYPE_WEB);
         }
 
-        //mobile version
+        // mobile version
         $imagesIdsIndexedBySliderItemsIds = [
             1 => 103,
             2 => 104,

--- a/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
@@ -4073,12 +4073,12 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
     {
         return [
             '9176544M' => [
-                '9176544', //36 / led
-                '9176588', //54 / crt
-                '9176522', //24 / led
-                '917652236', //36 / crt
-                '917652254', //54 / led
-                '91765223', //24 / crt
+                '9176544', // 36 / led
+                '9176588', // 54 / crt
+                '9176522', // 24 / led
+                '917652236', // 36 / crt
+                '917652254', // 54 / led
+                '91765223', // 24 / crt
             ],
             '32PFL4400' => [
                 '9176554', // 36 / led

--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -103,16 +103,16 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $this->assertCount(4, $logs);
 
         $logs = array_reverse($logs);
-        $this->assertSame(EntityLogActionEnum::CREATE, $logs[0]->getAction()); //order
+        $this->assertSame(EntityLogActionEnum::CREATE, $logs[0]->getAction()); // order
         $this->assertSame($orderFromDb->getNumber(), $logs[0]->getEntityIdentifier());
 
-        $this->assertSame(EntityLogActionEnum::CREATE, $logs[1]->getAction()); //product
+        $this->assertSame(EntityLogActionEnum::CREATE, $logs[1]->getAction()); // product
         $this->assertSame($orderFromDb->getProductItems()[0]->getName(), $logs[1]->getEntityIdentifier());
 
-        $this->assertSame(EntityLogActionEnum::CREATE, $logs[2]->getAction()); //transport
+        $this->assertSame(EntityLogActionEnum::CREATE, $logs[2]->getAction()); // transport
         $this->assertSame($orderFromDb->getTransportItem()->getName(), $logs[2]->getEntityIdentifier());
 
-        $this->assertSame(EntityLogActionEnum::CREATE, $logs[3]->getAction()); //payment
+        $this->assertSame(EntityLogActionEnum::CREATE, $logs[3]->getAction()); // payment
         $this->assertSame($orderFromDb->getPaymentItem()->getName(), $logs[3]->getEntityIdentifier());
     }
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/AutocompleteFavorites/AutocompleteFavoritesTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/AutocompleteFavorites/AutocompleteFavoritesTest.php
@@ -54,7 +54,7 @@ class AutocompleteFavoritesTest extends GraphQlTestCase
         /**
          * despite these products are set in @see \App\DataFixtures\Demo\AutocompleteFavoriteDataFixture,
          * they should not be returned by the query
-         **/
+         */
         $unexpectedProductNames = [
             $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148', Product::class)->getName($firstDomainLocale),
             $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '76', Product::class)->getName($firstDomainLocale),

--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
@@ -70,7 +70,7 @@ class GetOrdersAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
         // last 1 order
         yield [['last' => 1], 5, 1];
 
-        //last 2 orders
+        // last 2 orders
         yield [['last' => 2], 4, 2];
 
         // filter by order item catnum

--- a/upgrade-notes/backend_20260706_075358.md
+++ b/upgrade-notes/backend_20260706_075358.md
@@ -1,0 +1,3 @@
+#### Fix coding standard violations ([#4686](https://github.com/shopsys/shopsys/pull/4686))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

This PR brings PHP coding standards back to a clean state.

It applies the automatic style changes reported by the standards tooling, such as redundant import aliases, null coalescing assignments, inline comment spacing, and docblock formatting. It also keeps the ECS configuration from removing property variable names from annotation descriptions, so useful type documentation remains intact while standards checks pass.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-standards.odin.shopsys.cloud
  - https://cz.mg-fix-standards.odin.shopsys.cloud
  - https://mg-fix-standards.odin.shopsys.cloud/sk
<!-- Replace -->
