### PR TITLE
Remove unused Heureka widget setting and fix disabling the API key

### DIFF
--- a/packages/framework/src/Controller/Admin/HeurekaController.php
+++ b/packages/framework/src/Controller/Admin/HeurekaController.php
@@ -41,7 +41,6 @@ class HeurekaController extends AdminBaseController
         if ($this->heurekaFacade->isDomainLocaleSupported($locale)) {
             $heurekaShopCertificationData = [
                 'heurekaApiKey' => $this->heurekaSetting->getApiKeyByDomainId($domainId),
-                'heurekaWidgetCode' => $this->heurekaSetting->getHeurekaShopCertificationWidgetByDomainId($domainId),
             ];
 
             $form = $this->createForm(HeurekaShopCertificationFormType::class, $heurekaShopCertificationData, [
@@ -53,10 +52,6 @@ class HeurekaController extends AdminBaseController
                 $heurekaShopCertificationData = $form->getData();
 
                 $this->heurekaSetting->setApiKeyForDomain($heurekaShopCertificationData['heurekaApiKey'] ?? '', $domainId);
-                $this->heurekaSetting->setHeurekaShopCertificationWidgetForDomain(
-                    $heurekaShopCertificationData['heurekaWidgetCode'] ?? '',
-                    $domainId,
-                );
 
                 $this->addSuccessFlash(t('Settings modified.'));
             }

--- a/packages/framework/src/Controller/Admin/HeurekaController.php
+++ b/packages/framework/src/Controller/Admin/HeurekaController.php
@@ -51,7 +51,7 @@ class HeurekaController extends AdminBaseController
             if ($form->isSubmitted() && $form->isValid()) {
                 $heurekaShopCertificationData = $form->getData();
 
-                $this->heurekaSetting->setApiKeyForDomain($heurekaShopCertificationData['heurekaApiKey'] ?? '', $domainId);
+                $this->heurekaSetting->setApiKeyForDomain($heurekaShopCertificationData['heurekaApiKey'], $domainId);
 
                 $this->addSuccessFlash(t('Settings modified.'));
             }

--- a/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
+++ b/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
@@ -8,7 +8,6 @@ use Override;
 use Shopsys\FormTypesBundle\ActionBarType;
 use Shopsys\FrameworkBundle\Form\GroupType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -35,10 +34,6 @@ final class HeurekaShopCertificationFormType extends AbstractType
                 ],
                 'label' => 'Code of service Heureka - Verified by Customer',
                 'help' => t('Enter 32-digit code which will be sent to server') . ' ' . $options['server_name'],
-            ])
-            ->add('heurekaWidgetCode', TextareaType::class, [
-                'required' => false,
-                'label' => 'Heureka Widget code',
             ]);
 
         $builder

--- a/packages/framework/src/Migrations/Version20260805110000.php
+++ b/packages/framework/src/Migrations/Version20260805110000.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+final class Version20260805110000 extends AbstractMigration
+{
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('DELETE FROM setting_values WHERE name = \'heurekaWidgetCode\'');
+    }
+}

--- a/packages/framework/src/Model/Heureka/HeurekaFacade.php
+++ b/packages/framework/src/Model/Heureka/HeurekaFacade.php
@@ -26,11 +26,6 @@ class HeurekaFacade
         return $this->heurekaSetting->isHeurekaShopCertificationActivated($domainId);
     }
 
-    public function isHeurekaWidgetActivated(int $domainId): bool
-    {
-        return $this->heurekaSetting->isHeurekaWidgetActivated($domainId);
-    }
-
     public function isDomainLocaleSupported(string $locale): bool
     {
         return $this->heurekaShopCertificationLocaleHelper->isDomainLocaleSupported($locale);

--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -19,7 +19,7 @@ class HeurekaSetting
         return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId);
     }
 
-    public function setApiKeyForDomain(string $apiKey, int $domainId): void
+    public function setApiKeyForDomain(?string $apiKey, int $domainId): void
     {
         $this->setting->setForDomain(static::HEUREKA_API_KEY, $apiKey, $domainId);
     }

--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -9,7 +9,6 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 class HeurekaSetting
 {
     public const HEUREKA_API_KEY = 'heurekaApiKey';
-    protected const HEUREKA_WIDGET_CODE = 'heurekaWidgetCode';
 
     public function __construct(protected readonly Setting $setting)
     {
@@ -20,28 +19,13 @@ class HeurekaSetting
         return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId);
     }
 
-    public function getHeurekaShopCertificationWidgetByDomainId(int $domainId): ?string
-    {
-        return $this->setting->getForDomain(static::HEUREKA_WIDGET_CODE, $domainId);
-    }
-
     public function setApiKeyForDomain(string $apiKey, int $domainId): void
     {
         $this->setting->setForDomain(static::HEUREKA_API_KEY, $apiKey, $domainId);
     }
 
-    public function setHeurekaShopCertificationWidgetForDomain(string $heurekaWidgetCode, int $domainId): void
-    {
-        $this->setting->setForDomain(static::HEUREKA_WIDGET_CODE, $heurekaWidgetCode, $domainId);
-    }
-
     public function isHeurekaShopCertificationActivated(int $domainId): bool
     {
         return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId) !== null;
-    }
-
-    public function isHeurekaWidgetActivated(int $domainId): bool
-    {
-        return $this->setting->getForDomain(static::HEUREKA_WIDGET_CODE, $domainId) !== null;
     }
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1771,9 +1771,6 @@ msgstr "Titulek"
 msgid "Heureka"
 msgstr "Heureka"
 
-msgid "Heureka Widget code"
-msgstr "Kód Heureka Widgetu"
-
 msgid "Hidden"
 msgstr "Skryté"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1771,9 +1771,6 @@ msgstr ""
 msgid "Heureka"
 msgstr ""
 
-msgid "Heureka Widget code"
-msgstr ""
-
 msgid "Hidden"
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -1771,9 +1771,6 @@ msgstr "Nadpis"
 msgid "Heureka"
 msgstr "Heureka"
 
-msgid "Heureka Widget code"
-msgstr "Heureka Widget kód"
-
 msgid "Hidden"
 msgstr "Skryté"
 

--- a/upgrade-notes/backend_20260805_151454.md
+++ b/upgrade-notes/backend_20260805_151454.md
@@ -1,0 +1,10 @@
+#### heureka: removed unused widget code setting ([#4752](https://github.com/shopsys/shopsys/pull/4752))
+
+- the unused `heurekaWidgetCode` setting has been removed, its values are deleted from the `setting_values` table automatically by a migration
+- the following methods and constants have been removed, if you use any of them, reimplement them in your project:
+    - `Shopsys\FrameworkBundle\Model\Heureka\HeurekaSetting::getHeurekaShopCertificationWidgetByDomainId()`
+    - `Shopsys\FrameworkBundle\Model\Heureka\HeurekaSetting::setHeurekaShopCertificationWidgetForDomain()`
+    - `Shopsys\FrameworkBundle\Model\Heureka\HeurekaSetting::isHeurekaWidgetActivated()`
+    - `Shopsys\FrameworkBundle\Model\Heureka\HeurekaSetting::HEUREKA_WIDGET_CODE`
+    - `Shopsys\FrameworkBundle\Model\Heureka\HeurekaFacade::isHeurekaWidgetActivated()`
+- the `heurekaWidgetCode` field has been removed from `Shopsys\FrameworkBundle\Form\Admin\Heureka\HeurekaShopCertificationFormType`, if you extend the form and rely on the field, add it in your project


### PR DESCRIPTION
#### Description, the reason for the PR

The Heureka widget code setting was removed from the administration. The widget code was only stored and edited, but never read anywhere — no template, storefront, or API ever used it, so administrators were maintaining a value with no effect. A migration cleans up the stored values.

This PR also fixes disabling the Heureka "Verified by Customers" integration. The integration is considered active whenever an API key is set for the domain, but clearing the field in the administration saved an empty string instead of removing the key. The integration therefore stayed active and kept sending requests with an invalid key. Now, clearing the field removes the key and the integration is properly deactivated.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-heureka-cleanup.odin.shopsys.cloud
  - https://cz.rv-heureka-cleanup.odin.shopsys.cloud
  - https://rv-heureka-cleanup.odin.shopsys.cloud/sk
<!-- Replace -->
