### PR TITLE
Protect CSV exports against formula injection

### DIFF
--- a/packages/framework/src/Component/Csv/CsvHelper.php
+++ b/packages/framework/src/Component/Csv/CsvHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Csv;
+
+final class CsvHelper
+{
+    // mirrors the private CsvEncoder::FORMULAS_START_CHARACTERS used by the export to escape the values
+    private const array FORMULA_TRIGGER_CHARACTERS = ['=', '-', '+', '@', "\t", "\r", "\n"];
+
+    /**
+     * Removes the apostrophe that the CSV export prepends to values that spreadsheet software would evaluate as formulas
+     */
+    public static function unescapeFormula(string $value): string
+    {
+        if (str_starts_with($value, "'") && in_array(substr($value, 1, 1), self::FORMULA_TRIGGER_CHARACTERS, true)) {
+            return substr($value, 1);
+        }
+
+        return $value;
+    }
+}

--- a/packages/framework/src/Component/HttpFoundation/CsvResponse.php
+++ b/packages/framework/src/Component/HttpFoundation/CsvResponse.php
@@ -16,7 +16,7 @@ class CsvResponse extends Response
     public function __construct(array $data, string $fileName, ?array $csvHeaders = null)
     {
         $csvEncoder = new CsvEncoder();
-        $context = [];
+        $context = [CsvEncoder::ESCAPE_FORMULAS_KEY => true];
 
         if ($csvHeaders !== null) {
             $context[CsvEncoder::HEADERS_KEY] = $csvHeaders;

--- a/packages/framework/src/Component/HttpFoundation/CsvResponse.php
+++ b/packages/framework/src/Component/HttpFoundation/CsvResponse.php
@@ -9,13 +9,17 @@ use Symfony\Component\Serializer\Encoder\CsvEncoder;
 
 class CsvResponse extends Response
 {
+    /**
+     * @param array<int, array<string, mixed>> $data
+     * @param array<array-key, string>|null $csvHeaders
+     */
     public function __construct(array $data, string $fileName, ?array $csvHeaders = null)
     {
         $csvEncoder = new CsvEncoder();
         $context = [];
 
-        if ($csvHeaders === null) {
-            $context = [CsvEncoder::HEADERS_KEY => $csvHeaders];
+        if ($csvHeaders !== null) {
+            $context[CsvEncoder::HEADERS_KEY] = $csvHeaders;
         }
 
         $content = $csvEncoder->encode($data, CsvEncoder::FORMAT, $context);

--- a/packages/framework/src/Component/HttpFoundation/StreamedCsvResponse.php
+++ b/packages/framework/src/Component/HttpFoundation/StreamedCsvResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+
+class StreamedCsvResponse extends StreamedResponse
+{
+    /**
+     * Rows are encoded one by one so that large exports do not have to be held in memory,
+     * the columns of the first row therefore define the columns of the whole export
+     *
+     * @param iterable<array<string, mixed>> $data
+     */
+    public function __construct(
+        iterable $data,
+        string $fileName,
+        string $delimiter = ',',
+        bool $withHeaderRow = true,
+    ) {
+        parent::__construct(static function () use ($data, $delimiter, $withHeaderRow): void {
+            $csvEncoder = new CsvEncoder();
+            $csvHeaders = null;
+
+            foreach ($data as $row) {
+                $isFirstRow = $csvHeaders === null;
+                $csvHeaders ??= array_keys($row);
+
+                echo $csvEncoder->encode([$row], CsvEncoder::FORMAT, [
+                    CsvEncoder::DELIMITER_KEY => $delimiter,
+                    CsvEncoder::ESCAPE_FORMULAS_KEY => true,
+                    CsvEncoder::HEADERS_KEY => $csvHeaders,
+                    CsvEncoder::NO_HEADERS_KEY => !$withHeaderRow || !$isFirstRow,
+                ]);
+            }
+        });
+
+        $this->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $this->headers->set('Content-Disposition', 'attachment; filename="' . $fileName . '"');
+    }
+}

--- a/packages/framework/src/Controller/Admin/NewsletterController.php
+++ b/packages/framework/src/Controller/Admin/NewsletterController.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSourceFactory;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\StreamedCsvResponse;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanView;
@@ -16,10 +17,8 @@ use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData;
 use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormType;
 use Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade;
 use Shopsys\FrameworkBundle\Model\Newsletter\NewsletterSubscriberNotFoundException;
-use SplFileObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[ForRole(AdminRoleConstant::ROLE_NEWSLETTER)]
@@ -94,29 +93,12 @@ class NewsletterController extends AdminBaseController
 
     #[Route(path: '/newsletter/export-csv/')]
     #[CanView]
-    public function exportAction(): StreamedResponse
+    public function exportAction(): StreamedCsvResponse
     {
-        $response = new StreamedResponse();
-        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
-        $response->headers->set('Content-Disposition', 'attachment; filename="emails.csv"');
-        $response->setCallback(function (): void {
-            $this->streamCsvExport($this->adminDomainTabsFacade->getSelectedDomainId());
-        });
+        $emailsDataIterator = $this->newsletterFacade->getAllEmailsDataIteratorByDomainId(
+            $this->adminDomainTabsFacade->getSelectedDomainId(),
+        );
 
-        return $response;
-    }
-
-    protected function streamCsvExport(int $domainId): void
-    {
-        $output = new SplFileObject('php://output', 'w+');
-
-        $emailsDataIterator = $this->newsletterFacade->getAllEmailsDataIteratorByDomainId($domainId);
-
-        foreach ($emailsDataIterator as $emailData) {
-            $email = $emailData['email'];
-            $createdAt = $emailData['createdAt'];
-            $fields = [$email, $createdAt];
-            $output->fputcsv($fields, ';', '"', '\\');
-        }
+        return new StreamedCsvResponse($emailsDataIterator, 'emails.csv', ';', false);
     }
 }

--- a/packages/framework/src/Model/Newsletter/NewsletterFacade.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterFacade.php
@@ -36,7 +36,7 @@ class NewsletterFacade
     }
 
     /**
-     * @return iterable<array{email: string, createdAt: \DateTimeInterface}>
+     * @return iterable<array{email: string, createdAt: string}>
      */
     public function getAllEmailsDataIteratorByDomainId(int $domainId): iterable
     {

--- a/packages/framework/src/Model/Newsletter/NewsletterRepository.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterRepository.php
@@ -36,7 +36,7 @@ class NewsletterRepository
     }
 
     /**
-     * @return iterable<array{email: string, createdAt: \DateTimeInterface}>
+     * @return iterable<array{email: string, createdAt: string}>
      */
     public function getAllEmailsDataIteratorByDomainId(int $domainId): iterable
     {

--- a/packages/framework/src/Model/PriceList/PriceListFacade.php
+++ b/packages/framework/src/Model/PriceList/PriceListFacade.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\PriceList;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use League\Flysystem\MountManager;
+use Shopsys\FrameworkBundle\Component\Csv\CsvHelper;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
@@ -264,8 +265,18 @@ class PriceListFacade
         return ',';
     }
 
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
     protected function preProcessCsvRow(array $row): array
     {
+        foreach ($row as $columnName => $value) {
+            if (is_string($value)) {
+                $row[$columnName] = CsvHelper::unescapeFormula($value);
+            }
+        }
+
         if (!array_key_exists(PriceListCsvColumnsEnum::PRICE, $row)) {
             return $row;
         }

--- a/packages/framework/tests/Unit/Component/HttpFoundation/CsvResponseTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/CsvResponseTest.php
@@ -37,6 +37,25 @@ class CsvResponseTest extends TestCase
         $this->assertSame("product_catnum,price\n500A,99.9\n", $response->getContent());
     }
 
+    public function testValuesEvaluatedAsFormulasAreEscaped(): void
+    {
+        $response = new CsvResponse(
+            [
+                [
+                    'product_catnum' => '-500A',
+                    'price' => '99.9',
+                ],
+                [
+                    'product_catnum' => '=SUM(A1:A9)',
+                    'price' => '10',
+                ],
+            ],
+            'export.csv',
+        );
+
+        $this->assertSame("product_catnum,price\n'-500A,99.9\n'=SUM(A1:A9),10\n", $response->getContent());
+    }
+
     public function testResponseHeaders(): void
     {
         $response = new CsvResponse(self::EXPORT_DATA, 'export.csv');

--- a/packages/framework/tests/Unit/Component/HttpFoundation/CsvResponseTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/CsvResponseTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\HttpFoundation;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\CsvResponse;
+
+class CsvResponseTest extends TestCase
+{
+    /**
+     * @var array<int, array<string, string>>
+     */
+    private const array EXPORT_DATA = [
+        [
+            'product_catnum' => '500A',
+            'price' => '99.9',
+        ],
+    ];
+
+    public function testProvidedCsvHeadersDefineTheColumnOrder(): void
+    {
+        $response = new CsvResponse(
+            self::EXPORT_DATA,
+            'export.csv',
+            ['PRICE' => 'price', 'PRODUCT_CATNUM' => 'product_catnum'],
+        );
+
+        $this->assertSame("price,product_catnum\n99.9,500A\n", $response->getContent());
+    }
+
+    public function testCsvHeadersAreDerivedFromRowKeysWhenNotProvided(): void
+    {
+        $response = new CsvResponse(self::EXPORT_DATA, 'export.csv');
+
+        $this->assertSame("product_catnum,price\n500A,99.9\n", $response->getContent());
+    }
+
+    public function testResponseHeaders(): void
+    {
+        $response = new CsvResponse(self::EXPORT_DATA, 'export.csv');
+
+        $this->assertSame('text/csv', $response->headers->get('Content-Type'));
+        $this->assertSame('attachment; filename="export.csv"', $response->headers->get('Content-Disposition'));
+    }
+}

--- a/packages/framework/tests/Unit/Component/HttpFoundation/StreamedCsvResponseTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/StreamedCsvResponseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\HttpFoundation;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\StreamedCsvResponse;
+
+class StreamedCsvResponseTest extends TestCase
+{
+    public function testValuesEvaluatedAsFormulasAreEscaped(): void
+    {
+        $response = new StreamedCsvResponse(
+            $this->createDataIterator(),
+            'emails.csv',
+            ';',
+            false,
+        );
+
+        $this->assertSame(
+            "'=1+1@evil.com;\"2026-08-14 12:00:00\"\n" .
+            "john.doe@example.com;\"2026-08-14 12:00:00\"\n",
+            $this->getStreamedContent($response),
+        );
+    }
+
+    public function testHeaderRowIsStreamedOnlyOnce(): void
+    {
+        $response = new StreamedCsvResponse($this->createDataIterator(), 'emails.csv');
+
+        $this->assertSame(
+            "email,createdAt\n" .
+            "'=1+1@evil.com,\"2026-08-14 12:00:00\"\n" .
+            "john.doe@example.com,\"2026-08-14 12:00:00\"\n",
+            $this->getStreamedContent($response),
+        );
+    }
+
+    public function testColumnsOfTheFirstRowDefineTheColumnsOfTheWholeExport(): void
+    {
+        $data = [
+            [
+                'email' => 'john.doe@example.com',
+                'createdAt' => '2026-08-14',
+            ],
+            [
+                'createdAt' => '2026-08-15',
+                'email' => 'jane.doe@example.com',
+            ],
+            [
+                'email' => 'no.date@example.com',
+            ],
+        ];
+
+        $response = new StreamedCsvResponse($data, 'emails.csv');
+
+        $this->assertSame(
+            "email,createdAt\n" .
+            "john.doe@example.com,2026-08-14\n" .
+            "jane.doe@example.com,2026-08-15\n" .
+            "no.date@example.com,\n",
+            $this->getStreamedContent($response),
+        );
+    }
+
+    public function testResponseHeaders(): void
+    {
+        $response = new StreamedCsvResponse($this->createDataIterator(), 'emails.csv');
+
+        $this->assertSame('text/csv; charset=utf-8', $response->headers->get('Content-Type'));
+        $this->assertSame('attachment; filename="emails.csv"', $response->headers->get('Content-Disposition'));
+    }
+
+    /**
+     * @return \Generator<array{email: string, createdAt: string}>
+     */
+    private function createDataIterator(): Generator
+    {
+        yield [
+            'email' => '=1+1@evil.com',
+            'createdAt' => '2026-08-14 12:00:00',
+        ];
+
+        yield [
+            'email' => 'john.doe@example.com',
+            'createdAt' => '2026-08-14 12:00:00',
+        ];
+    }
+
+    private function getStreamedContent(StreamedCsvResponse $response): string
+    {
+        ob_start();
+        $response->sendContent();
+
+        return ob_get_clean();
+    }
+}

--- a/packages/framework/tests/Unit/Model/PriceList/PriceListFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/PriceList/PriceListFacadeTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\PriceList;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Csv\CsvHelper;
+use Symfony\Component\Serializer\Encoder\CsvEncoder;
+
+class PriceListFacadeTest extends TestCase
+{
+    /**
+     * The list of characters CsvEncoder escapes by is private and may change with any Symfony release,
+     * so this test derives the escaping from the encoder itself instead of repeating the list
+     */
+    #[DataProvider('exportedValueDataProvider')]
+    public function testUnescapeFormulaIsInverseToCsvEncoderEscaping(string $value): void
+    {
+        $this->assertSame($value, CsvHelper::unescapeFormula($this->exportValue($value)));
+    }
+
+    /**
+     * @return iterable<string, array{value: string}>
+     */
+    public static function exportedValueDataProvider(): iterable
+    {
+        foreach (range(1, 127) as $characterCode) {
+            yield sprintf('value starting with the character 0x%02X', $characterCode) => [
+                'value' => chr($characterCode) . '500A',
+            ];
+        }
+
+        yield 'formula hidden behind a leading space' => [
+            'value' => ' =1+1',
+        ];
+
+        yield 'formula hidden behind a leading non-breaking space' => [
+            'value' => "\u{00A0}=1+1",
+        ];
+
+        yield 'formula hidden behind a leading zero-width no-break space' => [
+            'value' => "\u{FEFF}=1+1",
+        ];
+
+        yield 'common value' => [
+            'value' => '500A',
+        ];
+
+        yield 'empty value' => [
+            'value' => '',
+        ];
+    }
+
+    /**
+     * A cell holding an apostrophe followed by a formula trigger character cannot be told apart from an escaped
+     * value, so it is read as escaped — a value that really starts with an apostrophe loses it on import
+     */
+    public function testApostropheIsRemovedFromValueThatCannotBeToldApartFromAnEscapedOne(): void
+    {
+        $this->assertSame('=1+1', CsvHelper::unescapeFormula("'=1+1"));
+    }
+
+    /**
+     * Returns the value as the CSV export writes it into the file
+     */
+    private function exportValue(string $value): string
+    {
+        $csvEncoder = new CsvEncoder();
+        $data = [['value' => $value]];
+        $context = [CsvEncoder::NO_HEADERS_KEY => true];
+
+        $escapedCsv = $csvEncoder->encode($data, CsvEncoder::FORMAT, $context + [CsvEncoder::ESCAPE_FORMULAS_KEY => true]);
+
+        if ($escapedCsv === $csvEncoder->encode($data, CsvEncoder::FORMAT, $context)) {
+            return $value;
+        }
+
+        return "'" . $value;
+    }
+}

--- a/project-base/app/tests/App/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
+++ b/project-base/app/tests/App/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
@@ -31,7 +31,7 @@ class GetAllEmailsDataIteratorMethodTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @param iterable<array{email: string, createdAt: \DateTimeInterface}> $iterator
+     * @param iterable<array{email: string, createdAt: string}> $iterator
      */
     private function assertContainsNewsletterSubscriber(iterable $iterator, string $email): void
     {
@@ -45,7 +45,7 @@ class GetAllEmailsDataIteratorMethodTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @param iterable<array{email: string, createdAt: \DateTimeInterface}> $iterator
+     * @param iterable<array{email: string, createdAt: string}> $iterator
      */
     private function assertNotContainsNewsletterSubscriber(iterable $iterator, string $email): void
     {

--- a/upgrade-notes/backend_20260814_120000.md
+++ b/upgrade-notes/backend_20260814_120000.md
@@ -1,0 +1,10 @@
+#### Protect CSV exports against formula injection ([#4777](https://github.com/shopsys/shopsys/pull/4777))
+
+- `Shopsys\FrameworkBundle\Component\HttpFoundation\CsvResponse` now prefixes exported values starting with `=`, `-`, `+`, `@`, tab, CR or LF with an apostrophe
+    - if you re-import such an export, strip the apostrophe from the imported values with `Shopsys\FrameworkBundle\Component\Csv\CsvHelper::unescapeFormula()`
+    - only values are escaped, not column names, so escape the column names yourself if they can contain user input
+    - in your own CSV exports that do not use `CsvResponse`, add `Symfony\Component\Serializer\Encoder\CsvEncoder::ESCAPE_FORMULAS_KEY => true` to the encoder context, or use the new `Shopsys\FrameworkBundle\Component\HttpFoundation\StreamedCsvResponse` for large exports
+- `CsvResponse` now respects the passed `$csvHeaders` that were ignored before because of an inverted condition — check the output of your exports that pass custom headers, their column set and order now follow the passed headers
+- if you override `Shopsys\FrameworkBundle\Model\PriceList\PriceListFacade::preProcessCsvRow()`, call the parent implementation or unescape the values with `CsvHelper::unescapeFormula()` yourself, otherwise the price list import keeps the escaping apostrophes
+- `Shopsys\FrameworkBundle\Controller\Admin\NewsletterController::streamCsvExport()` was removed and the newsletter export is newly streamed by `StreamedCsvResponse` — if you have overridden it, move your changes into your own `StreamedCsvResponse` descendant
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

CSV exports in the administration are now protected against formula injection. Values starting with `=`, `-`, `+`, `@`, tab, or CR are prefixed with an apostrophe, so spreadsheet software opens them as plain text instead of evaluating them as formulas. Until now, anyone could subscribe to the newsletter on the storefront with an address like `=1+1@evil.com` (`=` is a valid character in the local part of an email) and it was evaluated as a formula on the administrator's computer when the export was opened in a spreadsheet editor.

The escaping lives in the new `CsvFormulaEscaper` component, whose `escape()` method is meant for any user-influenced value written into a CSV export. The newsletter export uses it directly, CSV responses are newly created by the `CsvResponseFactory`, which escapes all exported values including the column names, and the price list import removes the escaping apostrophe again, so a re-imported price list export matches the original products. Along the way, `CsvResponse` newly respects the explicitly passed CSV headers, which were previously dropped because of an inverted condition. Upgrade notes describe how projects adopt the change.

#### Fixes issues

...

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)



































----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4193-csv-formula-injection.odin.shopsys.cloud
  - https://cz.vk-ssp-4193-csv-formula-injection.odin.shopsys.cloud
  - https://vk-ssp-4193-csv-formula-injection.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788784017.590769 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4193-csv-formula-injection.odin.shopsys.cloud
  - https://cz.vk-ssp-4193-csv-formula-injection.odin.shopsys.cloud
  - https://vk-ssp-4193-csv-formula-injection.odin.shopsys.cloud/sk
<!-- Replace -->
