### PR TITLE
Add find-jira-task-by-pr agent skill

### DIFF
--- a/.agents/skills/find-jira-task-by-pr/SKILL.md
+++ b/.agents/skills/find-jira-task-by-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: find-jira-task-by-pr
+description: >
+  Find the SSP Jira issue that belongs to a pull request (given a PR number or URL) and
+  report its key details — status, sprint, assignee, and the Merge Request link. Use
+  when the user asks which Jira issue tracks a PR, or invokes /find-jira-task-by-pr.
+user_invocable: true
+version: 1.0.0
+---
+
+# Find Jira Task by PR
+
+Resolves the SSP Jira issue belonging to a pull request and reports what it found.
+Read-only — never creates, edits, or transitions anything. Requires a connected Jira
+MCP server.
+
+## MCP tool names — two servers exist
+
+Use whichever set is available:
+
+| Action       | Official Atlassian server (local) | `mcp-atlassian` / sooperset (CI) |
+| ------------ | --------------------------------- | -------------------------------- |
+| Search (JQL) | `searchJiraIssuesUsingJql`        | `jira_search`                    |
+| Read issue   | `getJiraIssue`                    | `jira_get_issue`                 |
+
+The official server additionally needs `cloudId: shopsys.atlassian.net` on every call;
+the sooperset server does not (the site is fixed by its `JIRA_URL` env).
+
+## Command Arguments
+
+- **PR reference** (required): a bare PR number, or a full PR URL for the rare case
+  the PR lives outside `shopsys/shopsys` (e.g. `https://github.com/shopsys/deployment/pull/42`).
+
+## Field reference (SSP project)
+
+| Field         | Id                  | Content                    |
+| ------------- | ------------------- | -------------------------- |
+| Sprint        | `customfield_10020` | sprint entries with state  |
+| Merge Request | `customfield_10031` | the pull request URL       |
+
+## Workflow
+
+### Step 1: Canonical PR URL
+
+A full PR URL is used as-is. A bare number always means
+`https://github.com/shopsys/shopsys/pull/<number>` — that is where the pull requests
+tracked in SSP live.
+
+### Step 2: Find the issue
+
+1. Primary lookup — exact match on the Merge Request field:
+   `project = SSP AND cf[10031] = "<PR URL>"`
+   requesting `fields: ["summary", "status", "assignee", "customfield_10020", "customfield_10031"]`.
+   Use the `=` operator — `~` is rejected on this field type.
+2. Multiple matches are possible (several issues can reference the same PR). Some
+   issues happen to carry the PR number at the end of the summary (issues created
+   ad hoc from a PR are named that way) — if one of the matches does, prefer it and
+   report the others as related; otherwise report all matches.
+3. Fallback when the field search returns nothing: those same ad-hoc-named issues can
+   exist with the Merge Request field left empty, so try
+   `project = SSP AND summary ~ "<PR number>" ORDER BY created DESC` — Jira text search
+   tokenizes, so post-filter: the summary must **end with** `#<PR number>`
+   (e.g. `… #4753` — not `#47531`).
+
+### Step 3: Report
+
+For the matched issue report: key, summary, status, assignee, sprint (name and state
+of the `customfield_10020` entries), the Merge Request link, and — always, as its own
+line — the full clickable link to the issue detail:
+`https://shopsys.atlassian.net/browse/<KEY>`. If the fields came back incomplete from
+the search, fetch the issue directly by key first.
+
+Report facts only. The PR number in the summary is just a lookup aid — never comment
+on whether a summary carries it or what kind of work the issue represents.
+
+No issue is a valid outcome — report "no Jira issue found for PR #<number>". A failing
+MCP call is a connection problem, not "not found" — report which call failed and with
+what error.


### PR DESCRIPTION
#### Description, the reason for the PR

This PR adds the `find-jira-task-by-pr` agent skill, which resolves the SSP Jira issue belonging to a given pull request (by PR number or full URL) and reports its key state — status, sprint, assignee, and the Merge Request link.

Until now, an agent asked "which Jira issue tracks this PR?" had to improvise. The skill encodes the reliable lookup: an exact match on the "Merge Request" custom field, with a summary-suffix fallback (`<PR title> #<PR number>`) for issues created without the field. It also documents the tool-name differences between the official Atlassian MCP server (used locally) and the `mcp-atlassian` server (used headless in CI), so the same skill works in both environments. This is the first building block for planned CI automations that need Jira access (e.g. an action that fixes a broken build, opens a PR, and files the matching sprint issue automatically).

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
