### PR TITLE
links with target attribute get rel="noopener" automatically

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -10,7 +10,9 @@ use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff;
 use Shopsys\CodingStandards\CsFixer\FinalCompilerPassFixer;
 use Shopsys\CodingStandards\CsFixer\FinalFormTypeFixer;
 use Shopsys\CodingStandards\CsFixer\FinalMigrationFixer;
+use Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
+use Shopsys\CodingStandards\CsFixer\MissingButtonTypeFixer;
 use Shopsys\CodingStandards\Helper\CyclomaticComplexitySniffSetting;
 use Shopsys\CodingStandards\Sniffs\General\ForbiddenDumpSniff;
 use Shopsys\CodingStandards\Sniffs\General\ForbiddenSuperGlobalSniff;
@@ -36,6 +38,7 @@ foreach ($packagesDirectoryIterator as $path) {
         $pathCandidates = [
             $path->getPathname() . '/src',
             $path->getPathname() . '/tests',
+            $path->getPathname() . '/templates',
         ];
 
         foreach ($pathCandidates as $pathCandidate) {
@@ -66,6 +69,7 @@ return ECSConfig::configure()
         ...$packagePaths,
         __DIR__ . '/project-base/app/app',
         __DIR__ . '/project-base/app/src',
+        __DIR__ . '/project-base/app/templates',
         __DIR__ . '/project-base/app/tests',
         __DIR__ . '/utils/releaser/src',
         __DIR__ . '/utils/releaser/tests',
@@ -136,6 +140,10 @@ return ECSConfig::configure()
                 __DIR__ . '/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php',
                 __DIR__ . '/packages/framework/src/Model/AdminNavigation/RoutingExtension.php',
             ],
+            ForbiddenDumpFixer::class => [
+                // the profiler collector renders the dumped data on purpose, it is not a forgotten debug dump
+                __DIR__ . '/packages/framework/src/Resources/views/Components/Collector/elasticSearch.html.twig',
+            ],
             ForbiddenDumpSniff::class => [
                 __DIR__ . '/packages/framework/src/Component/DateTimeHelper/Exception/CannotParseDateTimeException.php',
                 __DIR__ . '/packages/framework/src/Twig/VarDumperExtension.php',
@@ -178,6 +186,10 @@ return ECSConfig::configure()
                 __DIR__ . '/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php',
                 __DIR__ . '/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php',
                 __DIR__ . '/utils/releaser/src/ReleaseWorker/Release/TagPhpImageReleaseWorker.php',
+            ],
+            MissingButtonTypeFixer::class => [
+                // the type attribute is a part of the attributes bag passed to the button
+                __DIR__ . '/packages/administration/templates/components/live_action_button.html.twig',
             ],
             ParentCallSpacingSniff::class . '.IncorrectLinesCountBeforeControlStructure' => [
                 __DIR__ . '/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php',

--- a/packages/administration/templates/content/blog/article/statusItems.html.twig
+++ b/packages/administration/templates/content/blog/article/statusItems.html.twig
@@ -19,7 +19,7 @@
 
             <div class="col">
                 {% if url is not null and blogArticle.isAccessibleOnStorefront(domain.id) %}
-                    <a href="{{ url }}" target="_blank">
+                    <a href="{{ url }}" target="_blank" rel="noopener">
                         {% if isMultidomain() %}
                             {{ getDomainName(domain.id) }}
                             {{ ux_icon('forward-page') }}

--- a/packages/administration/templates/content/brand/list.html.twig
+++ b/packages/administration/templates/content/brand/list.html.twig
@@ -32,6 +32,7 @@
                                 <a href="{{ findUrlByDomainId('front_brand_list', {}, domain.id) }}"
                                    class="text-reset d-block text-truncate"
                                    target="_blank"
+                                   rel="noopener"
                                 >{{ findUrlByDomainId('front_brand_list', {}, domain.id) }}</a>
                                 <div class="text-secondary text-truncate mt-n1">{{ getDomainName(domain.id) }}</div>
                             </div>

--- a/packages/administration/templates/content/categorySeo/listGrid.html.twig
+++ b/packages/administration/templates/content/categorySeo/listGrid.html.twig
@@ -21,5 +21,5 @@
 {% endblock %}
 
 {% block grid_value_cell_id_friendlyUrlSlug %}
-    <a href="{{ getAbsoluteUrlOfReadyCategorySeoMix(row.rcsmId) }}" target="_blank">{{ row.fuSlug }}</a>
+    <a href="{{ getAbsoluteUrlOfReadyCategorySeoMix(row.rcsmId) }}" target="_blank" rel="noopener">{{ row.fuSlug }}</a>
 {% endblock %}

--- a/packages/administration/templates/content/customer/loginAsUserLinkMacro.html.twig
+++ b/packages/administration/templates/content/customer/loginAsUserLinkMacro.html.twig
@@ -1,7 +1,7 @@
 {% macro loginAsUserLink(customerUser, linkCssClasses = "btn btn-light", onlyIcon = false) %}
     {% set loginAsUserUrl = getLoginAsUserUrl(customerUser) %}
     {% if loginAsUserUrl is not null %}
-        <a href="{{ loginAsUserUrl }}" target="_blank" class="{{ linkCssClasses }}" {% if onlyIcon is same as true %} title="{{ 'Log in as user'|trans }}"{% endif %}>
+        <a href="{{ loginAsUserUrl }}" target="_blank" class="{{ linkCssClasses }}" {% if onlyIcon is same as true %} title="{{ 'Log in as user'|trans }}"{% endif %} rel="noopener">
             {{ ux_icon('forward-page') }}
             {% if onlyIcon is same as false %}
                 <span>

--- a/packages/administration/templates/content/elasticsearch/_entityDataButton.html.twig
+++ b/packages/administration/templates/content/elasticsearch/_entityDataButton.html.twig
@@ -7,6 +7,7 @@
                 domainId: initialDomainId|default(null),
                 hideDomainSwitch: hideDomainSwitch|default(false),
             }) }}"
+            type="button"
     >
         {{ ux_icon('brand-elastic') }}
         {{ 'Indexed data'|trans }}

--- a/packages/administration/templates/content/elasticsearch/entityDataModal.html.twig
+++ b/packages/administration/templates/content/elasticsearch/entityDataModal.html.twig
@@ -83,6 +83,7 @@
                            class="btn btn-sm"
                            data-bs-toggle="tooltip"
                            title="{{ 'Open in a new tab'|trans }}"
+                           rel="noopener"
                         >
                             {{ ux_icon('forward-page', {class: 'icon-sm'}) }}
                         </a>
@@ -90,6 +91,7 @@
                     <button class="btn btn-sm btn-secondary"
                             data-js-clipboard-copy="{{ elasticsearchEntityData.prettyJson }}"
                             data-js-clipboard-copy-title="{{ 'Copy the entire JSON document'|trans }}"
+                            type="button"
                     >
                         {{ ux_icon('duplicate') }}
                         {{ 'Copy JSON'|trans }}

--- a/packages/administration/templates/content/feed/listGrid.html.twig
+++ b/packages/administration/templates/content/feed/listGrid.html.twig
@@ -11,7 +11,7 @@
 {% block grid_value_cell_id_label %}
     {% import _self as self %}
     {% if row.created %}
-        <a href="{{ row.url }}" target="_blank">{{ self.getLabel(row) }}</a>
+        <a href="{{ row.url }}" target="_blank" rel="noopener">{{ self.getLabel(row) }}</a>
     {% else %}
         {{ self.getLabel(row) }}
     {% endif %}

--- a/packages/administration/templates/content/order/detail/edit.html.twig
+++ b/packages/administration/templates/content/order/detail/edit.html.twig
@@ -6,7 +6,7 @@
 {% block h1 %}{{ 'Order Nr.'|trans }} {{ order.number }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ findUrlByDomainId('front_customer_order_detail_unregistered', { urlHash: order.urlHash }, order.domainId) }}" target="_blank" class="btn btn-outline-primary">
+    <a href="{{ findUrlByDomainId('front_customer_order_detail_unregistered', { urlHash: order.urlHash }, order.domainId) }}" target="_blank" class="btn btn-outline-primary" rel="noopener">
         {{ ux_icon('forward-page') }}
         {{ 'View order on Frontend'|trans }}
     </a>

--- a/packages/administration/templates/content/order/detail/sections/personal_view.html.twig
+++ b/packages/administration/templates/content/order/detail/sections/personal_view.html.twig
@@ -15,7 +15,7 @@
                     <span class="text-secondary d-inline-flex align-items-center">
                         {{ ux_icon('company', { class: 'icon icon-inline' }) }}
                     </span>
-                    <a href="{{ url('admin_customer_edit', { id: order.customerUser.customer.id }) }}" target="_blank" class="d-flex align-items-center gap-1">
+                    <a href="{{ url('admin_customer_edit', { id: order.customerUser.customer.id }) }}" target="_blank" class="d-flex align-items-center gap-1" rel="noopener">
                         {{ registeredCompanyName }} {{ ux_icon('forward-page', { class: 'icon icon-inline' }) }}
                     </a>
                 </span>
@@ -24,7 +24,7 @@
                 <span class="text-secondary d-inline-flex align-items-center">
                     {{ ux_icon('user', { class: 'icon icon-inline' }) }}
                 </span>
-                <a href="{{ url('admin_customer_user_edit', { id: order.customerUser.id }) }}" target="_blank" class="d-flex align-items-center gap-1">
+                <a href="{{ url('admin_customer_user_edit', { id: order.customerUser.id }) }}" target="_blank" class="d-flex align-items-center gap-1" rel="noopener">
                     {{ order.customerUser.firstName }} {{ order.customerUser.lastName }} {{ ux_icon('forward-page', { class: 'icon icon-inline' }) }}
                 </a>
             </span>

--- a/packages/administration/templates/content/order/orderItem.html.twig
+++ b/packages/administration/templates/content/order/orderItem.html.twig
@@ -16,7 +16,7 @@
                         {% set isNewItem = orderItemId starts with constant('Shopsys\\FrameworkBundle\\Model\\Order\\OrderData::NEW_ITEM_PREFIX') %}
                         {% if productItem and productItem.product %}
                             <span class="input-group-text">
-                                <a href="{{ path('admin_product_edit', { id: productItem.product.id }) }}" class="input-group-link" target="_blank">
+                                <a href="{{ path('admin_product_edit', { id: productItem.product.id }) }}" class="input-group-link" target="_blank" rel="noopener">
                                     {{ ux_icon('forward-page') }}
                                 </a>
                             </span>

--- a/packages/administration/templates/content/personalData/index.html.twig
+++ b/packages/administration/templates/content/personalData/index.html.twig
@@ -14,7 +14,7 @@
             <h3 class="card-title">{{ 'Personal information overview'|trans }}</h3>
             <div class="card-actions">
                 {{ 'Storefront URL:'|trans }}
-                <a href="{{ findUrlByDomainId('front_personal_data', {}, domainId) }}" target="_blank">
+                <a href="{{ findUrlByDomainId('front_personal_data', {}, domainId) }}" target="_blank" rel="noopener">
                     {{ findUrlByDomainId('front_personal_data', {}, domainId) }}
                 </a>
             </div>
@@ -29,7 +29,7 @@
             <h3 class="card-title">{{ 'Personal information export'|trans }}</h3>
             <div class="card-actions">
                 {{ 'Storefront URL:'|trans }}
-                <a href="{{ findUrlByDomainId('front_personal_data_export', {}, domainId) }}" target="_blank">
+                <a href="{{ findUrlByDomainId('front_personal_data_export', {}, domainId) }}" target="_blank" rel="noopener">
                     {{ findUrlByDomainId('front_personal_data_export', {}, domainId) }}
                 </a>
             </div>

--- a/packages/administration/templates/content/product/visibilityItems.html.twig
+++ b/packages/administration/templates/content/product/visibilityItems.html.twig
@@ -46,7 +46,7 @@
 
             <div class="col">
                 {% if isVisible %}
-                    <a href="{{ url }}" target="_blank">
+                    <a href="{{ url }}" target="_blank" rel="noopener">
                         {% if isMultidomain() %}
                             {{ getDomainName(domain.id) }}
                             {{ ux_icon('forward-page') }}

--- a/packages/administration/templates/content/uploadedFile/edit.html.twig
+++ b/packages/administration/templates/content/uploadedFile/edit.html.twig
@@ -8,7 +8,7 @@
 {% block btn %}
     {% if uploadedFileExists(entity) %}
         {% if isUploadedFileViewableInBrowser(entity) %}
-            <a href="{{ uploadedFileViewUrl(entity) }}" target="_blank" class="btn btn-secondary">
+            <a href="{{ uploadedFileViewUrl(entity) }}" target="_blank" class="btn btn-secondary" rel="noopener">
                 {{ ux_icon('forward-page') }}
                 {{ 'View'|trans }}
             </a>

--- a/packages/administration/templates/form/content/ComplaintItemsType.html.twig
+++ b/packages/administration/templates/form/content/ComplaintItemsType.html.twig
@@ -25,7 +25,7 @@
                                         {{ form_widget(complaintItemForm.productName) }}
                                         <span class="input-group-text">
                                         {% if product %}
-                                            <a href="{{ path('admin_product_edit', { id: product.id }) }}" target="_blank">
+                                            <a href="{{ path('admin_product_edit', { id: product.id }) }}" target="_blank" rel="noopener">
                                                 {{ ux_icon('forward-page') }}
                                             </a>
                                         {% else %}
@@ -56,7 +56,7 @@
                                 <td>
                                     {% for file in files.orderedFiles %}
                                         {% if customerUploadedFileExists(file) %}
-                                            <a class="btn btn-sm" href="{{ customerUploadedFileUrl(file) }}" target="_blank">
+                                            <a class="btn btn-sm" href="{{ customerUploadedFileUrl(file) }}" target="_blank" rel="noopener">
                                                 {{ file.name }}.{{ file.extension }}
                                             </a>
                                         {% else %}

--- a/packages/administration/templates/form/content/OrderItemsType.html.twig
+++ b/packages/administration/templates/form/content/OrderItemsType.html.twig
@@ -79,6 +79,7 @@
                                                        class="fw-medium"
                                                        target="_blank"
                                                        title="{{ 'Open product detail'|trans }}"
+                                                       rel="noopener"
                                                     >
                                                         {{ itemData.name }}
                                                         {{ ux_icon('forward-page', { class: 'icon icon-sm' }) }}

--- a/packages/administration/templates/form/content/PriceListOverviewType.html.twig
+++ b/packages/administration/templates/form/content/PriceListOverviewType.html.twig
@@ -16,7 +16,7 @@
                     {% for specialPrice in specialPrices %}
                         <tr class="{{ not isHighlighted and specialPrice.isNowActive ? "table-success" }}">
                             <td>
-                                <a href="{{ url('admin_pricelist_edit', {id: specialPrice.priceListId}) }}" target="_blank">
+                                <a href="{{ url('admin_pricelist_edit', {id: specialPrice.priceListId}) }}" target="_blank" rel="noopener">
                                     <span>{{ specialPrice.priceListName }}</span>&nbsp;
                                     {{ ux_icon('forward-page') }}
                                 </a>

--- a/packages/administration/templates/form/content/PriceListProductsPickerType.html.twig
+++ b/packages/administration/templates/form/content/PriceListProductsPickerType.html.twig
@@ -82,6 +82,7 @@
                 {% if product is not null %}
                     <a href="{{ url('admin_product_edit', {id: product.id}) }}"
                        target="_blank"
+                       rel="noopener"
                     >
                         {{ product.getName(getDomain().getDomainConfigById(domainId).getLocale()) }}
                         {{ ux_icon('forward-page') }}

--- a/packages/administration/templates/form/content/ProductVideosDataCollection.html.twig
+++ b/packages/administration/templates/form/content/ProductVideosDataCollection.html.twig
@@ -5,7 +5,7 @@
             {{ form_errors(formData) }}
         </div>
         <div class="col-auto">
-            <button class="js-remove-row btn btn-icon btn-ghost-danger">{{ ux_icon('delete') }}</button>
+            <button class="js-remove-row btn btn-icon btn-ghost-danger" type="button">{{ ux_icon('delete') }}</button>
         </div>
     </div>
 {% endmacro %}

--- a/packages/administration/templates/form/content/customer/orderListType.html.twig
+++ b/packages/administration/templates/form/content/customer/orderListType.html.twig
@@ -42,7 +42,7 @@
                             {% for order in orders %}
                                 <tr>
                                     <td>
-                                        <a href="{{ url('admin_order_edit', { id: order.id }) }}" target="_blank">
+                                        <a href="{{ url('admin_order_edit', { id: order.id }) }}" target="_blank" rel="noopener">
                                             {{ order.number }}{{ ux_icon('forward-page', { class: 'ms-1 icon icon-sm' }) }}
                                         </a>
                                     </td>

--- a/packages/administration/templates/form/type/DisplayOnlyCompanyNameType.html.twig
+++ b/packages/administration/templates/form/type/DisplayOnlyCompanyNameType.html.twig
@@ -1,6 +1,6 @@
 {% block display_only_company_name_widget %}
     <div class="form-control-plaintext">
-        <a href="{{ path('admin_billing_address_edit', { id: billingAddress.id }) }}" target="_blank">
+        <a href="{{ path('admin_billing_address_edit', { id: billingAddress.id }) }}" target="_blank" rel="noopener">
             {% if billingAddress.companyCustomer %}
                 {{ billingAddress.companyName }}
             {% else %}

--- a/packages/administration/templates/form/type/DisplayOnlyCustomerType.html.twig
+++ b/packages/administration/templates/form/type/DisplayOnlyCustomerType.html.twig
@@ -3,7 +3,7 @@
         {% if user is null %}
             {{ 'unregistered customer'|trans }}
         {% else %}
-            <a href="{{ path('admin_customer_edit', { id: user.id }) }}" target="_blank">
+            <a href="{{ path('admin_customer_edit', { id: user.id }) }}" target="_blank" rel="noopener">
                 {% if user.customer.billingAddress.companyCustomer %}
                     {{ user.customer.billingAddress.companyName }} -
                 {% endif %}

--- a/packages/administration/templates/form/type/DisplayOnlyOrderType.html.twig
+++ b/packages/administration/templates/form/type/DisplayOnlyOrderType.html.twig
@@ -1,7 +1,7 @@
 {% block display_only_order_widget %}
     <div class="form-control-plaintext">
         {% if order is not null %}
-            <a href="{{ path('admin_order_edit', { id: order.id }) }}" target="_blank">
+            <a href="{{ path('admin_order_edit', { id: order.id }) }}" target="_blank" rel="noopener">
                 {{ order.number }}
                 {{ ux_icon('forward-page') }}
             </a>

--- a/packages/administration/templates/form/type/DisplayOnlyUrlType.html.twig
+++ b/packages/administration/templates/form/type/DisplayOnlyUrlType.html.twig
@@ -6,7 +6,7 @@
             {% set url = url(route, route_params) %}
         {% endif %}
 
-        <a href="{{ url }}" target="{{ link_target }}" {% with {attr: route_attr} %}{{ block('attributes') }}{% endwith %}>
+        <a href="{{ url }}" target="{{ link_target }}"{% if link_target is same as('_blank') %} rel="noopener"{% endif %} {% with {attr: route_attr} %}{{ block('attributes') }}{% endwith %}>
             {% if link_target is same as('_blank') %}
                 {{ ux_icon('forward-page') }}
             {% endif %}

--- a/packages/administration/templates/form/type/ProductsType.html.twig
+++ b/packages/administration/templates/form/type/ProductsType.html.twig
@@ -66,7 +66,7 @@
 
             <div class="col text-truncate js-products-picker-item-product-name">
                 {% if product is not null %}
-                    <a href="{{ url('admin_product_edit', {id: product.id}) }}" target="_blank">
+                    <a href="{{ url('admin_product_edit', {id: product.id}) }}" target="_blank" rel="noopener">
                         <span>{{ product.name }}</span>&nbsp;{{ ux_icon('forward-page') }}
                     </a>
                     <div class="d-block text-secondary text-truncate">{{ product.catnum }}</div>

--- a/packages/administration/templates/form/type/UrlListType.html.twig
+++ b/packages/administration/templates/form/type/UrlListType.html.twig
@@ -38,6 +38,7 @@
                                 <a href="{{ absoluteUrl }}"
                                    title="{{ 'Open in a new tab'|trans }}"
                                    target="_blank"
+                                   rel="noopener"
                                 >
                                     {{ ux_icon('forward-page') }}
                                 </a>

--- a/packages/administration/templates/form/type/fileUpload/FileUploadType.html.twig
+++ b/packages/administration/templates/form/type/fileUpload/FileUploadType.html.twig
@@ -24,7 +24,7 @@
                                 <div class="d-flex align-items-center gap-1">
                                     {% if uploadedFileExists(file) %}
                                         {% if isUploadedFileViewableInBrowser(file) %}
-                                            <a href="{{ uploadedFileViewUrl(file) }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}">
+                                            <a href="{{ uploadedFileViewUrl(file) }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}" rel="noopener">
                                                 {{ ux_icon('forward-page', {class: 'icon mx-0'}) }}
                                             </a>
                                         {% endif %}

--- a/packages/administration/templates/form/type/fileUpload/ImageUploadType.html.twig
+++ b/packages/administration/templates/form/type/fileUpload/ImageUploadType.html.twig
@@ -24,7 +24,7 @@
                                 <div class="d-flex align-items-center gap-1">
                                     {% set currentImageUrl = imageUrl(image, image_type) %}
                                     {% if currentImageUrl %}
-                                        <a href="{{ currentImageUrl }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}">
+                                        <a href="{{ currentImageUrl }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}" rel="noopener">
                                             {{ ux_icon('forward-page', {class: 'icon mx-0'}) }}
                                         </a>
                                         <a href="{{ currentImageUrl }}" download class="btn btn-sm btn-ghost-secondary" title="{{ 'Download'|trans }}">

--- a/packages/administration/templates/form/type/fileUpload/filePicker.html.twig
+++ b/packages/administration/templates/form/type/fileUpload/filePicker.html.twig
@@ -5,7 +5,7 @@
             <div class="d-flex align-items-center gap-1 ms-auto">
                 {% if file and uploadedFileExists(file) %}
                     {% if isUploadedFileViewableInBrowser(file) %}
-                        <a href="{{ uploadedFileViewUrl(file) }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}">
+                        <a href="{{ uploadedFileViewUrl(file) }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}" rel="noopener">
                             {{ ux_icon('forward-page', {class: 'icon mx-0'}) }}
                         </a>
                     {% endif %}

--- a/packages/administration/templates/form/type/fileUpload/filesPicker.html.twig
+++ b/packages/administration/templates/form/type/fileUpload/filesPicker.html.twig
@@ -5,7 +5,7 @@
             <div class="d-flex align-items-center gap-1 ms-auto">
                 {% if file and uploadedFileExists(file) %}
                     {% if isUploadedFileViewableInBrowser(file) %}
-                        <a href="{{ uploadedFileViewUrl(file) }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}">
+                        <a href="{{ uploadedFileViewUrl(file) }}" target="_blank" class="btn btn-sm btn-ghost-secondary" title="{{ 'View'|trans }}" rel="noopener">
                             {{ ux_icon('forward-page', {class: 'icon mx-0'}) }}
                         </a>
                     {% endif %}

--- a/packages/administration/templates/layout/layout.html.twig
+++ b/packages/administration/templates/layout/layout.html.twig
@@ -122,6 +122,7 @@
                                            target="_blank"
                                            class="dropdown-item"
                                            title="{{ domainConfig.name }}"
+                                           rel="noopener"
                                         >
                                             {{ domainConfig.name }}
                                         </a>

--- a/packages/administration/templates/layout/layout_with_panel.html.twig
+++ b/packages/administration/templates/layout/layout_with_panel.html.twig
@@ -76,7 +76,7 @@
 
                             {% if btnContent|trim %}
                                 <div class="dropdown d-md-none">
-                                    <button class="btn dropdown-toggle" data-bs-toggle="dropdown">{{ ux_icon('dots') }}</button>
+                                    <button class="btn dropdown-toggle" data-bs-toggle="dropdown" type="button">{{ ux_icon('dots') }}</button>
                                     <div class="dropdown-menu">
                                         <div class="btn-list m-3 justify-content-end">
                                             {{ btnContent|raw }}

--- a/packages/administration/templates/partial/_pin_button.html.twig
+++ b/packages/administration/templates/partial/_pin_button.html.twig
@@ -9,6 +9,7 @@
       data-bs-toggle="tooltip"
       data-bs-custom-class="sidebar-pin-tooltip"
       title="{{ pinned ? 'Unpin'|trans : 'Pin'|trans }}"
+      type="button"
 >
     {{ ux_icon(pinned ? 'pinned' : 'pin', {class: 'icon icon-sm'}) }}
 </button>

--- a/packages/administration/templates/partial/display_uuid.html.twig
+++ b/packages/administration/templates/partial/display_uuid.html.twig
@@ -4,6 +4,7 @@
     <button class="btn btn-sm btn-link text-secondary d-none d-md-inline text-decoration-none"
           data-js-clipboard-copy="{{ uuid }}"
           data-js-clipboard-copy-title="{{ uuid }}"
+          type="button"
     >
         UUID {{ ux_icon('duplicate', {class: 'w-3 h-3'}) }}
     </button>

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -91,6 +91,7 @@ use PhpCsFixer\Fixer\Whitespace\NoSpacesAroundOffsetFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer;
 use Shopsys\CodingStandards\CsFixer\MissingButtonTypeFixer;
+use Shopsys\CodingStandards\CsFixer\MissingLinkRelNoopenerFixer;
 use Shopsys\CodingStandards\CsFixer\OrmJoinColumnRequireNullableFixer;
 use Shopsys\CodingStandards\CsFixer\Phpdoc\InheritDocFormatFixer;
 use Shopsys\CodingStandards\Helper\CyclomaticComplexitySniffSetting;
@@ -165,6 +166,7 @@ return ECSConfig::configure()
         InheritDocFormatFixer::class,
         ForbiddenDumpFixer::class,
         MissingButtonTypeFixer::class,
+        MissingLinkRelNoopenerFixer::class,
         OrmJoinColumnRequireNullableFixer::class,
         ObjectIsCreatedByFactorySniff::class,
         ForbiddenDumpSniff::class,

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -139,6 +139,7 @@ use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 return ECSConfig::configure()
     ->withParallel()
     ->withSpacing(indentation: Option::INDENTATION_SPACES, lineEnding: PHP_EOL)
+    ->withFileExtensions(['php', 'html.twig'])
     ->withSets([
         SetList::PSR_12,
         SetList::CLEAN_CODE,

--- a/packages/coding-standards/src/CsFixer/AppendsHtmlAttributeTrait.php
+++ b/packages/coding-standards/src/CsFixer/AppendsHtmlAttributeTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer;
+
+trait AppendsHtmlAttributeTrait
+{
+    /**
+     * Matches the indentation of the last attribute line, so that a tag written with one attribute per line
+     * keeps that formatting instead of getting the new attribute glued to the last one
+     */
+    protected const string LAST_ATTRIBUTE_LINE_PATTERN = '@(\R)([ \t]*)[^\r\n]*$@';
+
+    /**
+     * @param string $attributes everything between the tag name and the closing bracket of a single tag
+     * @param string $attribute the attribute to append, e.g. 'rel="noopener"'
+     */
+    protected function appendHtmlAttribute(string $attributes, string $attribute): string
+    {
+        if (preg_match(static::LAST_ATTRIBUTE_LINE_PATTERN, $attributes, $matches) === 1) {
+            return $attributes . $matches[1] . $matches[2] . $attribute;
+        }
+
+        return $attributes . ' ' . $attribute;
+    }
+}

--- a/packages/coding-standards/src/CsFixer/MissingButtonTypeFixer.php
+++ b/packages/coding-standards/src/CsFixer/MissingButtonTypeFixer.php
@@ -14,6 +14,10 @@ use SplFileInfo;
 
 final class MissingButtonTypeFixer implements FixerInterface
 {
+    use AppendsHtmlAttributeTrait;
+
+    private const string BUTTON_OPENING_TAG_PATTERN = '@(<button\b)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(\s*/?>)@imsu';
+
     /**
      * {@inheritdoc}
      */
@@ -55,14 +59,14 @@ final class MissingButtonTypeFixer implements FixerInterface
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         $code = preg_replace_callback(
-            '@(<button\b)(.*?)(\s*/?>)@imsu',
+            static::BUTTON_OPENING_TAG_PATTERN,
             function ($matches) {
                 $beginning = $matches[1];
                 $attributes = $matches[2];
                 $end = $matches[3];
 
-                if (!preg_match('@(?:^|\s+)type=@', $attributes)) {
-                    $attributes .= ' type="button"';
+                if (!preg_match('@(?:^|\s)type\s*=@i', $attributes)) {
+                    $attributes = $this->appendHtmlAttribute($attributes, 'type="button"');
                 }
 
                 return $beginning . $attributes . $end;

--- a/packages/coding-standards/src/CsFixer/MissingLinkRelNoopenerFixer.php
+++ b/packages/coding-standards/src/CsFixer/MissingLinkRelNoopenerFixer.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer;
+
+use Override;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class MissingLinkRelNoopenerFixer implements FixerInterface
+{
+    use AppendsHtmlAttributeTrait;
+
+    private const string NOOPENER = 'noopener';
+
+    private const string LINK_OPENING_TAG_PATTERN = '@(<a\b)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(\s*/?>)@imsu';
+
+    private const string BLANK_TARGET_ATTRIBUTE_PATTERN
+        = '@(?:^|\s)target\s*=\s*(?:"_blank"|\'_blank\'|_blank(?=[\s/]|$))@isu';
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Adds mandatory rel="noopener" to <a> HTML tag with a target="_blank" attribute.',
+            [
+                new CodeSample('<a href="https://example.com" target="_blank">label</a>'),
+                new CodeSample('<a href="https://example.com" target="_blank" rel="nofollow">label</a>'),
+                new CodeSample("<a\n    href=\"https://example.com\"\n    target=\"_blank\"\n>label</a>"),
+            ],
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $originalCode = $tokens->generateCode();
+        $code = preg_replace_callback(
+            self::LINK_OPENING_TAG_PATTERN,
+            function ($matches) {
+                $beginning = $matches[1];
+                $attributes = $matches[2];
+                $end = $matches[3];
+
+                if (!preg_match(self::BLANK_TARGET_ATTRIBUTE_PATTERN, $attributes)) {
+                    return $beginning . $attributes . $end;
+                }
+
+                return $beginning . $this->addNoopenerToRel($attributes) . $end;
+            },
+            $originalCode,
+        );
+
+        // the pattern is UTF-8 aware, so a template with broken encoding makes the match fail — leave it alone
+        $tokens->setCode($code ?? $originalCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getName(): string
+    {
+        return 'Shopsys/missing_link_rel_noopener';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function supports(SplFileInfo $file): bool
+    {
+        return preg_match('/\.html(?:\.twig)?$/ui', $file->getFilename()) === 1;
+    }
+
+    /**
+     * @param string $attributes everything between the tag name and the closing bracket of a single <a> tag
+     */
+    private function addNoopenerToRel(string $attributes): string
+    {
+        if (!preg_match('@(?:^|\s)rel\s*=@sui', $attributes)) {
+            return $this->appendHtmlAttribute($attributes, 'rel="' . self::NOOPENER . '"');
+        }
+
+        return preg_replace_callback(
+            '@((?:^|\s)rel\s*=\s*(["\']))(.*?)\2@sui',
+            static function ($matches) {
+                $relValues = preg_split('@\s+@', trim($matches[3]), -1, PREG_SPLIT_NO_EMPTY);
+
+                foreach ($relValues as $relValue) {
+                    if (strcasecmp($relValue, self::NOOPENER) === 0) {
+                        return $matches[0];
+                    }
+                }
+
+                $relValues[] = self::NOOPENER;
+
+                return $matches[1] . implode(' ', $relValues) . $matches[2];
+            },
+            $attributes,
+            1,
+        );
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingButtonTypeFixer/fixed/fixed.html.twig
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingButtonTypeFixer/fixed/fixed.html.twig
@@ -17,7 +17,8 @@
 <button name="asdf" type="button"></button>
 
 <button
-        attr="asdf" type="button"
+        attr="asdf"
+        type="button"
 />
 
 <button

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/MissingLinkRelNoopenerFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/MissingLinkRelNoopenerFixerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\MissingLinkRelNoopenerFixer;
+
+use Override;
+use Shopsys\CodingStandards\CsFixer\MissingLinkRelNoopenerFixer;
+use Tests\CodingStandards\Unit\CsFixer\AbstractFixerTestCase;
+
+final class MissingLinkRelNoopenerFixerTest extends AbstractFixerTestCase
+{
+    #[Override]
+    protected function createFixerService(): MissingLinkRelNoopenerFixer
+    {
+        return new MissingLinkRelNoopenerFixer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getTestingFiles(): iterable
+    {
+        yield [__DIR__ . '/fixed/fixed.html.twig', __DIR__ . '/wrong/wrong.html.twig'];
+
+        yield [__DIR__ . '/correct/correct.html.twig'];
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/correct/correct.html.twig
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/correct/correct.html.twig
@@ -1,0 +1,35 @@
+<a href="https://example.com" target="_blank" rel="noopener">label</a>
+
+<a href="https://example.com" target="_blank" rel="noopener"/>
+
+<a href="https://example.com" target="_blank" rel="noopener" />
+
+<a href="https://example.com" target="_blank" rel="nofollow noopener">label</a>
+
+<a href='https://example.com' target='_blank' rel='noopener noreferrer'>label</a>
+
+<a href="{{ url }}" target="{{ target }}" rel="noopener">{{ label }}</a>
+
+<a href="{{ url }}" target="{{ target }}"{% if target is same as('_blank') %} rel="noopener"{% endif %}>{{ label }}</a>
+
+<a href="https://example.com" target="_self">label</a>
+
+<a href="https://example.com" target="_top">label</a>
+
+<a href="https://example.com" target="content-frame">label</a>
+
+<a
+        href="https://example.com"
+        target="_blank"
+        rel="noopener"
+>label</a>
+
+<a href="https://example.com">label</a>
+
+<a href="https://example.com" rel="nofollow">label</a>
+
+<a href="https://example.com" target="_blank" rel = "noopener">label</a>
+
+<a href="https://example.com" TARGET="_blank" REL="NOOPENER">label</a>
+
+<abbr title="not a link" data-target="_blank">label</abbr>

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/fixed/fixed.html.twig
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/fixed/fixed.html.twig
@@ -1,0 +1,53 @@
+<a href="https://example.com" target="_blank" rel="noopener">label</a>
+
+<a href="https://example.com" target="_blank" rel="noopener"/>
+
+<a href="https://example.com" target="_blank" rel="noopener" />
+
+<a target="_top" href="https://example.com">label</a>
+
+<a target="_self" href="https://example.com">label</a>
+
+<a target="content-frame" href="https://example.com">label</a>
+
+<a target="_blankish" href="https://example.com">label</a>
+
+<a target=_blank href="https://example.com" rel="noopener">label</a>
+
+<a target="_BLANK" href="https://example.com" rel="noopener">label</a>
+
+<a href="https://example.com" target="_blank" rel="nofollow noopener">label</a>
+
+<a href="https://example.com" target="_blank" rel="noopener">label</a>
+
+<a href='https://example.com' target='_blank' rel='nofollow noreferrer noopener'>label</a>
+
+<a href="{{ url }}" target="{{ target }}">{{ label }}</a>
+
+<a
+        href="https://example.com"
+        target="_blank"
+        rel="noopener"
+>label</a>
+
+<a
+        href="https://example.com"
+        target="_blank"
+        rel="nofollow noopener"
+>label</a>
+
+<a href="https://example.com" rel="noopener">label</a>
+
+<a href="https://example.com">label</a>
+
+<abbr title="not a link" data-target="_blank">label</abbr>
+
+<a href="https://example.com" target="_blank" rel=nofollow>label</a>
+
+<a href="https://example.com" target="_blank" rel = "nofollow noopener">label</a>
+
+<a href="https://example.com" target ="_blank" rel="noopener">label</a>
+
+<a href="https://example.com" TARGET="_blank" REL="NOOPENER">label</a>
+
+<button type="button" data-target="_blank">label</button>

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/wrong/wrong.html.twig
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingLinkRelNoopenerFixer/wrong/wrong.html.twig
@@ -1,0 +1,52 @@
+<a href="https://example.com" target="_blank">label</a>
+
+<a href="https://example.com" target="_blank"/>
+
+<a href="https://example.com" target="_blank" />
+
+<a target="_top" href="https://example.com">label</a>
+
+<a target="_self" href="https://example.com">label</a>
+
+<a target="content-frame" href="https://example.com">label</a>
+
+<a target="_blankish" href="https://example.com">label</a>
+
+<a target=_blank href="https://example.com">label</a>
+
+<a target="_BLANK" href="https://example.com">label</a>
+
+<a href="https://example.com" target="_blank" rel="nofollow">label</a>
+
+<a href="https://example.com" target="_blank" rel="">label</a>
+
+<a href='https://example.com' target='_blank' rel='nofollow noreferrer'>label</a>
+
+<a href="{{ url }}" target="{{ target }}">{{ label }}</a>
+
+<a
+        href="https://example.com"
+        target="_blank"
+>label</a>
+
+<a
+        href="https://example.com"
+        target="_blank"
+        rel="nofollow"
+>label</a>
+
+<a href="https://example.com" rel="noopener">label</a>
+
+<a href="https://example.com">label</a>
+
+<abbr title="not a link" data-target="_blank">label</abbr>
+
+<a href="https://example.com" target="_blank" rel=nofollow>label</a>
+
+<a href="https://example.com" target="_blank" rel = "nofollow">label</a>
+
+<a href="https://example.com" target ="_blank">label</a>
+
+<a href="https://example.com" TARGET="_blank" REL="NOOPENER">label</a>
+
+<button type="button" data-target="_blank">label</button>

--- a/packages/framework/assets/js/admin/components/CKEditorLinkNoopener.js
+++ b/packages/framework/assets/js/admin/components/CKEditorLinkNoopener.js
@@ -1,0 +1,31 @@
+// rel="noopener" is added to links with target="_blank" whenever the content is saved through CKEditor,
+// both the classic editor and the one embedded in GrapesJS
+import { addRelNoopenerWhenTargetIsBlank } from '../../common/utils/addRelNoopenerWhenTargetIsBlank';
+import Register from '../../common/utils/Register';
+
+function initCKEditorLinkNoopener() {
+    if (typeof CKEDITOR === 'undefined') {
+        return;
+    }
+
+    if (CKEDITOR._linkNoopenerRegistered) {
+        return;
+    }
+    CKEDITOR._linkNoopenerRegistered = true;
+
+    CKEDITOR.on('instanceReady', event => {
+        event.editor.dataProcessor.htmlFilter.addRules({
+            elements: {
+                a: element => {
+                    const rel = addRelNoopenerWhenTargetIsBlank(element.attributes.rel, element.attributes.target);
+
+                    if (rel !== element.attributes.rel) {
+                        element.attributes.rel = rel;
+                    }
+                },
+            },
+        });
+    });
+}
+
+new Register().registerCallback(initCKEditorLinkNoopener, 'CKEditorLinkNoopener');

--- a/packages/framework/assets/js/admin/components/index.js
+++ b/packages/framework/assets/js/admin/components/index.js
@@ -5,6 +5,7 @@ import './AjaxConfirm';
 import './Article';
 import './TreeSelectionForm';
 import './CategoryTreeSorting';
+import './CKEditorLinkNoopener';
 import './CKEditorLinkVariableProtocol';
 import './CKEditorPreview';
 import './choiceControl';

--- a/packages/framework/assets/js/common/utils/addRelNoopenerWhenTargetIsBlank.js
+++ b/packages/framework/assets/js/common/utils/addRelNoopenerWhenTargetIsBlank.js
@@ -1,0 +1,19 @@
+// A page opened in a new tab can manipulate the opener window (reverse tabnabbing), which is prevented by
+// rel="noopener". Any existing rel value is kept, only noopener is merged into it.
+// Other target values are left alone — the attribute is meaningless for _self, _parent and _top, and for a
+// named target it would make the link open a new tab instead of navigating that window or frame.
+export const addRelNoopenerWhenTargetIsBlank = (rel, target) => {
+    if ((target || '').toLowerCase() !== '_blank') {
+        return rel;
+    }
+
+    const relValues = (rel || '').split(/\s+/).filter(value => value !== '');
+
+    if (relValues.some(value => value.toLowerCase() === 'noopener')) {
+        return rel;
+    }
+
+    relValues.push('noopener');
+
+    return relValues.join(' ');
+};

--- a/packages/framework/assets/js/common/utils/addRelNoopenerWhenTargetIsBlank.test.js
+++ b/packages/framework/assets/js/common/utils/addRelNoopenerWhenTargetIsBlank.test.js
@@ -1,0 +1,26 @@
+import { addRelNoopenerWhenTargetIsBlank } from './addRelNoopenerWhenTargetIsBlank';
+
+test.each([
+    // only _blank opens a new tab, the other values navigate an existing browsing context
+    [undefined, undefined, undefined],
+    ['nofollow', undefined, 'nofollow'],
+    ['nofollow', '', 'nofollow'],
+    ['nofollow', '_self', 'nofollow'],
+    ['nofollow', '_top', 'nofollow'],
+    ['nofollow', 'content-frame', 'nofollow'],
+    ['nofollow', '_blankish', 'nofollow'],
+
+    // target is _blank, noopener is added or merged into the existing rel
+    [undefined, '_blank', 'noopener'],
+    ['', '_blank', 'noopener'],
+    ['nofollow', '_blank', 'nofollow noopener'],
+    ['nofollow  noreferrer', '_blank', 'nofollow noreferrer noopener'],
+
+    // the keywords are compared case-insensitively
+    [undefined, '_BLANK', 'noopener'],
+    ['noopener', '_blank', 'noopener'],
+    ['NOOPENER', '_blank', 'NOOPENER'],
+    ['noreferrer noopener', '_blank', 'noreferrer noopener'],
+])('rel %j with target %j becomes %j', (rel, target, expectedRel) => {
+    expect(addRelNoopenerWhenTargetIsBlank(rel, target)).toBe(expectedRel);
+});

--- a/packages/framework/src/Component/Html/HtmlContentProcessor.php
+++ b/packages/framework/src/Component/Html/HtmlContentProcessor.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Html;
+
+class HtmlContentProcessor
+{
+    protected const string NOOPENER = 'noopener';
+
+    protected const string LINK_OPENING_TAG_PATTERN = '~(<a\b)((?:"[^"]*"|\'[^\']*\'|[^>"\'])*?)(\s*/?>)~i';
+
+    protected const string BLANK_TARGET_ATTRIBUTE_PATTERN
+        = '~(?:^|\s)target\s*=\s*(?:"_blank"|\'_blank\'|_blank(?=[\s/]|$))~i';
+
+    protected const string REL_ATTRIBUTE_PATTERN = '~(?:^|\s)rel\s*=~i';
+
+    protected const string QUOTED_REL_ATTRIBUTE_PATTERN = '~((?:^|\s)rel\s*=\s*(["\']))(.*?)\2~is';
+
+    public function process(?string $html): ?string
+    {
+        if ($html === null) {
+            return null;
+        }
+
+        return preg_replace_callback(
+            static::LINK_OPENING_TAG_PATTERN,
+            fn (array $matches): string => $matches[1] . $this->addRelNoopenerToLinkOpeningInNewTab($matches[2]) . $matches[3],
+            $html,
+        ) ?? $html;
+    }
+
+    /**
+     * @param string $attributes everything between the tag name and the closing bracket of a single <a> tag
+     */
+    protected function addRelNoopenerToLinkOpeningInNewTab(string $attributes): string
+    {
+        if (preg_match(static::BLANK_TARGET_ATTRIBUTE_PATTERN, $attributes) !== 1) {
+            return $attributes;
+        }
+
+        if (preg_match(static::REL_ATTRIBUTE_PATTERN, $attributes) !== 1) {
+            return $attributes . ' rel="' . static::NOOPENER . '"';
+        }
+
+        return preg_replace_callback(
+            static::QUOTED_REL_ATTRIBUTE_PATTERN,
+            fn (array $matches): string => $matches[1] . $this->mergeNoopenerIntoRelValue($matches[3]) . $matches[2],
+            $attributes,
+            1,
+        ) ?? $attributes;
+    }
+
+    /**
+     * @param string $relValue the value of a single rel attribute, e.g. "nofollow noreferrer"
+     */
+    protected function mergeNoopenerIntoRelValue(string $relValue): string
+    {
+        $relValues = (array)preg_split('~\s+~', trim($relValue), -1, PREG_SPLIT_NO_EMPTY);
+
+        if (array_any($relValues, fn ($existingRelValue) => strcasecmp((string)$existingRelValue, static::NOOPENER) === 0)) {
+            return $relValue;
+        }
+
+        $relValues[] = static::NOOPENER;
+
+        return implode(' ', $relValues);
+    }
+}

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -107,6 +107,7 @@ final class AdvertFormType extends AbstractType
             ->add('code', TextareaType::class, [
                 'label' => 'Code',
                 'required' => true,
+                'contains_html' => true,
                 'constraints' => [
                     new Constraints\NotBlank(
                         message: 'Please enter HTML code for advertisement area',

--- a/packages/framework/src/Form/Admin/GrapesJsMailType.php
+++ b/packages/framework/src/Form/Admin/GrapesJsMailType.php
@@ -53,6 +53,7 @@ final class GrapesJsMailType extends AbstractType
             ->setDefaults([
                 'body_variables' => [],
                 'custom_plugins' => [],
+                'contains_html' => true,
             ]);
     }
 }

--- a/packages/framework/src/Form/GrapesJsType.php
+++ b/packages/framework/src/Form/GrapesJsType.php
@@ -51,6 +51,7 @@ final class GrapesJsType extends AbstractType
             ->setAllowedTypes('allow_products', 'boolean')
             ->setDefaults([
                 'allow_products' => false,
+                'contains_html' => true,
                 'entry_options' => [
                     'attr' => [
                         'class' => 'js-grapesjs_textarea',

--- a/packages/framework/src/Form/HtmlContentTypeExtension.php
+++ b/packages/framework/src/Form/HtmlContentTypeExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form;
+
+use Override;
+use Shopsys\FrameworkBundle\Form\Transformers\HtmlContentDataTransformer;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class HtmlContentTypeExtension extends AbstractTypeExtension
+{
+    public function __construct(
+        private readonly HtmlContentDataTransformer $htmlContentDataTransformer,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'contains_html' => false,
+        ]);
+
+        $resolver->setAllowedTypes('contains_html', 'bool');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($options['contains_html'] === false) {
+            return;
+        }
+
+        $builder->addModelTransformer($this->htmlContentDataTransformer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public static function getExtendedTypes(): iterable
+    {
+        yield TextareaType::class;
+    }
+}

--- a/packages/framework/src/Form/Transformers/HtmlContentDataTransformer.php
+++ b/packages/framework/src/Form/Transformers/HtmlContentDataTransformer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form\Transformers;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Html\HtmlContentProcessor;
+use Symfony\Component\Form\DataTransformerInterface;
+
+class HtmlContentDataTransformer implements DataTransformerInterface
+{
+    public function __construct(protected readonly HtmlContentProcessor $htmlContentProcessor)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function transform($value): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function reverseTransform($value): ?string
+    {
+        return $this->htmlContentProcessor->process($value);
+    }
+}

--- a/packages/framework/src/Form/WysiwygTypeExtension.php
+++ b/packages/framework/src/Form/WysiwygTypeExtension.php
@@ -40,6 +40,7 @@ final class WysiwygTypeExtension extends AbstractTypeExtension
                 'format_tags' => static::ALLOWED_FORMAT_TAGS,
             ],
             'available_variables' => [],
+            'contains_html' => true,
         ]);
 
         $resolver->setAllowedTypes('available_variables', 'array');

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -13,7 +13,7 @@ services:
 
     Shopsys\FrameworkBundle\:
         exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
-        resource: '../../**/*{CategoryAutomatedFilter,Calculation,Context,Dispatcher,Enum,Executor,Extractor,Facade,Factory,Formatter,Freezer,Generator,Handler,Helper,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Sender,Service,Scheduler,Subscriber,Task,Transformer,DataFetcher}.php'
+        resource: '../../**/*{CategoryAutomatedFilter,Calculation,Context,Dispatcher,Enum,Executor,Extractor,Facade,Factory,Formatter,Freezer,Generator,Handler,Helper,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Processor,Provider,Recalculator,Registry,Repository,Resolver,Sender,Service,Scheduler,Subscriber,Task,Transformer,DataFetcher}.php'
 
     Shopsys\FrameworkBundle\Controller\:
         resource: '../../Controller/'
@@ -380,8 +380,6 @@ services:
     Shopsys\FrameworkBundle\Component\Image\ImageLocator:
         arguments: ['%shopsys.image_dir%']
 
-    Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor: ~
-
     Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatterInterface:
         class: 'Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatter'
 
@@ -729,8 +727,6 @@ services:
             $logger: '@monolog.logger.queue'
 
     Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessingStack: ~
-
-    Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor: ~
 
     Shopsys\FrameworkBundle\Model\Order\PromoCode\ProductPromoCodeFiller: ~
 

--- a/packages/framework/src/Resources/config/services/forms.yaml
+++ b/packages/framework/src/Resources/config/services/forms.yaml
@@ -19,6 +19,10 @@ services:
         tags:
             - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\ChoiceType }
 
+    Shopsys\FrameworkBundle\Form\HtmlContentTypeExtension:
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\TextareaType }
+
     Shopsys\FrameworkBundle\Form\InvertChoiceTypeExtension:
         tags:
             - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\ChoiceType }

--- a/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
+++ b/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
@@ -55,7 +55,7 @@
         <div class="sf-toolbar-info-group">
             <div class="sf-toolbar-info-piece">
                 <b>Resources</b>
-                <span><a href="{{ collector.docsUrl }}" target="_blank" rel="help">Documentation</a></span>
+                <span><a href="{{ collector.docsUrl }}" target="_blank" rel="help noopener">Documentation</a></span>
             </div>
         </div>
     {% endset %}

--- a/packages/framework/tests/Unit/Component/Html/HtmlContentProcessorTest.php
+++ b/packages/framework/tests/Unit/Component/Html/HtmlContentProcessorTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Html;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Html\HtmlContentProcessor;
+
+class HtmlContentProcessorTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{html: string|null, expectedResult: string|null}>
+     */
+    public static function getProcessData(): iterable
+    {
+        yield 'null stays null' => [
+            'html' => null,
+            'expectedResult' => null,
+        ];
+
+        yield 'content without links is untouched' => [
+            'html' => '<p>Just a text</p>',
+            'expectedResult' => '<p>Just a text</p>',
+        ];
+
+        yield 'link without target is untouched' => [
+            'html' => '<a href="http://example.com">link</a>',
+            'expectedResult' => '<a href="http://example.com">link</a>',
+        ];
+
+        yield 'link with target="_blank" gets rel="noopener"' => [
+            'html' => '<a href="http://example.com" target="_blank">link</a>',
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'link with target="_blank" written without quotes gets rel="noopener"' => [
+            'html' => '<a href="http://example.com" target=_blank>link</a>',
+            'expectedResult' => '<a href="http://example.com" target=_blank rel="noopener">link</a>',
+        ];
+
+        yield 'the target keyword is compared case-insensitively' => [
+            'html' => '<a href="http://example.com" TARGET="_BLANK">link</a>',
+            'expectedResult' => '<a href="http://example.com" TARGET="_BLANK" rel="noopener">link</a>',
+        ];
+
+        yield 'whitespace around the attribute equal sign is tolerated' => [
+            'html' => '<a href="http://example.com" target ="_blank">link</a>',
+            'expectedResult' => '<a href="http://example.com" target ="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'the greater-than character inside an attribute value does not end the tag' => [
+            'html' => '<a href="http://example.com" title="a > b" target="_blank">link</a>',
+            'expectedResult' => '<a href="http://example.com" title="a > b" target="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'self-closing link keeps its closing slash' => [
+            'html' => '<a href="http://example.com" target="_blank" />',
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel="noopener" />',
+        ];
+
+        yield 'only links with target are modified' => [
+            'html' => '<a href="/first">first</a> <a href="/second" target="_blank">second</a>',
+            'expectedResult' => '<a href="/first">first</a> <a href="/second" target="_blank" rel="noopener">second</a>',
+        ];
+
+        yield 'mention of target outside of a link does not modify the content' => [
+            'html' => '<p>Set the target= attribute</p><a href="http://example.com">link</a>',
+            'expectedResult' => '<p>Set the target= attribute</p><a href="http://example.com">link</a>',
+        ];
+
+        yield 'an element whose name starts with a is not treated as a link' => [
+            'html' => '<abbr title="x" data-target="_blank">label</abbr>',
+            'expectedResult' => '<abbr title="x" data-target="_blank">label</abbr>',
+        ];
+
+        yield 'content with broken encoding is processed instead of being wiped' => [
+            'html' => "<a href=\"/\xC3\x28\" target=\"_blank\">link</a>",
+            'expectedResult' => "<a href=\"/\xC3\x28\" target=\"_blank\" rel=\"noopener\">link</a>",
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{html: string}>
+     */
+    public static function getIgnoredTargetData(): iterable
+    {
+        yield 'a named target' => [
+            'html' => '<a href="http://example.com" target="content-frame">link</a>',
+        ];
+
+        yield 'target="_self"' => [
+            'html' => '<a href="http://example.com" target="_self">link</a>',
+        ];
+
+        yield 'target="_parent"' => [
+            'html' => '<a href="http://example.com" target="_parent">link</a>',
+        ];
+
+        yield 'target="_top"' => [
+            'html' => '<a href="http://example.com" target="_top">link</a>',
+        ];
+
+        yield 'a value merely starting with _blank' => [
+            'html' => '<a href="http://example.com" target="_blankish">link</a>',
+        ];
+
+        yield 'a target rendered from a template variable' => [
+            'html' => '<a href="http://example.com" target="{{ linkTarget }}">link</a>',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{html: string|null, expectedResult: string|null}>
+     */
+    public static function getRelAttributeMergingData(): iterable
+    {
+        yield 'noopener is merged into a rel attribute wrapped over several lines' => [
+            'html' => "<a href=\"http://example.com\" target=\"_blank\" rel=\"nofollow\n    noreferrer\">link</a>",
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel="nofollow noreferrer noopener">link</a>',
+        ];
+
+        yield 'noopener is merged into an existing rel attribute' => [
+            'html' => '<a href="http://example.com" rel="nofollow" target="_blank">link</a>',
+            'expectedResult' => '<a href="http://example.com" rel="nofollow noopener" target="_blank">link</a>',
+        ];
+
+        yield 'noopener is merged into a rel attribute written with whitespace around the equal sign' => [
+            'html' => '<a href="http://example.com" target="_blank" rel = "nofollow">link</a>',
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel = "nofollow noopener">link</a>',
+        ];
+
+        yield 'link that already has rel="noopener" is untouched' => [
+            'html' => '<a href="http://example.com" target="_blank" rel="noopener">link</a>',
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'noopener is not duplicated when the existing rel values are separated by a tab' => [
+            'html' => "<a href=\"http://example.com\" target=\"_blank\" rel=\"nofollow\tnoopener\">link</a>",
+            'expectedResult' => "<a href=\"http://example.com\" target=\"_blank\" rel=\"nofollow\tnoopener\">link</a>",
+        ];
+
+        yield 'noopener is not duplicated when the existing rel value differs in case' => [
+            'html' => '<a href="http://example.com" target="_blank" rel="NOOPENER">link</a>',
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel="NOOPENER">link</a>',
+        ];
+
+        yield 'rel attribute written without quotes is left untouched to avoid duplicating it' => [
+            'html' => '<a href="http://example.com" target="_blank" rel=nofollow>link</a>',
+            'expectedResult' => '<a href="http://example.com" target="_blank" rel=nofollow>link</a>',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{html: string|null, expectedResult: string|null}>
+     */
+    public static function getContentPreservationData(): iterable
+    {
+        yield 'utf-8 characters and entities are preserved' => [
+            'html' => '<p>Příliš žluťoučký kůň &amp; pěl</p><a href="http://example.com" target="_blank">odkaz</a>',
+            'expectedResult' => '<p>Příliš žluťoučký kůň &amp; pěl</p><a href="http://example.com" target="_blank" rel="noopener">odkaz</a>',
+        ];
+
+        yield 'a style block preceding the link is kept' => [
+            'html' => '<style>.a{color:red}</style><a href="http://example.com" target="_blank">link</a>',
+            'expectedResult' => '<style>.a{color:red}</style><a href="http://example.com" target="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'a script block preceding the link is kept' => [
+            'html' => '<script>if (a && b < c) {}</script><a href="http://example.com" target="_blank">link</a>',
+            'expectedResult' => '<script>if (a && b < c) {}</script><a href="http://example.com" target="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'a whole document keeps its doctype, head and body attributes' => [
+            'html' => '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body id="b">'
+                . '<a href="http://example.com" target="_blank">link</a></body></html>',
+            'expectedResult' => '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body id="b">'
+                . '<a href="http://example.com" target="_blank" rel="noopener">link</a></body></html>',
+        ];
+
+        yield 'markup outside the edited link is not normalized' => [
+            'html' => '<p><div>x</div></p><table><tr><td>y</td></tr></table>'
+                . '<a href="/a?x=1&y=2&nbsp;" target="_blank">link</a>',
+            'expectedResult' => '<p><div>x</div></p><table><tr><td>y</td></tr></table>'
+                . '<a href="/a?x=1&y=2&nbsp;" target="_blank" rel="noopener">link</a>',
+        ];
+
+        yield 'conditional comments are kept' => [
+            'html' => '<!--[if mso]><style>x</style><![endif]--><a href="http://example.com" target="_blank">link</a>',
+            'expectedResult' => '<!--[if mso]><style>x</style><![endif]-->'
+                . '<a href="http://example.com" target="_blank" rel="noopener">link</a>',
+        ];
+    }
+
+    #[DataProvider('getProcessData')]
+    public function testProcess(?string $html, ?string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, (new HtmlContentProcessor())->process($html));
+    }
+
+    #[DataProvider('getIgnoredTargetData')]
+    public function testLinkNotOpeningInNewTabIsLeftUntouched(string $html): void
+    {
+        $this->assertSame($html, (new HtmlContentProcessor())->process($html));
+    }
+
+    #[DataProvider('getRelAttributeMergingData')]
+    public function testNoopenerIsMergedIntoTheExistingRelAttribute(?string $html, ?string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, (new HtmlContentProcessor())->process($html));
+    }
+
+    #[DataProvider('getContentPreservationData')]
+    public function testContentOutsideOfTheEditedLinkIsPreserved(?string $html, ?string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, (new HtmlContentProcessor())->process($html));
+    }
+}

--- a/packages/framework/tests/Unit/Form/AbstractHtmlContentFieldTestCase.php
+++ b/packages/framework/tests/Unit/Form/AbstractHtmlContentFieldTestCase.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Cdn\CdnFacade;
+use Shopsys\FrameworkBundle\Component\Html\HtmlContentProcessor;
+use Shopsys\FrameworkBundle\Form\HtmlContentTypeExtension;
+use Shopsys\FrameworkBundle\Form\Transformers\HtmlContentDataTransformer;
+use Shopsys\FrameworkBundle\Form\Transformers\WysiwygCdnDataTransformer;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+abstract class AbstractHtmlContentFieldTestCase extends TypeTestCase
+{
+    protected const string LINK_WITH_TARGET = '<a href="https://example.com" target="_blank">label</a>';
+
+    protected const string PROCESSED_LINK_WITH_TARGET = '<a href="https://example.com" target="_blank" rel="noopener">label</a>';
+
+    /**
+     * @return class-string<\Symfony\Component\Form\FormTypeInterface>
+     */
+    abstract protected function getTestedFormTypeClass(): string;
+
+    /**
+     * @return \Symfony\Component\Form\FormTypeInterface[]
+     */
+    abstract protected function getPreloadedFormTypes(): array;
+
+    public function testSubmittedLinkWithTargetGetsRelNoopener(): void
+    {
+        $form = $this->factory->create($this->getTestedFormTypeClass());
+        $form->submit(static::LINK_WITH_TARGET);
+
+        $this->assertSame(static::PROCESSED_LINK_WITH_TARGET, $form->getData());
+    }
+
+    public function testSubmittedLinkWithoutTargetIsLeftUntouched(): void
+    {
+        $html = '<a href="https://example.com">label</a>';
+
+        $form = $this->factory->create($this->getTestedFormTypeClass());
+        $form->submit($html);
+
+        $this->assertSame($html, $form->getData());
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+
+        parent::setUp();
+    }
+
+    /**
+     * @return array<class-string<\Symfony\Component\Form\FormTypeInterface>, \Symfony\Component\Form\FormTypeExtensionInterface[]>
+     */
+    protected function getPreloadedTypeExtensions(): array
+    {
+        return [
+            TextareaType::class => [
+                new HtmlContentTypeExtension(
+                    new HtmlContentDataTransformer(new HtmlContentProcessor()),
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension($this->getPreloadedFormTypes(), $this->getPreloadedTypeExtensions()),
+        ];
+    }
+
+    protected function createWysiwygCdnDataTransformer(): WysiwygCdnDataTransformer
+    {
+        $cdnFacade = $this->createStub(CdnFacade::class);
+        $cdnFacade->method('replaceUrlsByCdnForAssets')->willReturnArgument(0);
+
+        return new WysiwygCdnDataTransformer($cdnFacade);
+    }
+}

--- a/packages/framework/tests/Unit/Form/Admin/GrapesJsMailTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/GrapesJsMailTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form\Admin;
+
+use Override;
+use Shopsys\FrameworkBundle\Form\Admin\GrapesJsMailType;
+use Tests\FrameworkBundle\Unit\Form\AbstractHtmlContentFieldTestCase;
+
+final class GrapesJsMailTypeTest extends AbstractHtmlContentFieldTestCase
+{
+    #[Override]
+    protected function getTestedFormTypeClass(): string
+    {
+        return GrapesJsMailType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getPreloadedFormTypes(): array
+    {
+        return [new GrapesJsMailType($this->createWysiwygCdnDataTransformer())];
+    }
+}

--- a/packages/framework/tests/Unit/Form/CKEditorTypeTest.php
+++ b/packages/framework/tests/Unit/Form/CKEditorTypeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form;
+
+use FOS\CKEditorBundle\Config\CKEditorConfigurationInterface;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
+use Override;
+use Shopsys\FrameworkBundle\Form\WysiwygTypeExtension;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+
+final class CKEditorTypeTest extends AbstractHtmlContentFieldTestCase
+{
+    #[Override]
+    protected function getTestedFormTypeClass(): string
+    {
+        return CKEditorType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getPreloadedFormTypes(): array
+    {
+        return [new CKEditorType($this->createStub(CKEditorConfigurationInterface::class))];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getPreloadedTypeExtensions(): array
+    {
+        $localization = $this->createStub(Localization::class);
+        $localization->method('getRequestLocale')->willReturn('en');
+
+        return parent::getPreloadedTypeExtensions() + [
+            CKEditorType::class => [
+                new WysiwygTypeExtension(
+                    $localization,
+                    // configureOptions() reads the file to build the contentsCss option, so it has to exist
+                    __DIR__ . '/CKEditorTypeTest/entrypoints.json',
+                    $this->createWysiwygCdnDataTransformer(),
+                ),
+            ],
+        ];
+    }
+}

--- a/packages/framework/tests/Unit/Form/CKEditorTypeTest/entrypoints.json
+++ b/packages/framework/tests/Unit/Form/CKEditorTypeTest/entrypoints.json
@@ -1,0 +1,3 @@
+{
+    "entrypoints": {}
+}

--- a/packages/framework/tests/Unit/Form/GrapesJsTypeTest.php
+++ b/packages/framework/tests/Unit/Form/GrapesJsTypeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form;
+
+use Override;
+use Shopsys\FrameworkBundle\Form\GrapesJsType;
+
+final class GrapesJsTypeTest extends AbstractHtmlContentFieldTestCase
+{
+    #[Override]
+    protected function getTestedFormTypeClass(): string
+    {
+        return GrapesJsType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getPreloadedFormTypes(): array
+    {
+        return [new GrapesJsType($this->createWysiwygCdnDataTransformer())];
+    }
+}

--- a/packages/framework/tests/Unit/Form/HtmlContentTypeExtensionTest.php
+++ b/packages/framework/tests/Unit/Form/HtmlContentTypeExtensionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Form;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Html\HtmlContentProcessor;
+use Shopsys\FrameworkBundle\Form\HtmlContentTypeExtension;
+use Shopsys\FrameworkBundle\Form\Transformers\HtmlContentDataTransformer;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+final class HtmlContentTypeExtensionTest extends TypeTestCase
+{
+    private const string LINK_WITH_TARGET = '<a href="https://example.com" target="_blank">label</a>';
+
+    public function testFieldDeclaringHtmlGetsItsLinksProcessed(): void
+    {
+        $form = $this->factory->create(TextareaType::class, null, ['contains_html' => true]);
+        $form->submit(self::LINK_WITH_TARGET);
+
+        $this->assertSame(
+            '<a href="https://example.com" target="_blank" rel="noopener">label</a>',
+            $form->getData(),
+        );
+    }
+
+    /**
+     * Plain text fields must not be touched — they should not be passed through a rule about markup at all
+     */
+    public function testFieldWithoutTheOptionIsLeftUntouched(): void
+    {
+        $form = $this->factory->create(TextareaType::class);
+        $form->submit(self::LINK_WITH_TARGET);
+
+        $this->assertSame(self::LINK_WITH_TARGET, $form->getData());
+    }
+
+    public function testFieldOptingOutExplicitlyIsLeftUntouched(): void
+    {
+        $form = $this->factory->create(TextareaType::class, null, ['contains_html' => false]);
+        $form->submit(self::LINK_WITH_TARGET);
+
+        $this->assertSame(self::LINK_WITH_TARGET, $form->getData());
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension(
+                [],
+                [
+                    TextareaType::class => [
+                        new HtmlContentTypeExtension(
+                            new HtmlContentDataTransformer(new HtmlContentProcessor()),
+                        ),
+                    ],
+                ],
+            ),
+        ];
+    }
+}

--- a/project-base/app/assets/js/admin/grapesjs/plugins/mail/mail-button-link.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/mail/mail-button-link.js
@@ -1,5 +1,6 @@
 import Translator from 'bazinga-translator';
 import grapesjs from 'grapesjs';
+import { addRelNoopenerToComponentWithBlankTarget } from '../shared/linkNoopener';
 
 const LINK_POSITION_DATA_ATTRIBUTE = 'data-link-position';
 const BUTTON_COLOR_ATTRIBUTE = 'backgroundColor';
@@ -52,6 +53,9 @@ export default grapesjs.plugins.add('mail-button-link', editor => {
             init() {
                 this.on(`change:attributes:${LINK_POSITION_DATA_ATTRIBUTE}`, this.handleLinkPositionChange);
                 this.on(`change:attributes:${BUTTON_COLOR_ATTRIBUTE}`, this.handleColorChange);
+                this.on('change:attributes:target', addRelNoopenerToComponentWithBlankTarget);
+
+                addRelNoopenerToComponentWithBlankTarget(this);
             },
 
             handleLinkPositionChange(component) {

--- a/project-base/app/assets/js/admin/grapesjs/plugins/shared/linkNoopener.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/shared/linkNoopener.js
@@ -1,0 +1,12 @@
+import { addRelNoopenerWhenTargetIsBlank } from 'framework/common/utils/addRelNoopenerWhenTargetIsBlank';
+
+// the target attribute set through the trait panel never passes through the CKEditor content,
+// so the editor filter cannot see it
+export const addRelNoopenerToComponentWithBlankTarget = component => {
+    const attributes = component.getAttributes();
+    const rel = addRelNoopenerWhenTargetIsBlank(attributes.rel, attributes.target);
+
+    if (rel !== attributes.rel) {
+        component.addAttributes({ rel });
+    }
+};

--- a/project-base/app/assets/js/admin/grapesjs/plugins/web/link.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/web/link.js
@@ -1,4 +1,5 @@
 import grapesjs from 'grapesjs';
+import { addRelNoopenerToComponentWithBlankTarget } from '../shared/linkNoopener';
 
 export const LINK_POSITION_DATA_ATTRIBUTE = 'data-link-position';
 
@@ -16,6 +17,9 @@ export default grapesjs.plugins.add('link', editor => {
         model: {
             init() {
                 this.on(`change:attributes:${LINK_POSITION_DATA_ATTRIBUTE}`, this.handleLinkPositionChange);
+                this.on('change:attributes:target', addRelNoopenerToComponentWithBlankTarget);
+
+                addRelNoopenerToComponentWithBlankTarget(this);
             },
 
             handleLinkPositionChange(element) {

--- a/project-base/app/assets/js/admin/grapesjs/plugins/web/web-button-link.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/web/web-button-link.js
@@ -1,5 +1,6 @@
 import Translator from 'bazinga-translator';
 import grapesjs from 'grapesjs';
+import { addRelNoopenerToComponentWithBlankTarget } from '../shared/linkNoopener';
 
 const LINK_POSITION_DATA_ATTRIBUTE = 'data-link-position';
 const BUTTON_COLOR_ATTRIBUTE = 'backgroundColor';
@@ -24,6 +25,9 @@ export default grapesjs.plugins.add('web-button-link', editor => {
                 this.on(`change:attributes:${LINK_POSITION_DATA_ATTRIBUTE}`, this.handleLinkPositionChange);
                 this.on(`change:attributes:${BUTTON_COLOR_ATTRIBUTE}`, this.handleColorChange);
                 this.on(`change:attributes:${TEXT_DATA_ATTRIBUTE}`, this.handleTextAttributeChange);
+                this.on('change:attributes:target', addRelNoopenerToComponentWithBlankTarget);
+
+                addRelNoopenerToComponentWithBlankTarget(this);
             },
 
             handleLinkPositionChange(element) {

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -20,7 +20,7 @@ services:
     App\:
         exclude:
             - '../src/{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
-        resource: '../src/**/*{Calculation,Collector,Context,Dispatcher,Enum,Executor,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Task,Transformer,Validator,Transfer,Helper,Converter,DataFetcher,Mutation,Query}.php'
+        resource: '../src/**/*{Calculation,Collector,Context,Dispatcher,Enum,Executor,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Processor,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Task,Transformer,Validator,Transfer,Helper,Converter,DataFetcher,Mutation,Query}.php'
 
     App\Command\:
         resource: '../src/Command'

--- a/project-base/app/ecs.php
+++ b/project-base/app/ecs.php
@@ -11,6 +11,7 @@ return ECSConfig::configure()
     ->withPaths([
         __DIR__ . '/app',
         __DIR__ . '/src',
+        __DIR__ . '/templates',
         __DIR__ . '/tests',
     ])
     ->withSets([

--- a/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
+++ b/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
@@ -11,6 +11,7 @@ import {
     FriendlyPagesTypesKey,
     FriendlyPagesTypesKeys,
 } from 'types/friendlyUrl';
+import { addRelNoopenerWhenTargetIsBlank } from 'utils/links/addRelNoopenerWhenTargetIsBlank';
 import { SLUG_TYPE_QUERY_PARAMETER_NAME } from 'utils/queryParamNames';
 import { isTextSelected } from 'utils/ui/isTextSelected';
 
@@ -32,6 +33,8 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
     skeletonType,
     className,
     tid,
+    rel,
+    target,
     preventRedirectOnTextSelection = false,
     ...props
 }) => {
@@ -51,7 +54,7 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
 
     const handleOnClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
         const mouseWheelClick = e.button === 1;
-        const isTargetBlank = props.target === '_blank';
+        const isTargetBlank = target === '_blank';
         const isWithoutOpeningInNewTab = !e.ctrlKey && !e.metaKey && !mouseWheelClick && !isTargetBlank;
 
         if (preventRedirectOnTextSelection && isTextSelected()) {
@@ -79,7 +82,9 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
             data-tid={tid}
             href={urlHref}
             prefetch={false}
+            rel={addRelNoopenerWhenTargetIsBlank(rel, target)}
             tabIndex={0}
+            target={target}
             onClick={handleOnClick}
             {...props}
         >

--- a/project-base/storefront/components/Basic/Link/Link.tsx
+++ b/project-base/storefront/components/Basic/Link/Link.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonBaseProps } from 'components/Forms/Button/Button';
 import { TIDs } from 'cypress/tids';
 import { AnchorHTMLAttributes } from 'react';
 import { ExtractNativePropsFromDefault } from 'types/ExtractNativePropsFromDefault';
+import { addRelNoopenerWhenTargetIsBlank } from 'utils/links/addRelNoopenerWhenTargetIsBlank';
 import { twMergeCustom } from 'utils/twMerge';
 
 type NativePropsAnchor = ExtractNativePropsFromDefault<
@@ -52,7 +53,7 @@ export const Link: FC<LinkProps> = ({
     const props = {
         className: classNameTwClass,
         href: isExternal ? href : undefined,
-        rel,
+        rel: addRelNoopenerWhenTargetIsBlank(rel, target),
         target,
         tabIndex: 0,
     };

--- a/project-base/storefront/utils/links/addRelNoopenerWhenTargetIsBlank.ts
+++ b/project-base/storefront/utils/links/addRelNoopenerWhenTargetIsBlank.ts
@@ -1,0 +1,16 @@
+export const addRelNoopenerWhenTargetIsBlank = (
+    rel: string | undefined,
+    target: string | undefined,
+): string | undefined => {
+    if (target?.toLowerCase() !== '_blank') {
+        return rel;
+    }
+
+    const relValues = (rel || '').split(/\s+/).filter((value) => value !== '');
+
+    if (!relValues.some((value) => value.toLowerCase() === 'noopener')) {
+        relValues.push('noopener');
+    }
+
+    return relValues.join(' ');
+};

--- a/project-base/storefront/vitest/components/Basic/Link/Link.test.tsx
+++ b/project-base/storefront/vitest/components/Basic/Link/Link.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import { Link } from 'components/Basic/Link/Link';
+import { DomainConfigProvider } from 'components/providers/DomainConfigProvider';
+import { describe, expect, test, vi } from 'vitest';
+import { defaultTestDomainConfig } from 'vitest/helpers/mockPublicConfig';
+
+vi.mock('next/router', () => ({
+    useRouter: () => ({
+        push: vi.fn(),
+        prefetch: vi.fn().mockResolvedValue(undefined),
+        pathname: '/',
+        query: {},
+        asPath: '/',
+    }),
+}));
+
+const renderLink = (props: Parameters<typeof Link>[0]) =>
+    render(
+        <DomainConfigProvider domainConfig={defaultTestDomainConfig}>
+            <Link {...props} />
+        </DomainConfigProvider>,
+    ).container.querySelector('a');
+
+describe('Link', () => {
+    test.each([
+        [undefined, 'noopener'],
+        ['nofollow', 'nofollow noopener'],
+        ['noopener noreferrer', 'noopener noreferrer'],
+    ])('link opening in a new tab with rel="%s" gets noopener', (rel, expectedRel) => {
+        const link = renderLink({ href: '/test-href', rel, target: '_blank', children: 'link text' });
+
+        expect(link).toHaveAttribute('rel', expectedRel);
+    });
+
+    test('link without a target keeps rel untouched', () => {
+        const link = renderLink({ href: '/test-href', rel: 'nofollow', children: 'link text' });
+
+        expect(link).toHaveAttribute('rel', 'nofollow');
+    });
+
+    test.each([
+        [undefined, 'noopener'],
+        ['nofollow', 'nofollow noopener'],
+    ])('external link opening in a new tab with rel="%s" gets noopener', (rel, expectedRel) => {
+        const link = renderLink({
+            href: 'https://example.com',
+            isExternal: true,
+            rel,
+            target: '_blank',
+            children: 'link text',
+        });
+
+        expect(link).toHaveAttribute('rel', expectedRel);
+    });
+});

--- a/project-base/storefront/vitest/components/ExtendedNextLink/ExtendedNextLink.test.tsx
+++ b/project-base/storefront/vitest/components/ExtendedNextLink/ExtendedNextLink.test.tsx
@@ -91,4 +91,58 @@ describe('ExtendedNextLink snapshot tests', () => {
 
         expect(component).toMatchFileSnapshot('snap-4.test.tsx.snap');
     });
+
+    test('render ExtendedNextLink opening in a new tab, which gets rel="noopener"', async () => {
+        const component = render(
+            <DomainConfigProvider domainConfig={defaultTestDomainConfig}>
+                <ExtendedNextLink href="/test-href" target="_blank">
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
+        );
+
+        await waitFor(() => {
+            expect(component.container).toBeInTheDocument();
+        });
+
+        expect(component).toMatchFileSnapshot('snap-5.test.tsx.snap');
+    });
+
+    test.each([
+        ['nofollow', 'nofollow noopener'],
+        ['noreferrer noopener', 'noreferrer noopener'],
+        ['noopener', 'noopener'],
+    ])('render ExtendedNextLink merging noopener into rel="%s"', async (rel, expectedRel) => {
+        const component = render(
+            <DomainConfigProvider domainConfig={defaultTestDomainConfig}>
+                <ExtendedNextLink href="/test-href" rel={rel} target="_blank">
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
+        );
+
+        await waitFor(() => {
+            expect(component.container.querySelector('a')).toHaveAttribute('rel', expectedRel);
+        });
+    });
+
+    test('render ExtendedNextLink without a target, which keeps rel untouched', async () => {
+        const component = render(
+            <DomainConfigProvider domainConfig={defaultTestDomainConfig}>
+                <ExtendedNextLink href="/test-href" rel="nofollow">
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
+        );
+
+        await waitFor(() => {
+            expect(component.container.querySelector('a')).toHaveAttribute('rel', 'nofollow');
+        });
+    });
 });

--- a/project-base/storefront/vitest/components/ExtendedNextLink/snap-5.test.tsx.snap
+++ b/project-base/storefront/vitest/components/ExtendedNextLink/snap-5.test.tsx.snap
@@ -1,0 +1,84 @@
+{
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <a
+        href="/test-href"
+        rel="noopener"
+        tabindex="0"
+        target="_blank"
+      >
+        <div>
+          <span>
+            link text
+          </span>
+        </div>
+      </a>
+    </div>
+  </body>,
+  "container": <div>
+    <a
+      href="/test-href"
+      rel="noopener"
+      tabindex="0"
+      target="_blank"
+    >
+      <div>
+        <span>
+          link text
+        </span>
+      </div>
+    </a>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}

--- a/project-base/storefront/vitest/utils/links/addRelNoopenerWhenTargetIsBlank.test.ts
+++ b/project-base/storefront/vitest/utils/links/addRelNoopenerWhenTargetIsBlank.test.ts
@@ -1,0 +1,32 @@
+import { addRelNoopenerWhenTargetIsBlank } from 'utils/links/addRelNoopenerWhenTargetIsBlank';
+import { describe, expect, test } from 'vitest';
+
+describe('addRelNoopenerWhenTargetIsBlank', () => {
+    test.each([
+        [undefined, undefined, undefined],
+        ['nofollow', undefined, 'nofollow'],
+        [undefined, '', undefined],
+        ['nofollow', '_self', 'nofollow'],
+        ['nofollow', '_top', 'nofollow'],
+        ['nofollow', 'content-frame', 'nofollow'],
+        ['nofollow', '_blankish', 'nofollow'],
+    ])('rel="%s" is kept as is when the target is "%s"', (rel, target, expectedRel) => {
+        expect(addRelNoopenerWhenTargetIsBlank(rel, target)).toBe(expectedRel);
+    });
+
+    test.each([
+        [undefined, 'noopener'],
+        ['', 'noopener'],
+        ['nofollow', 'nofollow noopener'],
+        ['nofollow  noreferrer', 'nofollow noreferrer noopener'],
+        ['noopener', 'noopener'],
+        ['noreferrer noopener', 'noreferrer noopener'],
+        ['NOOPENER', 'NOOPENER'],
+    ])('rel="%s" becomes "%s" when the target is _blank', (rel, expectedRel) => {
+        expect(addRelNoopenerWhenTargetIsBlank(rel, '_blank')).toBe(expectedRel);
+    });
+
+    test('the target keyword is compared case-insensitively', () => {
+        expect(addRelNoopenerWhenTargetIsBlank(undefined, '_BLANK')).toBe('noopener');
+    });
+});

--- a/upgrade-notes/backend_20260726_140000.md
+++ b/upgrade-notes/backend_20260726_140000.md
@@ -1,0 +1,19 @@
+#### links with target="_blank" get rel="noopener" automatically ([#4732](https://github.com/shopsys/shopsys/pull/4732))
+
+- add `'contains_html' => true` to your own textarea fields holding HTML
+- coding standards now collect `*.html.twig` templates, so the new `Shopsys\CodingStandards\CsFixer\MissingLinkRelNoopenerFixer` and the existing `MissingButtonTypeFixer` and `ForbiddenDumpFixer` finally reach them
+    - add your `templates` directory to `->withPaths()` in your `ecs.php`
+    - run `php phing standards-fix` and expect it to add `rel="noopener"` and `type="button"` in your templates
+    - a link whose target comes from a variable cannot be fixed automatically, add the attribute conditionally yourself (see `DisplayOnlyUrlType.html.twig` for an example)
+- if your project adds a GrapesJS component with a `target` trait, apply `addRelNoopenerToComponentWithBlankTarget()` in it the way the `link` plugin does
+- existing links in your database are not migrated, run an SQL update per wysiwyg column to fix them in one go:
+
+    ```sql
+    UPDATE articles
+    SET text = regexp_replace(text, '<a((?![^>]*\yrel=)[^>]*\ytarget\s*=\s*"_blank"[^>]*)>', '<a\1 rel="noopener">', 'gi')
+    WHERE text ~* '<a(?![^>]*\yrel=)[^>]*\ytarget\s*=\s*"_blank"';
+    ```
+
+    (adjust the table and column names and verify on a copy of production data first)
+
+- see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20260729_155413.md
+++ b/upgrade-notes/storefront_20260729_155413.md
@@ -1,0 +1,5 @@
+#### links with target="_blank" get rel="noopener" automatically ([#4732](https://github.com/shopsys/shopsys/pull/4732))
+
+- `ExtendedNextLink` and `Link` add `rel="noopener"` to every link rendered with `target="_blank"`, merging it into an existing `rel` value
+    - if your project renders links outside these two components, use `addRelNoopenerWhenTargetIsBlank()` from `utils/links` there as well
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

A page opened in a new tab can manipulate the opener window (reverse tabnabbing) unless the link carries `rel="noopener"`. The attribute is now added automatically everywhere a link with `target="_blank"` can be created or rendered, so an administrator cannot produce an unsafe link by accident and a developer cannot forget it in a template.

**Content authored in the administration** is fixed on save. Links written in CKEditor (both the classic editor and the one embedded in GrapesJS) get `rel="noopener"` merged into their `rel` attribute, and so do links whose target is switched on through the GrapesJS settings panel — those never pass through the editor content, so they needed handling of their own. The same rule is enforced again on the server by the new `HtmlContentProcessor`, so it holds even when the browser-side filter is bypassed. It now covers every field holding HTML: the wysiwyg fields, both GrapesJS editors and the advertisement code field, which had no protection at all. Fields declare that they hold HTML, so plain-text fields such as notes, meta descriptions or the CSP header are left untouched. The processor only ever rewrites the link tags and passes the rest of the markup through unchanged, because stored content legitimately holds advertisement scripts, GrapesJS inline styles and Outlook conditional comments.

**Hand-written markup** is covered by tooling. `rel="noopener"` was added to all links with `target="_blank"` in administration templates, and a new coding-standard fixer keeps it that way — it adds the attribute to any `<a>` tag with `target="_blank"` and can fix violations automatically. Wiring it up uncovered that coding standards never checked Twig templates at all, so the existing checks for a missing `<button type>` and for a forgotten `{{ dump() }}` had never run on a single template. Templates are checked from now on, which also added the missing `type` attribute to six administration buttons — without it a button placed inside a form submits it.

**The storefront** adds the attribute to every link rendered with `target="_blank"`, closing nine places where it was missing. The linter rule only checks plain `<a>` elements, so a target passed to a component was never reported.

Every layer deliberately looks at `target="_blank"` only, matching the keyword case-insensitively. The attribute is meaningless for `_self`, `_parent` and `_top`, which navigate an existing browsing context, and it is actively harmful for a named target: per the HTML specification a link carrying `rel="noopener"` ignores the target name, so `<a target="content-frame">` would stop navigating that frame and open a new tab instead. One link in the administration takes its target from a variable and therefore states the condition in the template itself, as the coding-standard fixer cannot resolve it.

Existing database content is not migrated automatically; the upgrade notes contain an optional SQL update.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-3084-wysiwyg-rel-noopener.odin.shopsys.cloud
  - https://cz.pk-ssp-3084-wysiwyg-rel-noopener.odin.shopsys.cloud
  - https://pk-ssp-3084-wysiwyg-rel-noopener.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1786453408.396359 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-3084-wysiwyg-rel-noopener.odin.shopsys.cloud
  - https://cz.pk-ssp-3084-wysiwyg-rel-noopener.odin.shopsys.cloud
  - https://pk-ssp-3084-wysiwyg-rel-noopener.odin.shopsys.cloud/sk
<!-- Replace -->
