### PR TITLE
Validate the checkout email only when the customer leaves the field

### DIFF
--- a/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationContent.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationContent.tsx
@@ -18,7 +18,7 @@ export const ContactInformationContent: FC = () => {
     const { goToPreviousStepFromContactInformationPage } = useContactInformationPageNavigation();
     const { createOrder } = useCreateOrder(formProviderMethods, formMeta);
 
-    useErrorPopup(formProviderMethods, formMeta.fields, undefined, GtmMessageOriginType.contact_information_page);
+    useErrorPopup(formProviderMethods, formMeta.fields, GtmMessageOriginType.contact_information_page);
 
     return (
         <OrderContentWrapper activeStep={3}>

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
@@ -15,7 +15,6 @@ import {
     validateTelephoneRequired,
 } from 'components/Forms/validationRules';
 import { useAuthorization } from 'components/providers/AuthorizationProvider';
-import { useEffect, useEffectEvent } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { ContactInformation } from 'store/slices/createContactInformationSlice';
 import { FormMeta } from 'types/formMeta';
@@ -182,17 +181,6 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
         deliveryAddressUuid: pickupPlace ? '' : contactInformationValues.deliveryAddressUuid,
     };
     const formProviderMethods = useFormWrapper(resolver, defaultValues);
-
-    const validatePrefilledEmail = useEffectEvent(() => {
-        if (defaultValues.email) {
-            formProviderMethods.trigger('email', { shouldFocus: false });
-        }
-    });
-
-    // deliberately mount-only, defaultValues.email mirrors every keystroke through the persist store
-    useEffect(() => {
-        validatePrefilledEmail();
-    }, []);
 
     return [formProviderMethods, defaultValues];
 };

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
@@ -15,7 +15,7 @@ import {
     validateTelephoneRequired,
 } from 'components/Forms/validationRules';
 import { useAuthorization } from 'components/providers/AuthorizationProvider';
-import { useEffect } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { ContactInformation } from 'store/slices/createContactInformationSlice';
 import { FormMeta } from 'types/formMeta';
@@ -183,13 +183,16 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
     };
     const formProviderMethods = useFormWrapper(resolver, defaultValues);
 
-    useEffect(() => {
-        if (defaultValues.email && defaultValues.email.length > 0) {
+    const validatePrefilledEmail = useEffectEvent(() => {
+        if (defaultValues.email) {
             formProviderMethods.trigger('email', { shouldFocus: false });
-        } else {
-            formProviderMethods.clearErrors('email');
         }
-    }, [defaultValues.email, formProviderMethods]);
+    });
+
+    // deliberately mount-only, defaultValues.email mirrors every keystroke through the persist store
+    useEffect(() => {
+        validatePrefilledEmail();
+    }, []);
 
     return [formProviderMethods, defaultValues];
 };

--- a/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
@@ -5,6 +5,7 @@ import {
     checkTransportSelectionIsNotVisible,
     checkTransportSelectionIsVisible,
     clearPostcodeInThirdStep,
+    clickOnSendOrderButton,
     fillBillingAdressInThirdStep,
     fillCustomerInformationInThirdStep,
     fillEmailInThirdStep,
@@ -16,6 +17,7 @@ import { changeExpectedDeliveryDateMessagesToStaticDemodata } from 'e2e/transpor
 import { staticData, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
 import {
+    checkFormLineError,
     checkUrl,
     clickOnLabel,
     getSnapshotIndexingFunction,
@@ -170,5 +172,48 @@ describe('Contact Information Page Tests', () => {
             blackout: [{ tid: TIDs.order_summary_cart_item_image }, { tid: TIDs.footer_copyright }],
         });
         checkThatContactInformationWasRemovedFromLocalStorage();
+    });
+
+    it('[Invalid Email] should not reopen the closed error popup while the invalid email is being corrected', function () {
+        cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
+        cy.preselectTransportForTest(staticData.transport.czechPost.uuid);
+        cy.preselectPaymentForTest(staticData.payment.onDelivery.uuid);
+        cy.visitAndWaitForStableAndInteractiveDOM(url.order.contactInformation);
+
+        fillEmailInThirdStep(staticData.invalidEmail);
+        fillCustomerInformationInThirdStep(
+            staticData.customer1.phone,
+            staticData.customer1.firstName,
+            staticData.customer1.lastName,
+        );
+        fillBillingAdressInThirdStep(
+            staticData.customer1.billingStreet,
+            staticData.customer1.billingCity,
+            staticData.customer1.billingPostCode,
+        );
+        clickOnSendOrderButton();
+
+        cy.getByTID([TIDs.layout_popup]).should('be.visible');
+        checkFormLineError('Please enter a valid email. Example: email@example.com');
+
+        cy.realPress('{esc}');
+        cy.getByTID([TIDs.layout_popup]).should('not.exist');
+
+        cy.get('#contact-information-form-email').type('shopsys');
+        checkFormLineError('Please enter a valid email. Example: email@example.com');
+        cy.getByTID([TIDs.layout_popup]).should('not.exist');
+    });
+
+    it('[Invalid Email Prefill] should validate the invalid email restored from local storage right after page load', function () {
+        cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
+        cy.preselectTransportForTest(staticData.transport.czechPost.uuid);
+        cy.preselectPaymentForTest(staticData.payment.onDelivery.uuid);
+        cy.visitAndWaitForStableAndInteractiveDOM(url.order.contactInformation);
+
+        fillEmailInThirdStep(staticData.invalidEmail);
+        cy.reloadAndWaitForStableAndInteractiveDOM();
+
+        cy.get('#contact-information-form-email').should('have.value', staticData.invalidEmail);
+        checkFormLineError('Please enter a valid email. Example: email@example.com');
     });
 });

--- a/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
@@ -204,7 +204,7 @@ describe('Contact Information Page Tests', () => {
         cy.getByTID([TIDs.layout_popup]).should('not.exist');
     });
 
-    it('[Invalid Email Prefill] should validate the invalid email restored from local storage right after page load', function () {
+    it('[Invalid Email Prefill] should not report the invalid email restored from local storage until the field is left', function () {
         cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
         cy.preselectTransportForTest(staticData.transport.czechPost.uuid);
         cy.preselectPaymentForTest(staticData.payment.onDelivery.uuid);
@@ -214,6 +214,11 @@ describe('Contact Information Page Tests', () => {
         cy.reloadAndWaitForStableAndInteractiveDOM();
 
         cy.get('#contact-information-form-email').should('have.value', staticData.invalidEmail);
+        cy.getByTID([TIDs.form_line_error]).should('not.exist');
+
+        cy.get('#contact-information-form-email').focus();
+        loseFocus();
+
         checkFormLineError('Please enter a valid email. Example: email@example.com');
     });
 });

--- a/project-base/storefront/cypress/fixtures/demodata.ts
+++ b/project-base/storefront/cypress/fixtures/demodata.ts
@@ -7,6 +7,7 @@ export const staticData = {
         password: 'user123',
         uuid: '7b817d8b-41a3-4fc0-8570-08c9989f6dd9',
     },
+    invalidEmail: 'no-reply123@',
     customer1: {
         email: 'no-reply123@shopsys.com',
         emailRegistered: 'no-reply@shopsys.com',

--- a/project-base/storefront/utils/forms/useErrorPopup.tsx
+++ b/project-base/storefront/utils/forms/useErrorPopup.tsx
@@ -20,8 +20,13 @@ export const useErrorPopup = <T extends FieldValues>(
     gtmMessageOrigin?: GtmMessageOriginType,
 ) => {
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
+    const { submitCount } = formProviderMethods.formState;
 
     const onShowError = useEffectEvent(() => {
+        if (Object.keys(formProviderMethods.formState.errors).length === 0 && !overrideVisibility) {
+            return;
+        }
+
         updatePortalContent(
             <ErrorPopup
                 errors={formProviderMethods.formState.errors as FieldErrors}
@@ -31,12 +36,10 @@ export const useErrorPopup = <T extends FieldValues>(
         );
     });
 
+    // deliberately not depending on errors, revalidation would reopen a popup the user already closed
     useEffect(() => {
-        if (
-            formProviderMethods.formState.isSubmitted &&
-            (Object.keys(formProviderMethods.formState.errors).length > 0 || overrideVisibility)
-        ) {
+        if (submitCount > 0) {
             onShowError();
         }
-    }, [formProviderMethods.formState.isSubmitted, formProviderMethods.formState.errors, overrideVisibility]);
+    }, [submitCount, overrideVisibility]);
 };

--- a/project-base/storefront/utils/forms/useErrorPopup.tsx
+++ b/project-base/storefront/utils/forms/useErrorPopup.tsx
@@ -16,14 +16,13 @@ export const useErrorPopup = <T extends FieldValues>(
             label: string | ReactElement;
         };
     },
-    overrideVisibility?: boolean,
     gtmMessageOrigin?: GtmMessageOriginType,
 ) => {
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
     const { submitCount } = formProviderMethods.formState;
 
     const onShowError = useEffectEvent(() => {
-        if (Object.keys(formProviderMethods.formState.errors).length === 0 && !overrideVisibility) {
+        if (Object.keys(formProviderMethods.formState.errors).length === 0) {
             return;
         }
 
@@ -41,5 +40,5 @@ export const useErrorPopup = <T extends FieldValues>(
         if (submitCount > 0) {
             onShowError();
         }
-    }, [submitCount, overrideVisibility]);
+    }, [submitCount]);
 };

--- a/project-base/storefront/vitest/utils/forms/useErrorPopup.test.tsx
+++ b/project-base/storefront/vitest/utils/forms/useErrorPopup.test.tsx
@@ -29,6 +29,8 @@ const fields = { email: { name: 'email', label: 'Email' } };
 const REQUIRED_ERROR = 'Please enter email';
 const INVALID_ERROR = 'Please enter a valid email';
 
+const onValidSubmitMock = vi.fn();
+
 const TestForm: FC = () => {
     const formProviderMethods = useFormWrapper(
         yupResolver<FormValues>(
@@ -43,9 +45,10 @@ const TestForm: FC = () => {
 
     return (
         <FormProvider {...formProviderMethods}>
-            <Form formName="test-form" onSubmit={formProviderMethods.handleSubmit(vi.fn())}>
+            <Form formName="test-form" onSubmit={formProviderMethods.handleSubmit(onValidSubmitMock)}>
                 <input id="test-form-email" aria-label="Email" {...formProviderMethods.register('email')} />
                 <span>{formProviderMethods.formState.errors.email?.message}</span>
+                <span data-testid="submit-count">{formProviderMethods.formState.submitCount}</span>
                 <button type="submit">Submit</button>
             </Form>
         </FormProvider>
@@ -72,6 +75,19 @@ describe('useErrorPopup', () => {
 
         await waitFor(() => expect(screen.getByText(INVALID_ERROR)).toBeInTheDocument());
         expect(updatePortalContentMock).toHaveBeenCalledOnce();
+    });
+
+    test('does not open the popup when the submit succeeds', async () => {
+        const user = userEvent.setup();
+        render(<TestForm />);
+
+        await user.type(screen.getByRole('textbox', { name: 'Email' }), 'no-reply@shopsys.com');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        // waits for the submitCount bump, so the popup effect has already run by the time we assert
+        await waitFor(() => expect(screen.getByTestId('submit-count')).toHaveTextContent('1'));
+        expect(onValidSubmitMock).toHaveBeenCalledOnce();
+        expect(updatePortalContentMock).not.toHaveBeenCalled();
     });
 
     test('opens the popup on every submit attempt', async () => {

--- a/project-base/storefront/vitest/utils/forms/useErrorPopup.test.tsx
+++ b/project-base/storefront/vitest/utils/forms/useErrorPopup.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form } from 'components/Forms/Form/Form';
+import { FormProvider } from 'react-hook-form';
+import { useErrorPopup } from 'utils/forms/useErrorPopup';
+import { useFormWrapper } from 'utils/forms/useFormWrapper';
+import { yupResolver } from 'utils/forms/yupResolver';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { object, string } from 'yup';
+
+const { updatePortalContentMock } = vi.hoisted(() => ({
+    updatePortalContentMock: vi.fn(),
+}));
+
+vi.mock('next/dynamic', () => ({
+    default: () => () => null,
+}));
+
+vi.mock('store/useSessionStore', () => ({
+    useSessionStore: (selector: any) => selector({ updatePortalContent: updatePortalContentMock }),
+}));
+
+type FormValues = {
+    email: string;
+};
+
+const fields = { email: { name: 'email', label: 'Email' } };
+
+const REQUIRED_ERROR = 'Please enter email';
+const INVALID_ERROR = 'Please enter a valid email';
+
+const TestForm: FC = () => {
+    const formProviderMethods = useFormWrapper(
+        yupResolver<FormValues>(
+            object({
+                email: string().email(INVALID_ERROR).required(REQUIRED_ERROR),
+            }),
+        ),
+        { email: '' },
+    );
+
+    useErrorPopup(formProviderMethods, fields);
+
+    return (
+        <FormProvider {...formProviderMethods}>
+            <Form formName="test-form" onSubmit={formProviderMethods.handleSubmit(vi.fn())}>
+                <input id="test-form-email" aria-label="Email" {...formProviderMethods.register('email')} />
+                <span>{formProviderMethods.formState.errors.email?.message}</span>
+                <button type="submit">Submit</button>
+            </Form>
+        </FormProvider>
+    );
+};
+
+describe('useErrorPopup', () => {
+    beforeEach(() => {
+        updatePortalContentMock.mockClear();
+        window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    });
+
+    test('does not open the popup again while the invalid field is being corrected', async () => {
+        const user = userEvent.setup();
+        render(<TestForm />);
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+        await waitFor(() => {
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+            expect(updatePortalContentMock).toHaveBeenCalledOnce();
+        });
+
+        await user.type(screen.getByRole('textbox', { name: 'Email' }), 'no-reply');
+
+        await waitFor(() => expect(screen.getByText(INVALID_ERROR)).toBeInTheDocument());
+        expect(updatePortalContentMock).toHaveBeenCalledOnce();
+    });
+
+    test('opens the popup on every submit attempt', async () => {
+        const user = userEvent.setup();
+        render(<TestForm />);
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+        await waitFor(() => expect(updatePortalContentMock).toHaveBeenCalledOnce());
+
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+        await waitFor(() => expect(updatePortalContentMock).toHaveBeenCalledTimes(2));
+    });
+});

--- a/upgrade-notes/storefront_20260819_105712.md
+++ b/upgrade-notes/storefront_20260819_105712.md
@@ -1,0 +1,6 @@
+#### Validate the checkout email only when the customer leaves the field ([#4783](https://github.com/shopsys/shopsys/pull/4783))
+
+- `useErrorPopup()` from `utils/forms/useErrorPopup` no longer accepts the `overrideVisibility` argument - remove it from your calls, so `useErrorPopup(methods, fields, undefined, gtmMessageOrigin)` becomes `useErrorPopup(methods, fields, gtmMessageOrigin)`
+- an order contact e-mail restored from the local storage is no longer validated on page load, so an invalid one is reported only after the customer leaves the field
+    - if your project asserts the former behaviour in acceptance tests, update them - no error is rendered right after the page loads anymore
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Correcting an invalid e-mail address in the third step of the order was needlessly noisy. After a failed submit, the address was re-validated on every keystroke, so the inline error message kept changing under the customer's hands and — worse — the "Please, check inserted details" popup reopened right after they had closed it. With twenty characters left to type, that made the form genuinely annoying to use.

The e-mail field is now validated the same way as every other field in the form: when the customer leaves it, and on each submit attempt. Closing the popup and fixing the address is quiet, and the popup comes back only when the customer submits again.

This also removes a second, related oddity. A locally stored invalid e-mail used to be reported as an error immediately after the page loaded, before the customer touched the field at all, while an equally invalid postcode restored from the same storage stayed silent. The e-mail no longer flags itself on load. The customer is not left without feedback though — the submit button stays inactive until the address is valid, and submitting opens the popup listing every error.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4252-email-validation-timing.odin.shopsys.cloud
  - https://cz.vk-ssp-4252-email-validation-timing.odin.shopsys.cloud
  - https://vk-ssp-4252-email-validation-timing.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788434602.563029 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4252-email-validation-timing.odin.shopsys.cloud
  - https://cz.vk-ssp-4252-email-validation-timing.odin.shopsys.cloud
  - https://vk-ssp-4252-email-validation-timing.odin.shopsys.cloud/sk
<!-- Replace -->
