### PR TITLE
cropZeros Twig filter accepts numeric and null values

### DIFF
--- a/packages/framework/src/Twig/CropZerosExtension.php
+++ b/packages/framework/src/Twig/CropZerosExtension.php
@@ -21,9 +21,9 @@ class CropZerosExtension extends AbstractExtension
         ];
     }
 
-    public function cropZeros(string $value): string
+    public function cropZeros(string|int|float|null $value): string
     {
-        return preg_replace('/(?:[,.]0+|([,.]\d*?)0+)$/', '$1', $value);
+        return preg_replace('/(?:[,.]0+|([,.]\d*?)0+)$/', '$1', (string)$value);
     }
 
     public function getName(): string

--- a/packages/framework/tests/Unit/Twig/CropZerosExtensionTest.php
+++ b/packages/framework/tests/Unit/Twig/CropZerosExtensionTest.php
@@ -19,6 +19,11 @@ class CropZerosExtensionTest extends TestCase
             ['input' => '12.630000', 'return' => '12.63'],
             ['input' => '12,630000', 'return' => '12,63'],
             ['input' => '1200', 'return' => '1200'],
+            ['input' => 12, 'return' => '12'],
+            ['input' => 1200, 'return' => '1200'],
+            ['input' => 12.00, 'return' => '12'],
+            ['input' => 12.63, 'return' => '12.63'],
+            ['input' => null, 'return' => ''],
         ];
     }
 

--- a/upgrade-notes/backend_20260726_120000.md
+++ b/upgrade-notes/backend_20260726_120000.md
@@ -1,0 +1,5 @@
+#### cropZeros Twig filter now accepts numbers ([#4730](https://github.com/shopsys/shopsys/pull/4730))
+
+- `CropZerosExtension::cropZeros()` parameter type was widened from `string` to `string|int|float|null`, so the filter no longer fails with a `TypeError` for `NumberType` form fields with numeric or empty values
+    - if your project overrides this method, widen the parameter type the same way
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The `cropZeros` Twig filter is used by the `number_widget` and `money_widget` form blocks, but its parameter was typed as `string` only. A `NumberType` field with a numeric model value (int/float) or an empty value caused a `TypeError` and a 500 error when rendering the form. The parameter type was widened to `string|int|float|null` and the value is cast before the regular expression is applied.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-1694-crop-zeros-number-type.odin.shopsys.cloud
  - https://cz.pk-ssp-1694-crop-zeros-number-type.odin.shopsys.cloud
  - https://pk-ssp-1694-crop-zeros-number-type.odin.shopsys.cloud/sk
<!-- Replace -->
