### PR TITLE
Prevent installation of doctrine/orm 3.6.8 that breaks migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -240,7 +240,8 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0"
+        "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0",
+        "doctrine/orm": ">=3.6.8"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -141,6 +141,9 @@
         "symfony/var-dumper": "^7.4",
         "symfony/yaml": "^7.4"
     },
+    "conflict": {
+        "doctrine/orm": ">=3.6.8"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -45,5 +45,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^12.5"
+    },
+    "conflict": {
+        "doctrine/orm": ">=3.6.8"
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

The `doctrine/orm` 3.6.8 release breaks all Doctrine schema tooling — `shopsys:migrations:migrate`, `doctrine:schema:create`, migration diff generation — with:

```
[BadMethodCallException]
The setSchema() method requires the DBAL Schema::edit() API which is not available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher.
```

ORM 3.6.8 added a `GenerateSchemaEventArgs::setSchema()` method that always throws unless `doctrine/dbal` ^4.5 is installed — which has not been released yet. The schema listeners in `symfony/doctrine-bridge` call this method based on a `method_exists()` check alone, so any schema-generating command crashes (see [doctrine/orm#12547](https://github.com/doctrine/orm/issues/12547)).

The proper fix is merged on the Symfony side ([symfony/symfony#65169](https://github.com/symfony/symfony/pull/65169)) but will only ship in `symfony/doctrine-bridge` 7.4.16. Until then, this PR marks `doctrine/orm >=3.6.8` as conflicting so Composer keeps resolving to the working 3.6.7.

The conflict is declared in `shopsys/framework` and in `shopsys/migrations` (which is usable standalone, without the framework); all other packages and project-base are protected transitively through their dependency on `shopsys/framework`.

**This conflict should be removed once `symfony/doctrine-bridge` 7.4.16 is released.**

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
<!-- SLACK_TIMESTAMP: 1786011877.386749 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-conflict-doctrine-orm-3-6-8.odin.shopsys.cloud
  - https://cz.rv-conflict-doctrine-orm-3-6-8.odin.shopsys.cloud
  - https://rv-conflict-doctrine-orm-3-6-8.odin.shopsys.cloud/sk
<!-- Replace -->
