### PR TITLE
Set auth cookies secure flag based on the domain protocol

### DIFF
--- a/project-base/storefront/cypress/e2e/authentication/login.cy.ts
+++ b/project-base/storefront/cypress/e2e/authentication/login.cy.ts
@@ -20,7 +20,7 @@ const checkRefreshCookieIsProtected = () => {
         expect(cookie).not.to.be.null;
         expect(cookie?.httpOnly).to.be.true;
         expect(cookie?.sameSite).to.equal('lax');
-        expect(cookie?.secure).to.be.true;
+        expect(cookie?.secure).to.equal(Cypress.config('baseUrl')?.startsWith('https') ?? false);
     });
     cy.window()
         .its('document.cookie')

--- a/project-base/storefront/utils/auth/removeTokensFromCookies.ts
+++ b/project-base/storefront/utils/auth/removeTokensFromCookies.ts
@@ -19,7 +19,7 @@ const deleteAuthCookie = (cookieName: string, domainConfig: DomainConfigType, co
         res: context?.res,
         path: '/',
         sameSite: 'lax',
-        secure: true,
+        secure: domainConfig.url.startsWith('https'),
     });
 };
 

--- a/project-base/storefront/utils/auth/setTokensToCookies.ts
+++ b/project-base/storefront/utils/auth/setTokensToCookies.ts
@@ -26,7 +26,7 @@ export const setTokensToCookies = (
         res: context?.res,
         path: '/',
         sameSite: 'lax',
-        secure: true,
+        secure: domainConfig.url.startsWith('https'),
     });
     setCookie(getCookieName(REFRESH_TOKEN_COOKIE_NAME, domainConfig.domainId), refreshToken, {
         httpOnly: true,
@@ -35,7 +35,7 @@ export const setTokensToCookies = (
         maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE,
         path: '/',
         sameSite: 'lax',
-        secure: true,
+        secure: domainConfig.url.startsWith('https'),
     });
     setCookie(getCookieName(REFRESH_TOKEN_PRESENT_COOKIE_NAME, domainConfig.domainId), '1', {
         httpOnly: false,
@@ -44,6 +44,6 @@ export const setTokensToCookies = (
         maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE,
         path: '/',
         sameSite: 'lax',
-        secure: true,
+        secure: domainConfig.url.startsWith('https'),
     });
 };

--- a/project-base/storefront/vitest/utils/auth/setTokensToCookies.test.ts
+++ b/project-base/storefront/vitest/utils/auth/setTokensToCookies.test.ts
@@ -8,7 +8,7 @@ vi.mock('cookies-next', () => ({
 }));
 
 describe('setTokensToCookies', () => {
-    const domainConfig = { domainId: 3 } as never;
+    const domainConfig = { domainId: 3, url: 'https://example.com' } as never;
     const context = {
         req: {} as IncomingMessage,
         res: {} as ServerResponse,

--- a/upgrade-notes/storefront_20260819_114626.md
+++ b/upgrade-notes/storefront_20260819_114626.md
@@ -1,0 +1,3 @@
+#### Set auth cookies secure flag based on the domain protocol ([#4754](https://github.com/shopsys/shopsys/pull/4754))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Logging in on the storefront did not work on domains served over plain HTTP — most notably in local development with Safari. The authentication cookies were always set with the `secure` flag, and browsers refuse to store secure cookies on an insecure connection, so the user was never actually logged in.

The `secure` flag of the access token, refresh token, and refresh-token-present cookies is now derived from the domain's configured protocol: it stays enabled on HTTPS domains and is turned off for HTTP ones, so login works in both environments.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://mg-fix-safari-https-local.odin.shopsys.cloud
  - https://cz.mg-fix-safari-https-local.odin.shopsys.cloud
  - https://mg-fix-safari-https-local.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1787133238.626049 -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-safari-https-local.odin.shopsys.cloud
  - https://cz.mg-fix-safari-https-local.odin.shopsys.cloud
  - https://mg-fix-safari-https-local.odin.shopsys.cloud/sk
<!-- Replace -->
