### PR TITLE
set max upload size in Elfinder and disable chunked uploads

### DIFF
--- a/project-base/app/config/packages/fm_elfinder.yaml
+++ b/project-base/app/config/packages/fm_elfinder.yaml
@@ -13,6 +13,11 @@ fm_elfinder:
                         flysystem:
                             enabled: true
                             filesystem: 'main_filesystem'
+                        # intentionally below the 32M limits of upload_max_filesize (php-ini-overrides.ini) and client_max_body_size (nginx.conf, orchestration/kubernetes/configmap/nginx.yaml)
+                        # so the whole multipart request fits within them and Elfinder rejects too large files with a clear message instead of a server error
+                        upload_max_size: 30M
+                        # disable chunked uploads entirely (chunks may land on different app replicas), multi-file uploads run serially
+                        upload_max_conn: -1
                         upload_allow:
                             - 'image/png'
                             - 'image/jpg'
@@ -57,6 +62,11 @@ fm_elfinder:
                         flysystem:
                             enabled: true
                             filesystem: 'main_filesystem'
+                        # intentionally below the 32M limits of upload_max_filesize (php-ini-overrides.ini) and client_max_body_size (nginx.conf, orchestration/kubernetes/configmap/nginx.yaml)
+                        # so the whole multipart request fits within them and Elfinder rejects too large files with a clear message instead of a server error
+                        upload_max_size: 30M
+                        # disable chunked uploads entirely (chunks may land on different app replicas), multi-file uploads run serially
+                        upload_max_conn: -1
                         upload_allow:
                             - 'image/png'
                             - 'image/jpg'

--- a/upgrade-notes/backend_20260725_101500.md
+++ b/upgrade-notes/backend_20260725_101500.md
@@ -1,0 +1,7 @@
+#### set max upload size in Elfinder and disable chunked uploads ([#4724](https://github.com/shopsys/shopsys/pull/4724))
+
+- Elfinder uploads are now limited to 30 MB (`upload_max_size`), intentionally slightly below the 32 MB PHP (`upload_max_filesize`, `post_max_size`) and nginx (`client_max_body_size`) limits, so the whole multipart request still fits within them and too large files are rejected with a clear message instead of a server error
+    - if your project uses different PHP/webserver limits, adjust `upload_max_size` in `app/config/packages/fm_elfinder.yaml` accordingly (keep it slightly below the PHP/webserver limits)
+- chunked uploads are disabled (`upload_max_conn: -1`) because chunking does not work with multiple application replicas
+    - as a side effect, multiple files selected at once are uploaded one by one instead of in parallel
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

When an administrator uploaded a file larger than 10 MB through the Elfinder file manager (used in the WYSIWYG editor and GrapesJS), the upload was silently split into chunks. On environments running multiple application replicas, each chunk can be handled by a different replica, so the file could not be reassembled and the upload failed.

Elfinder now has an explicit 32 MB upload limit (`upload_max_size`) matching the existing PHP (`upload_max_filesize`, `post_max_size`) and nginx (`client_max_body_size`) limits, so administrators get a clear error message before the upload even starts instead of a cryptic server error. Chunked uploads are disabled entirely (`upload_max_conn: -1`), so uploads of any allowed size work reliably regardless of the number of replicas. The only trade-off is that multiple files selected at once are now uploaded one by one instead of in parallel.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-3664-elfinder-upload-max-size.odin.shopsys.cloud
  - https://cz.pk-ssp-3664-elfinder-upload-max-size.odin.shopsys.cloud
  - https://pk-ssp-3664-elfinder-upload-max-size.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1785850543.776709 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-3664-elfinder-upload-max-size.odin.shopsys.cloud
  - https://cz.pk-ssp-3664-elfinder-upload-max-size.odin.shopsys.cloud
  - https://pk-ssp-3664-elfinder-upload-max-size.odin.shopsys.cloud/sk
<!-- Replace -->
