### PR TITLE
Fix GitLab storefront checks on current Node runtime

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -80,14 +80,14 @@ test:standards-with-graphql-schema-check:
 test:storefront-standards-with-codegen-with-tests-with-licenses-check:
     stage: test
     <<: *only-default
-    image: node:20-alpine3.17
+    image: node:24.14.0-alpine3.22
     tags:
         - tests
     needs:
         - build-storefront
     before_script:
         - corepack enable
-        - corepack prepare --activate pnpm@9.0.5
+        - corepack prepare --activate pnpm@10.30.3
         - pnpm config set store-dir .pnpm-store
         - apk add --no-cache grep git
         - cp ./app/schema.graphql ./storefront/schema.graphql

--- a/upgrade-notes/backend_20260708_102455.md
+++ b/upgrade-notes/backend_20260708_102455.md
@@ -1,0 +1,3 @@
+#### Fix GitLab storefront checks on current Node runtime ([#4690](https://github.com/shopsys/shopsys/pull/4690))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
GitLab storefront standards still ran in a standalone Node 20 image with pnpm 9, even though the storefront runtime and dependencies were upgraded to Node 24 and pnpm 10. That made code generation fail before the checks could run because current dependencies expect newer Node APIs.

This PR aligns the GitLab storefront checks with the storefront Docker runtime. The job now uses Node 24.14.0 and pnpm 10.30.3, matching the storefront Dockerfiles and package manager configuration.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-gitlab.odin.shopsys.cloud
  - https://cz.mg-fix-gitlab.odin.shopsys.cloud
  - https://mg-fix-gitlab.odin.shopsys.cloud/sk
<!-- Replace -->
