### PR TITLE
Improve custom actions and custom routes in CRUD controllers

### DIFF
--- a/docs/administration/admin-rights.md
+++ b/docs/administration/admin-rights.md
@@ -176,6 +176,7 @@ When multiple security attributes are applied to the same method, they follow a 
 - **SuperAdminOnly at class-level** takes precedence over all method-level attributes
 - **PublicAccess at class-level** can be overridden by method-level security attributes
 - **ForRole** provides default role for CRUD attributes but can be overridden per method
+- **On a CRUD controller** `#[ForRole]` sets the role of the whole controller: the built-in CRUD actions and permission attributes on custom routes are all guarded by that role, and the controller does not register its own generated role in the role matrix — pass a role directly in the permission attribute when a single route needs a different one
 
 ### 2. Access Type Priority
 

--- a/docs/administration/crud-controller/getting-started/extending-existing-crud-controller.md
+++ b/docs/administration/crud-controller/getting-started/extending-existing-crud-controller.md
@@ -141,3 +141,15 @@ You can also specify multiple extension classes for one CRUD Controller. This is
 For that purpose, you can use the `priority` parameter in the `#[CrudControllerExtension]` attribute.
 
 A higher priority value means that the extension will be executed later. The default priority is `0`. Extension from the `App` namespace will be automatically registered with the highest priority if the `priority` parameter is not set.
+
+## Overriding the role constant
+
+An extension can override the [role constant](../reference/crud-controller.md#role-constant) of the extended controller by declaring the `#[ForRole]` attribute on the extension class:
+
+```php
+#[CrudControllerExtension(crudController: OrderCrudController::class)]
+#[ForRole(CustomRoleConstant::ROLE_ORDER_MANAGER)]
+class OrderCrudControllerExtension extends AbstractCrudControllerExtension
+```
+
+When multiple extensions declare the attribute, the one executed last (the highest priority) wins.

--- a/docs/administration/crud-controller/reference/actions.md
+++ b/docs/administration/crud-controller/reference/actions.md
@@ -85,6 +85,13 @@ protected function configureActions(ActionsConfig $actions): void
 
     You can implement your own reusable actions by extending the `Shopsys\AdministrationBundle\Component\Action\AbstractAction` class.
 
+### What the closures receive
+
+The `displayIf()` and `linkToRoute()` closures receive the data of the page the action is displayed on:
+
+- `ActionType::EDIT` — the edited entity
+- `ActionType::LIST`, `ActionType::CREATE`, and `ActionType::DETAIL` — `null` (there is no single entity on these pages; for per-row actions in the list grid use row actions instead — their closures receive the data of the grid row they are rendered in)
+
 ### Configuration
 
 ```php

--- a/docs/administration/crud-controller/reference/actions.md
+++ b/docs/administration/crud-controller/reference/actions.md
@@ -96,6 +96,12 @@ The `displayIf()` and `linkToRoute()` closures receive the data of the page the 
 
     When the route linked via `linkToRoute()` is protected by the `#[CsrfProtection]` attribute, the CSRF token is appended to the generated URL automatically (unless you provide it yourself in the parameters).
 
+!!! note
+
+    Permission attributes (`#[CanView]`, `#[CanEdit]`, ...) on custom routes defined in a Crud Controller do not need an explicit role 
+    — they fall back to the controller's role constant (the generated one, or the one declared by the class-level `#[ForRole]` attribute), the same role the built-in CRUD actions use.
+    You only need to pass a role explicitly when the route should be guarded by a different role.
+
 ### Configuration
 
 ```php

--- a/docs/administration/crud-controller/reference/actions.md
+++ b/docs/administration/crud-controller/reference/actions.md
@@ -92,6 +92,10 @@ The `displayIf()` and `linkToRoute()` closures receive the data of the page the 
 - `ActionType::EDIT` — the edited entity
 - `ActionType::LIST`, `ActionType::CREATE`, and `ActionType::DETAIL` — `null` (there is no single entity on these pages; for per-row actions in the list grid use row actions instead — their closures receive the data of the grid row they are rendered in)
 
+!!! note
+
+    When the route linked via `linkToRoute()` is protected by the `#[CsrfProtection]` attribute, the CSRF token is appended to the generated URL automatically (unless you provide it yourself in the parameters).
+
 ### Configuration
 
 ```php

--- a/docs/administration/crud-controller/reference/crud-controller.md
+++ b/docs/administration/crud-controller/reference/crud-controller.md
@@ -33,6 +33,22 @@ Crud controller generates pretty URLs for each action. The URL is generated base
 | `edit`     | `admin_crud_{controller_name}_edit`   | `/admin/{controller-name}/edit/{entityId}`   |
 | `delete`   | `admin_crud_{controller_name}_delete` | `/admin/{controller-name}/delete/{entityId}` |
 
+### Role constant
+
+Role constant used for permission checking is generated automatically from the controller name (e.g. `PriceListController` -> `ROLE_CRUD_PRICE_LIST`) and registered in the administrator role matrix.
+If you want the controller to use an existing role instead, declare it with the `#[ForRole]` attribute on the controller class:
+
+```php
+#[CrudController(TransportGroup::class)]
+#[ForRole(AdminRoleConstant::ROLE_TRANSPORT_AND_PAYMENT)]
+class TransportGroupController extends AbstractCrudController
+```
+
+The role is then used by the built-in CRUD actions as well as by permission attributes on custom routes, and the controller does not register its own role in the role matrix — the referenced role must be provisioned by a role provider.
+The attribute can also be placed on a [CRUD Controller extension](../getting-started/extending-existing-crud-controller.md) class to override the role of the extended controller.
+
+See [Admin Rights and Access Control](../../admin-rights.md)
+
 ## Methods
 
 Crud Controller provides several methods that allow you to customize the behavior of the controller.
@@ -268,12 +284,6 @@ If you want for example to disable the `delete` action you can simply call `$con
 #### `disable(bool $disabled)`
 
 Fully disable the CRUD Controller that will not be accessible by the user.
-
-#### `setCustomRoleConstant(?string $roleConstant)`
-
-Role constant is generated automatically from the controller name by default. If you want to use a custom role constant for permission checking, you can set it using this method.
-
-See [Admin Rights and Access Control](../../admin-rights.md)
 
 #### `setCustomRoleSection(string $roleSection)`
 

--- a/packages/administration/config/services.yaml
+++ b/packages/administration/config/services.yaml
@@ -20,6 +20,10 @@ services:
             $crudControllers: '%shopsys.admin.crud_controllers%'
             $crudControllerExtensions: '%shopsys.admin.crud_controllers_extensions%'
 
+    Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider:
+        arguments:
+            $customRoleConstants: '%shopsys.admin.crud_role_constants%'
+
     Shopsys\AdministrationBundle\Component\Menu\CrudMenuSubscriber:
         tags:
             - { name: kernel.event_subscriber }

--- a/packages/administration/src/Component/Action/AbstractAction.php
+++ b/packages/administration/src/Component/Action/AbstractAction.php
@@ -45,7 +45,10 @@ abstract class AbstractAction
     /**
      * Set function that will determine if action should be displayed
      *
-     * @param \Closure(): bool $function Function must return boolean value. If function returns false, action will not be displayed
+     * @param \Closure(mixed): bool $function Function must return boolean value. If function returns false, action will not be displayed.
+     *      The closure receives the data the action is built with, depending on the action kind:
+     *      a top action (Action) gets the data of the current page — the entity on the edit page, null on the list, create, and detail pages;
+     *      a row action (RowAction) gets the data of the grid row it is rendered in
      */
     public function displayIf(Closure $function): static
     {

--- a/packages/administration/src/Component/Config/CrudConfig.php
+++ b/packages/administration/src/Component/Config/CrudConfig.php
@@ -41,8 +41,6 @@ final class CrudConfig
 
     private ?string $routePrefix = null;
 
-    private ?string $customRoleConstant = null;
-
     private ?string $customRoleSection = null;
 
     private ?string $menuIcon = null;
@@ -63,8 +61,13 @@ final class CrudConfig
         ActionType::CREATE->value => null,
     ];
 
-    public function __construct(private readonly string $entityName)
-    {
+    /**
+     * @param string|null $customRoleConstant role declared by the ForRole attribute on the CRUD controller (or its extension), resolved at compile time
+     */
+    public function __construct(
+        private readonly string $entityName,
+        private readonly ?string $customRoleConstant = null,
+    ) {
         $this->enabledActions = new ArrayCollection([
             ActionType::LIST,
         ]);
@@ -206,19 +209,6 @@ final class CrudConfig
     public function setRoutePrefix(?string $routePrefix): self
     {
         $this->routePrefix = $routePrefix;
-
-        return $this;
-    }
-
-    /**
-     * Set custom role constant for the CRUD controller. This will be used for access control checks.
-     * If not set, role constant will be generated from the controller name automatically.
-     *
-     * @return $this
-     */
-    public function setCustomRoleConstant(?string $roleConstant): self
-    {
-        $this->customRoleConstant = $roleConstant;
 
         return $this;
     }

--- a/packages/administration/src/Component/Crud/CrudControllerRegistry.php
+++ b/packages/administration/src/Component/Crud/CrudControllerRegistry.php
@@ -9,7 +9,6 @@ use RuntimeException;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfigData;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
-use SplPriorityQueue;
 use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Webmozart\Assert\Assert;
@@ -36,10 +35,11 @@ final class CrudControllerRegistry
 
     /**
      * @param array<int, array{class: class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, entityClass: string}> $crudControllers
-     * @param array<int, array{extensionClass: class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension>, controllerClass: class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, priority: int}> $crudControllerExtensions
+     * @param array<int, array{extensionClass: class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudControllerExtension>, controllerClass: class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, priority: int}> $crudControllerExtensions sorted by ascending priority
      */
     public function __construct(
         private readonly EntityNameResolver $entityNameResolver,
+        private readonly CrudRoleConstantProvider $crudRoleConstantProvider,
         #[TaggedLocator('shopsys.admin.crud_controllers')]
         private readonly ServiceLocator $controllers,
         #[TaggedLocator('shopsys.admin.crud_handler')]
@@ -113,7 +113,7 @@ final class CrudControllerRegistry
         /** @var \Shopsys\AdministrationBundle\Controller\AbstractCrudController $crudController */
         $crudController = $this->controllers->get($controllerClass);
 
-        $config = new CrudConfig($meta['entityName']);
+        $config = new CrudConfig($meta['entityName'], $this->crudRoleConstantProvider->findCustomRoleConstant($controllerClass));
         $crudController->configure($config);
 
         foreach ($extensions as $extension) {
@@ -153,23 +153,9 @@ final class CrudControllerRegistry
     {
         if ($this->resolvedExtensions === null) {
             $this->resolvedExtensions = [];
-            $queueByController = [];
 
             foreach ($this->crudControllerExtensions as $extension) {
-                if (isset($queueByController[$extension['controllerClass']]) === false) {
-                    $queueByController[$extension['controllerClass']] = new SplPriorityQueue();
-                }
-
-                $queueByController[$extension['controllerClass']]->insert(
-                    $this->controllers->get($extension['extensionClass']),
-                    $extension['priority'],
-                );
-            }
-
-            foreach ($queueByController as $controller => $queue) {
-                $queue->top();
-                $queue->setExtractFlags(SplPriorityQueue::EXTR_DATA);
-                $this->resolvedExtensions[$controller] = array_reverse(iterator_to_array($queue));
+                $this->resolvedExtensions[$extension['controllerClass']][] = $this->controllers->get($extension['extensionClass']);
             }
         }
 

--- a/packages/administration/src/Component/Crud/CrudRoleConstantProvider.php
+++ b/packages/administration/src/Component/Crud/CrudRoleConstantProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\Component\Crud;
+
+/**
+ * Reads the custom role constants of CRUD controllers resolved at compile time by ResolveCrudRoleConstantsCompilerPass
+ */
+final class CrudRoleConstantProvider
+{
+    public const string CRUD_ROLE_CONSTANTS_PARAMETER = 'shopsys.admin.crud_role_constants';
+
+    /**
+     * @param array<class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController>, string|null> $customRoleConstants role declared by the ForRole attribute, or null for the generated role, indexed by controller class
+     */
+    public function __construct(
+        private readonly array $customRoleConstants = [],
+    ) {
+    }
+
+    /**
+     * Returns the role declared by the ForRole attribute on the CRUD controller or one of its extensions, or null when the controller uses its generated role
+     *
+     * @param class-string<\Shopsys\AdministrationBundle\Controller\AbstractCrudController> $controllerClass
+     */
+    public function findCustomRoleConstant(string $controllerClass): ?string
+    {
+        return $this->customRoleConstants[$controllerClass] ?? null;
+    }
+}

--- a/packages/administration/src/Component/Security/Attribute/AttributeProcessor.php
+++ b/packages/administration/src/Component/Security/Attribute/AttributeProcessor.php
@@ -7,7 +7,10 @@ namespace Shopsys\AdministrationBundle\Component\Security\Attribute;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionMethod;
+use Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider;
+use Shopsys\AdministrationBundle\Component\Crud\Helper\CrudTransformationHelper;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlRuleFactory;
+use Shopsys\AdministrationBundle\Controller\AbstractCrudController;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanCreate;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanEdit;
@@ -27,6 +30,7 @@ final class AttributeProcessor
 {
     public function __construct(
         private readonly AccessControlRuleFactory $accessControlRuleFactory,
+        private readonly CrudRoleConstantProvider $crudRoleConstantProvider,
     ) {
     }
 
@@ -75,8 +79,13 @@ final class AttributeProcessor
             $rules[] = $this->accessControlRuleFactory->create($roleWithPermission, $attribute->getMethods());
         }
 
-        // Get class-level role if ForRole attribute is present
-        $classRole = $this->getClassAttribute($class, ForRole::class)?->role;
+        // CRUD controllers use their role constant (generated, or set by ForRole — resolved at compile time including extension overrides) so custom routes are guarded by the same role as the built-in actions, other classes read the ForRole attribute directly
+        $classRole = $class->isSubclassOf(AbstractCrudController::class)
+            ? CrudTransformationHelper::generateRoleConstant(
+                $class->getShortName(),
+                $this->crudRoleConstantProvider->findCustomRoleConstant($class->getName()),
+            )
+            : $this->getClassAttribute($class, ForRole::class)?->role;
 
         // Process CRUD attributes
         $this->processPermissionAttributes($method, $rules, CanView::class, $classRole);

--- a/packages/administration/src/Controller/AbstractCrudController.php
+++ b/packages/administration/src/Controller/AbstractCrudController.php
@@ -298,6 +298,7 @@ abstract class AbstractCrudController extends AdminBaseController
         return $this->render($this->getEditTemplate(), [
             'title' => $config->getTitle(ActionType::EDIT, $recordName),
             'topActions' => $this->getConfiguredActions(ActionType::EDIT),
+            'entity' => $entity,
             'form' => $form->createView(),
             ...$this->getEditViewData($entity),
         ]);

--- a/packages/administration/src/Controller/BlogArticleAuthorController.php
+++ b/packages/administration/src/Controller/BlogArticleAuthorController.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSourceFactory;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
 use Shopsys\FrameworkBundle\Form\Admin\Blog\BlogArticleAuthorFormType;
 use Shopsys\FrameworkBundle\Model\AdminNavigation\SideMenuBuilder;
@@ -23,6 +24,7 @@ use Shopsys\FrameworkBundle\Model\Blog\Author\BlogArticleAuthor;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 #[CrudController(BlogArticleAuthor::class)]
+#[ForRole(AdminRoleConstant::ROLE_BLOG_ARTICLE_AUTHOR)]
 class BlogArticleAuthorController extends AbstractCrudController
 {
     protected const int ARTICLES_GRID_DEFAULT_LIMIT = 10;
@@ -40,8 +42,7 @@ class BlogArticleAuthorController extends AbstractCrudController
     {
         $config
             ->registerHandler(BlogArticleAuthorCrudHandler::class)
-            ->setMenuSection(SideMenuBuilder::SECTION_BLOG)
-            ->setCustomRoleConstant(AdminRoleConstant::ROLE_BLOG_ARTICLE_AUTHOR);
+            ->setMenuSection(SideMenuBuilder::SECTION_BLOG);
     }
 
     #[Override]

--- a/packages/administration/src/Controller/TransportGroupController.php
+++ b/packages/administration/src/Controller/TransportGroupController.php
@@ -10,12 +10,14 @@ use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
 use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
 use Shopsys\AdministrationBundle\Model\Transport\TransportGroupCrudHandler;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
 use Shopsys\FrameworkBundle\Form\Admin\Transport\TransportGroupFormType;
 use Shopsys\FrameworkBundle\Model\AdminNavigation\SideMenuBuilder;
 use Shopsys\FrameworkBundle\Model\Transport\TransportGroup;
 
 #[CrudController(TransportGroup::class)]
+#[ForRole(AdminRoleConstant::ROLE_TRANSPORT_AND_PAYMENT)]
 class TransportGroupController extends AbstractCrudController
 {
     #[Override]
@@ -28,7 +30,6 @@ class TransportGroupController extends AbstractCrudController
                 SideMenuBuilder::SECTION_LISTS,
                 ['after' => SideMenuBuilder::LIST_TRANSPORT_AND_PAYMENT],
             )
-            ->setCustomRoleConstant(AdminRoleConstant::ROLE_TRANSPORT_AND_PAYMENT)
             ->registerHandler(TransportGroupCrudHandler::class);
     }
 

--- a/packages/administration/src/DependencyInjection/Compiler/LoadControllersExtensionCompilerPass.php
+++ b/packages/administration/src/DependencyInjection/Compiler/LoadControllersExtensionCompilerPass.php
@@ -30,6 +30,9 @@ final class LoadControllersExtensionCompilerPass implements CompilerPassInterfac
             }
         }
 
+        // ascending priority is the order the extensions are applied in, consumers rely on it instead of sorting again
+        usort($extensions, static fn (array $a, array $b): int => $a['priority'] <=> $b['priority']);
+
         $container->setParameter(
             CrudControllerRegistry::CRUD_CONTROLLERS_EXTENSIONS_PARAMETER,
             $extensions,

--- a/packages/administration/src/DependencyInjection/Compiler/ResolveCrudRoleConstantsCompilerPass.php
+++ b/packages/administration/src/DependencyInjection/Compiler/ResolveCrudRoleConstantsCompilerPass.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\AdministrationBundle\DependencyInjection\Compiler;
+
+use Override;
+use ReflectionClass;
+use Shopsys\AdministrationBundle\Component\Crud\CrudControllerRegistry;
+use Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Resolves the custom role constant of every CRUD controller from the class-level ForRole attribute of the controller and its extensions.
+ * Must run after InitializeControllersCompilerPass and LoadControllersExtensionCompilerPass, whose parameters it reads.
+ */
+final class ResolveCrudRoleConstantsCompilerPass implements CompilerPassInterface
+{
+    #[Override]
+    public function process(ContainerBuilder $container): void
+    {
+        /** @var array<int, array{class: class-string, entityClass: string}> $crudControllers */
+        $crudControllers = $container->getParameter(CrudControllerRegistry::CRUD_CONTROLLERS_PARAMETER);
+        /** @var array<int, array{extensionClass: class-string, controllerClass: class-string, priority: int}> $crudControllerExtensions */
+        $crudControllerExtensions = $container->getParameter(CrudControllerRegistry::CRUD_CONTROLLERS_EXTENSIONS_PARAMETER);
+
+        $extensionClassesByController = $this->groupExtensionClassesByController($crudControllerExtensions);
+        $customRoleConstants = [];
+
+        foreach ($crudControllers as $crudController) {
+            $controllerClass = $crudController['class'];
+            $customRoleConstant = $this->findForRole(new ReflectionClass($controllerClass));
+
+            // an extension may override the controller's role — the one whose configure() runs last (highest priority) wins
+            foreach ($extensionClassesByController[$controllerClass] ?? [] as $extensionClass) {
+                $customRoleConstant = $this->findForRole(new ReflectionClass($extensionClass)) ?? $customRoleConstant;
+            }
+
+            $customRoleConstants[$controllerClass] = $customRoleConstant;
+        }
+
+        $container->setParameter(CrudRoleConstantProvider::CRUD_ROLE_CONSTANTS_PARAMETER, $customRoleConstants);
+    }
+
+    /**
+     * @param array<int, array{extensionClass: class-string, controllerClass: class-string, priority: int}> $extensions sorted by ascending priority
+     * @return array<class-string, list<class-string>>
+     */
+    private function groupExtensionClassesByController(array $extensions): array
+    {
+        $extensionClassesByController = [];
+
+        foreach ($extensions as $extension) {
+            $extensionClassesByController[$extension['controllerClass']][] = $extension['extensionClass'];
+        }
+
+        return $extensionClassesByController;
+    }
+
+    private function findForRole(ReflectionClass $reflectionClass): ?string
+    {
+        $attributes = $reflectionClass->getAttributes(ForRole::class);
+
+        if (count($attributes) !== 0) {
+            return $attributes[0]->newInstance()->role;
+        }
+
+        return null;
+    }
+}

--- a/packages/administration/src/ShopsysAdministrationBundle.php
+++ b/packages/administration/src/ShopsysAdministrationBundle.php
@@ -8,6 +8,7 @@ use Override;
 use Shopsys\AdministrationBundle\DependencyInjection\Compiler\InitializeControllersCompilerPass;
 use Shopsys\AdministrationBundle\DependencyInjection\Compiler\LoadControllersExtensionCompilerPass;
 use Shopsys\AdministrationBundle\DependencyInjection\Compiler\RegisterControllerExtensionsCompilerPass;
+use Shopsys\AdministrationBundle\DependencyInjection\Compiler\ResolveCrudRoleConstantsCompilerPass;
 use Shopsys\AdministrationBundle\DependencyInjection\ShopsysAdministrationExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -33,5 +34,6 @@ class ShopsysAdministrationBundle extends AbstractBundle
         $container->addCompilerPass(new InitializeControllersCompilerPass());
         $container->addCompilerPass(new RegisterControllerExtensionsCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 150);
         $container->addCompilerPass(new LoadControllersExtensionCompilerPass());
+        $container->addCompilerPass(new ResolveCrudRoleConstantsCompilerPass(), priority: -50);
     }
 }

--- a/packages/administration/src/Twig/ActionExtension.php
+++ b/packages/administration/src/Twig/ActionExtension.php
@@ -10,6 +10,7 @@ use Shopsys\AdministrationBundle\Component\Action\RouteData\ActionRouteInterface
 use Shopsys\AdministrationBundle\Component\Action\RouteData\CrudActionRouteData;
 use Shopsys\AdministrationBundle\Component\Action\RouteData\RouteActionRouteData;
 use Shopsys\AdministrationBundle\Component\Action\RouteData\UrlActionRouteData;
+use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlDataProviderInterface;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Router\AdministrationRouter;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
@@ -23,6 +24,7 @@ class ActionExtension extends AbstractExtension
         protected readonly AdministrationRouter $router,
         protected readonly RouteAccessCheckerInterface $routeAccessChecker,
         protected readonly RouteCsrfProtector $csrfProtector,
+        protected readonly AccessControlDataProviderInterface $accessControlDataProvider,
     ) {
     }
 
@@ -65,7 +67,19 @@ class ActionExtension extends AbstractExtension
         }
 
         if ($actionRoute instanceof RouteActionRouteData) {
-            return $this->router->generate($actionRoute->getRouteName(), $actionRoute->getRouteParameters($data));
+            $parameters = $actionRoute->getRouteParameters($data);
+            $routeData = $this->accessControlDataProvider->findRouteByName($actionRoute->getRouteName());
+
+            if (
+                $routeData !== null
+                && class_exists($routeData->controllerClass)
+                && method_exists($routeData->controllerClass, $routeData->controllerMethod)
+                && $this->csrfProtector->isActionProtected($routeData->controllerClass, $routeData->controllerMethod)
+            ) {
+                $parameters[RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER] ??= $this->csrfProtector->getCsrfTokenByRoute($actionRoute->getRouteName());
+            }
+
+            return $this->router->generate($actionRoute->getRouteName(), $parameters);
         }
 
         throw new InvalidArgumentException('Action has invalid route type');

--- a/packages/administration/templates/crud/edit.html.twig
+++ b/packages/administration/templates/crud/edit.html.twig
@@ -7,7 +7,7 @@
 {% block h1 %}{{ title }}{% endblock %}
 
 {% block btn %}
-    {{ actions.render(topActions) }}
+    {{ actions.render(topActions, entity|default(null)) }}
 {% endblock %}
 
 {% block main_content %}

--- a/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlDataProviderTest.php
+++ b/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlDataProviderTest.php
@@ -8,6 +8,7 @@ use Override;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlRuleFactory;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\RouteAccessControlData;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\RouteAccessControlDataProvider;
@@ -52,7 +53,7 @@ class RouteAccessControlDataProviderTest extends TestCase
         // Create real AttributeProcessor with mocked dependencies
         $accessControlRuleFactory = new AccessControlRuleFactory($this->roleRegistry);
         $this->accessControlRuleFactory = $accessControlRuleFactory;
-        $this->attributeProcessor = new AttributeProcessor($accessControlRuleFactory);
+        $this->attributeProcessor = new AttributeProcessor($accessControlRuleFactory, new CrudRoleConstantProvider());
 
         // Set up role registry to return stub roles for any identifier
         $this->roleRegistry

--- a/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlSubscriberTest.php
+++ b/packages/administration/tests/Unit/Component/Security/AccessControl/RouteAccessControlSubscriberTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\AdministrationBundle\Unit\Component\Security\AccessControl;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlRuleFactory;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\RouteAccessControlSubscriber;
 use Shopsys\AdministrationBundle\Component\Security\Attribute\AttributeProcessor;
@@ -84,7 +85,7 @@ final class RouteAccessControlSubscriberTest extends TestCase
         return new RouteAccessControlSubscriber(
             $routeAccessChecker ?? $this->createStub(RouteAccessCheckerInterface::class),
             $this->createAdminContextResolver(),
-            new AttributeProcessor(new AccessControlRuleFactory($this->createRoleRegistry())),
+            new AttributeProcessor(new AccessControlRuleFactory($this->createRoleRegistry()), new CrudRoleConstantProvider()),
             $security ?? $this->createStub(Security::class),
         );
     }

--- a/packages/administration/tests/Unit/Component/Security/Attribute/AttributeProcessorTest.php
+++ b/packages/administration/tests/Unit/Component/Security/Attribute/AttributeProcessorTest.php
@@ -9,8 +9,10 @@ use Override;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider;
 use Shopsys\AdministrationBundle\Component\Security\AccessControl\AccessControlRuleFactory;
 use Shopsys\AdministrationBundle\Component\Security\Attribute\AttributeProcessor;
+use Shopsys\AdministrationBundle\Controller\AbstractCrudController;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanCreate;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
@@ -37,7 +39,18 @@ class AttributeProcessorTest extends TestCase
     {
         $this->roleRegistry = $this->createStub(RoleRegistryInterface::class);
         $accessControlRuleFactory = new AccessControlRuleFactory($this->roleRegistry);
-        $this->processor = new AttributeProcessor($accessControlRuleFactory);
+        $this->processor = new AttributeProcessor($accessControlRuleFactory, new CrudRoleConstantProvider());
+    }
+
+    /**
+     * @param array<class-string, string|null> $crudRoleConstants as resolved by ResolveCrudRoleConstantsCompilerPass
+     */
+    private function createProcessorWithCrudRoleConstants(array $crudRoleConstants): AttributeProcessor
+    {
+        return new AttributeProcessor(
+            new AccessControlRuleFactory($this->roleRegistry),
+            new CrudRoleConstantProvider($crudRoleConstants),
+        );
     }
 
     /**
@@ -165,6 +178,34 @@ class AttributeProcessorTest extends TestCase
 
         $reflectionClass = new ReflectionClass($testClass);
         $rules = $this->processor->processMethod($reflectionClass, $reflectionClass->getMethod('testMethod'));
+
+        $this->assertCount(1, $rules);
+        $this->assertEquals('ROLE_EDITOR_VIEW', $rules[0]->getRoleIdentifier());
+    }
+
+    public function testProcessMethodOnCrudControllerFallsBackToControllerRoleConstant(): void
+    {
+        $this->setupRoleRegistry(['ROLE_CRUD_ATTRIBUTE_FIXTURE_VIEW' => 'ROLE_CRUD_ATTRIBUTE_FIXTURE']);
+        $processor = $this->createProcessorWithCrudRoleConstants([
+            AttributeFixtureCrudController::class => null,
+        ]);
+
+        $reflectionClass = new ReflectionClass(AttributeFixtureCrudController::class);
+        $rules = $processor->processMethod($reflectionClass, $reflectionClass->getMethod('customAction'));
+
+        $this->assertCount(1, $rules);
+        $this->assertEquals('ROLE_CRUD_ATTRIBUTE_FIXTURE_VIEW', $rules[0]->getRoleIdentifier());
+    }
+
+    public function testForRoleOnCrudControllerIsUsedAsItsRoleConstant(): void
+    {
+        $this->setupRoleRegistry(['ROLE_EDITOR_VIEW' => 'ROLE_EDITOR']);
+        $processor = $this->createProcessorWithCrudRoleConstants([
+            AttributeFixtureWithForRoleCrudController::class => 'ROLE_EDITOR',
+        ]);
+
+        $reflectionClass = new ReflectionClass(AttributeFixtureWithForRoleCrudController::class);
+        $rules = $processor->processMethod($reflectionClass, $reflectionClass->getMethod('customAction'));
 
         $this->assertCount(1, $rules);
         $this->assertEquals('ROLE_EDITOR_VIEW', $rules[0]->getRoleIdentifier());
@@ -455,5 +496,23 @@ class AttributeProcessorTest extends TestCase
         $this->assertEquals('ROLE_USER_EDIT', $rules[0]->getRoleIdentifier());
         $this->assertCount(1, $rules[0]->httpMethods);
         $this->assertEquals([HttpMethod::GET], $rules[0]->httpMethods);
+    }
+}
+
+// named fixtures — CRUD role fallback derives the role from the controller class name and its custom role in the provider
+class AttributeFixtureCrudController extends AbstractCrudController
+{
+    #[CanView]
+    public function customAction(): void
+    {
+    }
+}
+
+#[ForRole('ROLE_EDITOR')]
+class AttributeFixtureWithForRoleCrudController extends AbstractCrudController
+{
+    #[CanView]
+    public function customAction(): void
+    {
     }
 }

--- a/upgrade-notes/backend_20260826_103410.md
+++ b/upgrade-notes/backend_20260826_103410.md
@@ -1,0 +1,20 @@
+#### Improve custom actions and custom routes in CRUD controllers ([#4794](https://github.com/shopsys/shopsys/pull/4794))
+
+- `Shopsys\AdministrationBundle\Component\Config\CrudConfig::setCustomRoleConstant()` was removed. Declare the custom role with the `#[ForRole]` attribute on the CRUD controller class instead (it can also be placed on a CRUD controller extension class to override the extended controller's role); `CrudConfigData::getCustomRoleConstant()` keeps returning it:
+    ```diff
+     #[CrudController(TransportGroup::class)]
+    +#[ForRole(AdminRoleConstant::ROLE_TRANSPORT_AND_PAYMENT)]
+     class TransportGroupController extends AbstractCrudController
+     {
+         public function configure(CrudConfig $config): void
+         {
+             $config
+                 ->setRoutePrefix('/transport-and-payment')
+    -            ->setCustomRoleConstant(AdminRoleConstant::ROLE_TRANSPORT_AND_PAYMENT)
+                 ->registerHandler(TransportGroupCrudHandler::class);
+         }
+    ```
+- `#[ForRole]` on a CRUD controller now sets the role of the whole controller: the built-in CRUD actions and permission attributes on custom routes are all guarded by that role, and the controller no longer registers its own generated role in the administrator role matrix. If you used `#[ForRole]` on a CRUD controller only to provide a default role for permission attributes on custom routes, remove it (the controller's own role constant is now used automatically), or keep it if the whole controller should be guarded by that role
+- permission attributes (`#[CanView]`, `#[CanEdit]`, ...) on custom routes in CRUD controllers no longer require an explicit role — they fall back to the controller's role constant, the same role the built-in CRUD actions use
+- the custom role of a CRUD controller (declared by `#[ForRole]`) is resolved at compile time by the new `ResolveCrudRoleConstantsCompilerPass` and read from the new `Shopsys\AdministrationBundle\Component\Crud\CrudRoleConstantProvider` service; `CrudConfig` constructor accepts the resolved custom role as a new optional `$customRoleConstant` parameter, and `CrudControllerRegistry` and `Component\Security\Attribute\AttributeProcessor` constructors accept a new `CrudRoleConstantProvider` dependency
+- `shopsys.admin.crud_controllers_extensions` container parameter is now sorted by ascending extension priority


### PR DESCRIPTION
#### Description, the reason for the PR

Custom actions and custom routes in CRUD controllers were documented, but several gaps made them hard (or impossible) to use in practice. This PR closes them, so a developer adding a quick action (for example an "Approve" button on an edit page) can follow the actions reference and it just works:

- **Top actions on the edit page now receive the edited entity.** The `displayIf()` and `linkToRoute()` closures documented in the actions reference were always called with `null`, so the documented entity-typed closures failed. Now the edit page passes the edited entity, allowing actions to be shown conditionally and to build URLs with the entity id.
- **`linkToRoute()` now appends the CSRF token for protected routes.** An action linking to a route guarded by `#[CsrfProtection]` generated a URL without the token, so clicking it always failed with a 400 error. The token is now appended automatically, resolved from the cached route access-control data.
- **Permission attributes on custom routes no longer need an explicit role.** A plain `#[CanEdit]` now guards the route with the same role the built-in CRUD actions use — no more hand-written role constants like `#[CanEdit('ROLE_CRUD_PRODUCT_REVIEW')]`.
- **A custom role of a CRUD controller is now declared with the class-level `#[ForRole]` attribute**, replacing the removed `CrudConfig::setCustomRoleConstant()`. On a CRUD controller, `#[ForRole]` governs the whole controller consistently: the built-in actions, custom routes, and the administrator role matrix all follow one role, so they can no longer diverge. The role is resolved at compile time from class attributes (a CRUD controller extension can override it), so building the admin access control no longer instantiates controllers and runs their `configure()`.

The actions reference and admin rights documentation are extended accordingly, and an upgrade note covers the removed `setCustomRoleConstant()` method and the extended `#[ForRole]` semantics.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

























----
:globe_with_meridians: Live Preview:
  - https://mg-crud-edit-page-actions.odin.shopsys.cloud
  - https://cz.mg-crud-edit-page-actions.odin.shopsys.cloud
  - https://mg-crud-edit-page-actions.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788893539.301139 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-crud-edit-page-actions.odin.shopsys.cloud
  - https://cz.mg-crud-edit-page-actions.odin.shopsys.cloud
  - https://mg-crud-edit-page-actions.odin.shopsys.cloud/sk
<!-- Replace -->
