### PR TITLE
add [TOC] to long documentation articles

### DIFF
--- a/docs/administration/admin-rights.md
+++ b/docs/administration/admin-rights.md
@@ -1,5 +1,7 @@
 # Admin Rights and Access Control
 
+[TOC]
+
 The administration interface uses PHP attributes to protect routes and integrate with the platform's role-based access control system. This provides intuitive, declaration-based security that's easy to read and maintain.
 
 !!! info "Global RBAC System"

--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -1,5 +1,7 @@
 # CRUD Controller
 
+[TOC]
+
 ## Actions
 
 The five main actions of the CRUD Controller are:

--- a/docs/administration/crud-controller/reference/handlers.md
+++ b/docs/administration/crud-controller/reference/handlers.md
@@ -1,5 +1,7 @@
 # Handlers
 
+[TOC]
+
 Handlers enable Create, Read, Update, and Delete operations for your entities. They act as a bridge between your CRUD controllers and your business logic (typically facades).
 
 !!! note

--- a/docs/administration/internal-grid/index.md
+++ b/docs/administration/internal-grid/index.md
@@ -1,5 +1,7 @@
 # Grid
 
+[TOC]
+
 ## Basics
 
 Grid is a component that displays data in a customizable table view in the administration.

--- a/docs/automated-testing/introduction-to-automated-testing.md
+++ b/docs/automated-testing/introduction-to-automated-testing.md
@@ -1,5 +1,7 @@
 # Introduction to Automated Testing
 
+[TOC]
+
 Testing is a crucial part of the development and maintenance of reliable software.  
 For this reason, Shopsys Platform comes with 6 types of automated tests:
 

--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -1,5 +1,7 @@
 # Backward Compatibility Promise
 
+[TOC]
+
 Smooth and safe upgrades of your e-commerce project are very important to us.
 At the same time, we need to improve Shopsys Platform for you by adding functionality, enhancing or simplifying current functions, and fixing bugs.
 After reading this promise, you'll understand backward compatibility, what changes you can expect, and how we plan to make changes in the future.

--- a/docs/cookbook/adding-a-new-elasticsearch-index.md
+++ b/docs/cookbook/adding-a-new-elasticsearch-index.md
@@ -1,5 +1,7 @@
 # Adding a New Elasticsearch Index
 
+[TOC]
+
 In this cookbook, we will add a new Elasticsearch index for categories, implement basic functions for data export, implement a cron module, and support for partial export.
 
 ## New Elasticsearch mapping

--- a/docs/cookbook/basic-data-import.md
+++ b/docs/cookbook/basic-data-import.md
@@ -1,5 +1,7 @@
 # Basic Data Import
 
+[TOC]
+
 This cookbook will guide you through the process of importing data into your e-shop from an external source,
 e.g., from an information system.
 

--- a/docs/cookbook/create-advanced-grid.md
+++ b/docs/cookbook/create-advanced-grid.md
@@ -1,5 +1,7 @@
 # Create Advanced Grid
 
+[TOC]
+
 This article provides step-by-step instructions for advanced grid configurations.
 After finishing this cookbook, you will know how to create a grid with inline editing, and drag&drop sorting.
 

--- a/docs/cookbook/create-basic-grid.md
+++ b/docs/cookbook/create-basic-grid.md
@@ -1,5 +1,7 @@
 # Create Basic Grid
 
+[TOC]
+
 In this cookbook, we will create a new grid to display salesmen data in the administration.
 We will learn how to use the grid factory properly, configure the data displayed, and override the default data presentation.
 In the end, we will be able to even sort our grid by column, paginate large result sets and delete records.

--- a/docs/frontend-api/introduction-to-frontend-api.md
+++ b/docs/frontend-api/introduction-to-frontend-api.md
@@ -1,5 +1,7 @@
 # Introduction to Frontend API
 
+[TOC]
+
 Shopsys Platform Frontend API is an interface to the application that is used for integration with external store frontend, for example, JS Storefront or a mobile app.
 We use [GraphQL](https://graphql.org) (implemented using [overblog/GraphQLBundle](https://github.com/overblog/GraphQLBundle)).
 

--- a/docs/functional/behavior-of-product-variants.md
+++ b/docs/functional/behavior-of-product-variants.md
@@ -1,5 +1,7 @@
 # Behavior of Product Variants
 
+[TOC]
+
 Product variants are specific type of products, and this article describes their specific behavior.
 Variants are used for products that are suitable to associate.
 These are products that vary for example, by size, pattern, color, etc.

--- a/docs/installation/installation-using-docker-windows-10.md
+++ b/docs/installation/installation-using-docker-windows-10.md
@@ -1,5 +1,7 @@
 # Installation Using Docker on Windows 10
 
+[TOC]
+
 **Expected installation time:** less than 1 hour.
 
 This guide covers building new projects based on Shopsys Platform.

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -1,5 +1,7 @@
 # Console Commands for Application Management (Phing Targets)
 
+[TOC]
+
 ## Phing
 
 [Phing](https://www.phing.info/) is a PHP project build tool with similar capabilities as GNU `make`. It can be configured via XML to install your application, run automatic tests and code standards checks, build CSS files from LESS and more.

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -1,5 +1,7 @@
 # How to Set Up Domains and Locales (Languages)
 
+[TOC]
+
 This article describes how to work with domains and languages during the development of your project.
 For an explanation of the basic terms, please read [domain, multidomain and multilanguage](domain-multidomain-multilanguage.md) article first.
 

--- a/docs/introduction/role-based-access-control.md
+++ b/docs/introduction/role-based-access-control.md
@@ -1,5 +1,7 @@
 # Role-Based Access Control (RBAC)
 
+[TOC]
+
 Shopsys Platform implements a comprehensive role-based access control (RBAC) system that provides unified security across both the Administration interface and Frontend API. This system ensures that users can only access the functionality and data appropriate to their assigned roles.
 
 ## Overview

--- a/docs/introduction/using-form-types.md
+++ b/docs/introduction/using-form-types.md
@@ -1,5 +1,7 @@
 # Using Form Types
 
+[TOC]
+
 In this article we will show what types you can use when creating or editing forms, what options they have and what they do.
 
 We use two types of naming for form types:

--- a/docs/introduction/working-with-date-time-values.md
+++ b/docs/introduction/working-with-date-time-values.md
@@ -1,5 +1,7 @@
 # Working with date-time values
 
+[TOC]
+
 Shopsys Platform internally works with dates in UTC timezone.
 That is for better portability and integration with other systems.
 Also, it allows you to work with time values more freely.

--- a/docs/model/entities.md
+++ b/docs/model/entities.md
@@ -1,5 +1,7 @@
 # Entities
 
+[TOC]
+
 This article describes how we work with entities and our specialities.
 
 1. Entity is a class encapsulating data and you can read more what is an entity in the [model architecture article](introduction-to-model-architecture.md).

--- a/docs/storefront/caching/graphcache.md
+++ b/docs/storefront/caching/graphcache.md
@@ -1,5 +1,7 @@
 # URQL Graphcache Exchange
 
+[TOC]
+
 ## Introduction
 
 The URQL library provides a flexible and efficient way to interact with GraphQL APIs in your JavaScript or TypeScript application. A significant part of this interaction is dealing with caching to reduce network requests, improve responsiveness, and manage the local state. This is where the Graphcache exchange comes in. When using this module, ensure you're familiar with the URQL graph cache and its related concepts. It's also crucial to be aware of the GraphQL schema and the generated GraphQL types, as they play a vital role in how the cache is managed.

--- a/docs/storefront/component-deferring.md
+++ b/docs/storefront/component-deferring.md
@@ -1,5 +1,7 @@
 # Component deferring
 
+[TOC]
+
 To improve certain metrics (such as TBT), improve user experience, and make the Storefront application feel faster, we have implemented a custom deferring logic. This mechanism allows developers to delay rendering of certain parts of the application so that the initial render and hydration tasks are shorter. In essence, this mechanism is based on strategically setting timeouts and only rendering the desired content once the timesout finishes. In the meantime, the developer can provide a placeholder (component with a partial content and structure) or a skeleton (purely visual component used to show that something is loading).
 
 In order to understand this mechanism and be able to work with it, read this documentation thoroughly. Only then will you be able to work with deferring efficiently.

--- a/docs/storefront/cypress.md
+++ b/docs/storefront/cypress.md
@@ -1,5 +1,7 @@
 # Cypress
 
+[TOC]
+
 For E2E testing, we use [Cypress](https://www.cypress.io/). Below you can read answers to some of the questions you might have.
 
 ## How to structure your cypress folder?

--- a/docs/storefront/domain-configuration.md
+++ b/docs/storefront/domain-configuration.md
@@ -1,5 +1,7 @@
 # Domain Configuration & Locale-in-Path Functionality
 
+[TOC]
+
 ## Overview
 
 The Shopsys storefront supports multi-domain configurations with flexible locale handling. Each domain can serve content for a specific locale, and domains can optionally include the locale in their URL path (e.g., `/sk/`). This documentation explains how domain configuration works, how cookies are isolated between domains, and how to work with locale-in-path domains.

--- a/docs/storefront/error-handling.md
+++ b/docs/storefront/error-handling.md
@@ -1,5 +1,7 @@
 # Error handling on Storefront
 
+[TOC]
+
 This document describes how errors flow from the Backend API through the Storefront and how they are displayed to users.
 
 ## Architecture Overview

--- a/docs/storefront/gtm/eventFactories.md
+++ b/docs/storefront/gtm/eventFactories.md
@@ -1,5 +1,7 @@
 # GTM Event Factories
 
+[TOC]
+
 These factories are responsible for creating and preparing GTM event objects. They can be written either as basic `get` methods, such as `getGtmCartViewEvent`, or as hooks, such as `useGtmStaticPageReadyEvent`. The difference between them is
 
 ## getGtmCartViewEvent

--- a/docs/storefront/gtm/events.md
+++ b/docs/storefront/gtm/events.md
@@ -1,5 +1,7 @@
 # GTM Event Objects
 
+[TOC]
+
 These objects represent all GTM events. They are composed of GtmEventInterface, GtmEventType, and the content of the event. Each event has a description of all its properties.
 
 ## GtmEventInterface<EventType, EventContent>

--- a/docs/storefront/gtm/objects.md
+++ b/docs/storefront/gtm/objects.md
@@ -1,5 +1,7 @@
 # GTM Objects
 
+[TOC]
+
 These objects are used all across the GTM module to represent various objects mapped according to what the data layer requires.
 
 ## GtmReviewConsentsType

--- a/docs/storefront/store-management.md
+++ b/docs/storefront/store-management.md
@@ -1,5 +1,7 @@
 # Store Management
 
+[TOC]
+
 For storing various data all over the app, we use [Zustand](https://github.com/pmndrs/zustand). Since we don't rely on some heavy storing data logic, Zustand's simple API is the perfect fit for our needs.
 
 Zustand allows us to create multiple stores. Each store consists of `slices`, which you can understand as one part of the store.

--- a/docs/storefront/unit-tests.md
+++ b/docs/storefront/unit-tests.md
@@ -1,5 +1,7 @@
 # Unit tests
 
+[TOC]
+
 Storefront unit tests are written using the [Vitest](https://vitest.dev/) testing library. It has a very similar API to Jest, so anybody with a skill in Vitest or Jest should be able to write them with ease. However, in order to follow a specific guideline and a set of standards, below you can see a _cookbook_ that should help you write unit tests for this codebase.
 
 ## Snapshot tests

--- a/docs/storefront/web-vitals.md
+++ b/docs/storefront/web-vitals.md
@@ -1,5 +1,7 @@
 # Web Vitals Improvements on Storefront
 
+[TOC]
+
 ## 1 Reduce DOM size
 
 This is probably the most time consuming part of our improvements. Math is pretty simple here. Bigger DOM size = higher blocking time (our worst metric). It also influences network traffic and from DX experience, it also brings more complex logic for work with styling. Besides one huge refactoring [pull request](https://github.com/shopsys/shopsys/pull/2749/commits) it was taken care of in every other touched task.


### PR DESCRIPTION
#### Description, the reason for the PR

Long documentation articles are hard to navigate without a table of contents. The `[TOC]` tag (supported by the `toc` MkDocs extension and recommended by our documentation guidelines) was added to all articles with 15 or more subheadings that did not have it yet — 30 articles in total, placed right after the main heading, consistently with the articles that already use it.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-1930-docs-toc.odin.shopsys.cloud
  - https://cz.pk-ssp-1930-docs-toc.odin.shopsys.cloud
  - https://pk-ssp-1930-docs-toc.odin.shopsys.cloud/sk
<!-- Replace -->
