### PR TITLE
Protect entity log change set against XSS via translation parameters

### DIFF
--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/AbstractChangeSetFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/AbstractChangeSetFormatter.php
@@ -17,9 +17,6 @@ abstract class AbstractChangeSetFormatter
     /**
      * Only escaped values may be passed to the translator - the result is rendered as raw HTML
      * and a translation referencing raw change values would inject unescaped customer input
-     *
-     * @param mixed $oldReadableValue
-     * @param mixed $newReadableValue
      */
     protected function formatFromToChanges(mixed $oldReadableValue, mixed $newReadableValue): string
     {

--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/AbstractChangeSetFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/AbstractChangeSetFormatter.php
@@ -20,9 +20,9 @@ abstract class AbstractChangeSetFormatter
      */
     protected function formatFromToChanges(mixed $oldReadableValue, mixed $newReadableValue): string
     {
-        return t('from oldReadableValue to newReadableValue', [
-            'oldReadableValue' => $this->formatCode($oldReadableValue),
-            'newReadableValue' => $this->formatCode($newReadableValue),
+        return t('from %oldReadableValue% to %newReadableValue%', [
+            '%oldReadableValue%' => $this->formatCode($oldReadableValue),
+            '%newReadableValue%' => $this->formatCode($newReadableValue),
         ]);
     }
 }

--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/AbstractChangeSetFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/AbstractChangeSetFormatter.php
@@ -13,4 +13,19 @@ abstract class AbstractChangeSetFormatter
             htmlspecialchars((string)$value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
         );
     }
+
+    /**
+     * Only escaped values may be passed to the translator - the result is rendered as raw HTML
+     * and a translation referencing raw change values would inject unescaped customer input
+     *
+     * @param mixed $oldReadableValue
+     * @param mixed $newReadableValue
+     */
+    protected function formatFromToChanges(mixed $oldReadableValue, mixed $newReadableValue): string
+    {
+        return t('from oldReadableValue to newReadableValue', [
+            'oldReadableValue' => $this->formatCode($oldReadableValue),
+            'newReadableValue' => $this->formatCode($newReadableValue),
+        ]);
+    }
 }

--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/BooleanDataTypeFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/BooleanDataTypeFormatter.php
@@ -11,9 +11,9 @@ class BooleanDataTypeFormatter extends AbstractChangeSetFormatter
      */
     public function formatChanges(array $changes): string
     {
-        $changes['oldReadableValue'] = $this->formatCode($changes['oldValue'] ? t('Yes') : t('No'));
-        $changes['newReadableValue'] = $this->formatCode($changes['newValue'] ? t('Yes') : t('No'));
-
-        return t('from oldReadableValue to newReadableValue', $changes);
+        return $this->formatFromToChanges(
+            $changes['oldValue'] ? t('Yes') : t('No'),
+            $changes['newValue'] ? t('Yes') : t('No'),
+        );
     }
 }

--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/DateTimeDataTypeFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/DateTimeDataTypeFormatter.php
@@ -19,9 +19,9 @@ class DateTimeDataTypeFormatter extends AbstractChangeSetFormatter
      */
     public function formatChanges(array $changes): string
     {
-        $changes['oldReadableValue'] = $this->formatCode($changes['oldValue'] ? $this->dateTimeFormatterExtension->formatDateTime(new DatePoint($changes['oldValue'])) : t('empty value'));
-        $changes['newReadableValue'] = $this->formatCode($changes['newValue'] ? $this->dateTimeFormatterExtension->formatDateTime(new DatePoint($changes['newValue'])) : t('empty value'));
-
-        return t('from oldReadableValue to newReadableValue', $changes);
+        return $this->formatFromToChanges(
+            $changes['oldValue'] ? $this->dateTimeFormatterExtension->formatDateTime(new DatePoint($changes['oldValue'])) : t('empty value'),
+            $changes['newValue'] ? $this->dateTimeFormatterExtension->formatDateTime(new DatePoint($changes['newValue'])) : t('empty value'),
+        );
     }
 }

--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/MoneyDataTypeFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/MoneyDataTypeFormatter.php
@@ -13,9 +13,9 @@ class MoneyDataTypeFormatter extends AbstractChangeSetFormatter
      */
     public function formatChanges(array $changes): string
     {
-        $changes['oldReadableValue'] = $this->formatCode($changes['oldReadableValue'] ? Money::create($changes['oldReadableValue'])->round(2)->getAmount() : t('empty value'));
-        $changes['newReadableValue'] = $this->formatCode($changes['newReadableValue'] ? Money::create($changes['newReadableValue'])->round(2)->getAmount() : t('empty value'));
-
-        return t('from oldReadableValue to newReadableValue', $changes);
+        return $this->formatFromToChanges(
+            $changes['oldReadableValue'] ? Money::create($changes['oldReadableValue'])->round(2)->getAmount() : t('empty value'),
+            $changes['newReadableValue'] ? Money::create($changes['newReadableValue'])->round(2)->getAmount() : t('empty value'),
+        );
     }
 }

--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/ScalarDataTypeFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/ScalarDataTypeFormatter.php
@@ -11,9 +11,9 @@ class ScalarDataTypeFormatter extends AbstractChangeSetFormatter
      */
     public function formatChanges(array $changes): string
     {
-        $changes['oldReadableValue'] = $this->formatCode($changes['oldReadableValue'] ?: t('empty value'));
-        $changes['newReadableValue'] = $this->formatCode($changes['newReadableValue'] ?: t('empty value'));
-
-        return t('from oldReadableValue to newReadableValue', $changes);
+        return $this->formatFromToChanges(
+            $changes['oldReadableValue'] ?: t('empty value'),
+            $changes['newReadableValue'] ?: t('empty value'),
+        );
     }
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -3805,8 +3805,8 @@ msgstr "prázdná hodnota"
 msgid "exists"
 msgstr "existuje"
 
-msgid "from oldReadableValue to newReadableValue"
-msgstr "z oldReadableValue na newReadableValue"
+msgid "from %oldReadableValue% to %newReadableValue%"
+msgstr "z %oldReadableValue% na %newReadableValue%"
 
 msgid "full"
 msgstr "Vše"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -3805,7 +3805,7 @@ msgstr ""
 msgid "exists"
 msgstr ""
 
-msgid "from oldReadableValue to newReadableValue"
+msgid "from %oldReadableValue% to %newReadableValue%"
 msgstr ""
 
 msgid "full"

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -3805,8 +3805,8 @@ msgstr "prázdna hodnota"
 msgid "exists"
 msgstr "existuje"
 
-msgid "from oldReadableValue to newReadableValue"
-msgstr "z oldReadableValue na newReadableValue"
+msgid "from %oldReadableValue% to %newReadableValue%"
+msgstr "z %oldReadableValue% na %newReadableValue%"
 
 msgid "full"
 msgstr "plný"

--- a/packages/framework/tests/Unit/Component/EntityLog/ChangeSet/Formatter/ResolvedChangesFormatterTest.php
+++ b/packages/framework/tests/Unit/Component/EntityLog/ChangeSet/Formatter/ResolvedChangesFormatterTest.php
@@ -128,7 +128,7 @@ class ResolvedChangesFormatterTest extends TestCase
     {
         // simulates a project translation where the translator mistakenly referenced the raw values instead of the readable ones
         $this->injectTranslatorStub([
-            'from oldReadableValue to newReadableValue' => 'z oldValue na newValue',
+            'from %oldReadableValue% to %newReadableValue%' => 'z %oldValue% na %newValue%',
         ]);
 
         $formattedChanges = $this->resolvedChangesFormatter->formatResolvedChanges([
@@ -142,7 +142,7 @@ class ResolvedChangesFormatterTest extends TestCase
         ]);
 
         $this->assertSame(
-            'Attribute <code>note</code> was changed z oldValue na newValue',
+            'Attribute <code>note</code> was changed z %oldValue% na %newValue%',
             $formattedChanges,
         );
     }

--- a/packages/framework/tests/Unit/Component/EntityLog/ChangeSet/Formatter/ResolvedChangesFormatterTest.php
+++ b/packages/framework/tests/Unit/Component/EntityLog/ChangeSet/Formatter/ResolvedChangesFormatterTest.php
@@ -124,12 +124,38 @@ class ResolvedChangesFormatterTest extends TestCase
         );
     }
 
-    private function injectTranslatorStub(): void
+    public function testTranslationReferencingRawValuesDoesNotInjectUnescapedHtml(): void
+    {
+        // simulates a project translation where the translator mistakenly referenced the raw values instead of the readable ones
+        $this->injectTranslatorStub([
+            'from oldReadableValue to newReadableValue' => 'z oldValue na newValue',
+        ]);
+
+        $formattedChanges = $this->resolvedChangesFormatter->formatResolvedChanges([
+            'note' => [
+                'dataType' => 'string',
+                'oldReadableValue' => '<img src=x onerror="alert(document.domain)">',
+                'newReadableValue' => 'harmless note',
+                'oldValue' => '<img src=x onerror="alert(document.domain)">',
+                'newValue' => 'harmless note',
+            ],
+        ]);
+
+        $this->assertSame(
+            'Attribute <code>note</code> was changed z oldValue na newValue',
+            $formattedChanges,
+        );
+    }
+
+    /**
+     * @param array<string, string> $translations
+     */
+    private function injectTranslatorStub(array $translations = []): void
     {
         $translator = $this->createStub(Translator::class);
         $translator
             ->method('trans')
-            ->willReturnCallback(static fn (string $id, array $parameters = []): string => strtr($id, $parameters));
+            ->willReturnCallback(static fn (string $id, array $parameters = []): string => strtr($translations[$id] ?? $id, $parameters));
 
         Translator::injectSelf($translator);
     }

--- a/upgrade-notes/backend_20260817_134753.md
+++ b/upgrade-notes/backend_20260817_134753.md
@@ -1,4 +1,4 @@
 #### Protect entity log change set against XSS via translation parameters ([#4778](https://github.com/shopsys/shopsys/pull/4778))
 
-- entity log change-set formatters now pass only the escaped `oldReadableValue` and `newReadableValue` placeholders to the translator — the raw `oldValue`, `newValue`, and `dataType` values are no longer available as translation parameters
-    - if your project overrides the `from oldReadableValue to newReadableValue` translation, make sure its text references only `oldReadableValue` and `newReadableValue` — any other placeholder now renders as literal text
+- entity log change-set formatters now pass only the escaped `%oldReadableValue%` and `%newReadableValue%` placeholders to the translator — the raw `oldValue`, `newValue`, and `dataType` values are no longer available as translation parameters
+    - the `from oldReadableValue to newReadableValue` message was renamed to `from %oldReadableValue% to %newReadableValue%` so it is obvious the values are placeholders — move your project override to the new message and use only these two placeholders in its text, any other placeholder now renders as literal text

--- a/upgrade-notes/backend_20260817_134753.md
+++ b/upgrade-notes/backend_20260817_134753.md
@@ -1,0 +1,4 @@
+#### Protect entity log change set against XSS via translation parameters ([#4778](https://github.com/shopsys/shopsys/pull/4778))
+
+- entity log change-set formatters now pass only the escaped `oldReadableValue` and `newReadableValue` placeholders to the translator — the raw `oldValue`, `newValue`, and `dataType` values are no longer available as translation parameters
+    - if your project overrides the `from oldReadableValue to newReadableValue` translation, make sure its text references only `oldReadableValue` and `newReadableValue` — any other placeholder now renders as literal text


### PR DESCRIPTION
#### Description, the reason for the PR

The entity log in the administration composes the "from X to Y" change messages through the translator, and until now the whole change set — including the raw, unescaped old and new values entered by customers — was passed as translation parameters. A project translation that referenced `oldValue`/`newValue` instead of the readable placeholders (a realistic translator mistake, and project translations override the framework ones) would substitute unescaped customer input into the change set, which is rendered as raw HTML in the order detail. A payload stored e.g. in the order note would then execute in the administrator's session.

The change-set formatters now build the message through the new `AbstractChangeSetFormatter::formatFromToChanges()`, which passes only the two escaped readable values to the translator, so no translation — however broken — can pull raw customer input into the output. This is the load-bearing fix: with no raw values left in the parameter bag, there is nothing unescaped for a translation to substitute. The behavior is covered by a unit test that simulates such a broken project translation. Upgrade notes describe the only visible change for projects.

On top of that, the placeholders are now properly delimited as `%oldReadableValue%`/`%newReadableValue%` following the Symfony convention. This is a correctness/defense-in-depth improvement, not the security boundary on its own — delimiting prevents a placeholder from accidentally matching a substring inside a translated word, but it does not remove raw values from the parameter bag, so it would not close the hole without the escaped-values change above.

#### Fixes issues

...

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)













----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4115-entity-log-escaping.odin.shopsys.cloud
  - https://cz.vk-ssp-4115-entity-log-escaping.odin.shopsys.cloud
  - https://vk-ssp-4115-entity-log-escaping.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1787561305.151579 -->