### PR TITLE
Storefront navigation now loads interaction features on demand

### DIFF
--- a/project-base/storefront/components/Layout/CommonLayout.tsx
+++ b/project-base/storefront/components/Layout/CommonLayout.tsx
@@ -100,6 +100,7 @@ export const CommonLayout: FC<CommonLayoutProps> = ({
                 >
                     <Header />
                     <DeferredNavigation
+                        isDesktop={isDesktop}
                         isNavigationFetching={isNavigationFetching}
                         navigation={navigationData?.navigation}
                     />

--- a/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomAccountDrawer.tsx
+++ b/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomAccountDrawer.tsx
@@ -1,0 +1,30 @@
+import { Drawer } from 'components/Basic/Drawer/Drawer';
+import { UserMenu } from 'components/Blocks/UserMenu/UserMenu';
+import { MenuIconicItemUserUnauthenticatedContent } from 'components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticatedContent';
+
+type MobileBottomAccountDrawerProps = {
+    isActive: boolean;
+    isUserLoggedIn: boolean;
+    setIsActive: (isActive: boolean) => void;
+    title: string;
+    onClose: () => void;
+};
+
+export const MobileBottomAccountDrawer: FC<MobileBottomAccountDrawerProps> = ({
+    isActive,
+    isUserLoggedIn,
+    setIsActive,
+    title,
+    onClose,
+}) => (
+    <Drawer isActive={isActive} setIsActive={setIsActive} title={title}>
+        {isUserLoggedIn ? (
+            <UserMenu />
+        ) : (
+            <MenuIconicItemUserUnauthenticatedContent
+                loginFormName="mobile-bottom-navigation-login-form"
+                onMenuClose={onClose}
+            />
+        )}
+    </Drawer>
+);

--- a/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomCartDrawer.tsx
+++ b/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomCartDrawer.tsx
@@ -1,0 +1,14 @@
+import { Drawer } from 'components/Basic/Drawer/Drawer';
+import { CartInHeaderList } from 'components/Layout/Header/Cart/CartInHeaderList';
+
+type MobileBottomCartDrawerProps = {
+    isActive: boolean;
+    setIsActive: (isActive: boolean) => void;
+    title: string;
+};
+
+export const MobileBottomCartDrawer: FC<MobileBottomCartDrawerProps> = ({ isActive, setIsActive, title }) => (
+    <Drawer isActive={isActive} setIsActive={setIsActive} title={title}>
+        <CartInHeaderList />
+    </Drawer>
+);

--- a/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomNavigation.tsx
+++ b/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomNavigation.tsx
@@ -1,20 +1,16 @@
-import { Drawer } from 'components/Basic/Drawer/Drawer';
 import { CartIcon } from 'components/Basic/Icon/CartIcon';
 import { HomeIcon } from 'components/Basic/Icon/HomeIcon';
 import { MenuIcon } from 'components/Basic/Icon/MenuIcon';
 import { SearchIcon } from 'components/Basic/Icon/SearchIcon';
 import { UserIcon } from 'components/Basic/Icon/UserIcon';
-import { UserMenu } from 'components/Blocks/UserMenu/UserMenu';
 import { CartCount } from 'components/Layout/Header/Cart/CartCount';
-import { CartInHeaderList } from 'components/Layout/Header/Cart/CartInHeaderList';
-import { MenuIconicItemUserUnauthenticatedContent } from 'components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticatedContent';
 import {
     MobileBottomNavigationButton,
     MobileBottomNavigationLink,
 } from 'components/Layout/Header/MobileBottomNavigation/MobileBottomNavigationItem';
 import { MobileBottomSearchWithOverlay } from 'components/Layout/Header/MobileBottomNavigation/MobileBottomSearchWithOverlay';
-import { MobileMenu } from 'components/Layout/Header/MobileMenu/MobileMenu';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
+import dynamic from 'next/dynamic';
 import { useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useIsUserLoggedIn } from 'utils/auth/useIsUserLoggedIn';
@@ -24,6 +20,22 @@ import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationa
 import { useKeypress } from 'utils/useKeyPress';
 
 type OpenPanel = 'catalog' | 'cart' | 'search' | 'account' | null;
+type Panel = Exclude<OpenPanel, null>;
+
+const MobileBottomAccountDrawer = dynamic(
+    () => import('./MobileBottomAccountDrawer').then((component) => component.MobileBottomAccountDrawer),
+    { ssr: false },
+);
+
+const MobileBottomCartDrawer = dynamic(
+    () => import('./MobileBottomCartDrawer').then((component) => component.MobileBottomCartDrawer),
+    { ssr: false },
+);
+
+const MobileMenu = dynamic(
+    () => import('components/Layout/Header/MobileMenu/MobileMenu').then((component) => component.MobileMenu),
+    { ssr: false },
+);
 
 export const MobileBottomNavigation: FC = () => {
     const { t } = useTranslation();
@@ -31,12 +43,13 @@ export const MobileBottomNavigation: FC = () => {
     const { cart } = useCurrentCart();
     const isUserLoggedIn = useIsUserLoggedIn();
     const searchInputRef = useRef<HTMLInputElement>(null);
+    const openedPanelsRef = useRef(new Set<Panel>());
     const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
     const [homeUrl] = getInternationalizedStaticUrls(['/'], url);
 
     const closeOpenPanel = () => setOpenPanel(null);
 
-    const togglePanel = (panel: Exclude<OpenPanel, null>) => {
+    const togglePanel = (panel: Panel) => {
         const shouldOpenPanel = openPanel !== panel;
 
         if (panel === 'search') {
@@ -49,6 +62,10 @@ export const MobileBottomNavigation: FC = () => {
             }
 
             return;
+        }
+
+        if (shouldOpenPanel) {
+            openedPanelsRef.current.add(panel);
         }
 
         setOpenPanel(shouldOpenPanel ? panel : null);
@@ -108,38 +125,35 @@ export const MobileBottomNavigation: FC = () => {
                 </ul>
             </nav>
 
-            <MobileMenu
-                isMenuOpened={openPanel === 'catalog'}
-                shouldRenderTrigger={false}
-                onMenuToggle={() => togglePanel('catalog')}
-            />
+            {openedPanelsRef.current.has('catalog') && (
+                <MobileMenu
+                    isMenuOpened={openPanel === 'catalog'}
+                    shouldRenderTrigger={false}
+                    onMenuToggle={() => togglePanel('catalog')}
+                />
+            )}
 
-            <Drawer
-                isActive={openPanel === 'cart'}
-                setIsActive={(isActive) => setOpenPanel(isActive ? 'cart' : null)}
-                title={t('Cart')}
-            >
-                <CartInHeaderList />
-            </Drawer>
+            {openedPanelsRef.current.has('cart') && (
+                <MobileBottomCartDrawer
+                    isActive={openPanel === 'cart'}
+                    setIsActive={(isActive) => setOpenPanel(isActive ? 'cart' : null)}
+                    title={t('Cart')}
+                />
+            )}
 
             {openPanel === 'search' && (
                 <MobileBottomSearchWithOverlay searchInputRef={searchInputRef} onClose={closeOpenPanel} />
             )}
 
-            <Drawer
-                isActive={openPanel === 'account'}
-                setIsActive={(isActive) => setOpenPanel(isActive ? 'account' : null)}
-                title={t('My account')}
-            >
-                {isUserLoggedIn ? (
-                    <UserMenu />
-                ) : (
-                    <MenuIconicItemUserUnauthenticatedContent
-                        loginFormName="mobile-bottom-navigation-login-form"
-                        onMenuClose={closeOpenPanel}
-                    />
-                )}
-            </Drawer>
+            {openedPanelsRef.current.has('account') && (
+                <MobileBottomAccountDrawer
+                    isActive={openPanel === 'account'}
+                    isUserLoggedIn={isUserLoggedIn}
+                    setIsActive={(isActive) => setOpenPanel(isActive ? 'account' : null)}
+                    title={t('My account')}
+                    onClose={closeOpenPanel}
+                />
+            )}
         </>
     );
 };

--- a/project-base/storefront/components/Layout/Header/Navigation/DeferredNavigation.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/DeferredNavigation.tsx
@@ -2,19 +2,37 @@ import { Webline } from 'components/Layout/Webline/Webline';
 import dynamic from 'next/dynamic';
 import { useDeferredRender } from 'utils/useDeferredRender';
 import type { NavigationProps } from './Navigation';
-import { Navigation } from './Navigation';
+import { NavigationPlaceholder } from './NavigationPlaceholder';
 
-const NavigationPlaceholder = dynamic(() =>
-    import('./NavigationPlaceholder').then((component) => component.NavigationPlaceholder),
-);
+const Navigation = dynamic<NavigationProps>(() => import('./Navigation').then((component) => component.Navigation), {
+    ssr: false,
+    loading: () => <NavigationPlaceholder />,
+});
 
 type DeferredNavigationProps = {
+    isDesktop?: boolean;
     isNavigationFetching?: boolean;
     navigation?: NavigationProps['navigation'];
 };
 
-export const DeferredNavigation: FC<DeferredNavigationProps> = ({ isNavigationFetching, navigation }) => {
+type DesktopDeferredNavigationProps = {
+    navigation: NavigationProps['navigation'];
+};
+
+const DesktopDeferredNavigation: FC<DesktopDeferredNavigationProps> = ({ navigation }) => {
     const shouldRender = useDeferredRender('navigation');
+
+    return (
+        <Webline className="relative">
+            {shouldRender ? <Navigation navigation={navigation} /> : <NavigationPlaceholder navigation={navigation} />}
+        </Webline>
+    );
+};
+
+export const DeferredNavigation: FC<DeferredNavigationProps> = ({ isDesktop, isNavigationFetching, navigation }) => {
+    if (isDesktop === false) {
+        return null;
+    }
 
     if (!navigation?.length) {
         return isNavigationFetching ? (
@@ -24,9 +42,13 @@ export const DeferredNavigation: FC<DeferredNavigationProps> = ({ isNavigationFe
         ) : null;
     }
 
-    return (
-        <Webline className="relative">
-            {shouldRender ? <Navigation navigation={navigation} /> : <NavigationPlaceholder navigation={navigation} />}
-        </Webline>
-    );
+    if (isDesktop === undefined) {
+        return (
+            <Webline className="relative">
+                <NavigationPlaceholder navigation={navigation} />
+            </Webline>
+        );
+    }
+
+    return <DesktopDeferredNavigation navigation={navigation} />;
 };

--- a/project-base/storefront/vitest/components/Layout/Header/MobileBottomNavigation.test.tsx
+++ b/project-base/storefront/vitest/components/Layout/Header/MobileBottomNavigation.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MobileBottomNavigation } from 'components/Layout/Header/MobileBottomNavigation/MobileBottomNavigation';
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 
 vi.mock('next-translate/useTranslation', () => ({
@@ -27,15 +27,6 @@ vi.mock('utils/auth/useIsUserLoggedIn', () => ({
     useIsUserLoggedIn: () => false,
 }));
 
-vi.mock('components/Basic/Drawer/Drawer', () => ({
-    Drawer: ({ children, isActive, title }: { children: ReactNode; isActive: boolean; title?: string }) =>
-        isActive ? (
-            <div aria-label={title} role="dialog">
-                {children}
-            </div>
-        ) : null,
-}));
-
 vi.mock('components/Basic/ExtendedNextLink/ExtendedNextLink', () => ({
     ExtendedNextLink: ({ children, href, skeletonType: _skeletonType, ...props }: any) => (
         <a href={href} {...props}>
@@ -45,23 +36,25 @@ vi.mock('components/Basic/ExtendedNextLink/ExtendedNextLink', () => ({
 }));
 
 vi.mock('components/Layout/Header/MobileMenu/MobileMenu', () => ({
-    MobileMenu: () => null,
+    MobileMenu: ({ isMenuOpened }: { isMenuOpened: boolean }) => (
+        <div data-active={isMenuOpened} data-testid="mobile-menu" />
+    ),
 }));
 
 vi.mock('components/Layout/Header/Cart/CartCount', () => ({
     CartCount: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
-vi.mock('components/Layout/Header/Cart/CartInHeaderList', () => ({
-    CartInHeaderList: () => <div>Cart panel</div>,
+vi.mock('components/Layout/Header/MobileBottomNavigation/MobileBottomCartDrawer', () => ({
+    MobileBottomCartDrawer: ({ isActive }: { isActive: boolean }) => (
+        <div data-active={isActive} data-testid="cart-drawer" />
+    ),
 }));
 
-vi.mock('components/Blocks/UserMenu/UserMenu', () => ({
-    UserMenu: () => <div>User menu</div>,
-}));
-
-vi.mock('components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticatedContent', () => ({
-    MenuIconicItemUserUnauthenticatedContent: () => <div>Login links</div>,
+vi.mock('components/Layout/Header/MobileBottomNavigation/MobileBottomAccountDrawer', () => ({
+    MobileBottomAccountDrawer: ({ isActive }: { isActive: boolean }) => (
+        <div data-active={isActive} data-testid="account-drawer" />
+    ),
 }));
 
 vi.mock('components/Layout/Header/AutocompleteSearch/AutocompleteSearch', () => ({
@@ -76,13 +69,40 @@ vi.mock('components/Layout/Header/AutocompleteSearch/AutocompleteSearch', () => 
 }));
 
 describe('MobileBottomNavigation', () => {
-    test('closes search overlay with Escape key', async () => {
+    test('mounts panel implementations only after their actions are used', async () => {
+        const user = userEvent.setup();
+
+        render(<MobileBottomNavigation />);
+
+        expect(screen.queryByTestId('cart-drawer')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('account-drawer')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /Cart$/ }));
+
+        expect(await screen.findByTestId('cart-drawer')).toHaveAttribute('data-active', 'true');
+
+        await user.click(screen.getByRole('button', { name: 'Menu' }));
+
+        expect(await screen.findByTestId('mobile-menu')).toHaveAttribute('data-active', 'true');
+        expect(screen.getByTestId('cart-drawer')).toHaveAttribute('data-active', 'false');
+
+        await user.click(screen.getByRole('button', { name: 'Account' }));
+
+        expect(await screen.findByTestId('account-drawer')).toHaveAttribute('data-active', 'true');
+        expect(screen.getByTestId('mobile-menu')).toHaveAttribute('data-active', 'false');
+    });
+
+    test('focuses search input while opening and closes overlay with Escape key', async () => {
         const user = userEvent.setup();
 
         render(<MobileBottomNavigation />);
 
         const searchButton = screen.getByRole('button', { name: 'Search' });
-        await user.click(searchButton);
+
+        expect(screen.queryByLabelText('Search input')).not.toBeInTheDocument();
+
+        fireEvent.click(searchButton);
 
         expect(screen.getByLabelText('Search input')).toHaveFocus();
         expect(screen.getByRole('button', { name: 'Close search overlay' })).toBeInTheDocument();

--- a/project-base/storefront/vitest/components/Layout/Header/Navigation/DeferredNavigation.test.tsx
+++ b/project-base/storefront/vitest/components/Layout/Header/Navigation/DeferredNavigation.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { DeferredNavigation } from 'components/Layout/Header/Navigation/DeferredNavigation';
+import type { TypeCategoriesByColumnFragment } from 'graphql/requests/navigation/fragments/CategoriesByColumnsFragment.generated';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { navigationRenderMock, useDeferredRenderMock } = vi.hoisted(() => ({
+    navigationRenderMock: vi.fn(),
+    useDeferredRenderMock: vi.fn(),
+}));
+
+vi.mock('utils/useDeferredRender', () => ({
+    useDeferredRender: useDeferredRenderMock,
+}));
+
+vi.mock('components/Layout/Header/Navigation/NavigationPlaceholder', () => ({
+    NavigationPlaceholder: () => <div>Navigation placeholder</div>,
+}));
+
+vi.mock('components/Layout/Header/Navigation/Navigation', () => ({
+    Navigation: () => {
+        navigationRenderMock();
+
+        return <div>Desktop navigation</div>;
+    },
+}));
+
+const navigation = [{} as TypeCategoriesByColumnFragment];
+
+describe('DeferredNavigation', () => {
+    beforeEach(() => {
+        navigationRenderMock.mockClear();
+        useDeferredRenderMock.mockReset();
+        useDeferredRenderMock.mockReturnValue(true);
+    });
+
+    test('keeps navigation unmounted on mobile after the deferred wave', () => {
+        render(<DeferredNavigation isDesktop={false} navigation={navigation} />);
+
+        expect(screen.queryByText('Navigation placeholder')).not.toBeInTheDocument();
+        expect(screen.queryByText('Desktop navigation')).not.toBeInTheDocument();
+        expect(navigationRenderMock).not.toHaveBeenCalled();
+        expect(useDeferredRenderMock).not.toHaveBeenCalled();
+    });
+
+    test('renders the placeholder before the viewport is recognized', () => {
+        render(<DeferredNavigation navigation={navigation} />);
+
+        expect(screen.getByText('Navigation placeholder')).toBeInTheDocument();
+        expect(useDeferredRenderMock).not.toHaveBeenCalled();
+    });
+
+    test('keeps the placeholder on desktop before the deferred wave', () => {
+        useDeferredRenderMock.mockReturnValue(false);
+
+        render(<DeferredNavigation isDesktop navigation={navigation} />);
+
+        expect(screen.getByText('Navigation placeholder')).toBeInTheDocument();
+        expect(navigationRenderMock).not.toHaveBeenCalled();
+    });
+
+    test('mounts desktop navigation after the deferred wave', async () => {
+        render(<DeferredNavigation isDesktop navigation={navigation} />);
+
+        expect(await screen.findByText('Desktop navigation')).toBeInTheDocument();
+        expect(navigationRenderMock).toHaveBeenCalledOnce();
+    });
+});

--- a/upgrade-notes/storefront_20260721_144403.md
+++ b/upgrade-notes/storefront_20260721_144403.md
@@ -1,0 +1,6 @@
+#### Storefront navigation now loads interaction features on demand ([#4714](https://github.com/shopsys/shopsys/pull/4714))
+
+- update `DeferredNavigation` and its usage in `CommonLayout` to load the full desktop navigation only on desktop after the deferred render wave, keeping its JavaScript out of the mobile render path
+- dynamically load the mobile menu, cart, and account implementations only after their first user interaction while keeping previously opened drawers mounted for closing animations
+- keep the mobile search overlay in the synchronous render path so its input is focused directly from the originating user gesture, preserving the iOS virtual keyboard behavior
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Mobile visitors previously downloaded and processed desktop navigation and the implementation of all mobile header panels during the initial page load, even though those features were not yet visible. This increased main-thread work and contributed to poorer Total Blocking Time.

The storefront now keeps desktop-only navigation out of the mobile render path and loads the mobile menu, cart, and account panels only when they are first opened. Mobile search remains in the synchronous render path so its input focus stays within the originating user gesture and opens the iOS virtual keyboard reliably. Existing navigation placeholders and drawer transitions are preserved.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4215-optimize-header-tbt.odin.shopsys.cloud
  - https://cz.tc-ssp-4215-optimize-header-tbt.odin.shopsys.cloud
  - https://tc-ssp-4215-optimize-header-tbt.odin.shopsys.cloud/sk
<!-- Replace -->
