### PR TITLE
add security.txt according to RFC 9116

### DIFF
--- a/project-base/storefront/.env
+++ b/project-base/storefront/.env
@@ -26,3 +26,6 @@ SHOULD_USE_DEFER=1
 
 USERSNAP_PROJECT_API_KEY=
 USERSNAP_STOREFRONT_ENABLED_BY_DEFAULT=0
+
+# Contact for the /.well-known/security.txt file (email address or full URI)
+SECURITY_TXT_CONTACT=security@shopsys.com

--- a/project-base/storefront/cypress/smokeTests/smokeTests.cy.ts
+++ b/project-base/storefront/cypress/smokeTests/smokeTests.cy.ts
@@ -7,6 +7,8 @@ type RoutesForSmokeTestsType = {
     skip?: boolean;
     logged?: boolean;
     test?: null | (() => void);
+    // for routes that do not render an HTML page, the raw response is checked via cy.request() instead of cy.visit()
+    responseTest?: (response: Cypress.Response<string>) => void;
     loginCredentials?: {
         email: string;
         password: string;
@@ -143,6 +145,22 @@ context('Smoke tests', () => {
             params: { ['q']: 'television' },
             test: () => {
                 checktHeadlineText('Search results for');
+            },
+        },
+        ['/security.txt']: {
+            skip: false,
+            responseTest: (response) => {
+                const expectValidSecurityTxt = (securityTxtResponse: Cypress.Response<string>) => {
+                    expect(securityTxtResponse.headers['content-type']).to.include('text/plain');
+                    expect(securityTxtResponse.body).to.match(/^Contact: .+$/m);
+                    expect(securityTxtResponse.body).to.match(/^Expires: .+$/m);
+                };
+
+                expectValidSecurityTxt(response);
+
+                // the canonical location defined by RFC 9116 is served via a rewrite
+                // (the Expires value is generated per request, so the two bodies cannot be compared for equality)
+                cy.request('/.well-known/security.txt').then(expectValidSecurityTxt);
             },
         },
         ['/social-login']: { skip: true },
@@ -312,6 +330,17 @@ context('Smoke tests', () => {
                         routeToRequest = `${routeToRequest}?${searchParams.toString()}`;
                     }
                 });
+            }
+
+            const responseTest = isCustomRoute ? filteredRoutes[routeName]?.responseTest : undefined;
+
+            if (responseTest) {
+                cy.request(routeToRequest).then((response) => {
+                    expect(response.status, '❌ Response status').to.equal(200);
+                    responseTest(response);
+                });
+
+                return;
             }
 
             const consoleErrors: string[] = [];

--- a/project-base/storefront/middleware.ts
+++ b/project-base/storefront/middleware.ts
@@ -49,6 +49,6 @@ export const middleware: NextMiddleware = async (request) => {
 export const config = {
     matcher: [
         '/', // Explicitly match the homepage
-        '/((?!api|_next|favicon.ico|fonts|svg|images|locales|content/locales|icons|grapesjs-template|grapesjs-homepage-article-template|grapesjs-article-template|tailwind-for-admin|robots).*)',
+        '/((?!api|_next|favicon.ico|fonts|svg|images|locales|content/locales|icons|grapesjs-template|grapesjs-homepage-article-template|grapesjs-article-template|tailwind-for-admin|robots|security.txt|.well-known).*)',
     ],
 };

--- a/project-base/storefront/next.config.js
+++ b/project-base/storefront/next.config.js
@@ -21,6 +21,12 @@ const nextConfig = {
     },
     reactStrictMode: true,
     assetPrefix: process.env.CDN_DOMAIN ?? undefined,
+    rewrites: async () => [
+        {
+            source: '/.well-known/security.txt',
+            destination: '/security.txt',
+        },
+    ],
     images: {
         loader: 'custom',
         deviceSizes: [480, 768, 1024, 1440], // Do not forget to update the same values in the `app/web/imageResizer.php` file

--- a/project-base/storefront/pages/security.txt.tsx
+++ b/project-base/storefront/pages/security.txt.tsx
@@ -1,0 +1,35 @@
+import { GetServerSideProps } from 'next';
+import { DEFAULT_LOCALE } from 'utils/domain/domainUtils';
+
+// mandatory for Next although it's not used
+const SecurityTxt: FC = (): null => {
+    return null;
+};
+
+const EXPIRES_IN_DAYS = 180;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    // Allow only root /security.txt, return 404 for locale-prefixed URLs
+    if (context.locale !== DEFAULT_LOCALE) {
+        return {
+            notFound: true,
+        };
+    }
+
+    const contact = process.env.SECURITY_TXT_CONTACT || 'security@shopsys.com';
+    const contactUri = contact.includes(':') ? contact : `mailto:${contact}`;
+
+    // RFC 9116 requires the Expires field and recommends a value less than a year in the future,
+    // generating it dynamically keeps the file always valid
+    const expires = new Date(Date.now() + EXPIRES_IN_DAYS * 24 * 60 * 60 * 1000);
+
+    const res = context.res;
+
+    res.setHeader('Content-Type', 'text/plain');
+    res.write(`Contact: ${contactUri}\nExpires: ${expires.toISOString()}\n`);
+    res.end();
+
+    return { props: {} };
+};
+
+export default SecurityTxt;


### PR DESCRIPTION
#### Description, the reason for the PR

Security researchers need a standard way to find out how to report vulnerabilities. The storefront now serves `/.well-known/security.txt` (and `/security.txt`) according to [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116).

The page is generated dynamically (modeled on the existing `robots.txt` page), which solves the expiration problem of a static file: the required `Expires` field is always generated 180 days ahead, within the RFC recommendation of less than a year. The contact is configurable via the `SECURITY_TXT_CONTACT` env variable (an email address or a full URI) with a default of `security@shopsys.com`.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-1361-security-txt.odin.shopsys.cloud
  - https://cz.pk-ssp-1361-security-txt.odin.shopsys.cloud
  - https://pk-ssp-1361-security-txt.odin.shopsys.cloud/sk
<!-- Replace -->
