### PR TITLE
Pin @tabler/core to version 1.4.0

### DIFF
--- a/packages/administration/assets/package.json
+++ b/packages/administration/assets/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@melloware/coloris": "^0.25.0",
-        "@tabler/core": "^1.2.0",
+        "@tabler/core": "1.4.0",
         "autosize": "^6.0.1",
         "bazinga-translator": "^8.0.0",
         "bootstrap": "^5.3.8",

--- a/packages/framework/assets/package.json
+++ b/packages/framework/assets/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@melloware/coloris": "^0.25.0",
-        "@tabler/core": "^1.2.0",
+        "@tabler/core": "1.4.0",
         "bazinga-translator": "^8.0.0",
         "chart.js": "^4.5.1",
         "flatpickr": "^4.6.13",


### PR DESCRIPTION
#### Description, the reason for the PR

This PR pins the tabler/core dependency to the exact version `1.4.0` in both the administration and framework asset packages. The upcoming Tabler 1.5.0 release is expected to contain backward incompatible changes, so locking the version now keeps the administration appearance stable and lets us upgrade deliberately, in a separate PR where the impact can be reviewed and tested.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-pin-tabler.odin.shopsys.cloud
  - https://cz.mg-pin-tabler.odin.shopsys.cloud
  - https://mg-pin-tabler.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1786623411.193929 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-pin-tabler.odin.shopsys.cloud
  - https://cz.mg-pin-tabler.odin.shopsys.cloud
  - https://mg-pin-tabler.odin.shopsys.cloud/sk
<!-- Replace -->
