### PR TITLE
TEST: rebase-autosquash workflow dry run — do not merge

### DIFF
--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -21,6 +21,12 @@ class HeurekaSetting
 
     public function setApiKeyForDomain(?string $apiKey, int $domainId): void
     {
+        $apiKey = trim($apiKey);
+
+        if ($apiKey === '') {
+            $apiKey = null;
+        }
+
         $this->setting->setForDomain(static::HEUREKA_API_KEY, $apiKey, $domainId);
     }
 

--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -30,6 +30,9 @@ class HeurekaSetting
         $this->setting->setForDomain(static::HEUREKA_API_KEY, $apiKey, $domainId);
     }
 
+    /**
+     * Certification is considered active as soon as a non-null API key is set for the domain.
+     */
     public function isHeurekaShopCertificationActivated(int $domainId): bool
     {
         return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId) !== null;


### PR DESCRIPTION
#### Description, the reason for the PR

**Test PR for the `rebase-pr` workflow (#4768) — do not merge.**

The branch is intentionally based on an outdated `20.0` (before the Heureka widget removal and the nullable API key change), carries two `fixup!` commits, and both regular commits touch lines that changed on `20.0` in the meantime — so a `/rebase` comment should exercise the whole flow: autosquash, two conflicting hunks (a modify/modify on `setApiKeyForDomain()` and a docblock added to a method that was removed upstream), verification, force-push by the workflow step, and the report comment.

This PR will be closed after the test.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-test-rebase-autosquash.odin.shopsys.cloud
  - https://cz.rv-test-rebase-autosquash.odin.shopsys.cloud
  - https://rv-test-rebase-autosquash.odin.shopsys.cloud/sk
<!-- Replace -->
