### PR TITLE
block merging pull requests with fixup commits

### DIFF
--- a/.github/workflows/block-fixup-commits.yaml
+++ b/.github/workflows/block-fixup-commits.yaml
@@ -1,0 +1,40 @@
+on:
+    pull_request:
+        branches:
+            - '**'
+concurrency:
+    group: block-fixup-commits-${{ github.ref }}
+    cancel-in-progress: true
+name: Block fixup commits
+permissions:
+    contents: read
+jobs:
+    block-fixup-commits:
+        name: Check PR for fixup commits
+        runs-on: ubuntu-22.04
+        steps:
+            -   name: GIT checkout branch - ${{ github.ref }}
+                uses: actions/checkout@v6
+                with:
+                    ref: ${{ github.ref }}
+                    fetch-depth: 0
+            -   name: Check for fixup commits
+                env:
+                    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                shell: bash
+                run: |
+                    if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+                        git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+                    fi
+
+                    COMMITS=$(git log --format='%h %s' "${BASE_SHA}..${HEAD_SHA}")
+                    FIXUP_COMMITS=$(grep -E '^[0-9a-f]+ (fixup|squash|amend)!' <<< "${COMMITS}" || true)
+
+                    if [ -n "${FIXUP_COMMITS}" ]; then
+                        echo "${FIXUP_COMMITS}"
+                        echo "::error::The pull request contains fixup commits. Squash them (git rebase --autosquash) before merging."
+                        exit 1
+                    fi
+
+                    echo "No fixup commits found."


### PR DESCRIPTION
#### Description, the reason for the PR

Fixup commits (`fixup!`, `squash!`, `amend!`) are handy during review but must not end up in the merged history. The new workflow checks every pull request and fails while such commits are present, so they can still be pushed during review but the PR cannot be merged until they are squashed (`git rebase --autosquash`).

The check is implemented as a small inline script instead of a third-party marketplace action to avoid a supply-chain dependency, following the style of the existing `check-upgrade-notes` job. To actually block merging, the check needs to be marked as required in the branch protection settings after this is merged.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-1105-block-fixup-commits.odin.shopsys.cloud
  - https://cz.pk-ssp-1105-block-fixup-commits.odin.shopsys.cloud
  - https://pk-ssp-1105-block-fixup-commits.odin.shopsys.cloud/sk
<!-- Replace -->
