### PR TITLE
Fix cart analytics for immediate quantity reversal

### DIFF
--- a/project-base/storefront/components/Pages/Cart/CartList/CartListItem.tsx
+++ b/project-base/storefront/components/Pages/Cart/CartList/CartListItem.tsx
@@ -32,7 +32,11 @@ export const CartListItem: FC<CartListItemProps> = ({
     isRemovingFromCart,
 }) => {
     const spinboxRef = useRef<HTMLInputElement>(null);
+    const confirmedQuantityRef = useRef(quantity);
+    const inFlightQuantityRef = useRef<number | null>(null);
     const lastSubmittedQuantityRef = useRef<number | null>(null);
+    const queuedQuantityRef = useRef<number | null>(null);
+    const [visibleQuantity, setVisibleQuantity] = useState(quantity);
     const [quantityChangeAnnouncement, setQuantityChangeAnnouncement] = useState('');
     const { t } = useTranslation();
     const formatPrice = useFormatPrice();
@@ -78,32 +82,74 @@ export const CartListItem: FC<CartListItemProps> = ({
         .filter(Boolean)
         .join(' ');
 
+    const restorePreviousQuantity = useCallback((quantity: number) => {
+        setVisibleQuantity(quantity);
+
+        if (spinboxRef.current) {
+            spinboxRef.current.valueAsNumber = quantity;
+        }
+    }, []);
+
     const onSubmitCartChange = useCallback(
         async (requestedQuantity: number) => {
-            const submittedQuantity = lastSubmittedQuantityRef.current;
-            const quantityToCompare = submittedQuantity ?? quantity;
-
-            if (requestedQuantity === quantityToCompare) {
-                lastSubmittedQuantityRef.current = null;
+            if (inFlightQuantityRef.current !== null) {
+                queuedQuantityRef.current = requestedQuantity;
 
                 return;
             }
 
-            lastSubmittedQuantityRef.current = requestedQuantity;
-            const addToCartResult = await onAddToCart(product.uuid, requestedQuantity, listIndex, true);
+            let quantityToSubmit: number | null = requestedQuantity;
 
-            if (addToCartResult) {
+            while (quantityToSubmit !== null) {
+                const quantityToCompare = lastSubmittedQuantityRef.current ?? confirmedQuantityRef.current;
+
+                if (quantityToSubmit === quantityToCompare) {
+                    quantityToSubmit = null;
+
+                    continue;
+                }
+
+                const submittedQuantity = quantityToSubmit;
+
+                inFlightQuantityRef.current = submittedQuantity;
+                lastSubmittedQuantityRef.current = submittedQuantity;
+                queuedQuantityRef.current = null;
+
+                const addToCartResult = await onAddToCart(product.uuid, submittedQuantity, listIndex, true);
+
+                inFlightQuantityRef.current = null;
+
+                if (!addToCartResult) {
+                    restorePreviousQuantity(confirmedQuantityRef.current);
+                    lastSubmittedQuantityRef.current = null;
+                    queuedQuantityRef.current = null;
+
+                    return;
+                }
+
+                const confirmedQuantity = addToCartResult.addProductResult.cartItem.quantity;
+
+                confirmedQuantityRef.current = confirmedQuantity;
+                lastSubmittedQuantityRef.current = confirmedQuantity;
+
                 setQuantityChangeAnnouncement(
                     t('Quantity of {{ productName }} updated to {{ quantity }} {{ unit }}', {
                         ns: 'accessibility',
                         productName: product.fullName,
-                        quantity: requestedQuantity,
+                        quantity: confirmedQuantity,
                         unit: product.unit.name,
                     }),
                 );
+
+                quantityToSubmit = queuedQuantityRef.current;
+                queuedQuantityRef.current = null;
+
+                if (quantityToSubmit === null) {
+                    restorePreviousQuantity(confirmedQuantity);
+                }
             }
         },
-        [listIndex, onAddToCart, product.fullName, product.unit.name, product.uuid, quantity, t],
+        [listIndex, onAddToCart, product.fullName, product.unit.name, product.uuid, restorePreviousQuantity, t],
     );
 
     useEffect(() => {
@@ -111,10 +157,8 @@ export const CartListItem: FC<CartListItemProps> = ({
             return;
         }
 
-        if (quantity > 0 && spinboxRef.current) {
-            spinboxRef.current.valueAsNumber = quantity;
-        }
-
+        confirmedQuantityRef.current = quantity;
+        setVisibleQuantity(quantity);
         lastSubmittedQuantityRef.current = null;
     }, [quantity]);
 
@@ -211,7 +255,7 @@ export const CartListItem: FC<CartListItemProps> = ({
                 <div className="flex vl:flex-row flex-col vl:items-center justify-between gap-2 vl:gap-8 xl:gap-15">
                     {isProduct ? (
                         <Spinbox
-                            defaultValue={quantity}
+                            defaultValue={visibleQuantity}
                             decreaseAriaLabel={t('Decrease quantity of {{ productName }}', {
                                 ns: 'accessibility',
                                 productName: product.fullName,
@@ -237,7 +281,10 @@ export const CartListItem: FC<CartListItemProps> = ({
                             ref={spinboxRef}
                             className="vl:w-35"
                             step={1}
-                            onChangeValueCallback={onSubmitCartChange}
+                            onChangeValueCallback={(requestedQuantity) => {
+                                setVisibleQuantity(requestedQuantity);
+                                onSubmitCartChange(requestedQuantity);
+                            }}
                             onMinValueDecrease={onRemoveFromCart}
                         />
                     ) : (

--- a/project-base/storefront/cypress/e2e/cart/cartPage.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/cartPage.cy.ts
@@ -29,6 +29,9 @@ import { TIDs } from 'tids';
 
 const SUBGROUP_INDEX = 2;
 const getSnapshotFullIndexAsString = getSnapshotIndexingFunction(SNAPSHOT_GROUP.CART, SUBGROUP_INDEX);
+type DataLayerWindow = Cypress.AUTWindow & {
+    dataLayer?: Array<{ ecommerce?: { products?: Array<{ quantity?: number }> }; event?: string }>;
+};
 
 describe('Cart Page Tests', () => {
     beforeEach(() => {
@@ -71,6 +74,41 @@ describe('Cart Page Tests', () => {
                 { tid: TIDs.footer_payment_images },
                 { tid: TIDs.footer_copyright },
             ],
+        });
+    });
+
+    it('[Immediate Quantity Reversal] should submit both cart changes and send matching GTM events', () => {
+        cy.intercept('POST', '/graphql/AddToCartMutation').as('addToCartMutation');
+        cy.window().then((window) => {
+            (window as DataLayerWindow).dataLayer = [];
+        });
+
+        increaseCartItemQuantityWithSpinbox(staticData.products.helloKitty.catnum);
+        cy.wait('@addToCartMutation').then(({ request }) => {
+            expect(request.body.variables.input).to.include({
+                isAbsoluteQuantity: true,
+                quantity: 3,
+            });
+        });
+        cy.getByTID([TIDs.loader_overlay]).should('not.exist');
+
+        decreaseCartItemQuantityWithSpinbox(staticData.products.helloKitty.catnum);
+        cy.wait('@addToCartMutation').then(({ request }) => {
+            expect(request.body.variables.input).to.include({
+                isAbsoluteQuantity: true,
+                quantity: 2,
+            });
+        });
+
+        cy.window().should((window) => {
+            const cartChangeEvents = (window as DataLayerWindow).dataLayer
+                ?.filter(({ event }) => event === 'ec.add_to_cart' || event === 'ec.remove_from_cart')
+                .map(({ ecommerce, event }) => ({ event, quantity: ecommerce?.products?.[0]?.quantity }));
+
+            expect(cartChangeEvents).to.deep.equal([
+                { event: 'ec.add_to_cart', quantity: 1 },
+                { event: 'ec.remove_from_cart', quantity: 1 },
+            ]);
         });
     });
 

--- a/project-base/storefront/utils/cart/useAddToCart.ts
+++ b/project-base/storefront/utils/cart/useAddToCart.ts
@@ -6,7 +6,7 @@ import {
 } from 'graphql/requests/cart/mutations/AddToCartMutation.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { usePersistStore } from 'store/usePersistStore';
 import { useIsUserLoggedIn } from 'utils/auth/useIsUserLoggedIn';
 import { useCurrentCart } from 'utils/cart/useCurrentCart';
@@ -31,6 +31,13 @@ export const useAddToCart = (gtmMessageOrigin: GtmMessageOriginType, gtmProductL
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
     const { canSeePrices } = useAuthorization();
     const addingToCartProductUuidsRef = useRef(new Set<string>());
+    const cartItemQuantitiesRef = useRef(new Map<string, number>());
+
+    useEffect(() => {
+        cartItemQuantitiesRef.current = new Map(
+            cart?.items.map((item) => [item.product.uuid, item.quantity] as const) ?? [],
+        );
+    }, [cart]);
 
     const addToCart: AddToCart = async (productUuid, quantity, listIndex, isAbsoluteQuantity = false) => {
         if (addingToCartProductUuidsRef.current.has(productUuid)) {
@@ -41,7 +48,7 @@ export const useAddToCart = (gtmMessageOrigin: GtmMessageOriginType, gtmProductL
 
         try {
             const itemToBeAdded = cart?.items.find((item) => item.product.uuid === productUuid);
-            const initialQuantity = itemToBeAdded?.quantity ?? 0;
+            const initialQuantity = cartItemQuantitiesRef.current.get(productUuid) ?? itemToBeAdded?.quantity ?? 0;
             const addToCartActionResult = await addToCartMutation({
                 input: { cartUuid, productUuid, quantity, isAbsoluteQuantity },
             });
@@ -79,6 +86,7 @@ export const useAddToCart = (gtmMessageOrigin: GtmMessageOriginType, gtmProductL
             dispatchBroadcastChannel('refetchCart', domainConfig.domainId);
 
             const addedCartItem = addToCartResult.addProductResult.cartItem;
+            cartItemQuantitiesRef.current.set(productUuid, addedCartItem.quantity);
 
             import('gtm/handlers/onGtmChangeCartItemEventHandler').then(({ onGtmChangeCartItemEventHandler }) => {
                 onGtmChangeCartItemEventHandler(

--- a/project-base/storefront/vitest/components/Pages/Cart/CartListItem.test.tsx
+++ b/project-base/storefront/vitest/components/Pages/Cart/CartListItem.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CartListItem } from 'components/Pages/Cart/CartList/CartListItem';
 import { TypeCartItemTypeEnum } from 'graphql/types';
 import type React from 'react';
@@ -32,9 +32,28 @@ vi.mock('components/Forms/Button/IconButton', () => ({
     ),
 }));
 
-vi.mock('components/Forms/Spinbox/Spinbox', () => ({
-    Spinbox: ({ ariaLabel }: { ariaLabel: string }) => <input aria-label={ariaLabel} type="number" />,
-}));
+vi.mock('components/Forms/Spinbox/Spinbox', async () => {
+    const { forwardRef } = await vi.importActual<typeof import('react')>('react');
+
+    return {
+        Spinbox: forwardRef<
+            HTMLInputElement,
+            {
+                defaultValue: number;
+                inputAriaLabel: string;
+                onChangeValueCallback: (quantity: number) => void;
+            }
+        >(({ defaultValue, inputAriaLabel, onChangeValueCallback }, ref) => (
+            <input
+                ref={ref}
+                aria-label={inputAriaLabel}
+                defaultValue={defaultValue}
+                type="number"
+                onChange={(event) => onChangeValueCallback(event.currentTarget.valueAsNumber)}
+            />
+        )),
+    };
+});
 
 vi.mock('components/Pages/Cart/CartItemPrice', () => ({
     CartItemPrice: () => <span>Cart item price</span>,
@@ -60,45 +79,46 @@ vi.mock('utils/useDebounce', () => ({
 }));
 
 describe('CartListItem', () => {
-    test('adds screen reader summary with code, availability, quantity, unit price and totals', () => {
-        const item = {
-            freeQuantity: 1,
-            product: {
-                __typename: 'RegularProduct',
-                availability: {
-                    name: 'In stock',
-                },
-                availableStoresCount: 1,
-                catalogNumber: 'ABC123',
-                categories: [{ name: 'TV, audio' }],
-                fullName: '32" Philips TV',
-                giftPrice: {
-                    priceWithVat: '0',
-                    priceWithoutVat: '0',
-                },
-                isAllowedNegativeStock: false,
-                isInquiryType: false,
-                mainImage: {
-                    url: '/image.jpg',
-                },
-                price: {
-                    priceWithVat: '10',
-                    priceWithoutVat: '8',
-                },
-                promotionBuyQuantity: null,
-                promotionFreeQuantity: null,
-                slug: '/32-philips-tv',
-                stockQuantity: 10,
-                unit: {
-                    name: 'pcs',
-                },
-                uuid: 'product-uuid',
+    const item = {
+        freeQuantity: 1,
+        product: {
+            __typename: 'RegularProduct',
+            availability: {
+                name: 'In stock',
             },
-            quantity: 3,
-            type: TypeCartItemTypeEnum.Product,
-            uuid: 'cart-item-uuid',
-        };
+            availableStoresCount: 1,
+            catalogNumber: 'ABC123',
+            categories: [{ name: 'TV, audio' }],
+            fullName: '32" Philips TV',
+            giftPrice: {
+                priceWithVat: '0',
+                priceWithoutVat: '0',
+            },
+            isAllowedNegativeStock: false,
+            isInquiryType: false,
+            mainImage: {
+                url: '/image.jpg',
+            },
+            price: {
+                priceWithVat: '10',
+                priceWithoutVat: '8',
+            },
+            promotionBuyQuantity: null,
+            promotionFreeQuantity: null,
+            slug: '/32-philips-tv',
+            stockQuantity: 10,
+            unit: {
+                name: 'pcs',
+            },
+            uuid: 'product-uuid',
+        },
+        quantity: 3,
+        type: TypeCartItemTypeEnum.Product,
+        uuid: 'cart-item-uuid',
+    };
+    const createAddToCartResult = (quantity: number) => ({ addProductResult: { cartItem: { quantity } } }) as any;
 
+    test('adds screen reader summary with code, availability, quantity, unit price and totals', () => {
         render(
             <CartListItem
                 isRemovingFromCart={false}
@@ -112,5 +132,59 @@ describe('CartListItem', () => {
         expect(screen.getByRole('region', { name: '32" Philips TV' })).toHaveAccessibleDescription(
             'Code: ABC123. Availability: In stock. Quantity: 3 pcs. Unit price with VAT: €10. Item total with VAT: €20. Item total without VAT: €16. 1 pcs is free.',
         );
+    });
+
+    test('restores the last server-confirmed quantity when a queued update fails', async () => {
+        let resolveFirstUpdate: (value: any) => void = () => undefined;
+        const firstUpdate = new Promise<any>((resolve) => {
+            resolveFirstUpdate = resolve;
+        });
+        const onAddToCart = vi.fn().mockReturnValueOnce(firstUpdate).mockResolvedValueOnce(null);
+
+        render(
+            <CartListItem
+                isRemovingFromCart={false}
+                item={{ ...item, freeQuantity: 0, quantity: 1 } as any}
+                listIndex={0}
+                onAddToCart={onAddToCart}
+                onRemoveFromCart={vi.fn()}
+            />,
+        );
+        const quantityInput = screen.getByRole('spinbutton', { name: 'Quantity of 32" Philips TV' });
+
+        fireEvent.change(quantityInput, { target: { value: '2' } });
+        fireEvent.change(quantityInput, { target: { value: '3' } });
+        await act(async () => {
+            resolveFirstUpdate(createAddToCartResult(2));
+            await firstUpdate;
+        });
+
+        await waitFor(() => {
+            expect(onAddToCart).toHaveBeenNthCalledWith(1, 'product-uuid', 2, 0, true);
+            expect(onAddToCart).toHaveBeenNthCalledWith(2, 'product-uuid', 3, 0, true);
+            expect(quantityInput).toHaveValue(2);
+        });
+    });
+
+    test('syncs the spinbox to a server-adjusted quantity when no update is queued', async () => {
+        const onAddToCart = vi.fn().mockResolvedValue(createAddToCartResult(2));
+
+        render(
+            <CartListItem
+                isRemovingFromCart={false}
+                item={{ ...item, freeQuantity: 0, quantity: 1 } as any}
+                listIndex={0}
+                onAddToCart={onAddToCart}
+                onRemoveFromCart={vi.fn()}
+            />,
+        );
+        const quantityInput = screen.getByRole('spinbutton', { name: 'Quantity of 32" Philips TV' });
+
+        fireEvent.change(quantityInput, { target: { value: '3' } });
+
+        await waitFor(() => {
+            expect(onAddToCart).toHaveBeenCalledWith('product-uuid', 3, 0, true);
+            expect(quantityInput).toHaveValue(2);
+        });
     });
 });

--- a/project-base/storefront/vitest/utils/cart/useAddToCart.test.ts
+++ b/project-base/storefront/vitest/utils/cart/useAddToCart.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
+import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
+import { useAddToCart } from 'utils/cart/useAddToCart';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { addToCartMutationMock, gtmSafePushEventMock } = vi.hoisted(() => ({
+    addToCartMutationMock: vi.fn(),
+    gtmSafePushEventMock: vi.fn(),
+}));
+
+vi.mock('components/providers/AuthorizationProvider', () => ({
+    useAuthorization: () => ({ canSeePrices: true }),
+}));
+
+vi.mock('components/providers/DomainConfigProvider', () => ({
+    useDomainConfig: () => ({ currencyCode: 'EUR', domainId: 1, url: 'https://example.com' }),
+}));
+
+vi.mock('graphql/requests/cart/mutations/AddToCartMutation.generated', () => ({
+    useAddToCartMutation: () => [{ fetching: false }, addToCartMutationMock],
+}));
+
+vi.mock('gtm/factories/getGtmChangeCartItemEvent', () => ({
+    getGtmChangeCartItemEvent: (event: GtmEventType) => ({ event }),
+}));
+
+vi.mock('gtm/utils/getGtmMappedCart', () => ({
+    getGtmMappedCart: () => null,
+}));
+
+vi.mock('gtm/utils/getGtmPriceBasedOnVisibility', () => ({
+    getGtmPriceBasedOnVisibility: () => 1,
+}));
+
+vi.mock('gtm/utils/gtmSafePushEvent', () => ({
+    gtmSafePushEvent: gtmSafePushEventMock,
+}));
+
+vi.mock('store/usePersistStore', () => ({
+    usePersistStore: (selector: (state: { cartUuid: string; updateCartUuid: () => void }) => unknown) =>
+        selector({ cartUuid: 'cart-uuid', updateCartUuid: vi.fn() }),
+}));
+
+vi.mock('utils/auth/useIsUserLoggedIn', () => ({
+    useIsUserLoggedIn: () => false,
+}));
+
+vi.mock('utils/cart/useCurrentCart', () => ({
+    useCurrentCart: () => ({
+        cart: {
+            items: [{ product: { uuid: 'product-uuid' }, quantity: 1 }],
+        },
+    }),
+}));
+
+vi.mock('utils/i18n/useTranslationWrapper', () => ({
+    default: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('utils/toasts/showInfoMessage', () => ({
+    showInfoMessage: vi.fn(),
+}));
+
+vi.mock('utils/useBroadcastChannel', () => ({
+    dispatchBroadcastChannel: vi.fn(),
+}));
+
+describe('useAddToCart', () => {
+    const createAddToCartResult = (quantity: number) => ({
+        data: {
+            AddToCart: {
+                addProductResult: {
+                    addedQuantity: quantity,
+                    cartItem: {
+                        product: { price: { priceWithVat: '1', priceWithoutVat: '1' }, uuid: 'product-uuid' },
+                        quantity,
+                    },
+                    notOnStockQuantity: 0,
+                },
+                cart: {
+                    items: [],
+                    promoCodes: [],
+                    uuid: 'cart-uuid',
+                },
+            },
+        },
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        addToCartMutationMock
+            .mockResolvedValueOnce(createAddToCartResult(2))
+            .mockResolvedValueOnce(createAddToCartResult(1));
+    });
+
+    test('uses the latest confirmed quantity for sequential absolute changes without a rerender', async () => {
+        const { result } = renderHook(() => useAddToCart(GtmMessageOriginType.cart, GtmProductListNameType.cart));
+
+        await act(async () => {
+            await result.current.addToCart('product-uuid', 2, 0, true);
+            await result.current.addToCart('product-uuid', 1, 0, true);
+        });
+
+        await waitFor(() => {
+            expect(gtmSafePushEventMock).toHaveBeenCalledTimes(2);
+        });
+        expect(gtmSafePushEventMock).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ event: GtmEventType.add_to_cart }),
+        );
+        expect(gtmSafePushEventMock).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ event: GtmEventType.remove_from_cart }),
+        );
+    });
+});

--- a/upgrade-notes/storefront_20260720_092357.md
+++ b/upgrade-notes/storefront_20260720_092357.md
@@ -1,0 +1,7 @@
+#### Fix cart analytics for immediate quantity reversal ([#4708](https://github.com/shopsys/shopsys/pull/4708))
+
+- if your project customizes cart quantity handling, update `CartListItem` to serialize absolute quantity mutations, retain the latest requested quantity while a mutation is in progress, and after every successful mutation store the returned `addProductResult.cartItem.quantity` as the last confirmed and submitted quantity
+    - submit the queued quantity after the current mutation finishes, or synchronize the spinbox with the confirmed backend quantity when the queue is empty
+    - when a mutation fails, restore the latest quantity confirmed by the backend
+- update customizations of `useAddToCart` to keep the last confirmed quantity for each cart product and refresh it from every successful mutation response before calculating the next GTM quantity difference, so immediate quantity reversals emit matching `ec.add_to_cart` and `ec.remove_from_cart` events
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Cart quantity updates are now processed in order while preserving the latest value selected by the customer. Sequential absolute quantity mutations keep an up-to-date confirmed quantity baseline, so GTM emits `ec.add_to_cart` for an increase and `ec.remove_from_cart` for an immediate decrease.

The regression coverage verifies both GraphQL mutations and their matching dataLayer events.

#### Fixes issues

Immediate cart quantity reversals no longer lose the second update or report it as another add-to-cart action.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4212-cart-quantity-analytics-race.odin.shopsys.cloud
  - https://cz.tc-ssp-4212-cart-quantity-analytics-race.odin.shopsys.cloud
  - https://tc-ssp-4212-cart-quantity-analytics-race.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1784538318.291159 -->