### PR TITLE
Fix navigation for articles of type link

### DIFF
--- a/project-base/storefront/components/Layout/Footer/FooterMenuItem.tsx
+++ b/project-base/storefront/components/Layout/Footer/FooterMenuItem.tsx
@@ -80,14 +80,18 @@ const FooterMenuItemTitle: FC<{ title: string }> = ({ title }) => {
 };
 
 const FooterMenuItemLink: FC<{ item: TypeSimpleNotBlogArticleFragment }> = ({ item }) => {
+    // ArticleLink can point to any URL (product, category, external site, ...), so it must not be
+    // routed as an article detail page and has to go through the friendly URL resolution instead
+    const isArticleSite = item.__typename === 'ArticleSite';
+
     return (
         <ExtendedNextLink
             className="block font-secondary font-semibold text-sm text-text-default tracking-wider no-underline hover:text-text-default hover:underline"
-            href={item.__typename === 'ArticleSite' ? item.slug : item.url}
+            href={isArticleSite ? item.slug : item.url}
             rel={item.external ? 'nofollow noreferrer noopener' : undefined}
-            skeletonType="article"
+            skeletonType={isArticleSite ? 'article' : undefined}
             target={item.external ? '_blank' : undefined}
-            type="article"
+            type={isArticleSite ? 'article' : undefined}
         >
             {item.name}
         </ExtendedNextLink>

--- a/project-base/storefront/middleware.ts
+++ b/project-base/storefront/middleware.ts
@@ -34,7 +34,7 @@ export const middleware: NextMiddleware = async (request) => {
             return staticRouteResponse;
         }
 
-        const slugTypeResponse = handleSlugTypeQueryParam(search, request.url, currentLocale);
+        const slugTypeResponse = handleSlugTypeQueryParam(search, request.url, currentLocale, pathname);
 
         if (slugTypeResponse) {
             return slugTypeResponse;

--- a/project-base/storefront/utils/middleware/friendlyUrlHandlers.ts
+++ b/project-base/storefront/utils/middleware/friendlyUrlHandlers.ts
@@ -8,9 +8,16 @@ export const handleSlugTypeQueryParam = (
     search: string,
     requestUrl: string,
     currentLocale: string | undefined,
+    pathname: string,
 ): NextResponse | null => {
     const queryParams = new URLSearchParams(search);
     const slugTypeQueryParam = queryParams.get('slugType');
+
+    // the slugType param can be carried over to the error page route when a friendly URL page fails,
+    // in which case it must not rewrite the error page back to the dynamic page (e.g. querying slug "404")
+    if (isErrorPagePath(pathname)) {
+        return null;
+    }
 
     if (slugTypeQueryParam && isFriendlyPageTypesValue(slugTypeQueryParam)) {
         return rewriteDynamicPages(slugTypeQueryParam as FriendlyPageTypesValue, requestUrl, search, currentLocale);
@@ -107,6 +114,9 @@ const createErrorResponse = (statusCode: number, request: NextRequest): NextResp
 };
 
 const isInRange = (number: number, start: number, end: number): boolean => number >= start && number <= end;
+
+// pathname comes normalized without the leading slash and may be prefixed with a locale (e.g. "sk/404")
+const isErrorPagePath = (pathname: string): boolean => `/${pathname}`.endsWith(ERROR_PAGE_ROUTE);
 
 function isFriendlyPageTypesValue(value: string): value is FriendlyPageTypesValue {
     return Object.values(FriendlyPagesTypes).includes(value as FriendlyPageTypesValue);

--- a/upgrade-notes/storefront_20260816_115529.md
+++ b/upgrade-notes/storefront_20260816_115529.md
@@ -1,0 +1,6 @@
+#### Fix navigation for articles of type link ([#4776](https://github.com/shopsys/shopsys/pull/4776))
+
+- footer menu items for articles of type link (`ArticleLink`) are no longer client-side routed as article detail pages — `type="article"` is passed to `ExtendedNextLink` only for `ArticleSite` items, so the target URL goes through friendly URL resolution and resolves to the correct page type (product, category, ...)
+- if your project customizes `FooterMenuItem` or renders `ArticleLink` items elsewhere with `type="article"`, apply the same change to avoid 500/404 errors when the link points to a non-article URL
+- storefront middleware `handleSlugTypeQueryParam()` now receives the normalized `pathname` and skips the `slugType` rewrite for the error page route (`/404`), so a leftover `slugType` query parameter can no longer rewrite the error page back to a dynamic page (which previously caused a nonsensical `ArticleDetailQuery` with `urlSlug: "404"`); if you override the storefront middleware, port this guard
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Clicking an article of type "link" on the storefront (when "open in new window" was disabled) ended with a 500 error instead of opening the link target.

The footer menu routed every article as an article detail page, even articles of type "link" whose URL can point anywhere — a product, a category, or an external site. The navigation therefore skipped friendly URL resolution and tried to load the target URL as an article, which failed. Links opening in a new window were unaffected, because a new tab always performs a full page load with proper URL resolution — which is also why the bug only appeared with "open in new window" disabled.

Now articles of type "link" navigate through the standard friendly URL resolution, so customers land on the correct page regardless of where the link points. As a follow-up hardening, the error page can no longer be misinterpreted as a content page when a navigation fails (previously visible as a nonsensical article request for slug "404").

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-fix-link-footer.odin.shopsys.cloud
  - https://cz.mg-fix-link-footer.odin.shopsys.cloud
  - https://mg-fix-link-footer.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1787129066.335919 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-link-footer.odin.shopsys.cloud
  - https://cz.mg-fix-link-footer.odin.shopsys.cloud
  - https://mg-fix-link-footer.odin.shopsys.cloud/sk
<!-- Replace -->
