### PR TITLE
Fix duplicate watchdog button on unavailable product variants

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
@@ -4000,7 +4000,6 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $this->productDemoDataSetter->setSellingFrom($productData, '15.1.2000');
         $this->productDemoDataSetter->setStocksQuantity($productData, 0);
         $this->productDemoDataSetter->setExpectedRestockingDate($productData, 'midnight +2 weeks');
-        $productData->isAllowedNegativeStock = false;
         $this->productDemoDataSetter->setCategoriesForAllDomains($productData, [CategoryDataFixture::CATEGORY_TV, CategoryDataFixture::CATEGORY_PC]);
         $this->productDemoDataSetter->setFlags($productData, [FlagDataFixture::FLAG_PRODUCT_ACTION]);
         $this->productDemoDataSetter->setBrand($productData, BrandDataFixture::BRAND_HYUNDAI);

--- a/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
@@ -2234,7 +2234,8 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $this->productDemoDataSetter->setOrderingPriority($productData, 8);
         $this->productDemoDataSetter->setPriceForAllPricingGroups($productData, '9173.5');
         $this->productDemoDataSetter->setSellingFrom($productData, '15.1.2000');
-        $this->productDemoDataSetter->setStocksQuantity($productData, 200);
+        $this->productDemoDataSetter->setStocksQuantity($productData, 0);
+        $productData->isAllowedNegativeStock = false;
         $this->productDemoDataSetter->setCategoriesForAllDomains($productData, [CategoryDataFixture::CATEGORY_TV, CategoryDataFixture::CATEGORY_PC]);
         $this->productDemoDataSetter->setFlags($productData, [FlagDataFixture::FLAG_PRODUCT_ACTION]);
         $this->productDemoDataSetter->setBrand($productData, BrandDataFixture::BRAND_HYUNDAI);
@@ -3997,7 +3998,9 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->ean = '8845781243205';
         $this->productDemoDataSetter->setPriceForAllPricingGroups($productData, '9173.5');
         $this->productDemoDataSetter->setSellingFrom($productData, '15.1.2000');
-        $this->productDemoDataSetter->setStocksQuantity($productData, 10);
+        $this->productDemoDataSetter->setStocksQuantity($productData, 0);
+        $this->productDemoDataSetter->setExpectedRestockingDate($productData, 'midnight +2 weeks');
+        $productData->isAllowedNegativeStock = false;
         $this->productDemoDataSetter->setCategoriesForAllDomains($productData, [CategoryDataFixture::CATEGORY_TV, CategoryDataFixture::CATEGORY_PC]);
         $this->productDemoDataSetter->setFlags($productData, [FlagDataFixture::FLAG_PRODUCT_ACTION]);
         $this->productDemoDataSetter->setBrand($productData, BrandDataFixture::BRAND_HYUNDAI);

--- a/project-base/storefront/components/Blocks/Product/ProductAction.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductAction.tsx
@@ -1,14 +1,39 @@
 import { AddToCart, AddToCartContent } from 'components/Blocks/Product/AddToCart';
 import { ProductInquiryButton } from 'components/Blocks/Product/ProductInquiryButton';
-import { WatchDogButton } from 'components/Blocks/Product/Watchdog/WatchDogButton';
+import { showWatchdogButton, WatchDogButton } from 'components/Blocks/Product/Watchdog/WatchDogButton';
 import { LinkButton } from 'components/Forms/Button/LinkButton';
 import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
 import { CurrentCartType } from 'types/cart';
-import { FunctionComponentProps } from 'types/globals';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
+
+type PurchaseAction = 'sellingDenied' | 'outOfStock' | 'inquiry' | 'chooseVariant' | 'addToCart' | 'none';
+
+const getPurchaseAction = (product: TypeListedProductFragment, canCreateOrder: boolean): PurchaseAction => {
+    if (product.isSellingDenied) {
+        return 'sellingDenied';
+    }
+
+    if (product.isCurrentlyOutOfStock) {
+        return 'outOfStock';
+    }
+
+    if (!product.isMainVariant && product.isInquiryType) {
+        return 'inquiry';
+    }
+
+    if (!canCreateOrder) {
+        return 'none';
+    }
+
+    if (product.isMainVariant) {
+        return 'chooseVariant';
+    }
+
+    return 'addToCart';
+};
 
 type ProductActionProps = {
     product: TypeListedProductFragment;
@@ -16,10 +41,10 @@ type ProductActionProps = {
     gtmMessageOrigin: GtmMessageOriginType;
     listIndex: number;
     buttonSize?: 'small' | 'medium' | 'large' | 'xlarge';
-    buttonVariant?: 'primary' | 'secondary';
+    isWatchdogButtonShownWithPurchaseAction?: boolean;
     skipKeyboardNavigation?: boolean;
     currentCart?: Pick<CurrentCartType, 'cart' | 'isCartFetchingOrUnavailable'>;
-} & FunctionComponentProps;
+};
 
 export const PRODUCT_VARIANTS_ID = 'product-variants';
 
@@ -29,61 +54,27 @@ export const ProductAction: FC<ProductActionProps> = ({
     gtmProductListName,
     gtmMessageOrigin,
     listIndex,
-    buttonSize,
-    buttonVariant = 'primary',
+    buttonSize = 'medium',
+    isWatchdogButtonShownWithPurchaseAction = false,
     skipKeyboardNavigation = false,
 }) => {
     const { t } = useTranslation();
     const { canCreateOrder } = useAuthorization();
 
-    if (product.isSellingDenied) {
-        return <div className="max-w-53 text-center">{t('This item can no longer be purchased')}</div>;
-    }
+    const purchaseAction = getPurchaseAction(product, canCreateOrder);
 
-    if (product.isCurrentlyOutOfStock) {
-        return (
-            <WatchDogButton className="w-full" listIndex={listIndex} product={product} size={buttonSize ?? 'medium'} />
-        );
-    }
+    // being out of stock is the only state in which the watchdog button stands in for the purchase action
+    const isWatchdogButtonVisible =
+        showWatchdogButton(product) && (isWatchdogButtonShownWithPurchaseAction || purchaseAction === 'outOfStock');
 
-    if (!product.isMainVariant && product.isInquiryType) {
-        return (
-            <ProductInquiryButton
-                buttonSize={buttonSize}
-                productName={product.fullName}
-                productUuid={product.uuid}
-                skipKeyboardNavigation={skipKeyboardNavigation}
-            />
-        );
-    }
-
-    if (!canCreateOrder) {
-        return null;
-    }
-
-    if (product.isMainVariant) {
-        return (
-            <LinkButton
-                className="w-full"
-                href={`${product.slug}#${PRODUCT_VARIANTS_ID}`}
-                tabIndex={skipKeyboardNavigation ? -1 : 0}
-                type="productMainVariant"
-                aria-label={t('Go to page with product variants of {{ productName }}', {
-                    ns: 'accessibility',
-                    productName: product.fullName,
-                })}
-            >
-                {t('Choose')}
-            </LinkButton>
-        );
-    }
+    const addToCartVariant: 'primary' | 'secondary' = isWatchdogButtonVisible ? 'secondary' : 'primary';
 
     const addToCartProps = {
         ariaPrice: product.price.priceWithVat,
         ariaProductName: product.fullName,
         ariaUnit: product.unit.name,
         buttonSize,
-        buttonVariant,
+        buttonVariant: addToCartVariant,
         gtmMessageOrigin,
         gtmProductListName,
         listIndex,
@@ -93,9 +84,46 @@ export const ProductAction: FC<ProductActionProps> = ({
         tabIndex: skipKeyboardNavigation ? -1 : 0,
     };
 
-    if (currentCart) {
-        return <AddToCartContent {...addToCartProps} {...currentCart} />;
-    }
+    return (
+        <>
+            {isWatchdogButtonVisible && (
+                <WatchDogButton className="w-full" listIndex={listIndex} product={product} size={buttonSize} />
+            )}
 
-    return <AddToCart {...addToCartProps} />;
+            {purchaseAction === 'sellingDenied' && (
+                <div className="max-w-53 text-center">{t('This item can no longer be purchased')}</div>
+            )}
+
+            {purchaseAction === 'inquiry' && (
+                <ProductInquiryButton
+                    buttonSize={buttonSize}
+                    productName={product.fullName}
+                    productUuid={product.uuid}
+                    skipKeyboardNavigation={skipKeyboardNavigation}
+                />
+            )}
+
+            {purchaseAction === 'chooseVariant' && (
+                <LinkButton
+                    className="w-full"
+                    href={`${product.slug}#${PRODUCT_VARIANTS_ID}`}
+                    tabIndex={skipKeyboardNavigation ? -1 : 0}
+                    type="productMainVariant"
+                    aria-label={t('Go to page with product variants of {{ productName }}', {
+                        ns: 'accessibility',
+                        productName: product.fullName,
+                    })}
+                >
+                    {t('Choose')}
+                </LinkButton>
+            )}
+
+            {purchaseAction === 'addToCart' &&
+                (currentCart ? (
+                    <AddToCartContent {...addToCartProps} {...currentCart} />
+                ) : (
+                    <AddToCart {...addToCartProps} />
+                ))}
+        </>
+    );
 };

--- a/project-base/storefront/components/Blocks/Product/Watchdog/WatchDogButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/Watchdog/WatchDogButton.tsx
@@ -1,5 +1,6 @@
 import { WatchdogIcon } from 'components/Basic/Icon/WatchdogIcon';
 import { Button, getButtonIconClassName } from 'components/Forms/Button/Button';
+import { TIDs } from 'cypress/tids';
 import { TypeAvailabilityStatusEnum } from 'graphql/types';
 import dynamic from 'next/dynamic';
 import { useSessionStore } from 'store/useSessionStore';
@@ -51,6 +52,7 @@ export const WatchDogButton: FC<WatchDogButtonProps> = ({ product, listIndex, si
                 productName: product.fullName,
             })}
             className={twJoin('whitespace-nowrap', className)}
+            tid={TIDs.blocks_product_watchdog_button}
             title={t('Watchdog popup')}
             size={size}
             variant="primary"

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
@@ -2,7 +2,6 @@ import { Image } from 'components/Basic/Image/Image';
 import { ProductAction } from 'components/Blocks/Product/ProductAction';
 import { ProductAvailability } from 'components/Blocks/Product/ProductAvailability';
 import { ProductPrice } from 'components/Blocks/Product/ProductPrice';
-import { showWatchdogButton, WatchDogButton } from 'components/Blocks/Product/Watchdog/WatchDogButton';
 import { Webline } from 'components/Layout/Webline/Webline';
 import { TIDs } from 'cypress/tids';
 import { TypeMainVariantDetailFragment } from 'graphql/requests/products/fragments/MainVariantDetailFragment.generated';
@@ -88,15 +87,13 @@ export const ProductVariantsTable: FC<ProductVariantsTableProps> = ({ variants }
                             <ProductPrice className="lg:flex-col lg:items-end" productPrice={variant.price} />
 
                             <div className="flex w-45 flex-col gap-2">
-                                <WatchDogButton listIndex={index} product={variant} />
-
                                 <ProductAction
                                     buttonSize="large"
+                                    isWatchdogButtonShownWithPurchaseAction
                                     gtmMessageOrigin={GtmMessageOriginType.product_detail_page}
                                     gtmProductListName={GtmProductListNameType.product_detail_variants_table}
                                     listIndex={index}
                                     product={variant}
-                                    buttonVariant={showWatchdogButton(variant) ? 'secondary' : 'primary'}
                                 />
                             </div>
                         </div>

--- a/project-base/storefront/cypress/e2e/watchdog/watchdog.cy.ts
+++ b/project-base/storefront/cypress/e2e/watchdog/watchdog.cy.ts
@@ -1,0 +1,40 @@
+import { staticData } from 'fixtures/demodata';
+import { initializePersistStoreInLocalStorageToDefaultValues } from 'support';
+import { visitEntityByUuid } from 'support/navigation';
+import { TIDs } from 'tids';
+
+describe('Watchdog Button Tests (SSP-4259)', () => {
+    beforeEach(() => {
+        initializePersistStoreInLocalStorageToDefaultValues();
+    });
+
+    it('[Variants Table] should show exactly one watchdog button for each unavailable variant', () => {
+        visitEntityByUuid('product', staticData.products.televisionHyundaiM.uuid);
+
+        cy.getByTID([
+            [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.outOfStockVariantCatnum],
+            TIDs.blocks_product_watchdog_button,
+        ])
+            .should('have.length', 1)
+            .find('svg')
+            .should('be.visible');
+        cy.getByTID([
+            [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.outOfStockVariantCatnum],
+            TIDs.blocks_product_addtocart,
+        ]).should('not.exist');
+
+        cy.getByTID([
+            [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.expectedRestockVariantCatnum],
+            TIDs.blocks_product_watchdog_button,
+        ]).should('have.length', 1);
+
+        cy.getByTID([
+            [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.inStockVariantCatnum],
+            TIDs.blocks_product_watchdog_button,
+        ]).should('not.exist');
+        cy.getByTID([
+            [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.inStockVariantCatnum],
+            TIDs.blocks_product_addtocart,
+        ]).should('have.length', 1);
+    });
+});

--- a/project-base/storefront/cypress/e2e/watchdog/watchdog.cy.ts
+++ b/project-base/storefront/cypress/e2e/watchdog/watchdog.cy.ts
@@ -27,6 +27,10 @@ describe('Watchdog Button Tests (SSP-4259)', () => {
             [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.expectedRestockVariantCatnum],
             TIDs.blocks_product_watchdog_button,
         ]).should('have.length', 1);
+        cy.getByTID([
+            [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.expectedRestockVariantCatnum],
+            TIDs.blocks_product_addtocart,
+        ]).should('have.length', 1);
 
         cy.getByTID([
             [TIDs.pages_productdetail_variant_, staticData.products.televisionHyundaiM.inStockVariantCatnum],

--- a/project-base/storefront/cypress/fixtures/demodata.ts
+++ b/project-base/storefront/cypress/fixtures/demodata.ts
@@ -79,8 +79,6 @@ export const staticData = {
         },
         televisionHyundaiM: {
             uuid: '0c625610-00b3-5a9a-bccd-a271db880461',
-            catnum: '32PFL4400',
-            name: 'Television Hyundai [M]',
             outOfStockVariantCatnum: '9176578',
             expectedRestockVariantCatnum: '91765782',
             inStockVariantCatnum: '9176554',

--- a/project-base/storefront/cypress/fixtures/demodata.ts
+++ b/project-base/storefront/cypress/fixtures/demodata.ts
@@ -77,6 +77,14 @@ export const staticData = {
         televisionPhilipsM: {
             uuid: 'f9c91468-c6b1-5b3f-b34e-1a2eef918504',
         },
+        televisionHyundaiM: {
+            uuid: '0c625610-00b3-5a9a-bccd-a271db880461',
+            catnum: '32PFL4400',
+            name: 'Television Hyundai [M]',
+            outOfStockVariantCatnum: '9176578',
+            expectedRestockVariantCatnum: '91765782',
+            inStockVariantCatnum: '9176554',
+        },
         a4techMouse: {
             uuid: 'd5a669ed-46aa-5c55-b1fe-54e7b81de4cd',
             catnum: '5960453',

--- a/project-base/storefront/cypress/tids.ts
+++ b/project-base/storefront/cypress/tids.ts
@@ -52,6 +52,7 @@ export enum TIDs {
     blocks_product_list_view_grid = 'blocks_product_list_view_grid',
     blocks_product_list_view_list = 'blocks_product_list_view_list',
     blocks_product_addtocart = 'blocks_product_addtocart',
+    blocks_product_watchdog_button = 'blocks_product_watchdog_button',
     blocks_product_slider_promoted_products = 'blocks_product_slider_promoted_products',
     blocks_sortingbar_option_ = 'blocks_sortingbar_option_',
     blocks_simplenavigation_ = 'blocks_simplenavigation_',

--- a/project-base/storefront/vitest/components/Blocks/Product/ProductAction.test.tsx
+++ b/project-base/storefront/vitest/components/Blocks/Product/ProductAction.test.tsx
@@ -291,11 +291,12 @@ describe('ProductAction', () => {
             expect(screen.getByTestId('product-inquiry')).toBeInTheDocument();
         });
 
-        test('offers nothing to a customer who cannot create an order', () => {
+        test('offers only the watchdog to a customer who cannot create an order', () => {
             canCreateOrder = false;
 
             renderProductAction(expectedRestockProduct, props);
 
+            expect(getWatchdogButtons()).toHaveLength(1);
             expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
         });
 

--- a/project-base/storefront/vitest/components/Blocks/Product/ProductAction.test.tsx
+++ b/project-base/storefront/vitest/components/Blocks/Product/ProductAction.test.tsx
@@ -1,10 +1,43 @@
 import { render, screen } from '@testing-library/react';
 import { PRODUCT_VARIANTS_ID, ProductAction } from 'components/Blocks/Product/ProductAction';
+import { getButtonIconClassName } from 'components/Forms/Button/Button';
 import type { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
+import { TypeAvailabilityStatusEnum } from 'graphql/types';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
-import type { ReactNode } from 'react';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+type StubbedButtonProps = {
+    buttonSize?: string;
+    buttonVariant?: string;
+};
+
+let canCreateOrder = true;
+
+vi.mock('components/providers/AuthorizationProvider', () => ({
+    useAuthorization: () => ({ canCreateOrder }),
+}));
+
+vi.mock('components/Blocks/Product/AddToCart', () => ({
+    AddToCart: ({ buttonSize, buttonVariant }: StubbedButtonProps) => (
+        <button data-size={buttonSize} data-testid="add-to-cart" data-variant={buttonVariant} type="button">
+            Add to cart
+        </button>
+    ),
+    AddToCartContent: ({ buttonSize, buttonVariant }: StubbedButtonProps) => (
+        <button data-size={buttonSize} data-testid="add-to-cart-with-cart" data-variant={buttonVariant} type="button">
+            Add to cart
+        </button>
+    ),
+}));
+
+vi.mock('components/Blocks/Product/ProductInquiryButton', () => ({
+    ProductInquiryButton: () => (
+        <button data-testid="product-inquiry" type="button">
+            Ask a question
+        </button>
+    ),
+}));
 
 vi.mock('components/Forms/Button/LinkButton', () => ({
     LinkButton: ({
@@ -13,46 +46,119 @@ vi.mock('components/Forms/Button/LinkButton', () => ({
         href,
     }: {
         'aria-label': string;
-        children: ReactNode;
+        children: React.ReactNode;
         href: string;
     }) => (
-        <a aria-label={ariaLabel} href={href}>
+        <a aria-label={ariaLabel} data-testid="choose-variant" href={href}>
             {children}
         </a>
     ),
 }));
 
-vi.mock('components/providers/AuthorizationProvider', () => ({
-    useAuthorization: () => ({ canCreateOrder: true }),
+vi.mock('store/useSessionStore', () => ({
+    useSessionStore: (selector: (state: { updatePortalContent: () => void }) => unknown) =>
+        selector({ updatePortalContent: vi.fn() }),
 }));
 
 vi.mock('utils/i18n/useTranslationWrapper', () => ({
     default: () => ({
-        t: (key: string, options?: { productName?: string }) =>
-            options?.productName ? key.replace('{{ productName }}', options.productName) : key,
+        t: (key: string, options?: Record<string, string | number>) =>
+            Object.entries(options ?? {}).reduce(
+                (translatedKey, [optionKey, optionValue]) =>
+                    translatedKey
+                        .replaceAll(`{{ ${optionKey} }}`, String(optionValue))
+                        .replaceAll(`{{${optionKey}}}`, String(optionValue)),
+                key,
+            ),
     }),
 }));
 
-const mainVariant = {
-    __typename: 'MainVariant',
-    fullName: 'Television Philips [M]',
-    isCurrentlyOutOfStock: false,
-    isInquiryType: false,
-    isMainVariant: true,
+const inStockProduct = {
+    __typename: 'RegularProduct',
+    id: 1,
+    uuid: 'e2d0a3b0-2f5e-4f0a-9d2b-2f1f0b6c9a11',
+    slug: '/product',
+    fullName: 'Product',
+    stockQuantity: 10,
+    isAllowedNegativeStock: false,
     isSellingDenied: false,
-    slug: '/television-philips-m',
-    uuid: 'b973951d-a6b3-4a24-ad83-00fb9f312b4c',
-} as TypeListedProductFragment;
+    isCurrentlyOutOfStock: false,
+    availableStoresCount: null,
+    catalogNumber: 'CAT-1',
+    isMainVariant: false,
+    isInquiryType: false,
+    unit: { __typename: 'Unit', name: 'pcs' },
+    flags: [],
+    mainImage: null,
+    price: {
+        __typename: 'ProductPrice',
+        priceWithVat: '121.00',
+        priceWithoutVat: '100.00',
+        vatAmount: '21.00',
+        isPriceFrom: false,
+        percentageDiscount: null,
+        basicPrice: { __typename: 'Price', priceWithVat: '121.00' },
+    },
+    expectedRestockingDate: null,
+    availability: { __typename: 'Availability', name: 'In stock', status: TypeAvailabilityStatusEnum.InStock },
+    brand: null,
+    categories: [],
+} satisfies TypeListedProductFragment;
+
+const createProduct = (overrides: Partial<TypeListedProductFragment>) =>
+    ({ ...inStockProduct, ...overrides }) as TypeListedProductFragment;
+
+const renderProductAction = (
+    product: TypeListedProductFragment,
+    props: Partial<React.ComponentProps<typeof ProductAction>> = {},
+) =>
+    render(
+        <ProductAction
+            gtmMessageOrigin={GtmMessageOriginType.other}
+            gtmProductListName={GtmProductListNameType.other}
+            listIndex={0}
+            product={product}
+            {...props}
+        />,
+    );
+
+const outOfStockProduct = createProduct({
+    isCurrentlyOutOfStock: true,
+    stockQuantity: 0,
+    availability: {
+        __typename: 'Availability',
+        name: 'Out of stock',
+        status: TypeAvailabilityStatusEnum.OutOfStock,
+    },
+});
+
+const expectedRestockProduct = createProduct({
+    stockQuantity: 0,
+    isAllowedNegativeStock: true,
+    availability: {
+        __typename: 'Availability',
+        name: 'Expected restock',
+        status: TypeAvailabilityStatusEnum.ExpectedRestock,
+    },
+});
+
+const sellingDeniedProduct = createProduct({ isSellingDenied: true });
+
+const getWatchdogButtons = () => screen.queryAllByRole('button', { name: /Open watchdog popup/ });
 
 describe('ProductAction', () => {
+    beforeEach(() => {
+        canCreateOrder = true;
+    });
+
     test('links the main variant action directly to the variants section', () => {
-        render(
-            <ProductAction
-                gtmMessageOrigin={GtmMessageOriginType.other}
-                gtmProductListName={GtmProductListNameType.other}
-                listIndex={0}
-                product={mainVariant}
-            />,
+        renderProductAction(
+            createProduct({
+                __typename: 'MainVariant',
+                fullName: 'Television Philips [M]',
+                isMainVariant: true,
+                slug: '/television-philips-m',
+            }),
         );
 
         expect(
@@ -60,5 +166,158 @@ describe('ProductAction', () => {
                 name: 'Go to page with product variants of Television Philips [M]',
             }),
         ).toHaveAttribute('href', `/television-philips-m#${PRODUCT_VARIANTS_ID}`);
+    });
+
+    test('offers only add to cart for a product in stock', () => {
+        renderProductAction(inStockProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.getByTestId('add-to-cart')).toHaveAttribute('data-variant', 'primary');
+    });
+
+    test('offers a single watchdog button and nothing else for a product out of stock', () => {
+        renderProductAction(outOfStockProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(1);
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers only add to cart for a product with an expected restocking date that can still be purchased', () => {
+        renderProductAction(expectedRestockProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.getByTestId('add-to-cart')).toHaveAttribute('data-variant', 'primary');
+    });
+
+    test('offers only the message that a selling denied product cannot be purchased', () => {
+        renderProductAction(sellingDeniedProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.getByText('This item can no longer be purchased')).toBeInTheDocument();
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers only an inquiry button for an inquiry type variant', () => {
+        renderProductAction(createProduct({ isInquiryType: true }));
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.getByTestId('product-inquiry')).toBeInTheDocument();
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers nothing for an inquiry type variant that is out of stock', () => {
+        renderProductAction(createProduct({ ...outOfStockProduct, isInquiryType: true }));
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.queryByTestId('product-inquiry')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers only a link to the variants for a main variant', () => {
+        renderProductAction(createProduct({ isMainVariant: true }));
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.getByTestId('choose-variant')).toBeInTheDocument();
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers only a link to the variants for a main variant that could be watched', () => {
+        renderProductAction(createProduct({ ...expectedRestockProduct, isMainVariant: true }));
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.getByTestId('choose-variant')).toBeInTheDocument();
+    });
+
+    test('offers nothing to a customer who cannot create an order', () => {
+        canCreateOrder = false;
+
+        renderProductAction(inStockProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers nothing to a customer who cannot create an order even when the goods could be watched', () => {
+        canCreateOrder = false;
+
+        renderProductAction(expectedRestockProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(0);
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('offers the watchdog even to a customer who cannot create an order', () => {
+        canCreateOrder = false;
+
+        renderProductAction(outOfStockProduct);
+
+        expect(getWatchdogButtons()).toHaveLength(1);
+    });
+
+    test('adds to cart against the current cart when one is passed', () => {
+        renderProductAction(inStockProduct, {
+            currentCart: { cart: null, isCartFetchingOrUnavailable: false },
+        });
+
+        expect(screen.getByTestId('add-to-cart-with-cart')).toBeInTheDocument();
+        expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+    });
+
+    test('sizes the watchdog button the same as the add to cart button', () => {
+        renderProductAction(expectedRestockProduct, {
+            buttonSize: 'large',
+            isWatchdogButtonShownWithPurchaseAction: true,
+        });
+
+        expect(screen.getByTestId('add-to-cart')).toHaveAttribute('data-size', 'large');
+        expect(getWatchdogButtons()[0].querySelector('svg')).toHaveClass(getButtonIconClassName('large'));
+    });
+
+    describe('with the watchdog button shown next to the purchase action', () => {
+        const props = { isWatchdogButtonShownWithPurchaseAction: true };
+
+        test('offers both the watchdog and add to cart for a product that can still be purchased', () => {
+            renderProductAction(expectedRestockProduct, props);
+
+            expect(getWatchdogButtons()).toHaveLength(1);
+            expect(screen.getByTestId('add-to-cart')).toHaveAttribute('data-variant', 'secondary');
+            expect(screen.getAllByRole('button')[0]).toHaveAccessibleName(/Open watchdog popup/);
+        });
+
+        test('offers no watchdog button for an inquiry type variant', () => {
+            renderProductAction(createProduct({ isInquiryType: true }), props);
+
+            expect(getWatchdogButtons()).toHaveLength(0);
+            expect(screen.getByTestId('product-inquiry')).toBeInTheDocument();
+        });
+
+        test('offers nothing to a customer who cannot create an order', () => {
+            canCreateOrder = false;
+
+            renderProductAction(expectedRestockProduct, props);
+
+            expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+        });
+
+        test('offers the watchdog next to the message that a selling denied product cannot be purchased', () => {
+            renderProductAction(sellingDeniedProduct, props);
+
+            expect(getWatchdogButtons()).toHaveLength(1);
+            expect(screen.getByText('This item can no longer be purchased')).toBeInTheDocument();
+        });
+
+        test('offers a single watchdog button for a product out of stock', () => {
+            renderProductAction(outOfStockProduct, props);
+
+            expect(getWatchdogButtons()).toHaveLength(1);
+            expect(screen.queryByTestId('add-to-cart')).not.toBeInTheDocument();
+        });
+
+        test('offers no watchdog button for a product in stock', () => {
+            renderProductAction(inStockProduct, props);
+
+            expect(getWatchdogButtons()).toHaveLength(0);
+            expect(screen.getByTestId('add-to-cart')).toHaveAttribute('data-variant', 'primary');
+        });
     });
 });

--- a/upgrade-notes/backend_20260818_082433.md
+++ b/upgrade-notes/backend_20260818_082433.md
@@ -1,0 +1,4 @@
+#### Fix duplicate watchdog button on unavailable product variants ([#4779](https://github.com/shopsys/shopsys/pull/4779))
+
+- two variants of the `32PFL4400` demo product are out of stock now, `9176578` without and `91765782` with an expected restocking date, and neither of them allows selling below zero stock - regenerate your demo data and update the tests that rely on the availability of these products
+- see #project-base-diff to update your project

--- a/upgrade-notes/backend_20260818_082433.md
+++ b/upgrade-notes/backend_20260818_082433.md
@@ -1,4 +1,4 @@
 #### Fix duplicate watchdog button on unavailable product variants ([#4779](https://github.com/shopsys/shopsys/pull/4779))
 
-- two variants of the `32PFL4400` demo product are out of stock now, `9176578` without and `91765782` with an expected restocking date, and neither of them allows selling below zero stock - regenerate your demo data and update the tests that rely on the availability of these products
+- two variants of the `32PFL4400` demo product have no stock now - `9176578` does not allow selling below zero stock so it cannot be purchased at all, and `91765782` has an expected restocking date and allows selling below zero stock so it can still be purchased - regenerate your demo data and update the tests that rely on the availability of these products
 - see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20260818_082433.md
+++ b/upgrade-notes/storefront_20260818_082433.md
@@ -1,0 +1,8 @@
+#### Fix duplicate watchdog button on unavailable product variants ([#4779](https://github.com/shopsys/shopsys/pull/4779))
+
+- `ProductAction` from `components/Blocks/Product/ProductAction` renders `WatchDogButton` itself now - remove `WatchDogButton` from every place where you render it as a sibling of `ProductAction`, otherwise the button is rendered twice
+- pass the new `isWatchdogButtonShownWithPurchaseAction` prop wherever the watchdog button has to stay next to the purchase action, the way `ProductDetailVariantsTable` does - without it `ProductAction` offers the watchdog button only when there is nothing to purchase, which is how product lists, the product comparison and the article product hero have always behaved
+- `ProductAction` no longer accepts `buttonVariant` - the inverted look of the add to cart button follows from the watchdog button being rendered next to it
+- `ProductAction` renders two sibling elements where the watchdog button is shown next to the purchase action, and it no longer accepts `className` - keep the layout classes on the parent element and make it a `flex flex-col gap-2` container
+- `buttonSize` of `ProductAction` sizes the watchdog button as well and defaults to `medium`, so the button in the variants table is `large` instead of `xlarge` now - the watchdog button can no longer be sized differently than the purchase action next to it
+- see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20260818_082433.md
+++ b/upgrade-notes/storefront_20260818_082433.md
@@ -3,6 +3,6 @@
 - `ProductAction` from `components/Blocks/Product/ProductAction` renders `WatchDogButton` itself now - remove `WatchDogButton` from every place where you render it as a sibling of `ProductAction`, otherwise the button is rendered twice
 - pass the new `isWatchdogButtonShownWithPurchaseAction` prop wherever the watchdog button has to stay next to the purchase action, the way `ProductDetailVariantsTable` does - without it `ProductAction` offers the watchdog button only when there is nothing to purchase, which is how product lists, the product comparison and the article product hero have always behaved
 - `ProductAction` no longer accepts `buttonVariant` - the inverted look of the add to cart button follows from the watchdog button being rendered next to it
-- `ProductAction` renders two sibling elements where the watchdog button is shown next to the purchase action, and it no longer accepts `className` - keep the layout classes on the parent element and make it a `flex flex-col gap-2` container
+- `ProductAction` renders two sibling elements where the watchdog button is shown next to the purchase action - keep the layout classes on the parent element and make it a `flex flex-col gap-2` container
 - `buttonSize` of `ProductAction` sizes the watchdog button as well and defaults to `medium`, so the button in the variants table is `large` instead of `xlarge` now - the watchdog button can no longer be sized differently than the purchase action next to it
 - see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

On the detail of a main variant, an unavailable variant offered the "Watch the goods" button twice, one above the other. Both were the same watchdog button — the variants table rendered one and the shared product action component rendered another one under its own, narrower condition.

The watchdog button has a single owner now: it is rendered by the product action component, which offers it next to the purchase action in the variants table, where both buttons have always been offered side by side. Everywhere else — product listings, the product comparison and the product hero in articles — the watchdog button keeps appearing in exactly the same situations as before this PR, because those places offer a single action only. Which of the two layouts a place wants is now its own decision instead of being hidden in the shared component.

The button in the variants table is no longer oversized, so its icon is visible again. Until now the label of the larger button left no room for the icon in the narrow column and the icon was silently squeezed to zero width.

Demo data now contain two unavailable variants of "Television Hyundai [M]" — one sold out and one with an expected restocking date. None of the existing demo products could reproduce the reported state at all: 153 of 154 of them allow selling below zero stock, and the button was duplicated only for goods that do not.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud
  - https://cz.vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud
  - https://vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud/sk

----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud
  - https://cz.vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud
  - https://vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788441567.249849 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud
  - https://cz.vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud
  - https://vk-ssp-4259-duplicate-watchdog-button.odin.shopsys.cloud/sk
<!-- Replace -->
