### PR TITLE
Fix test-send of administrator password-reset email template

### DIFF
--- a/packages/framework/src/Component/Security/NewPasswordUrlProvider.php
+++ b/packages/framework/src/Component/Security/NewPasswordUrlProvider.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrameworkBundle\Component\Security;
 use Psr\Clock\ClockInterface;
 use Shopsys\FrameworkBundle\Component\Router\AdministrationRouter;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
-use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Model\Mail\Exception\ResetPasswordHashNotValidException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -22,7 +21,7 @@ class NewPasswordUrlProvider
 
     public function getNewPasswordUrl(ResetPasswordInterface $user, int $domainId, string $routeName): string
     {
-        if ($user instanceof Administrator) {
+        if ($this->administrationRouter->getRouteCollection()->get($routeName) !== null) {
             $router = $this->administrationRouter;
         } else {
             $router = $this->domainRouterFactory->getRouter($domainId);


### PR DESCRIPTION
#### Description, the reason for the PR

Test-sending the administrator password-reset email template from the admin mail template settings failed with the error `Route 'admin_administrator_set-new-password' not found`. The regular reset-password flow worked correctly — only the test send was affected.

The reason was that the new-password link generator chose which router to use based on the concrete type of the user entity. During a test send a placeholder user is used instead of a real administrator, so the generator fell back to the storefront router, which does not know the administration route, and the link could not be built.

The router is now selected by checking whether the requested route actually exists in the administration router, falling back to the storefront router otherwise. As a result, administrators can test-send the reset-password email template without an error, and the resolution no longer depends on the user entity type or on route-naming conventions.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://rv-fix-mail-sender.odin.shopsys.cloud
  - https://cz.rv-fix-mail-sender.odin.shopsys.cloud
  - https://rv-fix-mail-sender.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1783432274.835969 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-mail-sender.odin.shopsys.cloud
  - https://cz.rv-fix-mail-sender.odin.shopsys.cloud
  - https://rv-fix-mail-sender.odin.shopsys.cloud/sk
<!-- Replace -->
