### PR TITLE
Allow doctrine/orm 3.6.8 now that symfony/doctrine-bridge is fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,6 +167,7 @@
         "symfony/clock": "^7.4",
         "symfony/console": "^7.4",
         "symfony/css-selector": "^7.4",
+        "symfony/doctrine-bridge": "^7.4.16",
         "symfony/doctrine-messenger": "^7.4",
         "symfony/dom-crawler": "^7.4",
         "symfony/dotenv": "^7.4",
@@ -240,8 +241,7 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0",
-        "doctrine/orm": ">=3.6.8"
+        "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -99,6 +99,7 @@
         "symfony/intl": "^7.4",
         "symfony/clock": "^7.4",
         "symfony/css-selector": "^7.4",
+        "symfony/doctrine-bridge": "^7.4.16",
         "symfony/doctrine-messenger": "^7.4",
         "symfony/dom-crawler": "^7.4",
         "symfony/error-handler": "^7.4",
@@ -140,9 +141,6 @@
         "symfony/process": "^7.4",
         "symfony/var-dumper": "^7.4",
         "symfony/yaml": "^7.4"
-    },
-    "conflict": {
-        "doctrine/orm": ">=3.6.8"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -47,6 +47,6 @@
         "phpunit/phpunit": "^12.5"
     },
     "conflict": {
-        "doctrine/orm": ">=3.6.8"
+        "symfony/doctrine-bridge": "<7.4.16"
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

`symfony/doctrine-bridge` 7.4.16 has been released with the fix for the schema tooling crash caused by `doctrine/orm` 3.6.8 ([symfony/symfony#65169](https://github.com/symfony/symfony/pull/65169)), so the temporary blockade of `doctrine/orm >=3.6.8` introduced in #4753 is no longer needed — projects can now safely receive the latest ORM patch releases again.

The bridge turns out to be a hidden direct dependency of `shopsys/framework` (`ToggleableDebugDataHolder` extends the bridge's `DebugDataHolder`), so instead of keeping conflict entries, the framework (and the monorepo root) now declare `symfony/doctrine-bridge ^7.4.16` as a regular requirement with the fixed version as the floor. This both removes the reliance on getting the bridge transitively and guarantees that a downstream project updating only `doctrine/orm` cannot end up with the broken combination (ORM ≥3.6.8 together with bridge ≤7.4.15) that made `shopsys:migrations:migrate`, `doctrine:schema:create`, and migration diff generation fail with `BadMethodCallException`.

`shopsys/migrations` does not use the bridge directly, so it keeps a `conflict` on `symfony/doctrine-bridge <7.4.16` instead of requiring it — the bridge always arrives transitively through `doctrine/doctrine-bundle` there, and the conflict only rules out the broken versions when it is installed.

Verified in the monorepo: with `doctrine/orm` 3.6.8 and `symfony/doctrine-bridge` 7.4.16 installed, `doctrine:schema:validate` generates the schema without the previous `BadMethodCallException`.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-allow-doctrine-orm-3-6-8.odin.shopsys.cloud
  - https://cz.rv-allow-doctrine-orm-3-6-8.odin.shopsys.cloud
  - https://rv-allow-doctrine-orm-3-6-8.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1786625449.602859 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-allow-doctrine-orm-3-6-8.odin.shopsys.cloud
  - https://cz.rv-allow-doctrine-orm-3-6-8.odin.shopsys.cloud
  - https://rv-allow-doctrine-orm-3-6-8.odin.shopsys.cloud/sk
<!-- Replace -->
