### PR TITLE
Use constant-time comparison for password reset tokens

### DIFF
--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -676,7 +676,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     #[Override]
     public function isResetPasswordHashValid(?string $hash): bool
     {
-        if ($hash === null || $this->resetPasswordHash !== $hash) {
+        if ($hash === null || $this->resetPasswordHash === null || !hash_equals($this->resetPasswordHash, $hash)) {
             return false;
         }
 

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -456,7 +456,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     #[Override]
     public function isResetPasswordHashValid(?string $hash): bool
     {
-        if ($hash === null || $this->resetPasswordHash !== $hash) {
+        if ($hash === null || $this->resetPasswordHash === null || !hash_equals($this->resetPasswordHash, $hash)) {
             return false;
         }
 


### PR DESCRIPTION
#### Description, the reason for the PR

Administrator and customer password-reset tokens are now compared in constant time. This prevents the reset endpoints from revealing how much of a submitted token matches through response timing, while preserving the existing reset flows.

The customer flow is reachable from the public storefront and Frontend API, so it was hardened the same way as the administrator flow.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://mg-password-hash-verify.odin.shopsys.cloud
  - https://cz.mg-password-hash-verify.odin.shopsys.cloud
  - https://mg-password-hash-verify.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1783865843.928029 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-password-hash-verify.odin.shopsys.cloud
  - https://cz.mg-password-hash-verify.odin.shopsys.cloud
  - https://mg-password-hash-verify.odin.shopsys.cloud/sk
<!-- Replace -->
