### PR TITLE
Improved customer return from the payment gateway

### DIFF
--- a/packages/framework/src/Model/Payment/ReturnHash/PaymentReturnHashFacade.php
+++ b/packages/framework/src/Model/Payment/ReturnHash/PaymentReturnHashFacade.php
@@ -12,7 +12,7 @@ use Shopsys\FrameworkBundle\Model\Order\Order;
 class PaymentReturnHashFacade
 {
     protected const int HASH_LENGTH = 64;
-    protected const string HASH_TTL_MODIFIER = '+30 minutes';
+    protected const string HASH_TTL_MODIFIER = '+60 minutes';
 
     public function __construct(
         protected readonly PaymentReturnHashRepository $paymentReturnHashRepository,

--- a/project-base/storefront/pages/order-confirmation.tsx
+++ b/project-base/storefront/pages/order-confirmation.tsx
@@ -1,5 +1,6 @@
 import { MetaRobots } from 'components/Basic/Head/MetaRobots';
 import { CheckmarkIcon } from 'components/Basic/Icon/CheckmarkIcon';
+import { InfoIcon } from 'components/Basic/Icon/InfoIcon';
 import { SpinnerIcon } from 'components/Basic/Icon/SpinnerIcon';
 import { WarningIcon } from 'components/Basic/Icon/WarningIcon';
 import { ConfirmationPageContent } from 'components/Blocks/ConfirmationPage/ConfirmationPageContent';
@@ -74,10 +75,12 @@ const OrderConfirmationPage: FC<ServerSidePropsType> = () => {
                 >
                     <Webline>
                         <ConfirmationPageContent
-                            content={t('Please check your order confirmation e-mail or sign in to your account.')}
-                            heading={t('Order confirmation can no longer be displayed.')}
-                            headingIcon={WarningIcon}
-                            headingVariant="error"
+                            content={t(
+                                'It took a while, so for security reasons this page no longer shows the order details. If you have completed the payment, it will be processed automatically. You will find all the details in the order confirmation e-mail, or after signing in to your account.',
+                            )}
+                            heading={t('Your order is fine, but we can no longer show it here.')}
+                            headingIcon={InfoIcon}
+                            headingVariant="info"
                         />
                     </Webline>
                 </CommonLayout>

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -1,5 +1,7 @@
 {
     "404": "404",
+    "It took a while, so for security reasons this page no longer shows the order details. If you have completed the payment, it will be processed automatically. You will find all the details in the order confirmation e-mail, or after signing in to your account.": "Chvíli to trvalo, a tak už tady z bezpečnostních důvodů podrobnosti objednávky nezobrazujeme. Pokud jste platbu dokončili, zpracuje se automaticky. Všechny podrobnosti najdete v e-mailu s potvrzením objednávky, případně po přihlášení do svého účtu.",
+    "Your order is fine, but we can no longer show it here.": "Vaše objednávka je v pořádku, jen už ji tady nemůžeme zobrazit.",
     "{{ count }} error type(s) being ignored_one": "{{ count }} typ chyby je ignorován",
     "{{ count }} error type(s) being ignored_few": "{{ count }} typy chyb jsou ignorovány",
     "{{ count }} error type(s) being ignored_many": "{{ count }} typů chyb je ignorováno",
@@ -385,7 +387,6 @@
     "or at {{ count }} stores_other": "nebo na {{ count }} prodejnách",
     "Order": "Objednávka",
     "Order confirmation": "Potvrzení objednávky",
-    "Order confirmation can no longer be displayed.": "Potvrzení objednávky již nelze zobrazit.",
     "Order content has expired. <link>View order details</link>": "Platnost obsahu objednávky vypršela. <link>Zobrazit detail objednávky</link>",
     "Order content has expired. Check your email for order details.": "Platnost obsahu objednávky vypršela. Zkontrolujte svůj e-mail pro detail objednávky.",
     "Order detail": "Detail objednávky",
@@ -443,7 +444,6 @@
     "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.": "Prosím, přiložte obrázky reklamovaného zboží ve formátu JPG nebo PNG s maximální velikostí souboru {{ max }}. Maximální počet souborů je {{ maxFilesCount }}.",
     "Please check inserted details": "Prosím zkontrolujte zadané údaje.",
     "Please check Tax number format": "Prosím zkontrolujte formát DIČ",
-    "Please check your order confirmation e-mail or sign in to your account.": "Zkontrolujte prosím e-mail s potvrzením objednávky nebo se přihlaste do svého účtu.",
     "Please enter a message": "Vyplňte prosím zprávu",
     "Please enter a valid email. Example: email@example.com": "Vyplňte prosím platný e-mail. Příklad: email@example.com",
     "Please enter a valid phone prefix": "Vyplňte prosím telefonní předvolbu",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -1,5 +1,7 @@
 {
     "404": "404",
+    "It took a while, so for security reasons this page no longer shows the order details. If you have completed the payment, it will be processed automatically. You will find all the details in the order confirmation e-mail, or after signing in to your account.": "It took a while, so for security reasons this page no longer shows the order details. If you have completed the payment, it will be processed automatically. You will find all the details in the order confirmation e-mail, or after signing in to your account.",
+    "Your order is fine, but we can no longer show it here.": "Your order is fine, but we can no longer show it here.",
     "{{ count }} error type(s) being ignored_one": "{{ count }} error type is being ignored",
     "{{ count }} error type(s) being ignored_other": "{{ count }} error types are being ignored",
     "{{ distance }} km away": "{{ distance }} km away",
@@ -365,7 +367,6 @@
     "or at {{ count }} stores_other": "or at {{ count }} stores",
     "Order": "Order",
     "Order confirmation": "Order confirmation",
-    "Order confirmation can no longer be displayed.": "Order confirmation can no longer be displayed.",
     "Order content has expired. <link>View order details</link>": "Order content has expired. <link>View order details</link>",
     "Order content has expired. Check your email for order details.": "Order content has expired. Check your email for order details.",
     "Order detail": "Order detail",
@@ -421,7 +422,6 @@
     "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.": "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.",
     "Please check inserted details": "Please, check inserted details",
     "Please check Tax number format": "Please check Tax number format",
-    "Please check your order confirmation e-mail or sign in to your account.": "Please check your order confirmation e-mail or sign in to your account.",
     "Please enter a message": "Please enter a message",
     "Please enter a valid email. Example: email@example.com": "Please enter a valid email. Example: email@example.com",
     "Please enter a valid phone prefix": "Please enter a valid phone prefix",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -1,5 +1,7 @@
 {
     "404": "404",
+    "It took a while, so for security reasons this page no longer shows the order details. If you have completed the payment, it will be processed automatically. You will find all the details in the order confirmation e-mail, or after signing in to your account.": "Chvíľu to trvalo, a tak tu už z bezpečnostných dôvodov podrobnosti objednávky nezobrazujeme. Ak ste platbu dokončili, spracuje sa automaticky. Všetky podrobnosti nájdete v e-maile s potvrdením objednávky, prípadne po prihlásení do svojho účtu.",
+    "Your order is fine, but we can no longer show it here.": "Vaša objednávka je v poriadku, len ju tu už nemôžeme zobraziť.",
     "{{ count }} error type(s) being ignored_one": "{{ count }} typ chyby je ignorovaný",
     "{{ count }} error type(s) being ignored_few": "{{ count }} typy chýb sú ignorované",
     "{{ count }} error type(s) being ignored_many": "{{ count }} typov chýb je ignorovaných",
@@ -385,7 +387,6 @@
     "or at {{ count }} stores_other": "alebo na {{ count }} predajniach",
     "Order": "Objednávka",
     "Order confirmation": "Potvrdenie objednávky",
-    "Order confirmation can no longer be displayed.": "Potvrdenie objednávky už nie je možné zobraziť.",
     "Order content has expired. <link>View order details</link>": "Platnosť obsahu objednávky vypršala. <link>Zobraziť detail objednávky</link>",
     "Order content has expired. Check your email for order details.": "Platnosť obsahu objednávky vypršala. Skontrolujte prosím svoj e-mail pre detail objednávky.",
     "Order detail": "Detail objednávky",
@@ -443,7 +444,6 @@
     "Please attach JPG or PNG images of the claimed goods with a maximum file size of {{ max }}. Maximum files count is {{ maxFilesCount }}.": "Prosím, priložte obrázky reklamovaného tovaru vo formáte JPG alebo PNG s maximálnou veľkosťou súboru {{ max }}. Maximálny počet súborov je {{ maxFilesCount }}.",
     "Please check inserted details": "Prosím, skontrolujte zadané údaje.",
     "Please check Tax number format": "Prosím, skontrolujte formát IČ DPH",
-    "Please check your order confirmation e-mail or sign in to your account.": "Skontrolujte prosím e-mail s potvrdením objednávky alebo sa prihláste do svojho účtu.",
     "Please enter a message": "Vyplňte prosím správu",
     "Please enter a valid email. Example: email@example.com": "Vyplňte prosím platný e-mail. Príklad: email@example.com",
     "Please enter a valid phone prefix": "Vyplňte prosím platnú telefónnu predvoľbu",

--- a/project-base/storefront/utils/auth/useLogin.tsx
+++ b/project-base/storefront/utils/auth/useLogin.tsx
@@ -9,6 +9,7 @@ import { usePersistStore } from 'store/usePersistStore';
 import { useSessionStore } from 'store/useSessionStore';
 import { OperationResult } from 'urql';
 import { getAuthMutationFetcher } from 'utils/auth/authMutationFetcher';
+import { clearOrderConfirmationContext } from 'utils/order/orderConfirmationContextStorage';
 import { dispatchBroadcastChannel } from 'utils/useBroadcastChannel';
 
 type LoginHandler = (
@@ -52,6 +53,7 @@ export const useHandleActionsAfterLogin = () => {
     const handleActionsAfterLogin = (showCartMergeInfo: boolean, rewriteUrl: string | undefined) => {
         updateCartUuid(null);
         updateProductListUuids({});
+        clearOrderConfirmationContext();
 
         updateAuthLoadingState(showCartMergeInfo ? 'login-loading-with-cart-modifications' : 'login-loading');
         updateUserEntryState('login');
@@ -78,6 +80,7 @@ export const useLoginAfterPasswordRecovery = () => {
     const handleActionsAfterPasswordRecovery = (showCartMergeInfo: boolean) => {
         updateCartUuid(null);
         updateProductListUuids({});
+        clearOrderConfirmationContext();
 
         updateAuthLoadingState(showCartMergeInfo ? 'login-loading-with-cart-modifications' : 'login-loading');
         updateUserEntryState('login');

--- a/project-base/storefront/utils/auth/useLogout.tsx
+++ b/project-base/storefront/utils/auth/useLogout.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { usePersistStore } from 'store/usePersistStore';
 import { useSessionStore } from 'store/useSessionStore';
 import { getAuthMutationFetcher } from 'utils/auth/authMutationFetcher';
+import { clearOrderConfirmationContext } from 'utils/order/orderConfirmationContextStorage';
 import { dispatchBroadcastChannel } from 'utils/useBroadcastChannel';
 
 export const useLogout = () => {
@@ -22,6 +23,7 @@ export const useLogout = () => {
 
         if (logoutResult.data?.Logout) {
             resetContactInformation();
+            clearOrderConfirmationContext();
             updateProductListUuids({});
             updatePageLoadingState({ isPageLoading: true, redirectPageType: 'homepage' });
             updateAuthLoadingState('logout-loading');

--- a/project-base/storefront/utils/order/orderConfirmationContextStorage.ts
+++ b/project-base/storefront/utils/order/orderConfirmationContextStorage.ts
@@ -1,5 +1,5 @@
 const ORDER_CONFIRMATION_CONTEXT_STORAGE_KEY = 'orderConfirmationContext';
-const ORDER_CONFIRMATION_CONTEXT_TTL_IN_MS = 30 * 60 * 1000;
+const ORDER_CONFIRMATION_CONTEXT_TTL_IN_MS = 60 * 60 * 1000;
 
 type OrderConfirmationContext = {
     orderUrlHash: string;

--- a/upgrade-notes/backend_20260821_105825.md
+++ b/upgrade-notes/backend_20260821_105825.md
@@ -1,0 +1,3 @@
+#### Improved customer return from the payment gateway ([#4789](https://github.com/shopsys/shopsys/pull/4789))
+
+- the payment return hash is now valid for 60 minutes instead of 30 — if your project needs a different validity window, override `\Shopsys\FrameworkBundle\Model\Payment\ReturnHash\PaymentReturnHashFacade::HASH_TTL_MODIFIER`

--- a/upgrade-notes/storefront_20260821_105825.md
+++ b/upgrade-notes/storefront_20260821_105825.md
@@ -1,0 +1,3 @@
+#### Improved customer return from the payment gateway ([#4789](https://github.com/shopsys/shopsys/pull/4789))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Customers who took longer to pay through the GoPay payment gateway returned to an error-styled dead end saying "Order confirmation can no longer be displayed." The return link from the gateway was only valid for 30 minutes, so a customer who went to answer a phone call mid-payment came back to what looked like a failed order — even though the order existed and the payment result gets processed automatically.

The return window is now 60 minutes, so the vast majority of slower payments still end on the regular order confirmation with a live payment status. Customers who exceed even that window now see a calm informational page instead of an error: it reassures them the order is fine, explains that the completed payment will be processed automatically, and points them to the confirmation e-mail or their account.

As a related hardening, the order confirmation context stored in the browser tab is now cleared on login and logout, so on a shared computer the next signed-in customer can no longer see the previous customer's order confirmation.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-gopay-return-context-fallback.odin.shopsys.cloud
  - https://cz.mg-gopay-return-context-fallback.odin.shopsys.cloud
  - https://mg-gopay-return-context-fallback.odin.shopsys.cloud/sk
<!-- Replace -->
