### PR TITLE
docs: update product variant fields in Elasticsearch mapping description

### DIFF
--- a/docs/model/elasticsearch.md
+++ b/docs/model/elasticsearch.md
@@ -62,7 +62,10 @@ Following product attributes are exported into Elasticsearch (i.e. the search or
 - calculated_selling_denied (calculated true/false value whether the product is already sold out)
 - selling_denied (true/false value whether the product can be sold)
 - availability (translation of product availability)
-- main_variant (true/false value whether the product is main variant or not. You can find more about behavior of variants [here](../functional/behavior-of-product-variants.md))
+- is_main_variant (true/false value whether the product is main variant or not. You can find more about behavior of variants [here](../functional/behavior-of-product-variants.md))
+- is_variant (true/false value whether the product is variant or not)
+- main_variant_id (ID of the main variant if the product is a variant)
+- variants (IDs of the variants if the product is a main variant)
 - slug (relative url to page with products detail)
 - visibility (all visibilities for all pricing groups and domains)
 - and more, see `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider` and services implementing `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportDataProviderInterface` for more information


### PR DESCRIPTION
#### Description, the reason for the PR

The list of exported product attributes in `docs/model/elasticsearch.md` still described the old `main_variant` field, but the mapping was changed in #1557 — the index now contains `is_main_variant`, `is_variant`, `main_variant_id`, and `variants`. The documentation now matches the current mapping. The cookbook mentioned in the issue (`extending-product-list.md`) no longer exists, so there is nothing else to update.

#### Fixes issues

closes #1702

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-1926-elasticsearch-docs-variants.odin.shopsys.cloud
  - https://cz.pk-ssp-1926-elasticsearch-docs-variants.odin.shopsys.cloud
  - https://pk-ssp-1926-elasticsearch-docs-variants.odin.shopsys.cloud/sk
<!-- Replace -->
