### PR TITLE
Refresh project-base Symfony recipe lock entries

### DIFF
--- a/project-base/app/symfony.lock
+++ b/project-base/app/symfony.lock
@@ -1043,6 +1043,21 @@
     "symfony/service-contracts": {
         "version": "v2.0.1"
     },
+    "symfony/stimulus-bundle": {
+        "version": "3.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.25",
+            "ref": "9b51a69079f3629061dfe0e5d7e20f5a9b20752c"
+        },
+        "files": [
+            "assets/controllers.json",
+            "assets/controllers/csrf_protection_controller.js",
+            "assets/controllers/hello_controller.js",
+            "assets/stimulus_bootstrap.js"
+        ]
+    },
     "symfony/stopwatch": {
         "version": "v3.4.33"
     },
@@ -1101,6 +1116,30 @@
         },
         "files": [
             "assets/icons/symfony.svg"
+        ]
+    },
+    "symfony/ux-live-component": {
+        "version": "3.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.6",
+            "ref": "b7130b7b5ddc2f8994bd6149d7c093b184782f0c"
+        },
+        "files": [
+            "config/routes/ux_live_component.yaml"
+        ]
+    },
+    "symfony/ux-twig-component": {
+        "version": "3.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.13",
+            "ref": "f367ae2a1faf01c503de2171f1ec22567febeead"
+        },
+        "files": [
+            "config/packages/twig_component.yaml"
         ]
     },
     "symfony/validator": {

--- a/upgrade-notes/backend_20260602_155325.md
+++ b/upgrade-notes/backend_20260602_155325.md
@@ -20,4 +20,4 @@
 - if you render `Shopsys\FrameworkBundle\Controller\Admin\FlashMessageController::indexAction`, use `{{ component('Admin:FlashMessages') }}` instead
 - if you override or include administration flash message templates, replace usages of `@ShopsysAdministration/partial/flash_message/index.html.twig` or `@ShopsysAdministration/partial/flash_message/_messages.html.twig` with `{{ component('Admin:FlashMessages') }}` or overrides of `@ShopsysAdministration/partial/flash_message/all_messages.html.twig` and `@ShopsysAdministration/partial/flash_message/_toasts.html.twig`
 - use the [Extending order detail page](https://docs.shopsys.com/en/latest/cookbook/extending-order-detail-page/) cookbook when rewriting custom order detail fields, tabs, or sections
-- see #project-base-diff to update your project
+- see #project-base-diff to update your project and also #project-base-diff-4692 to update the symfony.lock file


### PR DESCRIPTION
#### Description, the reason for the PR

This PR refreshes the Symfony recipe lock in `project-base` so it reflects the Symfony UX packages that are already part of the application setup.

Keeping the lock file complete prevents Symfony Flex recipe state from drifting between installations and updates. Developers working with `project-base` get a cleaner dependency setup because the applied recipes for Stimulus, UX Live Component, and UX Twig Component are tracked consistently.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-symfony-lock-fix.odin.shopsys.cloud
  - https://cz.mg-symfony-lock-fix.odin.shopsys.cloud
  - https://mg-symfony-lock-fix.odin.shopsys.cloud/sk
<!-- Replace -->
