### PR TITLE
add missing translations of 2FA texts in administrator detail

### DIFF
--- a/packages/administration/templates/content/administrator/detail.html.twig
+++ b/packages/administration/templates/content/administrator/detail.html.twig
@@ -12,8 +12,8 @@
         {% else %}
             <div class="dropdown">
                 <a href="#" class="btn dropdown-toggle" data-bs-toggle="dropdown">
-                    <span class="d-none d-md-inline-block">{{ 'Enable two factor authentication' }}</span>
-                    <span class="d-md-none">{{ '2FA' }}</span>
+                    <span class="d-none d-md-inline-block">{{ 'Enable two factor authentication'|trans }}</span>
+                    <span class="d-md-none">{{ '2FA'|trans }}</span>
                 </a>
                 <div class="dropdown-menu">
                     <a class="dropdown-item" href="{{ url('admin_administrator_enable-two-factor-authentication', {'id': administrator.id, 'twoFactorAuthenticationType': 'google_auth'}) }}">

--- a/packages/administration/templates/content/administrator/disableTwoFactorAuthentication.html.twig
+++ b/packages/administration/templates/content/administrator/disableTwoFactorAuthentication.html.twig
@@ -10,7 +10,7 @@
     <div class="card card-md">
         <div class="card-body">
             {% if administrator.emailAuthEnabled %}
-                <h2 class="card-title mb-2">1. {{ 'Request authentication code' }}</h2>
+                <h2 class="card-title mb-2">1. {{ 'Request authentication code'|trans }}</h2>
                 <div class="mb-3">
                     {{ form(formSendEmail) }}
                 </div>

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -25,6 +25,9 @@ msgstr "%defaultCurrency% za 1 jednotku"
 msgid "%entityName% (%entityIdentifier%)"
 msgstr "%entityName% (%entityIdentifier%)"
 
+msgid "2FA"
+msgstr "2FA"
+
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr "<a href=\"%url%\">Zpět</a> na přihlašovací stránku."
 
@@ -943,6 +946,9 @@ msgstr "E-maily budou odeslány pouze na adresy, které odpovídají alespoň je
 msgid "Enable"
 msgstr "Zapnout"
 
+msgid "Enable two factor authentication"
+msgstr "Zapnout dvoufaktorové ověřování"
+
 msgid "Enable two factor authentication via email"
 msgstr "Zapnout dvoufaktorové ověřování pomocí e-mailu"
 
@@ -1851,6 +1857,9 @@ msgstr "Nahradit soubor"
 
 msgid "Request a one-time passcode by email"
 msgstr "Požádejte o jednorázový přístupový kód e-mailem"
+
+msgid "Request authentication code"
+msgstr "Vyžádejte si ověřovací kód"
 
 msgid "Requested at"
 msgstr "Vyžádáno dne"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -25,6 +25,9 @@ msgstr ""
 msgid "%entityName% (%entityIdentifier%)"
 msgstr ""
 
+msgid "2FA"
+msgstr ""
+
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr ""
 
@@ -943,6 +946,9 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
+msgid "Enable two factor authentication"
+msgstr ""
+
 msgid "Enable two factor authentication via email"
 msgstr ""
 
@@ -1850,6 +1856,9 @@ msgid "Replace file"
 msgstr ""
 
 msgid "Request a one-time passcode by email"
+msgstr ""
+
+msgid "Request authentication code"
 msgstr ""
 
 msgid "Requested at"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -25,6 +25,9 @@ msgstr "%defaultCurrency% za jednotku"
 msgid "%entityName% (%entityIdentifier%)"
 msgstr "%entityName% (%entityIdentifier%)"
 
+msgid "2FA"
+msgstr "2FA"
+
 msgid "<a href=\"%url%\">Go back</a> to login page."
 msgstr "<a href=\"%url%\">Späť</a> na prihlasovaciu stránku."
 
@@ -943,6 +946,9 @@ msgstr "E-maily budú odoslané iba na adresy, ktoré zodpovedajú aspoň jedné
 msgid "Enable"
 msgstr "Povoliť"
 
+msgid "Enable two factor authentication"
+msgstr "Zapnúť dvojfaktorové overovanie"
+
 msgid "Enable two factor authentication via email"
 msgstr "Zapnúť dvojfaktorové overovanie pomocou e-mailu"
 
@@ -1851,6 +1857,9 @@ msgstr "Nahradiť súbor"
 
 msgid "Request a one-time passcode by email"
 msgstr "Požiadať o jednorazový prístupový kód e-mailom"
+
+msgid "Request authentication code"
+msgstr "Vyžiadajte si overovací kód"
 
 msgid "Requested at"
 msgstr "Vyžiadané dňa"


### PR DESCRIPTION
#### Description, the reason for the PR

The administrator detail page showed untranslated texts because three of them were missing the `|trans` filter: "Enable two factor authentication", "2FA", and "Request authentication code" (on the 2FA disabling page). The filters were added and the Czech and Slovak translations were filled in, following the terminology of the surrounding 2FA texts.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-3466-2fa-translations.odin.shopsys.cloud
  - https://cz.pk-ssp-3466-2fa-translations.odin.shopsys.cloud
  - https://pk-ssp-3466-2fa-translations.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1785424331.184919 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-3466-2fa-translations.odin.shopsys.cloud
  - https://cz.pk-ssp-3466-2fa-translations.odin.shopsys.cloud
  - https://pk-ssp-3466-2fa-translations.odin.shopsys.cloud/sk
<!-- Replace -->
