### PR TITLE
IndexRepository find methods return null instead of throwing exception

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/IndexFacade.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexFacade.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory;
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade;
-use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchAliasNotFoundException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchIndexAliasAlreadyExistsException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchIndexAliasNotFoundException;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -31,16 +30,15 @@ class IndexFacade
         ));
 
         $alias = $indexDefinition->getIndexAlias();
+        $existingIndexName = $this->resolveExistingIndexName($indexDefinition);
 
-        try {
-            if (!$this->isIndexUpToDate($indexDefinition)) {
-                throw new ElasticsearchIndexAliasAlreadyExistsException(sprintf(
-                    'There is an index for alias "%s" already. You have to migrate it first due to different definition.',
-                    $alias,
-                ));
-            }
-        } catch (ElasticsearchAliasNotFoundException $exception) {
+        if ($existingIndexName === null) {
             $output->writeln(sprintf('Alias "%s" does not exist', $alias));
+        } elseif ($existingIndexName !== $indexDefinition->getVersionedIndexName()) {
+            throw new ElasticsearchIndexAliasAlreadyExistsException(sprintf(
+                'There is an index for alias "%s" already. You have to migrate it first due to different definition.',
+                $alias,
+            ));
         }
 
         $this->createIndexWhenNeeded($indexDefinition, $output);
@@ -130,12 +128,8 @@ class IndexFacade
             return;
         }
 
-        try {
-            $this->resolveExistingIndexName($indexDefinition);
-        } catch (ElasticsearchAliasNotFoundException $exception) {
-            throw new ElasticsearchIndexAliasNotFoundException(sprintf(
-                $indexDefinition->getIndexAlias(),
-            ));
+        if ($this->resolveExistingIndexName($indexDefinition) === null) {
+            throw new ElasticsearchIndexAliasNotFoundException($indexDefinition->getIndexAlias());
         }
 
         $output->writeln(sprintf(
@@ -177,9 +171,9 @@ class IndexFacade
         $indexName = $indexDefinition->getIndexName();
         $domainId = $indexDefinition->getDomainId();
 
-        try {
-            $existingIndexName = $this->resolveExistingIndexName($indexDefinition);
-        } catch (ElasticsearchAliasNotFoundException $exception) {
+        $existingIndexName = $this->resolveExistingIndexName($indexDefinition);
+
+        if ($existingIndexName === null) {
             $output->writeln(sprintf('No index for alias "%s" was not found on domain "%s"', $indexName, $domainId));
             $this->create($indexDefinition, $output);
 
@@ -243,16 +237,16 @@ class IndexFacade
 
     protected function createIndexWhenNoAliasFound(IndexDefinition $indexDefinition, OutputInterface $output): void
     {
-        try {
-            $this->indexRepository->findCurrentIndexNameForAlias($indexDefinition->getIndexAlias());
-        } catch (ElasticsearchAliasNotFoundException $exception) {
-            $output->writeln(sprintf(
-                'Index "%s" does not exist on domain "%s"',
-                $indexDefinition->getIndexName(),
-                $indexDefinition->getDomainId(),
-            ));
-            $this->create($indexDefinition, $output);
+        if ($this->indexRepository->findCurrentIndexNameForAlias($indexDefinition->getIndexAlias()) !== null) {
+            return;
         }
+
+        $output->writeln(sprintf(
+            'Index "%s" does not exist on domain "%s"',
+            $indexDefinition->getIndexName(),
+            $indexDefinition->getDomainId(),
+        ));
+        $this->create($indexDefinition, $output);
     }
 
     protected function createIndexWhenNeeded(IndexDefinition $indexDefinition, OutputInterface $output): void
@@ -268,7 +262,7 @@ class IndexFacade
         }
     }
 
-    protected function resolveExistingIndexName(IndexDefinition $indexDefinition): string
+    protected function resolveExistingIndexName(IndexDefinition $indexDefinition): ?string
     {
         return $this->indexRepository->findCurrentIndexNameForAlias(
             $indexDefinition->getIndexAlias(),

--- a/packages/framework/src/Component/Elasticsearch/IndexRepository.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 
 use Elasticsearch\Client;
-use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchAliasNotFoundException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchBulkUpdateException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchCreateAliasException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchCreateIndexException;
@@ -144,21 +143,18 @@ class IndexRepository
         }
     }
 
+    /**
+     * @return string[]
+     */
     protected function findIndexNamesForAlias(string $aliasName): array
     {
         if (!$this->isAliasCreated($aliasName)) {
-            throw new ElasticsearchAliasNotFoundException($aliasName);
+            return [];
         }
 
         $indexes = $this->elasticsearchClient->indices();
 
-        $indexesWithAlias = array_keys($indexes->getAlias(['name' => $aliasName]));
-
-        if (count($indexesWithAlias) === 0) {
-            throw new ElasticsearchAliasNotFoundException($aliasName);
-        }
-
-        return $indexesWithAlias;
+        return array_keys($indexes->getAlias(['name' => $aliasName]));
     }
 
     protected function isAliasCreated(string $aliasName): bool
@@ -168,9 +164,13 @@ class IndexRepository
         return $indexes->existsAlias(['name' => $aliasName]);
     }
 
-    public function findCurrentIndexNameForAlias(string $aliasName): string
+    public function findCurrentIndexNameForAlias(string $aliasName): ?string
     {
         $indexesWithAlias = $this->findIndexNamesForAlias($aliasName);
+
+        if (count($indexesWithAlias) === 0) {
+            return null;
+        }
 
         if (count($indexesWithAlias) > 1) {
             throw new ElasticsearchMoreThanOneIndexFoundForAliasException($aliasName, $indexesWithAlias);

--- a/upgrade-notes/backend_20260725_110000.md
+++ b/upgrade-notes/backend_20260725_110000.md
@@ -1,0 +1,7 @@
+#### IndexRepository: find methods now return null instead of throwing an exception ([#4726](https://github.com/shopsys/shopsys/pull/4726))
+
+- `Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRepository::findCurrentIndexNameForAlias()` now returns `null` instead of throwing `ElasticsearchAliasNotFoundException` when the alias does not exist (return type changed from `string` to `?string`)
+- `Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRepository::findIndexNamesForAlias()` now returns an empty array instead of throwing `ElasticsearchAliasNotFoundException`
+- `Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade::resolveExistingIndexName()` return type changed from `string` to `?string`
+- if your project catches `ElasticsearchAliasNotFoundException` around these calls, replace the try-catch with a `null` (or empty array) check
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

By convention, `find*` methods return `null` when nothing is found while `get*` methods throw. `IndexRepository::findCurrentIndexNameForAlias()` and `findIndexNamesForAlias()` violated this by throwing `ElasticsearchAliasNotFoundException`, and `IndexFacade` had to use exception-based control flow around every call. The find methods now return `null` (or an empty array), and `IndexFacade` uses plain null checks.

#### Fixes issues

closes #2244

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-2934-index-repository-find-null.odin.shopsys.cloud
  - https://cz.pk-ssp-2934-index-repository-find-null.odin.shopsys.cloud
  - https://pk-ssp-2934-index-repository-find-null.odin.shopsys.cloud/sk
<!-- Replace -->
