### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,16 @@ updates:
                 update-types: [ "version-update:semver-major" ]
         pull-request-branch-name:
             separator: "-"
+
+    -   package-ecosystem: github-actions
+        directories:
+            - "/"
+            - "/packages/*"
+            - "/project-base"
+            - "/.github/actions/*"
+        schedule:
+            interval: "weekly"
+        groups:
+            github-actions:
+                patterns:
+                    - "*"


### PR DESCRIPTION
#### Description, the reason for the PR

Add configuration for GitHub Actions dependencies in Dependabot.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
<!-- SLACK_TIMESTAMP: 1786094740.841339 -->