### PR TITLE
customer role group form shows individual permissions as granted when the all scope is checked

### DIFF
--- a/packages/framework/assets/js/admin/components/CustomerRoleGroupForm.js
+++ b/packages/framework/assets/js/admin/components/CustomerRoleGroupForm.js
@@ -9,13 +9,20 @@ export default class CustomerRoleGroupForm {
             return;
         }
 
-        $allRolesCheckbox.on('change', function () {
-            if ($(this).is(':checked')) {
-                $individualRolesCheckboxes.prop('checked', false).prop('disabled', true);
+        const applyAllRolesState = function () {
+            if ($allRolesCheckbox.is(':checked')) {
+                $individualRolesCheckboxes.prop('checked', true).prop('disabled', true);
             } else {
-                $individualRolesCheckboxes.prop('disabled', false);
+                $individualRolesCheckboxes.prop('checked', false).prop('disabled', false);
             }
-        });
+        };
+
+        $allRolesCheckbox.on('change', applyAllRolesState);
+
+        // the "all" scope grants every individual permission, so show them as checked also on page load
+        if ($allRolesCheckbox.is(':checked')) {
+            applyAllRolesState();
+        }
     }
 
     static init($container) {


### PR DESCRIPTION
#### Description, the reason for the PR

In the customer role group editing, the first checkbox grants all permissions, but when editing a group with this "all" scope enabled, the individual permission checkboxes looked unchecked and enabled — at first glance the group seemed to have no permissions at all. The JavaScript only reacted to the change event and never applied the state on page load.

The visual state is now applied on page load as well, and the individual permissions are shown as checked (and disabled) whenever the "all" scope is active, so it is clear the first checkbox includes all of them. Disabled checkboxes are not submitted, so the server-side behavior stays unchanged.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-ssp-2666-customer-role-group-all-checkbox.odin.shopsys.cloud
  - https://cz.pk-ssp-2666-customer-role-group-all-checkbox.odin.shopsys.cloud
  - https://pk-ssp-2666-customer-role-group-all-checkbox.odin.shopsys.cloud/sk
<!-- Replace -->
