### PR TITLE
session cookie is marked as secure on HTTPS

### DIFF
--- a/project-base/app/config/packages/framework.yaml
+++ b/project-base/app/config/packages/framework.yaml
@@ -19,6 +19,9 @@ framework:
     session:
         cookie_httponly: true
         cookie_lifetime: 31536000 # 365 days * 24 hours * 3600 seconds
+        # The session cookie is marked as secure when the request comes over HTTPS
+        # (requires correctly configured trusted_proxies when running behind an HTTPS-terminating proxy)
+        cookie_secure: auto
         # Disable the default PHP session garbage collection.
         # Session garbage collection is responsibility of hosting.
         gc_probability: 0

--- a/upgrade-notes/backend_20260726_100000.md
+++ b/upgrade-notes/backend_20260726_100000.md
@@ -1,0 +1,5 @@
+#### session cookie is now marked as secure on HTTPS ([#4727](https://github.com/shopsys/shopsys/pull/4727))
+
+- `cookie_secure: auto` was added to the session configuration in `app/config/packages/framework.yaml`, so the session cookie is sent with the `Secure` flag when the site runs on HTTPS
+    - when running behind an HTTPS-terminating proxy, make sure `TRUSTED_PROXIES` is configured properly so Symfony detects the original protocol from the `X-Forwarded-Proto` header
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The session cookie (PHPSESSID) was not marked as `Secure`, so browsers would send it over plain HTTP as well, making a man-in-the-middle attack easier. With `cookie_secure: auto`, Symfony marks the cookie as secure whenever the request comes over HTTPS (behind an HTTPS-terminating proxy this relies on correctly configured `TRUSTED_PROXIES`, which the application already uses).

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-1008-secure-session-cookie.odin.shopsys.cloud
  - https://cz.pk-ssp-1008-secure-session-cookie.odin.shopsys.cloud
  - https://pk-ssp-1008-secure-session-cookie.odin.shopsys.cloud/sk
<!-- Replace -->
