### PR TITLE
admin product list price is displayed with the currency of the first domain

### DIFF
--- a/packages/administration/templates/content/product/listGrid.html.twig
+++ b/packages/administration/templates/content/product/listGrid.html.twig
@@ -4,6 +4,13 @@
     {{ 'No product found.'|trans }}
 {% endblock %}
 
+{# the listed price is the manual input price of the first domain, so it must be displayed with the currency of the first domain (not the default admin currency) #}
+{% block grid_value_cell_id_price %}
+    {% if value is not null %}
+        {{ value|priceWithCurrencyByDomainId(getFirstDomain().id) }}
+    {% endif %}
+{% endblock %}
+
 {% block grid_value_cell_id_name %}
     {% if row.productType == TYPE_INQUIRY %}
         <span class="cursor-help badge badge-pill bg-indigo-lt"


### PR DESCRIPTION
#### Description, the reason for the PR

The price column in the admin product list shows the manual input price of the first domain (see the long-standing note in `ProductListAdminFacade`), but it was formatted with the default administration currency. When the two differed, the list showed a wrong currency label — e.g. domain 1 prices in EUR labeled as CZK after changing the default admin currency. The price is now displayed with the currency of the first domain, so the label always matches the value.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-716-product-list-price-currency.odin.shopsys.cloud
  - https://cz.pk-ssp-716-product-list-price-currency.odin.shopsys.cloud
  - https://pk-ssp-716-product-list-price-currency.odin.shopsys.cloud/sk
<!-- Replace -->
