### PR TITLE
add text search to transfer issues overview

### DIFF
--- a/packages/administration/templates/content/transfer/issue/list.html.twig
+++ b/packages/administration/templates/content/transfer/issue/list.html.twig
@@ -15,8 +15,10 @@
     {{ form_start(form) }}
     {% include '@ShopsysAdministration/partial/_quick_search_form.html.twig' with {
         title: 'Search in transfers'|trans,
-        form_input: form.transfer,
+        form_extra_input: form.transfer,
+        form_input: form.searchText,
         form_submit: form.submit,
+        placeholder: 'Search in transfer issue messages...'|trans,
     } %}
     {{ form_end(form) }}
 

--- a/packages/administration/templates/partial/_quick_search_form.html.twig
+++ b/packages/administration/templates/partial/_quick_search_form.html.twig
@@ -1,6 +1,7 @@
 {#
 @var title: string
 @var form_input: FormTypeInterface
+@var form_extra_input: FormTypeInterface (optional, rendered before form_input)
 @var form_submit: FormTypeInterface
 @var info_message: string
 @var placeholder: string
@@ -15,6 +16,9 @@
 {% endif %}
 
         <div class="input-group input-group-flat">
+            {% if form_extra_input|default(false) %}
+                {{ form_widget(form_extra_input) }}
+            {% endif %}
             {{ form_widget(form_input, { attr: { placeholder: placeholder|default(null) } }) }}
             {% if info_message|default(false) %}
                 <span class="input-group-text">

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -1990,6 +1990,9 @@ msgstr "Vyhledat dle názvu sekce…"
 msgid "Search by slug..."
 msgstr "Vyhledat podle slugu..."
 
+msgid "Search in transfer issue messages..."
+msgstr "Hledat v textech problémů v přenosech..."
+
 msgid "Search in transfers"
 msgstr "Hledání v přenosech"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -1990,6 +1990,9 @@ msgstr ""
 msgid "Search by slug..."
 msgstr ""
 
+msgid "Search in transfer issue messages..."
+msgstr ""
+
 msgid "Search in transfers"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -1990,6 +1990,9 @@ msgstr "Hľadať podľa názvu sekcie…"
 msgid "Search by slug..."
 msgstr "Hľadať podľa slug..."
 
+msgid "Search in transfer issue messages..."
+msgstr "Hľadať v textoch problémov v prenosoch..."
+
 msgid "Search in transfers"
 msgstr "Hľadať v prenosoch"
 

--- a/packages/framework/src/Controller/Admin/TransferIssueController.php
+++ b/packages/framework/src/Controller/Admin/TransferIssueController.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanView;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
+use Shopsys\FrameworkBundle\Component\String\DatabaseSearchingHelper;
 use Shopsys\FrameworkBundle\Form\Admin\Transfer\TransferIssueSearchFormType;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade;
@@ -30,6 +31,7 @@ class TransferIssueController extends AdminBaseController
         protected readonly AdministratorGridFacade $administratorGridFacade,
         protected readonly AdministratorFacade $administratorFacade,
         protected readonly QueryBuilderDataSourceFactory $queryBuilderDataSourceFactory,
+        protected readonly DatabaseSearchingHelper $databaseSearchingHelper,
     ) {
     }
 
@@ -53,6 +55,14 @@ class TransferIssueController extends AdminBaseController
                 $queryBuilder
                     ->andWhere('ti.transfer = :transfer')
                     ->setParameter('transfer', $filteredTransfer);
+            }
+
+            $searchText = $form->getData()['searchText'];
+
+            if ($searchText !== null && $searchText !== '') {
+                $queryBuilder
+                    ->andWhere('NORMALIZED(ti.message) LIKE NORMALIZED(:searchText)')
+                    ->setParameter('searchText', $this->databaseSearchingHelper->getFullTextLikeSearchString($searchText));
             }
         }
         $dataSource = $this->queryBuilderDataSourceFactory->create($queryBuilder, 'ti.id');

--- a/packages/framework/src/Form/Admin/Transfer/TransferIssueSearchFormType.php
+++ b/packages/framework/src/Form/Admin/Transfer/TransferIssueSearchFormType.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Model\Transfer\TransferFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -31,6 +32,9 @@ final class TransferIssueSearchFormType extends AbstractType
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'placeholder' => '-- Select name of the transfer --',
+            ])
+            ->add('searchText', TextType::class, [
+                'required' => false,
             ])
             ->add('submit', SubmitType::class);
     }

--- a/upgrade-notes/backend_20260726_130000.md
+++ b/upgrade-notes/backend_20260726_130000.md
@@ -1,0 +1,5 @@
+#### text search in transfer issues overview ([#4731](https://github.com/shopsys/shopsys/pull/4731))
+
+- the transfer issues overview in administration now allows case-insensitive text search in issue messages, in addition to the existing filter by transfer
+- if your project extends `Shopsys\FrameworkBundle\Controller\Admin\TransferIssueController`, add the new `Shopsys\FrameworkBundle\Component\String\DatabaseSearchingHelper` constructor dependency
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The transfer issues overview in administration could only be filtered by the transfer. Administrators can now also search the issue messages by text (case-insensitive, using the same `NORMALIZED(...) LIKE` approach as other admin searches), so it is easy to find out whether a particular product, order, or customer had a transfer problem. Both filters can be combined.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-2999-transfer-issues-search.odin.shopsys.cloud
  - https://cz.pk-ssp-2999-transfer-issues-search.odin.shopsys.cloud
  - https://pk-ssp-2999-transfer-issues-search.odin.shopsys.cloud/sk
<!-- Replace -->
