### PR TITLE
No longer force installing friendsofsymfony/ckeditor-bundle from source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -261,10 +261,7 @@
         }
     },
     "config": {
-        "preferred-install": {
-            "friendsofsymfony/ckeditor-bundle": "source",
-            "*": "dist"
-        },
+        "preferred-install": "dist",
         "component-dir": "project-base/app/web/components",
         "sort-packages": true,
         "platform": {

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -171,10 +171,7 @@
     },
     "config": {
         "process-timeout": 1200,
-        "preferred-install": {
-            "friendsofsymfony/ckeditor-bundle": "source",
-            "*": "dist"
-        },
+        "preferred-install": "dist",
         "component-dir": "web/components",
         "sort-packages": true,
         "platform": {

--- a/upgrade-notes/backend_20260716_110002.md
+++ b/upgrade-notes/backend_20260716_110002.md
@@ -1,5 +1,0 @@
-#### Force installing friendsofsymfony/ckeditor-bundle from source ([#4707](https://github.com/shopsys/shopsys/pull/4707))
-
-- the `dist` archive of `friendsofsymfony/ckeditor-bundle` is broken (see [FOSCKEditorBundle#279](https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/279)), which prevents `composer install` from completing; `config.preferred-install` now forces this package to be installed from `source` as a temporary workaround
-- remove this override once the upstream package publishes a fixed release
-- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

In #4707 we had to force `friendsofsymfony/ckeditor-bundle` to be installed from `source`, because GitHub's archive service kept serving a truncated (corrupted) ZIP for version 2.8.0 and `composer install` could not finish.

The upstream issue [FOSCKEditorBundle#279](https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/279) is now closed — GitHub support repaired the cached archive and the ZIP downloads in full again (verified: 58 232 B, 73 files, valid end-of-central-directory record). The workaround is therefore removed and every dependency is installed from `dist` again, which keeps `composer install` as fast as it was before (no git clone of the bundle).

The upgrade note introduced by #4707 is deleted as well — version 20.0 has not been released yet, so no project ever saw that override and there is nothing to upgrade from.

#### Fixes issues

...

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-revert-ckeditor-source-install.odin.shopsys.cloud
  - https://cz.rv-revert-ckeditor-source-install.odin.shopsys.cloud
  - https://rv-revert-ckeditor-source-install.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1785314842.148929 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-revert-ckeditor-source-install.odin.shopsys.cloud
  - https://cz.rv-revert-ckeditor-source-install.odin.shopsys.cloud
  - https://rv-revert-ckeditor-source-install.odin.shopsys.cloud/sk
<!-- Replace -->
