### PR TITLE
Skip AI review stages for Dependabot pull requests

### DIFF
--- a/.github/workflows/ai-acceptance-criteria-ready-for-review.yaml
+++ b/.github/workflows/ai-acceptance-criteria-ready-for-review.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     variables:
         name: Extract variables
-        if: github.event.pull_request.head.repo.full_name == 'shopsys/shopsys'
+        if: github.event.pull_request.head.repo.full_name == 'shopsys/shopsys' && github.actor != 'dependabot[bot]'
         runs-on: ubuntu-22.04
         timeout-minutes: 5
         outputs:

--- a/.github/workflows/ai-security-review.yaml
+++ b/.github/workflows/ai-security-review.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
     security-audit:
         name: Claude security audit
-        if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         runs-on: ubuntu-22.04
         timeout-minutes: 20
         steps:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1338,6 +1338,7 @@ jobs:
             github.event_name == 'pull_request' &&
             github.event.pull_request.draft == false &&
             github.event.pull_request.head.repo.full_name == 'shopsys/shopsys' &&
+            github.actor != 'dependabot[bot]' &&
             needs.review.result == 'success'
         permissions:
             contents: read


### PR DESCRIPTION
#### Description, the reason for the PR

Dependabot pull requests triggered the AI review stages (acceptance criteria check and security audit) like any other pull request. These runs bring no value on automated dependency bumps — there is no linked Jira issue to verify, and the security audit spends an agent run on a machine-generated diff. Moreover, Dependabot-triggered workflow runs don't receive repository secrets, so the jobs could not even authenticate properly.

Now all three AI review entry points skip runs triggered by Dependabot. The check is based on the triggering actor, as recommended by the GitHub documentation, so when a developer later pushes their own commits to a Dependabot branch, the reviews run again with full access — human-authored changes still get reviewed.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-no-dependabot-reviews.odin.shopsys.cloud
  - https://cz.mg-no-dependabot-reviews.odin.shopsys.cloud
  - https://mg-no-dependabot-reviews.odin.shopsys.cloud/sk
<!-- Replace -->
