### PR TITLE
open frontend product detail link from admin product list in a new tab

### DIFF
--- a/packages/administration/templates/content/product/listGrid.html.twig
+++ b/packages/administration/templates/content/product/listGrid.html.twig
@@ -85,7 +85,7 @@
         </span>
     {% else %}
         {% if row.isVisible %}
-            <a href="{{ findUrlByDomainId('front_product_detail', { id: row.id }, getFirstDomain().id) }}">
+            <a href="{{ findUrlByDomainId('front_product_detail', { id: row.id }, getFirstDomain().id) }}" target="_blank" rel="noopener">
                 {{ _self.singleDomainIcon(visibilityTitle, visibilityClass, visibilityIcon) }}
                 {{ _self.singleDomainIcon(sellabilityTitle, sellabilityClass, sellabilityIcon) }}
             </a>


### PR DESCRIPTION
#### Description, the reason for the PR

The visibility column in the admin product list links to the product detail on the storefront. With multiple domains, the link opens from a popover in a new tab, but with a single domain the direct link opened in the same tab, navigating the administrator away from the administration. The single-domain link now opens in a new tab as well (`target="_blank"` with `rel="noopener"`).

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-461-admin-fe-links-new-tab.odin.shopsys.cloud
  - https://cz.pk-ssp-461-admin-fe-links-new-tab.odin.shopsys.cloud
  - https://pk-ssp-461-admin-fe-links-new-tab.odin.shopsys.cloud/sk
<!-- Replace -->
