### PR TITLE
Quote generated SQL identifiers and literals

### DIFF
--- a/packages/framework/src/Component/Doctrine/DatabaseSchemaFacade.php
+++ b/packages/framework/src/Component/Doctrine/DatabaseSchemaFacade.php
@@ -17,12 +17,18 @@ class DatabaseSchemaFacade
 
     public function createSchema(string $schemaName): void
     {
-        $this->em->getConnection()->executeStatement('CREATE SCHEMA ' . $schemaName);
+        $connection = $this->em->getConnection();
+        $databasePlatform = $connection->getDatabasePlatform();
+        $connection->executeStatement('CREATE SCHEMA ' . $databasePlatform->quoteSingleIdentifier($schemaName));
     }
 
     public function dropSchemaIfExists(string $schemaName): void
     {
-        $this->em->getConnection()->executeStatement('DROP SCHEMA IF EXISTS ' . $schemaName . ' CASCADE');
+        $connection = $this->em->getConnection();
+        $databasePlatform = $connection->getDatabasePlatform();
+        $connection->executeStatement(
+            'DROP SCHEMA IF EXISTS ' . $databasePlatform->quoteSingleIdentifier($schemaName) . ' CASCADE',
+        );
     }
 
     public function importDefaultSchema(): void
@@ -48,10 +54,13 @@ class DatabaseSchemaFacade
     public function dropTables(): void
     {
         $connection = $this->em->getConnection();
+        $databasePlatform = $connection->getDatabasePlatform();
         $tableNames = $connection->fetchAllAssociative('SELECT tablename FROM pg_tables WHERE schemaname = \'public\'');
 
         foreach ($tableNames as $tableName) {
-            $connection->executeStatement('DROP TABLE IF EXISTS ' . $tableName['tablename'] . ' CASCADE');
+            $connection->executeStatement(
+                'DROP TABLE IF EXISTS ' . $databasePlatform->quoteSingleIdentifier($tableName['tablename']) . ' CASCADE',
+            );
         }
     }
 }

--- a/packages/framework/src/Component/Domain/DomainDbFunctionsFacade.php
+++ b/packages/framework/src/Component/Domain/DomainDbFunctionsFacade.php
@@ -20,6 +20,8 @@ class DomainDbFunctionsFacade
 
     protected function createDomainIdsByLocaleFunction(): void
     {
+        $connection = $this->em->getConnection();
+        $databasePlatform = $connection->getDatabasePlatform();
         $domainsIdsByLocale = [];
 
         foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domainConfig) {
@@ -29,7 +31,7 @@ class DomainDbFunctionsFacade
         $domainIdsByLocaleSqlClauses = [];
 
         foreach ($domainsIdsByLocale as $locale => $domainIds) {
-            $sql = 'WHEN locale = \'' . $locale . '\' THEN ';
+            $sql = 'WHEN locale = ' . $databasePlatform->quoteStringLiteral($locale) . ' THEN ';
 
             foreach ($domainIds as $domainId) {
                 $sql .= ' RETURN NEXT ' . $domainId . ';';
@@ -37,7 +39,7 @@ class DomainDbFunctionsFacade
             $domainIdsByLocaleSqlClauses[] = $sql;
         }
 
-        $this->em->getConnection()->executeStatement(
+        $connection->executeStatement(
             'CREATE OR REPLACE FUNCTION get_domain_ids_by_locale(locale text) RETURNS SETOF integer AS $$
             BEGIN
                 CASE
@@ -51,15 +53,17 @@ class DomainDbFunctionsFacade
 
     protected function createLocaleByDomainIdFunction(): void
     {
+        $connection = $this->em->getConnection();
+        $databasePlatform = $connection->getDatabasePlatform();
         $localeByDomainIdSqlClauses = [];
 
         foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domainConfig) {
             $localeByDomainIdSqlClauses[] =
                 'WHEN domain_id = ' . $domainConfig->getId()
-                . ' THEN RETURN \'' . $domainConfig->getLocale() . '\';';
+                . ' THEN RETURN ' . $databasePlatform->quoteStringLiteral($domainConfig->getLocale()) . ';';
         }
 
-        $this->em->getConnection()->executeStatement(
+        $connection->executeStatement(
             'CREATE OR REPLACE FUNCTION get_domain_locale(domain_id integer) RETURNS text AS $$
             BEGIN
                 CASE


### PR DESCRIPTION
#### Description, the reason for the PR

Schema-management commands now safely quote PostgreSQL identifiers and domain locales before generating DDL. This makes maintenance operations resilient to valid names and locale values that contain quote characters, while keeping the existing schema and domain-function behavior unchanged.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

----
:globe_with_meridians: Live Preview:
  - https://mg-sql-better.odin.shopsys.cloud
  - https://cz.mg-sql-better.odin.shopsys.cloud
  - https://mg-sql-better.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1783868134.767729 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-sql-better.odin.shopsys.cloud
  - https://cz.mg-sql-better.odin.shopsys.cloud
  - https://mg-sql-better.odin.shopsys.cloud/sk
<!-- Replace -->
