### PR TITLE
remove unused GTM settings from homepage banners

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/SliderItemDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/SliderItemDataFixture.php
@@ -36,7 +36,6 @@ class SliderItemDataFixture extends AbstractReferenceFixture
             $sliderItemData = $this->sliderItemDataFactory->create();
             $sliderItemData->domainId = $domainId;
             $sliderItemData->hidden = false;
-            $sliderItemData->gtmId = 'sliderItemTest';
             $sliderItemData->uuid = Uuid::uuid5(self::UUID_NAMESPACE, 'Terms of promotion' . $domainId)->toString();
 
             $sliderItemData->name = 'Shopsys';

--- a/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
@@ -12,7 +12,6 @@ use Shopsys\FrameworkBundle\Form\Constraints\MustUploadFile;
 use Shopsys\FrameworkBundle\Form\ImageUploadType;
 use Shopsys\FrameworkBundle\Model\Slider\SliderItem;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
 
@@ -25,7 +24,6 @@ final class SliderItemFormTypeExtension extends AbstractTypeExtension
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->buildImagesGroup($builder, $options);
-        $this->buildGtmForm($builder);
     }
 
     private function buildImagesGroup(FormBuilderInterface $builder, array $options): void
@@ -81,22 +79,6 @@ final class SliderItemFormTypeExtension extends AbstractTypeExtension
                 'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],
                 'hide_delete_button' => $options['scenario'] === SliderItemFormType::SCENARIO_EDIT,
             ]);
-    }
-
-    private function buildGtmForm(FormBuilderInterface $builder): void
-    {
-        $builder->add('gtmId', TextType::class, [
-            'required' => true,
-            'label' => t('GTM ID'),
-            'constraints' => [
-                new Constraints\NotBlank(message: 'Please enter GTM ID'),
-            ],
-            'attr' => ['placeholder' => t('e.g. Sale-04-20-2020')],
-        ])->add('gtmCreative', TextType::class, [
-            'required' => false,
-            'label' => t('GTM creative'),
-            'attr' => ['placeholder' => t('e.g. red-1035x340-jpg-carousel')],
-        ]);
     }
 
     /**

--- a/project-base/app/src/Migrations/Version20260726120000.php
+++ b/project-base/app/src/Migrations/Version20260726120000.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+final class Version20260726120000 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE slider_items DROP COLUMN gtm_id');
+        $this->sql('ALTER TABLE slider_items DROP COLUMN gtm_creative');
+    }
+}

--- a/project-base/app/src/Model/Slider/SliderItem.php
+++ b/project-base/app/src/Model/Slider/SliderItem.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Model\Slider;
 
 use Doctrine\ORM\Mapping as ORM;
-use Override;
 use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Slider\SliderItem as BaseSliderItem;
 use Shopsys\FrameworkBundle\Model\Slider\SliderItemData as BaseSliderItemData;
@@ -16,26 +15,13 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
  * SliderItem
  *
  * @method void setData(\App\Model\Slider\SliderItemData $sliderItemData)
+ * @method void edit(\App\Model\Slider\SliderItemData $sliderItemData)
  */
 #[AsMcpTable]
 #[ORM\Table(name: 'slider_items')]
 #[ORM\Entity]
 class SliderItem extends BaseSliderItem
 {
-    /**
-     * @var string|null
-     */
-    #[AsMcpColumn]
-    #[ORM\Column(type: 'text', nullable: false)]
-    protected $gtmId;
-
-    /**
-     * @var string|null
-     */
-    #[AsMcpColumn]
-    #[ORM\Column(type: 'text', nullable: true)]
-    protected $gtmCreative;
-
     #[AsMcpColumn]
     #[ORM\Column(type: 'guid', unique: true)]
     protected string $uuid;
@@ -47,31 +33,7 @@ class SliderItem extends BaseSliderItem
     {
         parent::__construct($sliderItemData);
 
-        $this->gtmId = $sliderItemData->gtmId;
-        $this->gtmCreative = $sliderItemData->gtmCreative;
         $this->uuid = $sliderItemData->uuid ?: Uuid::uuid4()->toString();
-    }
-
-    /**
-     * @param \App\Model\Slider\SliderItemData $sliderItemData
-     */
-    #[Override]
-    public function edit(BaseSliderItemData $sliderItemData): void
-    {
-        parent::edit($sliderItemData);
-
-        $this->gtmId = $sliderItemData->gtmId;
-        $this->gtmCreative = $sliderItemData->gtmCreative;
-    }
-
-    public function getGtmId(): string
-    {
-        return $this->gtmId;
-    }
-
-    public function getGtmCreative(): ?string
-    {
-        return $this->gtmCreative;
     }
 
     public function getUuid(): string

--- a/project-base/app/src/Model/Slider/SliderItemData.php
+++ b/project-base/app/src/Model/Slider/SliderItemData.php
@@ -13,15 +13,5 @@ class SliderItemData extends BaseSliderItemData
      */
     public $mobileImage;
 
-    /**
-     * @var string
-     */
-    public $gtmId;
-
-    /**
-     * @var string|null
-     */
-    public $gtmCreative;
-
     public ?string $uuid = null;
 }

--- a/project-base/app/src/Model/Slider/SliderItemDataFactory.php
+++ b/project-base/app/src/Model/Slider/SliderItemDataFactory.php
@@ -49,8 +49,5 @@ class SliderItemDataFactory extends BaseSliderItemDataFactory
 
         $sliderItemData->image = $this->imageUploadDataFactory->createFromEntityAndType($sliderItem, SliderItemFacade::IMAGE_TYPE_WEB);
         $sliderItemData->mobileImage = $this->imageUploadDataFactory->createFromEntityAndType($sliderItem, SliderItemFacade::IMAGE_TYPE_MOBILE);
-
-        $sliderItemData->gtmId = $sliderItem->getGtmId();
-        $sliderItemData->gtmCreative = $sliderItem->getGtmCreative();
     }
 }

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -10,12 +10,6 @@ msgstr "Zavřít"
 msgid "File not found in main filesystem. Please try again later."
 msgstr "Soubor se nepodařilo nalézt na hlavním uložišti. Zkuste to, prosím znovu později."
 
-msgid "GTM ID"
-msgstr "GTM ID"
-
-msgid "GTM creative"
-msgstr ""
-
 msgid "Insert variable"
 msgstr "Vložit proměnnou"
 
@@ -54,12 +48,6 @@ msgstr "Nahrát obrázek pro mobilní zařízení"
 
 msgid "You can upload following formats: PNG, JPG"
 msgstr "Můžete nahrát následující formáty: PNG, JPG"
-
-msgid "e.g. Sale-04-20-2020"
-msgstr "např. Akce-04-20-2020"
-
-msgid "e.g. red-1035x340-jpg-carousel"
-msgstr "např. cervena-1035x340-jpg-carousel"
 
 msgid "from most expensive"
 msgstr "od nejdražšího"

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -10,12 +10,6 @@ msgstr ""
 msgid "File not found in main filesystem. Please try again later."
 msgstr ""
 
-msgid "GTM ID"
-msgstr ""
-
-msgid "GTM creative"
-msgstr ""
-
 msgid "Insert variable"
 msgstr ""
 
@@ -53,12 +47,6 @@ msgid "Upload image for mobile devices"
 msgstr ""
 
 msgid "You can upload following formats: PNG, JPG"
-msgstr ""
-
-msgid "e.g. Sale-04-20-2020"
-msgstr ""
-
-msgid "e.g. red-1035x340-jpg-carousel"
 msgstr ""
 
 msgid "from most expensive"

--- a/project-base/app/translations/messages.sk.po
+++ b/project-base/app/translations/messages.sk.po
@@ -10,12 +10,6 @@ msgstr "Zavrieť"
 msgid "File not found in main filesystem. Please try again later."
 msgstr "Súbor nebol nájdený v hlavnom súborovom systéme. Prosím, skúste to neskôr."
 
-msgid "GTM ID"
-msgstr "GTM ID"
-
-msgid "GTM creative"
-msgstr "GTM kreativa"
-
 msgid "Insert variable"
 msgstr "Vložiť premennú"
 
@@ -54,12 +48,6 @@ msgstr "Nahrať obrázok pre mobilné zariadenia"
 
 msgid "You can upload following formats: PNG, JPG"
 msgstr "Môžete nahrať nasledujúce formáty: PNG, JPG"
-
-msgid "e.g. Sale-04-20-2020"
-msgstr "napr. Vypredaj-04-20-2020"
-
-msgid "e.g. red-1035x340-jpg-carousel"
-msgstr "napr. cerveny-1035x340-jpg-carousel"
 
 msgid "from most expensive"
 msgstr "od najdrahších"

--- a/project-base/app/translations/validators.cs.po
+++ b/project-base/app/translations/validators.cs.po
@@ -7,9 +7,6 @@ msgstr ""
 msgid "Image can be only in JPG or PNG format"
 msgstr "Obrázek může být pouze ve formátu JPG nebo PNG"
 
-msgid "Please enter GTM ID"
-msgstr "Prosím vyplňte GTM ID"
-
 msgid "Uploaded image is too large ({{ size }} {{ suffix }}). Maximum size of an image is {{ limit }} {{ suffix }}."
 msgstr "Uploadovaný obrázek je příliš velký ({{ size }} {{ suffix }}). Maximální velikost obrázku je {{ limit }} {{ suffix }}."
 

--- a/project-base/app/translations/validators.en.po
+++ b/project-base/app/translations/validators.en.po
@@ -7,9 +7,6 @@ msgstr ""
 msgid "Image can be only in JPG or PNG format"
 msgstr ""
 
-msgid "Please enter GTM ID"
-msgstr ""
-
 msgid "Uploaded image is too large ({{ size }} {{ suffix }}). Maximum size of an image is {{ limit }} {{ suffix }}."
 msgstr ""
 

--- a/project-base/app/translations/validators.sk.po
+++ b/project-base/app/translations/validators.sk.po
@@ -7,9 +7,6 @@ msgstr ""
 msgid "Image can be only in JPG or PNG format"
 msgstr "Obrázok môže byť len v formáte JPG alebo PNG"
 
-msgid "Please enter GTM ID"
-msgstr "Prosím, zadajte GTM ID"
-
 msgid "Uploaded image is too large ({{ size }} {{ suffix }}). Maximum size of an image is {{ limit }} {{ suffix }}."
 msgstr "Nahrávaný obrázok je príliš veľký ({{ size }} {{ suffix }}). Maximálna veľkosť obrázka je {{ limit }} {{ suffix }}."
 

--- a/upgrade-notes/backend_20260727_100000.md
+++ b/upgrade-notes/backend_20260727_100000.md
@@ -1,0 +1,5 @@
+#### remove unused GTM settings from homepage banners ([#4736](https://github.com/shopsys/shopsys/pull/4736))
+
+- the `GTM ID` and `GTM creative` fields were removed from the homepage banner (slider item) administration as they had no effect on the storefront
+- the `gtm_id` and `gtm_creative` columns are dropped from the `slider_items` table by a migration — if your project uses these fields, skip the migration and keep your own implementation
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The homepage banner (slider item) form in administration required a `GTM ID` (and offered `GTM creative`), but these fields had no effect on the storefront — administrators were forced to fill in something meaningless. The fields were removed from the form, entity, data fixture, and the `gtm_id`/`gtm_creative` columns are dropped from the `slider_items` table by a migration. Projects that actually use these fields can skip the migration and keep their own implementation (mentioned in the upgrade notes).

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-2964-remove-banner-gtm-fields.odin.shopsys.cloud
  - https://cz.pk-ssp-2964-remove-banner-gtm-fields.odin.shopsys.cloud
  - https://pk-ssp-2964-remove-banner-gtm-fields.odin.shopsys.cloud/sk
<!-- Replace -->
