### PR TITLE
MCP OAuth client registrations now survive deploys and cache cleaning

### DIFF
--- a/.agents/skills/adhoc-pr/SKILL.md
+++ b/.agents/skills/adhoc-pr/SKILL.md
@@ -93,6 +93,13 @@ gh pr create --base <default-branch> --head <branch> --title "<title>" --body-fi
 
 Record the PR **title**, **number**, and **URL** — the Jira issue is derived from them.
 
+4. **Backfill the PR number into upgrade notes.** Upgrade notes written before the PR
+   exists (in `upgrade-notes/`) carry the `{pullRequestId}` placeholder from
+   `upgrade-notes/_template.md`. After creating the PR, search the branch for the
+   placeholder (`git grep -l pullRequestId upgrade-notes/`), replace it with the real
+   PR number, and **amend** the commit that introduced the note (then push with
+   `--force-with-lease`) — the placeholder must never survive into the merged history.
+
 ### Step 5: Jira Issue
 
 Use the Atlassian MCP tools with `cloudId: shopsys.atlassian.net`.

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -427,6 +427,7 @@ services:
                 - '@snc_redis.global'
                 - '@snc_redis.blog_article_export_queue'
                 - '@snc_redis.product_recalculation_queue'
+                - '@snc_redis.mcp_oauth'
 
     Shopsys\FrameworkBundle\Component\Redis\RedisVersionsFacade:
         arguments:

--- a/project-base/app/config/packages/snc_redis.yaml
+++ b/project-base/app/config/packages/snc_redis.yaml
@@ -80,7 +80,7 @@ snc_redis:
             dsn: 'redis://%env(REDIS_HOST)%'
             logging: false
             options:
-                prefix: '%env(REDIS_PREFIX)%:%build-version%:cache:mcp_oauth:'
+                prefix: '%env(REDIS_PREFIX)%:mcp_oauth:'
                 connection_timeout: 2
                 read_write_timeout: 5
         mcp_rate_limiter:

--- a/upgrade-notes/backend_20260724_120000.md
+++ b/upgrade-notes/backend_20260724_120000.md
@@ -1,0 +1,3 @@
+#### MCP OAuth client registrations now survive deploys and cache cleaning ([#4719](https://github.com/shopsys/shopsys/pull/4719))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

MCP clients (e.g. Claude Code) register themselves on the server via OAuth Dynamic Client Registration and keep the issued `client_id` locally for future re-authorizations. The server, however, stored these registrations in a Redis pool whose key prefix contained `%build-version%`, and the pool was not excluded from cache cleaning. As a result, the registrations were silently discarded on every deploy (new build version + old-version key cleanup) and on every `shopsys:redis:clean-cache` run (the `clean-redis` phing target, which runs routinely during local builds).

When the client later started a new authorization with its remembered `client_id`, the authorize endpoint rejected it with "The OAuth client or redirect_uri is invalid." — a dead end in the browser that the MCP client cannot detect or recover from, forcing the user to manually clear the client's stored credentials.

The `mcp_oauth` Redis pool is now versionless (following the same pattern as `frontend_api_refresh_token`) and is listed among the persistent clients of `RedisFacade`, so client registrations survive both deploys and cache cleaning. All entries in the pool carry their own TTL (30 days for client registrations, minutes for authorization codes), so nothing accumulates indefinitely.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-mcp-oauth-registrations-survive-cache-clean.odin.shopsys.cloud
  - https://cz.rv-mcp-oauth-registrations-survive-cache-clean.odin.shopsys.cloud
  - https://rv-mcp-oauth-registrations-survive-cache-clean.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1784892354.455319 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-mcp-oauth-registrations-survive-cache-clean.odin.shopsys.cloud
  - https://cz.rv-mcp-oauth-registrations-survive-cache-clean.odin.shopsys.cloud
  - https://rv-mcp-oauth-registrations-survive-cache-clean.odin.shopsys.cloud/sk
<!-- Replace -->
