### PR TITLE
Fix admin assets build failing with webpack 5.109.0

### DIFF
--- a/project-base/app/webpack.config.js
+++ b/project-base/app/webpack.config.js
@@ -78,4 +78,14 @@ Encore.addAliases({
     'icons': path.resolve(path.join(__dirname, 'assets/icons'))
 });
 
-module.exports = Encore.getWebpackConfig();
+const webpackConfig = Encore.getWebpackConfig();
+
+// webpack >= 5.109.0 defaults experiments.typescript to "auto", which makes enhanced-resolve read tsconfig.json
+// files found next to resolved modules — vendor/symfony/ux-live-component ships one extending a file
+// that is not part of the composer package, failing the whole build
+webpackConfig.experiments = {
+    ...webpackConfig.experiments,
+    typescript: false,
+};
+
+module.exports = webpackConfig;

--- a/upgrade-notes/backend_20260724_111906.md
+++ b/upgrade-notes/backend_20260724_111906.md
@@ -1,0 +1,3 @@
+#### Fix admin assets build failing with webpack 5.109.0 ([#4720](https://github.com/shopsys/shopsys/pull/4720))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Every CI build of project-base (GitHub Actions on `20.0`, GitLab project pipelines) started failing on 24 July during the admin assets build with:

```
error in ./vendor/symfony/ux-live-component/assets/dist/live.min.css
Module not found: Error: ENOENT: no such file or directory, open '/var/www/html/vendor/symfony/tsconfig.package.json'
```

The trigger is webpack 5.109.0 (released 23 July), which is picked up by every fresh `npm install` because there is no lockfile. It newly defaults `experiments.typescript` to `"auto"`, enabling built-in TypeScript support on Node.js >= 22.6 — as a side effect, enhanced-resolve starts reading `tsconfig.json` files found next to resolved modules. The composer package of `symfony/ux-live-component` ships `assets/tsconfig.json` that extends a file existing only in the symfony/ux monorepo, so the resolution fails hard and breaks the whole build.

This PR disables `experiments.typescript` in the webpack config — we don't rely on webpack's built-in TypeScript support, admin assets are plain JavaScript. Builds now pass again with webpack >= 5.109.0.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-fix-project-base.odin.shopsys.cloud
  - https://cz.rv-fix-project-base.odin.shopsys.cloud
  - https://rv-fix-project-base.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1784886763.702939 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-project-base.odin.shopsys.cloud
  - https://cz.rv-fix-project-base.odin.shopsys.cloud
  - https://rv-fix-project-base.odin.shopsys.cloud/sk
<!-- Replace -->
