### PR TITLE
Add disabled state support to tree selection form fields

### DIFF
--- a/docs/administration/disabling-form-fields.md
+++ b/docs/administration/disabling-form-fields.md
@@ -11,3 +11,10 @@ To enable disabling defined fields there, need to be set ENV variable `DISABLE_F
 ## Define disabled fields
 
 Disabled fields are defined by constant `DISABLED_FIELDS` for example in: `App\Form\Admin\CategoryFormTypeExtension`
+
+## Supported field types
+
+Standard Symfony form fields render the `disabled` attribute automatically.
+Tree selection fields (`TreeSelectionType`, e.g. `CategoriesType` used for product category assignment) are supported as well —
+all checkboxes in the tree are rendered as disabled, including branches lazily loaded via AJAX,
+while the tree itself can still be expanded and browsed.

--- a/packages/administration/templates/form/type/TreeSelectionType.html.twig
+++ b/packages/administration/templates/form/type/TreeSelectionType.html.twig
@@ -1,4 +1,4 @@
-{% macro treeSelectionItem(loadChildrenUrl, isExpandable, isVisible, checkboxId, checkboxName, value, label, isChecked, childrenHtml = null) %}
+{% macro treeSelectionItem(loadChildrenUrl, isExpandable, isVisible, checkboxId, checkboxName, value, label, isChecked, isDisabled = false, childrenHtml = null) %}
     <li class="tree-item {% if not isVisible %}text-secondary{% endif %} js-tree-selection-form-item"
         data-load-url="{{ loadChildrenUrl }}"
         data-expandable="{{ isExpandable }}"
@@ -17,6 +17,7 @@
                             value="{{ value }}"
                             class="js-tree-selection-form-item-checkbox form-check-input"
                             {% if isChecked %}checked="checked"{% endif %}
+                            {% if isDisabled %}disabled="disabled"{% endif %}
                         >
                         <label for="{{ checkboxId }}" class="form-check-label">
                             {{ label }}
@@ -33,7 +34,7 @@
     </li>
 {% endmacro %}
 
-{% macro treeSelectionItems(nodes, checkboxIdPrefix, checkboxName, selectedIds, branchLoadRoute, domainId) %}
+{% macro treeSelectionItems(nodes, checkboxIdPrefix, checkboxName, selectedIds, branchLoadRoute, domainId, isDisabled = false) %}
     {% for node in nodes %}
         {% set item = node.item %}
         {{ _self.treeSelectionItem(
@@ -45,7 +46,8 @@
             value=item.id,
             label=item.name,
             isChecked=item.id in selectedIds,
-            childrenHtml=_self.treeSelectionItems(node.children, checkboxIdPrefix, checkboxName, selectedIds, branchLoadRoute, domainId),
+            isDisabled=isDisabled,
+            childrenHtml=_self.treeSelectionItems(node.children, checkboxIdPrefix, checkboxName, selectedIds, branchLoadRoute, domainId, isDisabled),
         ) }}
     {% endfor %}
 {% endmacro %}
@@ -76,10 +78,11 @@
                 value='__value__',
                 label='__label__',
                 isChecked=false,
+                isDisabled=disabled,
             ) }}
         </template>
         <ul class="js-tree-selection-form-children-container tree">
-            {{ _self.treeSelectionItems(tree_items, checkbox_id_prefix, checkbox_name, selected_ids, branch_load_route, domain_id) }}
+            {{ _self.treeSelectionItems(tree_items, checkbox_id_prefix, checkbox_name, selected_ids, branch_load_route, domain_id, disabled) }}
         </ul>
     </div>
 {% endblock %}


### PR DESCRIPTION
#### Description, the reason for the PR

On projects where product category assignment (or other tree-structured data) is imported from an external system, such fields must not be editable in the administration. The existing field disabling mechanism (`DISABLE_FORM_FIELDS_FROM_TRANSFER` + `DISABLED_FIELDS`) already protected the data server-side — submitted changes were ignored — but the tree selection widget did not reflect the disabled state in the UI. Administrators could still check and uncheck categories and save the form, and their changes were silently discarded, which was confusing.

Now, when a tree selection field (e.g. `CategoriesType` on the product form) is disabled, all its checkboxes render as disabled — including branches lazily loaded via AJAX — and their labels are visually muted. The tree can still be expanded and browsed, so administrators can see the imported assignment, they just cannot edit it. The documentation of the form field disabling mechanism was extended to cover this.

<img width="850" height="533" alt="image" src="https://github.com/user-attachments/assets/ddda4512-4d33-4199-af5b-d2e173a5d1f6" />


#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




----
:globe_with_meridians: Live Preview:
  - https://rv-disable-trees.odin.shopsys.cloud
  - https://cz.rv-disable-trees.odin.shopsys.cloud
  - https://rv-disable-trees.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1784021617.770139 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-disable-trees.odin.shopsys.cloud
  - https://cz.rv-disable-trees.odin.shopsys.cloud
  - https://rv-disable-trees.odin.shopsys.cloud/sk
<!-- Replace -->
