### PR TITLE
Fix expanding lazily loaded branches in admin tree selection

### DIFF
--- a/packages/administration/templates/form/type/TreeSelectionType.html.twig
+++ b/packages/administration/templates/form/type/TreeSelectionType.html.twig
@@ -26,7 +26,7 @@
                 </div>
             </div>
         </div>
-        {% if childrenHtml is not empty or isExpandable == 'true' %}
+        {% if childrenHtml is not empty or isExpandable == 'true' or isExpandable == '__expandable__' %}
             <ul class="js-tree-selection-form-children-container tree-group">
                 {{ childrenHtml }}
             </ul>

--- a/packages/framework/assets/js/admin/components/TreeSelectionFormItem.js
+++ b/packages/framework/assets/js/admin/components/TreeSelectionFormItem.js
@@ -141,6 +141,9 @@ export default class TreeSelectionFormItem {
 
         $newItem.data('load-url', itemData.loadUrl);
         $newItem.data('expandable', itemData.isExpandable);
+        if (!itemData.isExpandable) {
+            $newItem.find('.js-tree-selection-form-children-container:first').remove();
+        }
         if (itemData.isVisible === false) {
             $newItem.addClass($form.data('hidden-item-class'));
         }


### PR DESCRIPTION
#### Description, the reason for the PR

In the administration, category tree branches that were loaded lazily (via AJAX) could not be expanded any further. For example on the product detail page, when a category had a third level of nesting and the product was not assigned in that branch, the deepest level could not be opened at all — clicking the expand icon loaded the data but nothing appeared.

The cause was a regression from #4587: the HTML template used by JavaScript to render lazily loaded items was missing the children container element, because the Twig condition compared the `__expandable__` placeholder against the literal `'true'`. Children of such items were then appended into an empty jQuery set and never reached the DOM. Branches pre-rendered on the server (root levels and paths to the product's assigned categories) were unaffected, which is why the bug only showed up from a certain nesting level.

The template now always includes the children container for expandable items, and the JavaScript removes it from non-expandable leaves so their markup stays identical to the server-rendered output. This affects all tree selection forms (product categories, blog categories, discount coupons, adverts, …).

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://rv-fix-tree-selection-lazy-branch-expand.odin.shopsys.cloud
  - https://cz.rv-fix-tree-selection-lazy-branch-expand.odin.shopsys.cloud
  - https://rv-fix-tree-selection-lazy-branch-expand.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1784023092.281079 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-tree-selection-lazy-branch-expand.odin.shopsys.cloud
  - https://cz.rv-fix-tree-selection-lazy-branch-expand.odin.shopsys.cloud
  - https://rv-fix-tree-selection-lazy-branch-expand.odin.shopsys.cloud/sk
<!-- Replace -->
