### PR TITLE
Elasticsearch profiler now displays bulk (NDJSON) request bodies

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php
+++ b/packages/framework/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Debug;
 
-use InvalidArgumentException;
 use Nette\Utils\Json;
+use Nette\Utils\JsonException;
 use Override;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
@@ -23,20 +23,40 @@ class ElasticsearchTracer extends AbstractLogger
     {
     }
 
-    protected function extractData(string $requestMessage): mixed
+    protected function extractBody(string $requestMessage): ?string
     {
         $matches = null;
 
-        if (preg_match('/^.* -d \'(?<json>.*)\'$/U', $requestMessage, $matches) === 0) {
+        if (preg_match('/^.* -d \'(?<json>.*)\'$/sU', $requestMessage, $matches) === 0) {
             return null;
         }
 
-        return Json::decode($matches['json'], true);
+        return trim($matches['json']);
     }
 
-    protected function formatData(mixed $requestData): string
+    protected function extractData(string $requestBody): mixed
     {
-        return Json::encode($requestData, JSON_PRETTY_PRINT);
+        // bulk APIs (e.g. _msearch) send NDJSON - multiple JSON objects separated by newlines
+        if (str_contains($requestBody, "\n")) {
+            return array_map(
+                static fn (string $line) => Json::decode($line, true),
+                explode("\n", $requestBody),
+            );
+        }
+
+        return Json::decode($requestBody, true);
+    }
+
+    protected function formatBody(string $requestBody): string
+    {
+        // each NDJSON line is pretty-printed separately so the output stays usable in Kibana,
+        // decoding to objects (not arrays) keeps empty objects as `{}` instead of `[]`
+        $prettyLines = array_map(
+            static fn (string $line) => Json::encode(Json::decode($line), JSON_PRETTY_PRINT),
+            explode("\n", $requestBody),
+        );
+
+        return implode("\n", $prettyLines);
     }
 
     /**
@@ -73,11 +93,15 @@ class ElasticsearchTracer extends AbstractLogger
         $requestJson = null;
         $requestData = null;
 
-        try {
-            $requestData = $this->extractData($this->lastRequestCurl);
-            $requestJson = $this->formatData($requestData);
-        } catch (InvalidArgumentException $exception) {
-            // It's ok, It'll not have formatted dump.
+        $requestBody = $this->extractBody($this->lastRequestCurl);
+
+        if ($requestBody !== null) {
+            try {
+                $requestData = $this->extractData($requestBody);
+                $requestJson = $this->formatBody($requestBody);
+            } catch (JsonException $exception) {
+                // It's ok, It'll not have formatted dump.
+            }
         }
 
         $this->elasticsearchRequestCollection->addRequest(

--- a/packages/framework/src/Resources/views/Components/Collector/elasticSearch.html.twig
+++ b/packages/framework/src/Resources/views/Components/Collector/elasticSearch.html.twig
@@ -86,18 +86,18 @@
                 <th class="{{ statusClass }}" style="width: 70px;">{{ request.method }}</th>
                 <th class="{{ statusClass }}">{{ request.uri }}</th>
                 <td class="{{ statusClass }}" style="width: 250px">
-                    {% if request.requestJson is not null %}
-                        <button type="button" class="btn" onclick="document.getElementById('js-elasticsearch-response-data-{{ index }}').classList.toggle('hidden'); return false;">
+                    {% if request.response is not null %}
+                        <button type="button" class="btn btn-sm" onclick="document.getElementById('js-elasticsearch-response-data-{{ index }}').classList.toggle('hidden'); return false;">
                             Response
                         </button>
                     {% endif %}
                     {% if request.requestData is not null %}
-                    <button type="button" class="btn" onclick="document.getElementById('js-elasticsearch-request-data-{{ index }}').classList.toggle('hidden'); return false;">
+                    <button type="button" class="btn btn-sm" onclick="document.getElementById('js-elasticsearch-request-data-{{ index }}').classList.toggle('hidden'); return false;">
                         Request
                     </button>
                     {% endif %}
-                    {% if request.response is not null %}
-                        <button type="button" class="btn" onclick="document.getElementById('js-elasticsearch-request-json-{{ index }}').classList.toggle('hidden'); return false;">
+                    {% if request.requestJson is not null %}
+                        <button type="button" class="btn btn-sm" onclick="document.getElementById('js-elasticsearch-request-json-{{ index }}').classList.toggle('hidden'); return false;">
                             Json
                         </button>
                     {% endif %}


### PR DESCRIPTION
#### Description, the reason for the PR

The Elasticsearch panel in the Symfony profiler was unusable for bulk requests. Bulk endpoints such as `_msearch` send their body as NDJSON (multiple JSON objects separated by newlines), which the tracer failed to parse as a single JSON document — so the profiler showed no request data at all for exactly the queries developers most often need to debug. The tracer now recognizes multiline request bodies and formats each NDJSON line separately, so bulk request bodies are displayed pretty-printed and stay usable for copy-pasting into Kibana.

Additionally, the Response and Json toggle buttons in the panel were swapped — each opened the other's data block. They now toggle their matching blocks, and the buttons are smaller so all three fit the table row.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://mg-profiler-es-fix.odin.shopsys.cloud
  - https://cz.mg-profiler-es-fix.odin.shopsys.cloud
  - https://mg-profiler-es-fix.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1789535106.558779 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-profiler-es-fix.odin.shopsys.cloud
  - https://cz.mg-profiler-es-fix.odin.shopsys.cloud
  - https://mg-profiler-es-fix.odin.shopsys.cloud/sk
<!-- Replace -->
