### PR TITLE
Add domain controls to CRUD lists

### DIFF
--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -102,6 +102,78 @@ protected function configureQuery(QueryBuilder $queryBuilder): void
 }
 ```
 
+### List domain control
+
+Use `setListDomainControl()` in `configure()` to display a domain control above the datagrid.
+
+```php
+use Shopsys\AdministrationBundle\Component\Config\CrudListDomainControl;
+
+public function configure(CrudConfig $config): void
+{
+    $config->setListDomainControl(CrudListDomainControl::QUICK_FILTER, [1, 3]);
+}
+```
+
+- `CrudListDomainControl::QUICK_FILTER` displays a per-list filter with an "All domains" option.
+  The filter stores its selection under a namespace generated from the controller name.
+  The optional `$allowedDomainIds` argument restricts the filter to the specified domain IDs; the list is always intersected with the domains available to the administrator.
+- `CrudListDomainControl::SWITCHER` displays the global administration domain switcher.
+  It always returns one selected domain ID and does not support `$allowedDomainIds`.
+
+When the entity implements `\Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface`, the domain condition is applied to the list query automatically (no `configureQuery()` code is needed).
+A selected domain limits the list to that domain, and the "All domains" option of a quick filter limits it to the domains available to the administrator (intersected with the configured allowed domain IDs).
+
+#### Entities without `DomainSeparatedEntityInterface`
+
+When the entity is related to a domain in another way (e.g. through a joined entity), nothing is applied to the list query automatically.
+Decide first what the domain control should affect on your list — the two cases need different code and can be combined.
+
+**Limiting which entities are listed** — apply the condition in `configureQuery()` using `addListDomainIdsCondition()` with the DQL field holding the domain ID:
+
+```php
+protected function configureQuery(QueryBuilder $queryBuilder): void
+{
+    $queryBuilder->join('o.domains', 'od');
+    $this->addListDomainIdsCondition($queryBuilder, 'od.domainId');
+}
+```
+
+The condition respects the selected domain (or all domains available to the list when "All domains" is selected in a quick filter) and matches nothing when no domain is available to the administrator.
+It excludes an entity only when the entity has no row for the given domain — joined entities that are created for every domain are never excluded.
+
+The join lists the entity once per matching domain, so use it only where a single domain is always selected (`SWITCHER`).
+With "All domains" selected, an entity related to three domains is listed three times.
+
+**Showing per-domain values in a column** (status, publish date, …) — select the value for the selected domain, or aggregate it over the domains of the list when "All domains" is selected:
+
+```php
+protected function configureQuery(QueryBuilder $queryBuilder): void
+{
+    $queryBuilder
+        ->addSelect(sprintf(
+            '(SELECT MIN(bad.status) FROM %s bad WHERE bad.blogArticle = o AND bad.domainId IN (:domainIds)) AS domainStatus',
+            BlogArticleDomain::class,
+        ))
+        ->setParameter('domainIds', $this->getEffectiveListDomainIds());
+}
+```
+
+`getEffectiveListDomainIds()` returns the selected domain, or the domains of the list when "All domains" is selected.
+A subselect is used instead of a join to keep one row per entity, and each subselect needs its own DQL alias, as aliases are unique within the whole query.
+
+Such a value does not map to a property of the listed entity, so display it with a `virtual` datagrid field whose `transform` reads it from the row:
+
+```php
+$datagrid->add('status', [
+    'label' => t('Status'),
+    'virtual' => true,
+    'transform' => fn (mixed $value, array $row): mixed => $row['domainStatus'] ?? null,
+]);
+```
+
+For fully custom conditions, use `getSelectedListDomainId()` and `getEffectiveListDomainIds()`.
+
 ### `configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void`
 
 Configure the form for create and edit pages. The `$entity` parameter is `null` for create action and contains the entity being edited for edit action.

--- a/ecs.php
+++ b/ecs.php
@@ -58,6 +58,7 @@ $pathsExcludedFromStrictTyping = [
     __DIR__ . '/packages/framework/src/Model/Localization/TranslatableEntityTrait.php',
     __DIR__ . '/packages/framework/src/Model/Security/UniqueLoginInterface.php',
     __DIR__ . '/packages/framework/src/Model/Security/TimelimitLoginInterface.php',
+    __DIR__ . '/packages/framework/src/Component/Domain/Entity/DomainSeparatedEntityInterface.php',
     __DIR__ . '/packages/framework/src/Component/Security/ResetPasswordInterface.php',
     __DIR__ . '/packages/framework/src/Component/FileUpload/EntityFileUploadInterface.php',
     __DIR__ . '/packages/framework/src/Component/AbstractUploadedFile/UploadedFileInterface.php',

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -47,6 +47,13 @@ final class CrudConfig
 
     private ?string $menuIcon = null;
 
+    private ?CrudListDomainControl $listDomainControl = null;
+
+    /**
+     * @var int[]|null
+     */
+    private ?array $listAllowedDomainIds = null;
+
     /**
      * @var array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, class-string<\Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface>|null>
      */
@@ -242,6 +249,28 @@ final class CrudConfig
     }
 
     /**
+     * Sets the domain control displayed on the list page.
+     *
+     * @param int[]|null $allowedDomainIds Domain IDs available in the quick domain filter. Null allows all domains available to the administrator.
+     * @return $this
+     */
+    public function setListDomainControl(
+        CrudListDomainControl $listDomainControl,
+        ?array $allowedDomainIds = null,
+    ): self {
+        if ($listDomainControl === CrudListDomainControl::SWITCHER && $allowedDomainIds !== null) {
+            throw new InvalidArgumentException('Domain switcher does not support allowed domain IDs.');
+        }
+
+        Assert::allInteger($allowedDomainIds ?? []);
+
+        $this->listDomainControl = $listDomainControl;
+        $this->listAllowedDomainIds = $allowedDomainIds;
+
+        return $this;
+    }
+
+    /**
      * @template T of \Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface
      *
      * Register handler class or classes for CRUD actions.
@@ -331,6 +360,8 @@ final class CrudConfig
             $this->customRoleSection,
             $this->handlerClasses,
             $this->menuIcon,
+            $this->listDomainControl,
+            $this->listAllowedDomainIds,
         );
     }
 }

--- a/packages/administration/src/Component/Config/CrudConfigData.php
+++ b/packages/administration/src/Component/Config/CrudConfigData.php
@@ -17,6 +17,7 @@ final readonly class CrudConfigData
      * @param \Shopsys\AdministrationBundle\Component\Config\ActionType[] $enabledActions
      * @param MenuItemPosition $menuSectionPosition
      * @param array<value-of<\Shopsys\AdministrationBundle\Component\Config\ActionType>, null|class-string<\Shopsys\AdministrationBundle\Component\Crud\Handler\HandlerInterface>> $handlerClasses
+     * @param int[]|null $listAllowedDomainIds
      */
     public function __construct(
         private ?string $entityNameSingular,
@@ -34,6 +35,8 @@ final readonly class CrudConfigData
         private ?string $customRoleSection,
         private array $handlerClasses,
         private ?string $menuIcon,
+        private ?CrudListDomainControl $listDomainControl,
+        private ?array $listAllowedDomainIds,
     ) {
         foreach ($this->enabledActions as $action) {
             if (array_key_exists($action->value, $this->handlerClasses) && $this->handlerClasses[$action->value] === null) {
@@ -166,5 +169,18 @@ final readonly class CrudConfigData
     public function getMenuIcon(): ?string
     {
         return $this->menuIcon;
+    }
+
+    public function getListDomainControl(): ?CrudListDomainControl
+    {
+        return $this->listDomainControl;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getListAllowedDomainIds(): ?array
+    {
+        return $this->listAllowedDomainIds;
     }
 }

--- a/packages/administration/src/Component/Config/CrudListDomainControl.php
+++ b/packages/administration/src/Component/Config/CrudListDomainControl.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Config;
+
+enum CrudListDomainControl
+{
+    case QUICK_FILTER;
+    case SWITCHER;
+}

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -6,10 +6,12 @@ namespace Shopsys\AdministrationBundle\Controller;
 
 use Closure;
 use Doctrine\ORM\QueryBuilder;
+use LogicException;
 use Psr\Log\LoggerInterface;
 use Shopsys\AdministrationBundle\Component\Config\ActionsConfig;
 use Shopsys\AdministrationBundle\Component\Config\ActionType;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
+use Shopsys\AdministrationBundle\Component\Config\CrudListDomainControl;
 use Shopsys\AdministrationBundle\Component\Crud\Definition;
 use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudCreateHookExtensionInterface;
 use Shopsys\AdministrationBundle\Component\Crud\Extension\CrudDeleteHookExtensionInterface;
@@ -20,6 +22,10 @@ use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
 use Shopsys\AdministrationBundle\Component\Datagrid\Adapter\Orm\OrmAdapterFactory;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
 use Shopsys\AdministrationBundle\Component\Datagrid\DatagridFactory;
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\SilencedExceptionEvent;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Utils\Presentable;
@@ -60,6 +66,15 @@ abstract class AbstractCrudController extends AdminBaseController
     #[Required]
     public CrudEntityIdentifierExtractor $crudEntityIdentifierExtractor;
 
+    #[Required]
+    public AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade;
+
+    #[Required]
+    public AdminDomainTabsFacade $adminDomainTabsFacade;
+
+    #[Required]
+    public Domain $domain;
+
     public function setDefinition(Definition $definition): void
     {
         $this->definition = $definition;
@@ -79,6 +94,89 @@ abstract class AbstractCrudController extends AdminBaseController
 
     protected function configureQuery(QueryBuilder $queryBuilder): void
     {
+    }
+
+    protected function getSelectedListDomainId(): ?int
+    {
+        return match ($this->definition->getConfig()->getListDomainControl()) {
+            CrudListDomainControl::QUICK_FILTER => $this->adminDomainFilterTabsFacade->getSelectedDomainId(
+                $this->getListDomainFilterNamespace(),
+                $this->getListDomainIds(),
+            ),
+            CrudListDomainControl::SWITCHER => $this->adminDomainTabsFacade->getSelectedDomainId(),
+            null => throw new LogicException('List domain control is not configured.'),
+        };
+    }
+
+    /**
+     * Returns the namespace the quick domain filter stores its selection under, generated from the controller name.
+     */
+    protected function getListDomainFilterNamespace(): string
+    {
+        return 'crud_' . CrudTransformationHelper::transformToRouteName($this->definition->controllerName);
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getListDomainIds(): array
+    {
+        $allowedDomainIds = $this->definition->getConfig()->getListAllowedDomainIds();
+        $adminEnabledDomainIds = $this->domain->getAdminEnabledDomainIds();
+
+        if ($allowedDomainIds === null) {
+            return $adminEnabledDomainIds;
+        }
+
+        return array_values(array_intersect($adminEnabledDomainIds, $allowedDomainIds));
+    }
+
+    /**
+     * Returns the domain IDs the list is allowed to show: the selected domain,
+     * or all domains available to the list when "All domains" is selected.
+     *
+     * @return int[]
+     */
+    protected function getEffectiveListDomainIds(): array
+    {
+        $selectedDomainId = $this->getSelectedListDomainId();
+
+        return $selectedDomainId !== null ? [$selectedDomainId] : $this->getListDomainIds();
+    }
+
+    /**
+     * Adds the list domain condition on the given DQL field; matches nothing when no domain is available.
+     */
+    protected function addListDomainIdsCondition(QueryBuilder $queryBuilder, string $domainIdField): void
+    {
+        $domainIds = $this->getEffectiveListDomainIds();
+
+        if ($domainIds === []) {
+            $queryBuilder->andWhere('1 = 0');
+
+            return;
+        }
+
+        $queryBuilder
+            ->andWhere($domainIdField . ' IN (:listDomainFilterDomainIds)')
+            ->setParameter('listDomainFilterDomainIds', $domainIds);
+    }
+
+    /**
+     * Applies the configured domain condition to the list query of a domain-separated entity.
+     *
+     * Override with an empty body to opt out, or with custom logic when the domain relation
+     * cannot be expressed as a condition on the root entity's `domainId` field.
+     */
+    protected function applyListDomainFilter(QueryBuilder $queryBuilder): void
+    {
+        if ($this->definition->getConfig()->getListDomainControl() === null
+            || !is_a($this->definition->entityClass, DomainSeparatedEntityInterface::class, true)
+        ) {
+            return;
+        }
+
+        $this->addListDomainIdsCondition($queryBuilder, $queryBuilder->getRootAliases()[0] . '.domainId');
     }
 
     /**
@@ -103,7 +201,9 @@ abstract class AbstractCrudController extends AdminBaseController
 
     public function listAction(): Response
     {
+        $listDomainControl = $this->definition->getConfig()->getListDomainControl();
         $adapter = $this->ormAdapterFactory->create($this->definition->entityClass, function (QueryBuilder $queryBuilder): void {
+            $this->applyListDomainFilter($queryBuilder);
             $this->configureQuery($queryBuilder);
             $this->executeExtensions(fn (AbstractCrudControllerExtension $extension) => $extension->configureQuery($queryBuilder));
         });
@@ -119,6 +219,9 @@ abstract class AbstractCrudController extends AdminBaseController
             'title' => $this->definition->getConfig()->getTitle(ActionType::LIST),
             'grid' => $datagrid->createView(),
             'topActions' => $this->getConfiguredActions(ActionType::LIST),
+            'listDomainControl' => $listDomainControl,
+            'listDomainFilterNamespace' => $listDomainControl === CrudListDomainControl::QUICK_FILTER ? $this->getListDomainFilterNamespace() : null,
+            'listDomainIds' => $listDomainControl === CrudListDomainControl::QUICK_FILTER ? $this->getListDomainIds() : [],
         ]);
     }
 

--- a/packages/administration/templates/crud/list.html.twig
+++ b/packages/administration/templates/crud/list.html.twig
@@ -11,5 +11,11 @@
 {% endblock %}
 
 {% block main_content %}
+    {% if listDomainControl is same as(constant('Shopsys\\AdministrationBundle\\Component\\Config\\CrudListDomainControl::QUICK_FILTER')) %}
+        {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainFilterController::domainFilterTabsAction', { namespace: listDomainFilterNamespace, domainIds: listDomainIds })) }}
+    {% elseif listDomainControl is same as(constant('Shopsys\\AdministrationBundle\\Component\\Config\\CrudListDomainControl::SWITCHER')) %}
+        {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainController::domainTabsAction')) }}
+    {% endif %}
+
     {{ grid.render }}
 {% endblock %}

--- a/packages/administration/templates/partial/quick_domain_filter.html.twig
+++ b/packages/administration/templates/partial/quick_domain_filter.html.twig
@@ -1,4 +1,4 @@
-{% if isMultidomain() %}
+{% if domainConfigs|length > 1 %}
     <div class="card">
         <div class="card-body">
             <div class="card-title text-secondary">{{ 'Quick Domain Filter'|trans }}</div>

--- a/packages/administration/tests/Unit/Component/Config/CrudListDomainControlTest.php
+++ b/packages/administration/tests/Unit/Component/Config/CrudListDomainControlTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\AdministrationBundle\Unit\Component\Config;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
+use LogicException;
+use Override;
+use PHPUnit\Framework\TestCase;
+use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
+use Shopsys\AdministrationBundle\Component\Config\CrudListDomainControl;
+use Shopsys\AdministrationBundle\Component\Crud\Definition;
+use Shopsys\AdministrationBundle\Controller\AbstractCrudController;
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
+use stdClass;
+
+final class CrudListDomainControlTest extends TestCase
+{
+    public function testQuickDomainFilterConfigurationIsStored(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER, [1, 3]);
+
+        $crudConfigData = $crudConfig->getConfig();
+
+        $this->assertSame(CrudListDomainControl::QUICK_FILTER, $crudConfigData->getListDomainControl());
+        $this->assertSame([1, 3], $crudConfigData->getListAllowedDomainIds());
+    }
+
+    public function testDomainSwitcherConfigurationIsStored(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+
+        $crudConfig->setListDomainControl(CrudListDomainControl::SWITCHER);
+
+        $crudConfigData = $crudConfig->getConfig();
+
+        $this->assertSame(CrudListDomainControl::SWITCHER, $crudConfigData->getListDomainControl());
+        $this->assertNull($crudConfigData->getListAllowedDomainIds());
+    }
+
+    public function testDomainSwitcherWithAllowedDomainIdsThrowsException(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Domain switcher does not support allowed domain IDs.');
+
+        $crudConfig->setListDomainControl(CrudListDomainControl::SWITCHER, [1, 3]);
+    }
+
+    public function testSelectedListDomainIdUsesNamespaceGeneratedFromControllerName(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER);
+        $crudController = $this->createCrudController($crudConfig);
+        $domainFilterTabsFacadeMock = $this->createMock(AdminDomainFilterTabsFacade::class);
+        $domainFilterTabsFacadeMock
+            ->expects($this->once())
+            ->method('getSelectedDomainId')
+            ->with('crud_test', [1, 2, 3])
+            ->willReturn(2);
+        $crudController->adminDomainFilterTabsFacade = $domainFilterTabsFacadeMock;
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+
+        $selectedDomainId = $crudController->getSelectedListDomainIdForTest();
+
+        $this->assertSame(2, $selectedDomainId);
+    }
+
+    public function testSelectedListDomainIdUsesDomainSwitcher(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::SWITCHER);
+        $crudController = $this->createCrudController($crudConfig);
+        $domainTabsFacadeMock = $this->createMock(AdminDomainTabsFacade::class);
+        $domainTabsFacadeMock
+            ->expects($this->once())
+            ->method('getSelectedDomainId')
+            ->willReturn(3);
+        $crudController->adminDomainFilterTabsFacade = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $crudController->adminDomainTabsFacade = $domainTabsFacadeMock;
+
+        $selectedDomainId = $crudController->getSelectedListDomainIdForTest();
+
+        $this->assertSame(3, $selectedDomainId);
+    }
+
+    public function testSelectedListDomainIdIsRestrictedByListDomainIds(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER, [1, 3]);
+        $crudController = $this->createCrudController($crudConfig, [1, 2, 3]);
+        $domainFilterTabsFacadeMock = $this->createMock(AdminDomainFilterTabsFacade::class);
+        $domainFilterTabsFacadeMock
+            ->expects($this->once())
+            ->method('getSelectedDomainId')
+            ->with('crud_test', [1, 3])
+            ->willReturn(null);
+        $crudController->adminDomainFilterTabsFacade = $domainFilterTabsFacadeMock;
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+
+        $selectedDomainId = $crudController->getSelectedListDomainIdForTest();
+
+        $this->assertNull($selectedDomainId);
+    }
+
+    public function testListDomainIdsAreLimitedByAllowedAndAdminEnabledDomains(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER, [1, 3, 4]);
+        $crudController = $this->createCrudController($crudConfig, [1, 2, 3]);
+
+        $this->assertSame([1, 3], $crudController->getListDomainIdsForTest());
+    }
+
+    public function testSelectedListDomainIdWithoutConfiguredControlThrowsException(): void
+    {
+        $crudController = $this->createCrudController(new CrudConfig('Product review'));
+        $crudController->adminDomainFilterTabsFacade = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('List domain control is not configured.');
+
+        $crudController->getSelectedListDomainIdForTest();
+    }
+
+    public function testListDomainFilterAppliesSelectedDomain(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER);
+        $crudController = $this->createCrudController($crudConfig, [1, 2, 3], TestDomainSeparatedEntity::class);
+        $domainFilterTabsFacadeStub = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $domainFilterTabsFacadeStub->method('getSelectedDomainId')->willReturn(2);
+        $crudController->adminDomainFilterTabsFacade = $domainFilterTabsFacadeStub;
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+        $queryBuilder = $this->createQueryBuilder();
+
+        $crudController->applyListDomainFilterForTest($queryBuilder);
+
+        $this->assertStringContainsString('o.domainId IN (:listDomainFilterDomainIds)', (string)$queryBuilder->getDQLPart('where'));
+        $this->assertSame([2], $queryBuilder->getParameter('listDomainFilterDomainIds')->getValue());
+    }
+
+    public function testListDomainFilterAppliesAllDomains(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER, [1, 3, 4]);
+        $crudController = $this->createCrudController($crudConfig, [1, 2, 3], TestDomainSeparatedEntity::class);
+        $domainFilterTabsFacadeStub = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $domainFilterTabsFacadeStub->method('getSelectedDomainId')->willReturn(null);
+        $crudController->adminDomainFilterTabsFacade = $domainFilterTabsFacadeStub;
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+        $queryBuilder = $this->createQueryBuilder();
+
+        $crudController->applyListDomainFilterForTest($queryBuilder);
+
+        $this->assertStringContainsString('o.domainId IN (:listDomainFilterDomainIds)', (string)$queryBuilder->getDQLPart('where'));
+        $this->assertSame([1, 3], $queryBuilder->getParameter('listDomainFilterDomainIds')->getValue());
+    }
+
+    public function testListDomainFilterAppliesDomainSwitcherSelection(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::SWITCHER);
+        $crudController = $this->createCrudController($crudConfig, [1, 2, 3], TestDomainSeparatedEntity::class);
+        $domainTabsFacadeStub = $this->createStub(AdminDomainTabsFacade::class);
+        $domainTabsFacadeStub->method('getSelectedDomainId')->willReturn(3);
+        $crudController->adminDomainFilterTabsFacade = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $crudController->adminDomainTabsFacade = $domainTabsFacadeStub;
+        $queryBuilder = $this->createQueryBuilder();
+
+        $crudController->applyListDomainFilterForTest($queryBuilder);
+
+        $this->assertStringContainsString('o.domainId IN (:listDomainFilterDomainIds)', (string)$queryBuilder->getDQLPart('where'));
+        $this->assertSame([3], $queryBuilder->getParameter('listDomainFilterDomainIds')->getValue());
+    }
+
+    public function testListDomainFilterExcludesEverythingWithoutAvailableDomains(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER, [4]);
+        $crudController = $this->createCrudController($crudConfig, [1, 2, 3], TestDomainSeparatedEntity::class);
+        $domainFilterTabsFacadeStub = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $domainFilterTabsFacadeStub->method('getSelectedDomainId')->willReturn(null);
+        $crudController->adminDomainFilterTabsFacade = $domainFilterTabsFacadeStub;
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+        $queryBuilder = $this->createQueryBuilder();
+
+        $crudController->applyListDomainFilterForTest($queryBuilder);
+
+        $this->assertStringContainsString('1 = 0', (string)$queryBuilder->getDQLPart('where'));
+        $this->assertCount(0, $queryBuilder->getParameters());
+    }
+
+    public function testListDomainFilterSkipsEntityWithoutDomainSeparatedEntityInterface(): void
+    {
+        $crudConfig = new CrudConfig('Product review');
+        $crudConfig->setListDomainControl(CrudListDomainControl::QUICK_FILTER);
+        $crudController = $this->createCrudController($crudConfig);
+        $crudController->adminDomainFilterTabsFacade = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+        $queryBuilder = $this->createQueryBuilder();
+
+        $crudController->applyListDomainFilterForTest($queryBuilder);
+
+        $this->assertNull($queryBuilder->getDQLPart('where'));
+        $this->assertCount(0, $queryBuilder->getParameters());
+    }
+
+    public function testListDomainFilterSkipsListWithoutConfiguredControl(): void
+    {
+        $crudController = $this->createCrudController(new CrudConfig('Product review'), [1, 2, 3], TestDomainSeparatedEntity::class);
+        $crudController->adminDomainFilterTabsFacade = $this->createStub(AdminDomainFilterTabsFacade::class);
+        $crudController->adminDomainTabsFacade = $this->createStub(AdminDomainTabsFacade::class);
+        $queryBuilder = $this->createQueryBuilder();
+
+        $crudController->applyListDomainFilterForTest($queryBuilder);
+
+        $this->assertNull($queryBuilder->getDQLPart('where'));
+        $this->assertCount(0, $queryBuilder->getParameters());
+    }
+
+    /**
+     * @param int[] $adminEnabledDomainIds
+     * @param class-string $entityClass
+     */
+    private function createCrudController(
+        CrudConfig $crudConfig,
+        array $adminEnabledDomainIds = [1, 2, 3],
+        string $entityClass = stdClass::class,
+    ): TestCrudController {
+        $crudController = new TestCrudController();
+        $crudController->setDefinition(new Definition(
+            TestCrudController::class,
+            'TestCrudController',
+            $entityClass,
+            'Product review',
+            $crudConfig->getConfig(),
+            [],
+            [],
+        ));
+        $domainStub = $this->createStub(Domain::class);
+        $domainStub->method('getAdminEnabledDomainIds')->willReturn($adminEnabledDomainIds);
+        $crudController->domain = $domainStub;
+
+        return $crudController;
+    }
+
+    private function createQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = new QueryBuilder($this->createStub(EntityManagerInterface::class));
+        $queryBuilder->select('o')->from(TestDomainSeparatedEntity::class, 'o');
+
+        return $queryBuilder;
+    }
+}
+
+final class TestCrudController extends AbstractCrudController
+{
+    public function getSelectedListDomainIdForTest(): ?int
+    {
+        return $this->getSelectedListDomainId();
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getListDomainIdsForTest(): array
+    {
+        return $this->getListDomainIds();
+    }
+
+    public function applyListDomainFilterForTest(QueryBuilder $queryBuilder): void
+    {
+        $this->applyListDomainFilter($queryBuilder);
+    }
+}
+
+final class TestDomainSeparatedEntity implements DomainSeparatedEntityInterface
+{
+    #[Override]
+    public function getDomainId(): int
+    {
+        return 1;
+    }
+}

--- a/packages/framework/src/Component/Domain/AdminDomainFilterTabsFacade.php
+++ b/packages/framework/src/Component/Domain/AdminDomainFilterTabsFacade.php
@@ -19,9 +19,12 @@ class AdminDomainFilterTabsFacade
     ) {
     }
 
-    public function getSelectedDomainId(string $namespace): ?int
+    /**
+     * @param int[]|null $allowedDomainIds A selected domain outside these IDs is cleared. Null allows all domains available to the administrator.
+     */
+    public function getSelectedDomainId(string $namespace, ?array $allowedDomainIds = null): ?int
     {
-        return $this->getSelectedDomainConfig($namespace)?->getId();
+        return $this->getSelectedDomainConfig($namespace, $allowedDomainIds)?->getId();
     }
 
     public function setSelectedDomainId(string $namespace, ?int $domainId): void
@@ -29,7 +32,10 @@ class AdminDomainFilterTabsFacade
         $this->requestStack->getSession()->set($this->getSessionKey($namespace), $domainId);
     }
 
-    public function getSelectedDomainConfig(string $namespace): ?DomainConfig
+    /**
+     * @param int[]|null $allowedDomainIds A selected domain outside these IDs is cleared. Null allows all domains available to the administrator.
+     */
+    public function getSelectedDomainConfig(string $namespace, ?array $allowedDomainIds = null): ?DomainConfig
     {
         try {
             $domainId = $this->requestStack->getSession()->get($this->getSessionKey($namespace));
@@ -38,7 +44,9 @@ class AdminDomainFilterTabsFacade
                 return null;
             }
 
-            if (!in_array($domainId, $this->domain->getAdminEnabledDomainIds(), true)) {
+            if (!in_array($domainId, $this->domain->getAdminEnabledDomainIds(), true)
+                || ($allowedDomainIds !== null && !in_array($domainId, $allowedDomainIds, true))
+            ) {
                 throw new InvalidDomainIdException();
             }
 

--- a/packages/framework/src/Component/Domain/Entity/DomainSeparatedEntityInterface.php
+++ b/packages/framework/src/Component/Domain/Entity/DomainSeparatedEntityInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Domain\Entity;
+
+/**
+ * Marks an entity whose every row belongs to exactly one domain.
+ *
+ * The implementing entity must have an integer `domainId` field mapped by Doctrine
+ * (queryable as `<alias>.domainId` in DQL).
+ */
+interface DomainSeparatedEntityInterface
+{
+    /**
+     * @return int
+     */
+    public function getDomainId();
+}

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrl.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrl.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
@@ -13,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Index(columns: ['route_name', 'entity_id'])]
 #[ORM\Index(columns: ['route_name', 'entity_id', 'domain_id', 'main'])]
 #[ORM\Entity]
-class FriendlyUrl
+class FriendlyUrl implements DomainSeparatedEntityInterface
 {
     /**
      * @var string
@@ -111,6 +113,7 @@ class FriendlyUrl
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Controller/Admin/DomainFilterController.php
+++ b/packages/framework/src/Controller/Admin/DomainFilterController.php
@@ -21,13 +21,21 @@ class DomainFilterController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @param int[]|null $domainIds
+     */
     #[RequireRole(SystemRole::ADMIN)]
-    public function domainFilterTabsAction(string $namespace): Response
+    public function domainFilterTabsAction(string $namespace, ?array $domainIds = null): Response
     {
         return $this->render('@ShopsysAdministration/partial/quick_domain_filter.html.twig', [
-            'domainConfigs' => $this->domain->getAdminEnabledDomains(),
+            'domainConfigs' => $domainIds === null
+                ? $this->domain->getAdminEnabledDomains()
+                : array_filter(
+                    $this->domain->getAdminEnabledDomains(),
+                    static fn ($domainConfig): bool => in_array($domainConfig->getId(), $domainIds, true),
+                ),
             'namespace' => $namespace,
-            'selectedDomainId' => $this->adminDomainFilterTabsFacade->getSelectedDomainId($namespace),
+            'selectedDomainId' => $this->adminDomainFilterTabsFacade->getSelectedDomainId($namespace, $domainIds),
         ]);
     }
 

--- a/packages/framework/src/Model/Advert/Advert.php
+++ b/packages/framework/src/Model/Advert/Advert.php
@@ -6,7 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Advert;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Image\Config\Attributes\EntityImage;
 use Shopsys\FrameworkBundle\Component\Image\Config\Attributes\EntityImageFolder;
 use Shopsys\FrameworkBundle\Model\Category\Category;
@@ -20,7 +22,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[EntityImage]
 #[EntityImage('web')]
 #[EntityImage('mobile')]
-class Advert
+class Advert implements DomainSeparatedEntityInterface
 {
     public const TYPE_IMAGE = 'image';
     public const TYPE_CODE = 'code';
@@ -165,6 +167,7 @@ class Advert
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Article/Article.php
+++ b/packages/framework/src/Model/Article/Article.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -15,7 +16,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[AsMcpTable]
 #[ORM\Table(name: 'articles')]
 #[ORM\Entity]
-class Article implements OrderableEntityInterface
+class Article implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     public const PLACEMENT_NONE = 'none';
     public const PLACEMENT_FOOTER_1 = 'footer1';
@@ -185,6 +186,7 @@ class Article implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Autocomplete/AutocompleteFavoriteBrand.php
+++ b/packages/framework/src/Model/Autocomplete/AutocompleteFavoriteBrand.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Autocomplete;
 
 use Doctrine\ORM\Mapping as ORM;
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
@@ -14,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[AsMcpTable]
 #[ORM\Table(name: 'autocomplete_favorite_brands')]
 #[ORM\Entity]
-class AutocompleteFavoriteBrand implements OrderableEntityInterface
+class AutocompleteFavoriteBrand implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand
@@ -58,6 +59,7 @@ class AutocompleteFavoriteBrand implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Autocomplete/AutocompleteFavoriteCategory.php
+++ b/packages/framework/src/Model/Autocomplete/AutocompleteFavoriteCategory.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Autocomplete;
 
 use Doctrine\ORM\Mapping as ORM;
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
@@ -14,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[AsMcpTable]
 #[ORM\Table(name: 'autocomplete_favorite_categories')]
 #[ORM\Entity]
-class AutocompleteFavoriteCategory implements OrderableEntityInterface
+class AutocompleteFavoriteCategory implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\Category
@@ -58,6 +59,7 @@ class AutocompleteFavoriteCategory implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Autocomplete/AutocompleteFavoriteProduct.php
+++ b/packages/framework/src/Model/Autocomplete/AutocompleteFavoriteProduct.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Autocomplete;
 
 use Doctrine\ORM\Mapping as ORM;
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
@@ -14,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[AsMcpTable]
 #[ORM\Table(name: 'autocomplete_favorite_products')]
 #[ORM\Entity]
-class AutocompleteFavoriteProduct implements OrderableEntityInterface
+class AutocompleteFavoriteProduct implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product
@@ -58,6 +59,7 @@ class AutocompleteFavoriteProduct implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMix.php
+++ b/packages/framework/src/Model/CategorySeo/ReadyCategorySeoMix.php
@@ -6,7 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\CategorySeo;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
@@ -17,7 +19,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'ready_category_seo_mixes')]
 #[ORM\UniqueConstraint(name: 'selected_category_seo_mix_combination_json', columns: ['selected_category_seo_mix_combination_json'])]
 #[ORM\Entity]
-class ReadyCategorySeoMix
+class ReadyCategorySeoMix implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -261,6 +263,7 @@ class ReadyCategorySeoMix
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Complaint/Complaint.php
+++ b/packages/framework/src/Model/Complaint/Complaint.php
@@ -6,7 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Complaint;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatus;
 use Shopsys\FrameworkBundle\Model\Country\Country;
 use Shopsys\FrameworkBundle\Model\Customer\Customer;
@@ -19,7 +21,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[AsMcpTable]
 #[ORM\Table(name: 'complaints')]
 #[ORM\Entity]
-class Complaint
+class Complaint implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -245,6 +247,7 @@ class Complaint
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Customer/Customer.php
+++ b/packages/framework/src/Model/Customer/Customer.php
@@ -6,13 +6,15 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
 #[AsMcpTable]
 #[ORM\Table(name: 'customers')]
 #[ORM\Entity]
-class Customer
+class Customer implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -107,6 +109,7 @@ class Customer
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Security\ResetPasswordInterface;
 use Shopsys\FrameworkBundle\Model\Customer\Customer;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress;
@@ -27,7 +28,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[ORM\Index(columns: ['email'])]
 #[ORM\UniqueConstraint(name: 'email_domain', columns: ['email', 'domain_id'])]
 #[ORM\Entity]
-class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAuthenticatedUserInterface, ResetPasswordInterface
+class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAuthenticatedUserInterface, ResetPasswordInterface, DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -269,6 +270,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Feed/FeedModule.php
+++ b/packages/framework/src/Model/Feed/FeedModule.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Feed;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
 #[AsMcpTable]
 #[ORM\Table(name: 'feed_modules')]
 #[ORM\Entity]
-class FeedModule
+class FeedModule implements DomainSeparatedEntityInterface
 {
     /**
      * @var string
@@ -54,6 +56,7 @@ class FeedModule
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/GoPay/PaymentMethod/GoPayPaymentMethod.php
+++ b/packages/framework/src/Model/GoPay/PaymentMethod/GoPayPaymentMethod.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\GoPay\PaymentMethod;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -13,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'gopay_payment_methods')]
 #[ORM\UniqueConstraint(name: 'gopay_payment_method_unique', columns: ['domain_id', 'identifier'])]
 #[ORM\Entity]
-class GoPayPaymentMethod
+class GoPayPaymentMethod implements DomainSeparatedEntityInterface
 {
     public const IDENTIFIER_PAYMENT_CARD = 'PAYMENT_CARD';
     public const IDENTIFIER_BANK_TRANSFER = 'BANK_ACCOUNT';
@@ -166,6 +168,7 @@ class GoPayPaymentMethod
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Inquiry/Inquiry.php
+++ b/packages/framework/src/Model/Inquiry/Inquiry.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrameworkBundle\Model\Inquiry;
 
 use Doctrine\ORM\Mapping as ORM;
 use LogicException;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\PhonePrefix\PhoneData;
 use Shopsys\FrameworkBundle\Model\Product\Product;
@@ -16,7 +18,7 @@ use Symfony\Component\Clock\DatePoint;
 #[AsMcpTable]
 #[ORM\Table(name: 'inquiries')]
 #[ORM\Entity]
-class Inquiry
+class Inquiry implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -197,6 +199,7 @@ class Inquiry
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Mail/MailTemplate.php
+++ b/packages/framework/src/Model/Mail/MailTemplate.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Mail;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatus;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
@@ -14,7 +16,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'mail_templates')]
 #[ORM\UniqueConstraint(name: 'name_domain', columns: ['name', 'domain_id'])]
 #[ORM\Entity]
-class MailTemplate
+class MailTemplate implements DomainSeparatedEntityInterface
 {
     public const REGISTRATION_CONFIRM_NAME = 'registration_confirm';
     public const RESET_PASSWORD_NAME = 'reset_password';
@@ -128,6 +130,7 @@ class MailTemplate
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Navigation/NavigationItem.php
+++ b/packages/framework/src/Model/Navigation/NavigationItem.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Navigation;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -15,7 +16,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'navigation_items')]
 #[ORM\Index(name: 'domain_id_idx', columns: ['domain_id'])]
 #[ORM\Entity]
-class NavigationItem implements OrderableEntityInterface
+class NavigationItem implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -131,6 +132,7 @@ class NavigationItem implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Newsletter/NewsletterSubscriber.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterSubscriber.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrameworkBundle\Model\Newsletter;
 
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
@@ -13,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'newsletter_subscribers')]
 #[ORM\UniqueConstraint(name: 'newsletter_subscribers_uni', columns: ['email', 'domain_id'])]
 #[ORM\Entity]
-class NewsletterSubscriber
+class NewsletterSubscriber implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -74,5 +76,14 @@ class NewsletterSubscriber
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    /**
+     * @return int
+     */
+    #[Override]
+    public function getDomainId()
+    {
+        return $this->domainId;
     }
 }

--- a/packages/framework/src/Model/NotificationBar/NotificationBar.php
+++ b/packages/framework/src/Model/NotificationBar/NotificationBar.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\NotificationBar;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Image\Config\Attributes\EntityImage;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -14,7 +16,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'notification_bars')]
 #[ORM\Entity]
 #[EntityImage]
-class NotificationBar
+class NotificationBar implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -114,6 +116,7 @@ class NotificationBar
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -6,7 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\EntityLogIdentify;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\ExcludeLog;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\Loggable;
@@ -34,7 +36,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[Loggable(Loggable::STRATEGY_INCLUDE_ALL)]
 #[ORM\Table(name: 'orders')]
 #[ORM\Entity]
-class Order
+class Order implements DomainSeparatedEntityInterface
 {
     public const int MAX_TRANSACTION_COUNT = 2;
 
@@ -1231,6 +1233,7 @@ class Order
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Order/PromoCode/PromoCode.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCode.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Order\PromoCode;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
@@ -12,7 +14,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'promo_codes')]
 #[ORM\UniqueConstraint(name: 'domain_code_unique', columns: ['domain_id', 'code'])]
 #[ORM\Entity]
-class PromoCode
+class PromoCode implements DomainSeparatedEntityInterface
 {
     public const int MASS_GENERATED_CODE_LENGTH = 6;
 
@@ -154,6 +156,7 @@ class PromoCode
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequest.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequest.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\PersonalData;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
 #[AsMcpTable]
 #[ORM\Table(name: 'personal_data_access_request')]
 #[ORM\Entity]
-class PersonalDataAccessRequest
+class PersonalDataAccessRequest implements DomainSeparatedEntityInterface
 {
     public const TYPE_DISPLAY = 'display';
     public const TYPE_EXPORT = 'export';
@@ -104,6 +106,7 @@ class PersonalDataAccessRequest
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/PhonePrefix/Settings/PhonePrefix.php
+++ b/packages/framework/src/Model/PhonePrefix/Settings/PhonePrefix.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\PhonePrefix\Settings;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
@@ -12,7 +14,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'phone_prefixes')]
 #[ORM\UniqueConstraint(name: 'phone_prefixes_domain_code', columns: ['domain_id', 'code'])]
 #[ORM\Entity]
-class PhonePrefix
+class PhonePrefix implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -62,6 +64,7 @@ class PhonePrefix
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/PriceList/PriceList.php
+++ b/packages/framework/src/Model/PriceList/PriceList.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrameworkBundle\Model\PriceList;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 use Symfony\Component\Clock\DatePoint;
@@ -13,7 +15,7 @@ use Symfony\Component\Clock\DatePoint;
 #[AsMcpTable]
 #[ORM\Table(name: 'price_lists')]
 #[ORM\Entity]
-class PriceList
+class PriceList implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -107,6 +109,7 @@ class PriceList
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Pricing/Group/PricingGroup.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroup.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
 #[AsMcpTable]
 #[ORM\Table(name: 'pricing_groups')]
 #[ORM\Entity]
-class PricingGroup
+class PricingGroup implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -74,6 +76,7 @@ class PricingGroup
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Pricing/Vat/Vat.php
+++ b/packages/framework/src/Model/Pricing/Vat/Vat.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing\Vat;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
 
 #[AsMcpTable]
 #[ORM\Table(name: 'vats')]
 #[ORM\Entity]
-class Vat
+class Vat implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -116,6 +118,7 @@ class Vat
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProduct.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProduct.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\BestsellingProduct;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
@@ -15,7 +17,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\UniqueConstraint(columns: ['product_id', 'category_id', 'domain_id'])]
 #[ORM\UniqueConstraint(columns: ['position', 'category_id', 'domain_id'])]
 #[ORM\Entity]
-class ManualBestsellingProduct
+class ManualBestsellingProduct implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -95,6 +97,7 @@ class ManualBestsellingProduct
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Product/GiftPlan/GiftPlan.php
+++ b/packages/framework/src/Model/Product/GiftPlan/GiftPlan.php
@@ -6,7 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\GiftPlan;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -16,7 +18,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Index(columns: ['domain_id', 'valid_from', 'valid_to'])]
 #[ORM\Index(columns: ['gift_product_id'])]
 #[ORM\Entity]
-class GiftPlan
+class GiftPlan implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -133,6 +135,7 @@ class GiftPlan
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Slider/SliderItem.php
+++ b/packages/framework/src/Model/Slider/SliderItem.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Slider;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Component\Image\Config\Attributes\EntityImage;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
@@ -21,7 +22,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[EntityImage]
 #[EntityImage('web')]
 #[EntityImage('mobile')]
-class SliderItem implements OrderableEntityInterface
+class SliderItem implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -161,6 +162,7 @@ class SliderItem implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Store/ClosedDay/ClosedDay.php
+++ b/packages/framework/src/Model/Store/ClosedDay/ClosedDay.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrameworkBundle\Model\Store\ClosedDay;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Store\Store;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -13,7 +15,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[AsMcpTable]
 #[ORM\Table(name: 'closed_days')]
 #[ORM\Entity]
-class ClosedDay
+class ClosedDay implements DomainSeparatedEntityInterface
 {
     /**
      * @var int
@@ -83,6 +85,7 @@ class ClosedDay
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Store/Store.php
+++ b/packages/framework/src/Model/Store/Store.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Override;
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Component\Image\Config\Attributes\EntityImage;
 use Shopsys\FrameworkBundle\Model\Country\Country;
@@ -21,7 +22,7 @@ use Shopsys\McpAttributes\Attribute\AsMcpTable;
 #[ORM\Table(name: 'stores')]
 #[ORM\Entity]
 #[EntityImage(multiple: true)]
-class Store implements OrderableEntityInterface
+class Store implements OrderableEntityInterface, DomainSeparatedEntityInterface
 {
     protected const GEDMO_SORTABLE_LAST_POSITION = -1;
 
@@ -373,6 +374,7 @@ class Store implements OrderableEntityInterface
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/src/Model/Watchdog/Watchdog.php
+++ b/packages/framework/src/Model/Watchdog/Watchdog.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Watchdog;
 
 use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\McpAttributes\Attribute\AsMcpColumn;
 use Shopsys\McpAttributes\Attribute\AsMcpTable;
@@ -13,7 +15,7 @@ use Symfony\Component\Clock\DatePoint;
 #[AsMcpTable]
 #[ORM\Table(name: 'watchdogs')]
 #[ORM\Entity]
-class Watchdog
+class Watchdog implements DomainSeparatedEntityInterface
 {
     protected const string VALIDITY_PERIOD = '2 years';
 
@@ -136,6 +138,7 @@ class Watchdog
     /**
      * @return int
      */
+    #[Override]
     public function getDomainId()
     {
         return $this->domainId;

--- a/packages/framework/tests/Unit/Component/Domain/AdminDomainFilterTabsFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/AdminDomainFilterTabsFacadeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Domain;
+
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+final class AdminDomainFilterTabsFacadeTest extends TestCase
+{
+    private const string NAMESPACE = 'product-reviews';
+
+    public function testSelectedDomainIdIsReturned(): void
+    {
+        $adminDomainFilterTabsFacade = $this->createAdminDomainFilterTabsFacade($session);
+        $adminDomainFilterTabsFacade->setSelectedDomainId(self::NAMESPACE, 2);
+
+        $this->assertSame(2, $adminDomainFilterTabsFacade->getSelectedDomainId(self::NAMESPACE));
+    }
+
+    public function testSelectedDomainIdWithinAllowedDomainIdsIsReturned(): void
+    {
+        $adminDomainFilterTabsFacade = $this->createAdminDomainFilterTabsFacade($session);
+        $adminDomainFilterTabsFacade->setSelectedDomainId(self::NAMESPACE, 2);
+
+        $this->assertSame(2, $adminDomainFilterTabsFacade->getSelectedDomainId(self::NAMESPACE, [1, 2]));
+    }
+
+    public function testSelectedDomainIdOutsideAllowedDomainIdsIsCleared(): void
+    {
+        $adminDomainFilterTabsFacade = $this->createAdminDomainFilterTabsFacade($session);
+        $adminDomainFilterTabsFacade->setSelectedDomainId(self::NAMESPACE, 2);
+
+        $this->assertNull($adminDomainFilterTabsFacade->getSelectedDomainId(self::NAMESPACE, [1, 3]));
+        $this->assertNull($session->get('admin_domain_filter_tabs_' . self::NAMESPACE));
+    }
+
+    public function testSelectedDomainConfigOutsideAllowedDomainIdsIsCleared(): void
+    {
+        $adminDomainFilterTabsFacade = $this->createAdminDomainFilterTabsFacade($session);
+        $adminDomainFilterTabsFacade->setSelectedDomainId(self::NAMESPACE, 2);
+
+        $this->assertNull($adminDomainFilterTabsFacade->getSelectedDomainConfig(self::NAMESPACE, [1, 3]));
+        $this->assertNull($session->get('admin_domain_filter_tabs_' . self::NAMESPACE));
+    }
+
+    public function testSelectedDomainIdOutsideAdminEnabledDomainIdsIsCleared(): void
+    {
+        $adminDomainFilterTabsFacade = $this->createAdminDomainFilterTabsFacade($session);
+        $adminDomainFilterTabsFacade->setSelectedDomainId(self::NAMESPACE, 4);
+
+        $this->assertNull($adminDomainFilterTabsFacade->getSelectedDomainId(self::NAMESPACE));
+        $this->assertNull($session->get('admin_domain_filter_tabs_' . self::NAMESPACE));
+    }
+
+    /**
+     * @param-out \Symfony\Component\HttpFoundation\Session\SessionInterface $session
+     */
+    private function createAdminDomainFilterTabsFacade(?SessionInterface &$session): AdminDomainFilterTabsFacade
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $domainStub = $this->createStub(Domain::class);
+        $domainStub->method('getAdminEnabledDomainIds')->willReturn([1, 2, 3]);
+        $domainStub->method('getDomainConfigById')->willReturnCallback(
+            static fn (int $domainId): DomainConfig => new DomainConfig(
+                $domainId,
+                'http://example.com',
+                'Domain ' . $domainId,
+                'en',
+                new DateTimeZone('UTC'),
+                'http://example.com',
+            ),
+        );
+
+        return new AdminDomainFilterTabsFacade($requestStack, $domainStub);
+    }
+}

--- a/upgrade-notes/backend_20260810_104751.md
+++ b/upgrade-notes/backend_20260810_104751.md
@@ -1,0 +1,12 @@
+#### admin: CRUD lists now support domain controls ([#4741](https://github.com/shopsys/shopsys/pull/4741))
+
+- use `CrudConfig::setListDomainControl()` to display a quick domain filter or the selected-domain switcher above a CRUD list, see [CRUD controller reference](https://docs.shopsys.com/en/latest/administration/crud-controller/reference/crud-controller/) for details
+    - the quick domain filter stores its selection under a namespace generated from the controller name; override `AbstractCrudController::getListDomainFilterNamespace()` to share the selection with another list
+- new `\Shopsys\FrameworkBundle\Component\Domain\Entity\DomainSeparatedEntityInterface` marks an entity whose every row belongs to exactly one domain — standalone framework entities with a `domainId` field now implement it
+    - implement it on your standalone project entities with a `domainId` field to benefit from the automatic domain filtering; per-domain satellite entities of a multi-domain entity (e.g. `ProductDomain`) must not implement it — filter such lists with `addListDomainIdsCondition()` in `configureQuery()`
+- CRUD lists with `setListDomainControl()` filter the list query by domain automatically when the entity implements `DomainSeparatedEntityInterface`
+    - remove manual domain conditions from `configureQuery()` in your CRUD controllers, or override `applyListDomainFilter()` to customize or opt out
+- `AdminDomainFilterTabsFacade::getSelectedDomainId()` and `getSelectedDomainConfig()` have a new optional `$allowedDomainIds` parameter — if you override these methods, add the parameter to your signature; a stored selection outside the allowed IDs is cleared and `null` is returned
+- `DomainFilterController::domainFilterTabsAction()` has a new optional `$domainIds` parameter restricting the rendered domain tabs — if you override this method, add the parameter to your signature
+- if you have overridden `@ShopsysAdministration/partial/quick_domain_filter.html.twig`, change its wrapping condition from `{% if isMultidomain() %}` to `{% if domainConfigs|length > 1 %}` so a restricted filter hides correctly
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Administrators can now filter CRUD list pages by domain. With a single line of configuration, a CRUD controller displays one of two controls above the list: the per-list quick domain filter with an "All domains" option, or the global administration domain switcher. The quick filter can additionally be limited to a subset of domains for agendas that only exist on some of them, and it always respects the domains available to the logged-in administrator — a restricted administrator never sees other domains' records, not even under "All domains".

Until now, a domain-filtered list meant a custom template and a hand-written query condition in every controller, so most CRUD lists offered no domain filtering at all. Now, entities whose records belong to exactly one domain — newly marked with `DomainSeparatedEntityInterface` (orders, stores, mail templates, newsletter subscribers, and others) — are filtered automatically without any query code, and entities related to a domain through another entity apply the same condition with a one-line helper. Both paths are covered in the CRUD controller documentation, and upgrade notes describe how projects adopt the feature.

#### Fixes issues

...

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)










<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-crud-list-domain-control.odin.shopsys.cloud
  - https://cz.mg-crud-list-domain-control.odin.shopsys.cloud
  - https://mg-crud-list-domain-control.odin.shopsys.cloud/sk
<!-- Replace -->
