### PR TITLE
add missing factory for AdministratorRoleGroupData

### DIFF
--- a/packages/framework/src/Controller/Admin/AdministratorRoleGroupController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorRoleGroupController.php
@@ -16,7 +16,7 @@ use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
 use Shopsys\FrameworkBundle\Form\Admin\Administrator\AdministratorRoleGroupFormType;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
-use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupData;
+use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupDataFactory;
 use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupFacade;
 use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\Exception\AdministratorRoleGroupNotFoundException;
 use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\Exception\DuplicateNameException;
@@ -34,6 +34,7 @@ class AdministratorRoleGroupController extends AdminBaseController
         protected readonly BreadcrumbOverrider $breadcrumbOverrider,
         protected readonly AdministratorFacade $administratorFacade,
         protected readonly QueryBuilderDataSourceFactory $queryBuilderDataSourceFactory,
+        protected readonly AdministratorRoleGroupDataFactory $administratorRoleGroupDataFactory,
     ) {
     }
 
@@ -63,7 +64,7 @@ class AdministratorRoleGroupController extends AdminBaseController
     #[CanCreate]
     public function newAction(Request $request): Response
     {
-        $roleGroupData = new AdministratorRoleGroupData();
+        $roleGroupData = $this->administratorRoleGroupDataFactory->create();
         $form = $this->createForm(AdministratorRoleGroupFormType::class, $roleGroupData, []);
         $form->handleRequest($request);
 
@@ -105,8 +106,7 @@ class AdministratorRoleGroupController extends AdminBaseController
     public function editAction(Request $request, int $id): Response
     {
         $administratorRoleGroup = $this->administratorRoleGroupFacade->getById($id);
-        $administratorRoleGroupData = new AdministratorRoleGroupData();
-        $administratorRoleGroupData->fillFromEntity($administratorRoleGroup);
+        $administratorRoleGroupData = $this->administratorRoleGroupDataFactory->createFromAdministratorRoleGroup($administratorRoleGroup);
 
         $form = $this->createForm(AdministratorRoleGroupFormType::class, $administratorRoleGroupData, [
             'administrator_role_group' => $administratorRoleGroup,
@@ -156,8 +156,7 @@ class AdministratorRoleGroupController extends AdminBaseController
     {
         try {
             $administratorRoleGroup = $this->administratorRoleGroupFacade->getById($id);
-            $administratorRoleGroupData = new AdministratorRoleGroupData();
-            $administratorRoleGroupData->fillFromEntity($administratorRoleGroup);
+            $administratorRoleGroupData = $this->administratorRoleGroupDataFactory->createFromAdministratorRoleGroup($administratorRoleGroup);
 
             $form = $this->createForm(AdministratorRoleGroupFormType::class, $administratorRoleGroupData, [
                 'action' => $this->generateUrl('admin_administratorrolegroup_new'),

--- a/packages/framework/src/Model/Administrator/RoleGroup/AdministratorRoleGroupData.php
+++ b/packages/framework/src/Model/Administrator/RoleGroup/AdministratorRoleGroupData.php
@@ -15,10 +15,4 @@ class AdministratorRoleGroupData
      * @var string[]
      */
     public $roles = [];
-
-    public function fillFromEntity(AdministratorRoleGroup $administratorRoleGroup): void
-    {
-        $this->name = $administratorRoleGroup->getName();
-        $this->roles = $administratorRoleGroup->getRoles();
-    }
 }

--- a/packages/framework/src/Model/Administrator/RoleGroup/AdministratorRoleGroupDataFactory.php
+++ b/packages/framework/src/Model/Administrator/RoleGroup/AdministratorRoleGroupDataFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\RoleGroup;
+
+class AdministratorRoleGroupDataFactory
+{
+    protected function createInstance(): AdministratorRoleGroupData
+    {
+        return new AdministratorRoleGroupData();
+    }
+
+    public function create(): AdministratorRoleGroupData
+    {
+        return $this->createInstance();
+    }
+
+    public function createFromAdministratorRoleGroup(
+        AdministratorRoleGroup $administratorRoleGroup,
+    ): AdministratorRoleGroupData {
+        $administratorRoleGroupData = $this->createInstance();
+        $this->fillFromAdministratorRoleGroup($administratorRoleGroupData, $administratorRoleGroup);
+
+        return $administratorRoleGroupData;
+    }
+
+    protected function fillFromAdministratorRoleGroup(
+        AdministratorRoleGroupData $administratorRoleGroupData,
+        AdministratorRoleGroup $administratorRoleGroup,
+    ): void {
+        $administratorRoleGroupData->name = $administratorRoleGroup->getName();
+        $administratorRoleGroupData->roles = $administratorRoleGroup->getRoles();
+    }
+}

--- a/project-base/app/src/DataFixtures/Demo/AdministratorRoleGroupDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/AdministratorRoleGroupDataFixture.php
@@ -7,20 +7,21 @@ namespace App\DataFixtures\Demo;
 use Doctrine\Persistence\ObjectManager;
 use Override;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
-use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupData;
+use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupDataFactory;
 use Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupFacade;
 
 class AdministratorRoleGroupDataFixture extends AbstractReferenceFixture
 {
     public function __construct(
         private readonly AdministratorRoleGroupFacade $administratorRoleGroupFacade,
+        private readonly AdministratorRoleGroupDataFactory $administratorRoleGroupDataFactory,
     ) {
     }
 
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        $administratorRoleGroupData = new AdministratorRoleGroupData();
+        $administratorRoleGroupData = $this->administratorRoleGroupDataFactory->create();
         $administratorRoleGroupData->name = 'Blogger';
         $administratorRoleGroupData->roles = ['ROLE_PRODUCT_VIEW', 'ROLE_ARTICLE_FULL', 'ROLE_BLOG_CATEGORY_FULL', 'ROLE_BLOG_ARTICLE_FULL'];
 

--- a/upgrade-notes/backend_20260725_100000.md
+++ b/upgrade-notes/backend_20260725_100000.md
@@ -1,0 +1,6 @@
+#### add missing factory for AdministratorRoleGroupData ([#4722](https://github.com/shopsys/shopsys/pull/4722))
+
+- `AdministratorRoleGroupData` objects are now created via the new `Shopsys\FrameworkBundle\Model\Administrator\RoleGroup\AdministratorRoleGroupDataFactory`
+    - if your project extends `AdministratorRoleGroupData`, override the factory's `createInstance()` method to return your class
+- `AdministratorRoleGroupData::fillFromEntity()` was removed, use `AdministratorRoleGroupDataFactory::createFromAdministratorRoleGroup()` instead
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Data objects are created via factories across the framework, but `AdministratorRoleGroupData` was missing one, so the controller and data fixtures instantiated it directly and filled it via the ad-hoc `AdministratorRoleGroupData::fillFromEntity()` method.

The new `AdministratorRoleGroupDataFactory` follows the established pattern of the sibling `AdministratorDataFactory` (`create()`, `createFromAdministratorRoleGroup()`, protected `createInstance()` for extensibility). The `fillFromEntity()` method was removed as the factory now covers its purpose.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-2886-administrator-role-group-data-factory.odin.shopsys.cloud
  - https://cz.pk-ssp-2886-administrator-role-group-data-factory.odin.shopsys.cloud
  - https://pk-ssp-2886-administrator-role-group-data-factory.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1785311218.153649 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-2886-administrator-role-group-data-factory.odin.shopsys.cloud
  - https://cz.pk-ssp-2886-administrator-role-group-data-factory.odin.shopsys.cloud
  - https://pk-ssp-2886-administrator-role-group-data-factory.odin.shopsys.cloud/sk
<!-- Replace -->
