### PR TITLE
Add on-demand PR rebase with autosquash via GitHub Actions

### DIFF
--- a/.agents/skills/rebase-autosquash/SKILL.md
+++ b/.agents/skills/rebase-autosquash/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: rebase-autosquash
+description: >
+  Rebase a branch onto the latest base branch and apply its fixup commits
+  (git rebase --autosquash), resolving conflicts semantically along the way. Works on
+  a pull request (rebases its head branch, force-pushes with --force-with-lease only,
+  and posts a report comment) or on the currently checked-out local branch — no PR
+  needed. Verifies the result with git range-diff. Use when a PR is stale, blocked by
+  fixup commits, or conflicts with its base, when the user asks to rebase and apply
+  fixups on the current branch, or when the user invokes /rebase-autosquash. Runs
+  locally or in CI (wrapped by the rebase-pr workflow).
+user_invocable: true
+version: 1.0.0
+---
+
+# rebase-autosquash (monorepo)
+
+The rebase itself — autosquash, conflict resolution, range-diff verification — is
+authored from the project perspective as a pure-git flow. **Read the canonical:**
+
+- `project-base/.agents/skills/rebase-autosquash/SKILL.md`
+
+Then apply the monorepo delta (`.agents/skills/monorepo-vs-project/SKILL.md`). The
+monorepo (GitHub-hosted, `gh` available) adds a **PR mode** on top:
+
+## Mode selection
+
+- **PR mode** — a PR reference was given (bare number, full URL, or
+  `owner/repo#number`), or running in CI: the flow below applies.
+- **Branch mode** — no PR reference, running locally: follow the canonical on the
+  currently checked-out branch. If the branch has an open PR
+  (`gh pr view --json number,state`), adopt its base and continue as PR mode.
+  Otherwise resolve the base per the canonical, preferring
+  `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`.
+
+## PR mode — additions to the canonical
+
+### Preconditions
+
+On top of the canonical's checks, resolve the PR first:
+
+```
+gh pr view <number> --json number,state,isDraft,headRefName,baseRefName,headRepository,headRepositoryOwner,title,url
+```
+
+Abort with a clear report (no comment, no push) when the PR is not `OPEN`, or its
+head branch lives in a fork (`headRepositoryOwner` differs from the base repo
+owner) — there is nothing we can push to.
+
+### Prepare
+
+The PR dictates both branches — instead of the canonical's Step 1:
+
+```
+git fetch origin <base> <head>
+git checkout <head>            # make sure it matches origin/<head>
+```
+
+Then continue with the canonical's Steps 1–4 (everything after the fetch —
+recording `ORIG_HEAD_SHA`, nothing-to-do check, rebase, conflicts, verification)
+unchanged.
+
+### Force-push
+
+PR mode pushes without asking — that is its purpose:
+
+```
+git push --force-with-lease origin <head>
+```
+
+Only ever `--force-with-lease`, never plain `--force`. If the lease fails, someone
+updated the branch in the meantime — abort, report, and do **not** retry with a
+fresher lease without re-running the whole flow from the preconditions.
+
+This applies to local runs only — in CI the push is performed by a dedicated
+workflow step, not by Claude (see "CI wrapper" below).
+
+### Report
+
+Whenever the branch was pushed, post a PR comment (`gh pr comment`) in English
+carrying the canonical's report content (base tip, old → new head SHA, applied
+fixups, per-conflict resolutions, dropped/skipped commits), closing with a note that
+the author should review the conflict resolutions before merging (only when there
+were any). On failure in CI, post a comment explaining what blocked the rebase and
+what needs to be done manually. When run locally, additionally summarize the same
+facts in the chat.
+
+## CI wrapper
+
+`.github/workflows/rebase-pr.yaml` runs this skill via `claude-code-action` —
+triggered from the Actions tab (`workflow_dispatch` with a PR number) or by a
+`/rebase` comment on the PR (write permission required). Differences from a local
+PR-mode run:
+
+- The workflow itself hard-gates the trigger (exact `/rebase` command, commenter
+  write permission, PR open and not from a fork) before Claude starts — the skill's
+  preconditions become a second line of defense.
+- `GIT_SEQUENCE_EDITOR=:` and `GIT_EDITOR=true` are preset in the environment, so
+  plain `git rebase -i --autosquash --empty=drop origin/<base>` works without the
+  env prefix.
+- Claude neither pushes nor comments: it stops after the canonical's verification
+  and writes the report body to the file named in the prompt. A deterministic
+  workflow step then force-pushes the fixed `origin <head>` refspec (after its own
+  safety checks — clean tree, rebased onto the base, no fixup subjects left) and
+  posts the report as the PR comment.

--- a/.github/workflows/rebase-pr.yaml
+++ b/.github/workflows/rebase-pr.yaml
@@ -1,0 +1,166 @@
+name: Rebase PR with autosquash
+
+on:
+    workflow_dispatch:
+        inputs:
+            pr_number:
+                description: 'Pull request number to rebase'
+                required: true
+                type: string
+    issue_comment:
+        types: [created]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+concurrency:
+    group: rebase-pr-${{ github.event.inputs.pr_number || github.event.issue.number }}
+    cancel-in-progress: false
+
+jobs:
+    rebase:
+        name: Claude rebase with autosquash
+        if: github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && (github.event.comment.body == '/rebase' || startsWith(github.event.comment.body, '/rebase ')))
+        runs-on: ubuntu-22.04
+        timeout-minutes: 30
+        env:
+            PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.issue.number }}
+        steps:
+            -   name: Check commenter has write permission
+                id: permission
+                if: github.event_name == 'issue_comment'
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                    COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+                run: |
+                    PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${COMMENT_AUTHOR}/permission" --jq '.permission')
+                    if [ "${PERMISSION}" != "admin" ] && [ "${PERMISSION}" != "write" ]; then
+                        gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=-1 || true
+                        echo "::error::User ${COMMENT_AUTHOR} does not have write permission to trigger a rebase."
+                        exit 1
+                    fi
+
+            -   name: Ensure the PR is open and not from a fork
+                id: pr
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                run: |
+                    if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+                        echo "::error::Invalid PR number: ${PR_NUMBER}"
+                        exit 1
+                    fi
+                    PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+                    STATE=$(jq -r '.state' <<< "${PR_JSON}")
+                    HEAD_REPO=$(jq -r '.head.repo.full_name' <<< "${PR_JSON}")
+                    if [ "${STATE}" != "open" ]; then
+                        echo "::error::PR #${PR_NUMBER} is not open (state: ${STATE})."
+                        exit 1
+                    fi
+                    if [ "${HEAD_REPO}" != "${{ github.repository }}" ]; then
+                        echo "::error::PR #${PR_NUMBER} comes from a fork (${HEAD_REPO}) — its branch cannot be rebased here."
+                        exit 1
+                    fi
+                    HEAD_REF=$(jq -r '.head.ref' <<< "${PR_JSON}")
+                    BASE_REF=$(jq -r '.base.ref' <<< "${PR_JSON}")
+                    for REF in "${BASE_REF}" "${HEAD_REF}"; do
+                        if ! [[ "${REF}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+                            echo "::error::Unsafe ref name: ${REF}"
+                            exit 1
+                        fi
+                    done
+                    {
+                        echo "head_ref=${HEAD_REF}"
+                        echo "base_ref=${BASE_REF}"
+                    } >> "${GITHUB_OUTPUT}"
+
+            -   name: React to the triggering comment
+                if: github.event_name == 'issue_comment'
+                continue-on-error: true
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                run: gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
+
+            -   name: GIT checkout
+                uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
+                    persist-credentials: false
+
+            -   name: Configure git identity
+                run: |
+                    git config user.name "github-actions[bot]"
+                    git config user.email "41898024+github-actions[bot]@users.noreply.github.com"
+
+            -   name: Run Claude rebase
+                uses: anthropics/claude-code-action@v1
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                    GIT_SEQUENCE_EDITOR: ':'
+                    GIT_EDITOR: 'true'
+                with:
+                    github_token: ${{ github.token }}
+                    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                    prompt: |
+                        /rebase-autosquash ${{ github.repository }}#${{ env.PR_NUMBER }}
+
+                        You are running in CI: do NOT push and do NOT post any PR comment yourself — a follow-up workflow step force-pushes the branch and posts the report. Instead, write the report body (Markdown) to ${{ runner.temp }}/rebase-report.md. On failure, write the explanation of what blocked the rebase to the same file.
+                    claude_args: |
+                        --model claude-opus-4-8
+                        --max-turns 100
+                        --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git fetch:*),Bash(git checkout:*),Bash(git rebase -i --autosquash --empty=drop origin/${{ steps.pr.outputs.base_ref }}),Bash(git rebase --continue),Bash(git rebase --abort),Bash(git rebase --skip),Bash(git rebase --show-current-patch),Bash(git add:*),Bash(git rm:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git range-diff:*),Bash(git merge-base:*),Bash(git rev-parse:*),Bash(gh pr view:*)"
+
+            -   name: Force-push the rebased branch
+                id: push
+                env:
+                    HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+                    BASE_REF: ${{ steps.pr.outputs.base_ref }}
+                    PUSH_TOKEN: ${{ secrets.ACTIONS_GIT_PUSH_TOKEN }}
+                run: |
+                    if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
+                        echo "::error::A rebase is still in progress — not pushing."
+                        exit 1
+                    fi
+                    if [ "$(git rev-parse --abbrev-ref HEAD)" != "${HEAD_REF}" ]; then
+                        echo "Branch ${HEAD_REF} is not checked out — nothing to push."
+                        exit 0
+                    fi
+                    if [ -n "$(git status --porcelain)" ]; then
+                        echo "::error::The working tree is not clean — not pushing."
+                        exit 1
+                    fi
+                    if [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/${HEAD_REF}")" ]; then
+                        echo "Branch unchanged — nothing to push."
+                        exit 0
+                    fi
+                    if ! git merge-base --is-ancestor "origin/${BASE_REF}" HEAD; then
+                        echo "::error::HEAD is not rebased onto origin/${BASE_REF} — not pushing."
+                        exit 1
+                    fi
+                    if git log --format='%s' "origin/${BASE_REF}..HEAD" | grep -qE '^(fixup|squash|amend)!'; then
+                        echo "::error::Fixup commits remain after the rebase — not pushing."
+                        exit 1
+                    fi
+                    git config http.https://github.com/.extraheader "AUTHORIZATION: basic $(printf 'x-access-token:%s' "${PUSH_TOKEN}" | base64 -w0)"
+                    trap 'git config --unset-all http.https://github.com/.extraheader' EXIT
+                    git push --force-with-lease origin "${HEAD_REF}"
+                    echo "pushed=true" >> "${GITHUB_OUTPUT}"
+
+            -   name: Post the report comment
+                if: always() && (github.event_name == 'workflow_dispatch' || steps.permission.outcome == 'success')
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                    RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                run: |
+                    if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+                        echo "No valid PR number — skipping the comment."
+                        exit 0
+                    fi
+                    if [ -f "${RUNNER_TEMP}/rebase-report.md" ]; then
+                        gh pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" --body-file "${RUNNER_TEMP}/rebase-report.md"
+                    elif [ "${{ steps.push.outputs.pushed }}" = "true" ]; then
+                        gh pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" --body "The branch was rebased and force-pushed, but no detailed report was produced — see the run: ${RUN_URL}"
+                    elif [ "${{ job.status }}" != "success" ]; then
+                        gh pr comment "${PR_NUMBER}" --repo "${{ github.repository }}" --body "The rebase workflow failed before producing a report — see the run: ${RUN_URL}"
+                    fi

--- a/project-base/.agents/skills/rebase-autosquash/SKILL.md
+++ b/project-base/.agents/skills/rebase-autosquash/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: rebase-autosquash
+description: >
+  Rebase the currently checked-out branch onto the latest tip of its base branch and
+  apply its fixup commits (git rebase --autosquash), resolving conflicts semantically
+  along the way. Verifies the result with git range-diff; pushing is left to the user.
+  Use when the branch is stale, carries fixup commits, or conflicts with its base,
+  when the user asks to rebase and apply fixups, or when the user invokes
+  /rebase-autosquash.
+user_invocable: true
+version: 1.0.0
+---
+
+# Rebase with Autosquash
+
+Brings the current branch up to date in one pass: rebases it onto the current tip of
+its base branch, squashes `fixup!`/`squash!`/`amend!` commits into their targets, and
+resolves conflicts. The goal is a branch that is identical in content to the original
+plus the base updates — nothing more.
+
+This is a **pure-git flow** — it needs no hosting CLI, so it works the same whether
+the project's merge/pull requests live on GitLab or GitHub.
+
+## Command Arguments
+
+- **base branch** (optional): the branch to rebase onto.
+
+## Base branch resolution
+
+1. An explicit base argument wins.
+2. Otherwise use the remote's default branch:
+   `git symbolic-ref --short refs/remotes/origin/HEAD` (run
+   `git remote set-head origin --auto` first if the ref is not set).
+3. Never hardcode a branch name — default branches change over time.
+
+## Preconditions — verify before touching anything
+
+Abort with a clear report when:
+
+- the working tree is not clean — never stash or discard the user's work,
+- the current branch **is** the resolved base branch — there is nothing to rebase.
+
+## Workflow
+
+### Step 1: Prepare
+
+```
+git fetch origin <base>
+ORIG_HEAD_SHA=$(git rev-parse HEAD)
+git rev-parse origin/<base>
+```
+
+Record both SHAs — they go into the final report and the range-diff verification.
+
+If the branch is already based on the tip of `origin/<base>` **and** contains no
+`fixup!`/`squash!`/`amend!` commits, there is nothing to do — report that and stop.
+
+### Step 2: Rebase with autosquash
+
+```
+GIT_SEQUENCE_EDITOR=: GIT_EDITOR=true git rebase -i --autosquash --empty=drop origin/<base>
+```
+
+- `GIT_SEQUENCE_EDITOR=:` accepts the generated todo list (with fixups already moved
+  into place) without opening an editor; `GIT_EDITOR=true` accepts commit messages the
+  same way.
+- `--empty=drop` silently drops commits whose changes already landed in the base —
+  list any dropped commits in the report.
+- Never edit the todo list beyond what `--autosquash` generates: no reordering, no
+  dropping, no rewording.
+
+### Step 3: Resolve conflicts
+
+When the rebase stops on a conflict:
+
+1. Identify the commit being applied (`git status`, `git rebase --show-current-patch`)
+   and read its message — it states the intent of the change.
+2. For each conflicted file, read the conflict markers **and** enough surrounding code
+   to understand both sides: what the commit wanted to change vs. how the base evolved
+   (`git log origin/<base> -- <file>` helps for the base side).
+3. Resolve so that **both intents survive**. Blanket strategies (`-X ours`,
+   `-X theirs`, checking out one side wholesale) are forbidden — every hunk gets an
+   informed decision.
+4. Handle modify/delete and rename conflicts explicitly: figure out where the code
+   moved and apply the change there.
+5. `git rebase --skip` is allowed only when the commit's change verifiably already
+   exists in the base (check with `git log`/`git show`) — note it in the report.
+6. Stage the resolved files and `git rebase --continue`.
+7. Keep a per-conflict note (file, commit, one-line description of the resolution)
+   for the report.
+
+If the rebase cannot be completed safely, `git rebase --abort`, leave the branch
+untouched, and report why.
+
+### Step 4: Verify
+
+All checks must pass before declaring success:
+
+- The rebase finished and the working tree is clean (`git status`).
+- No `fixup!`/`squash!`/`amend!` subjects remain in
+  `git log --format='%s' origin/<base>..HEAD`. Also skim the final commit messages —
+  a squashed `squash!` commit can leave its marker line in a message body; amend it
+  away if it does.
+- `git range-diff origin/<base> ${ORIG_HEAD_SHA} HEAD` — every difference must be
+  explained by (a) the base update itself, (b) a squashed fixup, (c) a conflict
+  resolution from Step 3, or (d) a dropped already-applied commit. Anything else means
+  the rebase went wrong — investigate before reporting success.
+
+### Step 5: Pushing stays with the user
+
+Do **not** push unless the user explicitly asked for it. When they did, push with
+`--force-with-lease` only — never plain `--force`; if the lease fails, someone updated
+the branch in the meantime — stop and report instead of retrying. The original commits
+stay reachable via `ORIG_HEAD_SHA`/reflog either way, so the rebase is recoverable.
+
+### Step 6: Report
+
+Summarize for the user in the chat:
+
+- the base tip the branch was rebased onto (branch + short SHA),
+- previous head SHA → new head SHA,
+- how many fixup/squash commits were applied and into which commits,
+- each resolved conflict: file, commit, one line on how it was resolved,
+- any dropped (already-applied) or skipped commits,
+- whether the branch was pushed (and if not, that pushing — typically with
+  `--force-with-lease` — is the user's next step).


### PR DESCRIPTION
#### Description, the reason for the PR

An approved pull request often cannot be merged right away because its branch has fallen behind the base branch, still carries `fixup!` commits (which the *Block fixup commits* check rejects), or conflicts with the base. Until now the author had to check the branch out locally, run the interactive rebase, resolve conflicts, and force-push by hand.

This PR makes that whole routine runnable directly from GitHub. A new `rebase-pr` workflow can be triggered either from the Actions tab (`workflow_dispatch` with a PR number) or by commenting `/rebase` on the pull request (restricted to users with write permission; the workflow also verifies the PR is open and not from a fork before touching anything). It runs Claude with the new `rebase-autosquash` agent skill, which rebases the branch onto the current tip of its base branch, applies fixup commits via `git rebase --autosquash`, resolves conflicts while preserving the intent of both sides, and verifies the result with `git range-diff`. The force-push itself is not in Claude's hands: a deterministic workflow step pushes the branch — always with `--force-with-lease`, never a plain force push — after its own safety checks, and posts Claude's report as a PR comment summarizing what was rebased and how each conflict was resolved, so the author can review the resolutions before merging.

The branch is pushed with `ACTIONS_GIT_PUSH_TOKEN`, so the regular CI checks run on the rebased head as they would after a manual push. The skill can also be invoked locally in Claude Code — either as `/rebase-autosquash <PR>`, or with no PR at all ("rebase this branch and apply the fixups"): it then works on the currently checked-out branch, resolves the base itself, and leaves pushing to the user.

The rebase flow itself is pure git with no hosting-CLI dependency, so its canonical version lives in `project-base/.agents/skills/` and ships to downstream projects — usable locally there as well, even when their merge requests live on GitLab. The monorepo keeps a thin wrapper (the established stub pattern) that adds the GitHub-specific PR mode and the CI integration.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
