### PR TITLE
Force installing friendsofsymfony/ckeditor-bundle from source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -261,7 +261,10 @@
         }
     },
     "config": {
-        "preferred-install": "dist",
+        "preferred-install": {
+            "friendsofsymfony/ckeditor-bundle": "source",
+            "*": "dist"
+        },
         "component-dir": "project-base/app/web/components",
         "sort-packages": true,
         "platform": {

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -171,7 +171,10 @@
     },
     "config": {
         "process-timeout": 1200,
-        "preferred-install": "dist",
+        "preferred-install": {
+            "friendsofsymfony/ckeditor-bundle": "source",
+            "*": "dist"
+        },
         "component-dir": "web/components",
         "sort-packages": true,
         "platform": {

--- a/upgrade-notes/backend_20260716_110002.md
+++ b/upgrade-notes/backend_20260716_110002.md
@@ -1,0 +1,5 @@
+#### Force installing friendsofsymfony/ckeditor-bundle from source ([#4707](https://github.com/shopsys/shopsys/pull/4707))
+
+- the `dist` archive of `friendsofsymfony/ckeditor-bundle` is broken (see [FOSCKEditorBundle#279](https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/279)), which prevents `composer install` from completing; `config.preferred-install` now forces this package to be installed from `source` as a temporary workaround
+- remove this override once the upstream package publishes a fixed release
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The `dist` archive of `friendsofsymfony/ckeditor-bundle` is currently broken ([FOSCKEditorBundle#279](https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/279)), which makes `composer install` fail and blocks setting up the project.

As a temporary workaround, the `config.preferred-install` setting now forces this single package to be installed from `source` (everything else stays on `dist`). This is applied to both the root monorepo `composer.json` and `project-base/app/composer.json`. The override should be removed once the upstream package publishes a fixed release.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-force-ckeditor-bundle-source-install.odin.shopsys.cloud
  - https://cz.rv-force-ckeditor-bundle-source-install.odin.shopsys.cloud
  - https://rv-force-ckeditor-bundle-source-install.odin.shopsys.cloud/sk
<!-- Replace -->
