### PR TITLE
Deduplicate product recalculation messages in web tests

### DIFF
--- a/project-base/app/tests/App/Test/WebTestCase.php
+++ b/project-base/app/tests/App/Test/WebTestCase.php
@@ -219,6 +219,8 @@ abstract class WebTestCase extends BaseWebTestCase implements ServiceContainerTe
         $this->dispatchFakeKernelResponseEventToTriggerSendMessageToTransport();
         $envelopes = [...$highPriorityTransport->getSent(), ...$regularPriorityTransport->getSent()];
 
+        $processedProductIds = [];
+
         foreach ($envelopes as $envelope) {
             $message = $envelope->getMessage();
 
@@ -229,6 +231,12 @@ abstract class WebTestCase extends BaseWebTestCase implements ServiceContainerTe
             if ($allowedProductIds !== null && !in_array($message->productId, $allowedProductIds, true)) {
                 continue;
             }
+
+            if (in_array($message->productId, $processedProductIds, true)) {
+                continue;
+            }
+
+            $processedProductIds[] = $message->productId;
 
             $productRecalculationMessageHandler($message);
         }

--- a/upgrade-notes/backend_20260824_152254.md
+++ b/upgrade-notes/backend_20260824_152254.md
@@ -1,0 +1,3 @@
+#### Deduplicate product recalculation messages in web tests ([#4797](https://github.com/shopsys/shopsys/pull/4797))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

During web tests, every dispatched product recalculation message was handled individually, so a product touched by several actions within one test was recalculated (and re-exported) multiple times. This did not change the outcome — the last recalculation always produced the same result — it only made the tests do redundant work and run longer.

Dispatched recalculation messages are now deduplicated by product ID before being handled, so each product is recalculated only once per test request regardless of how many messages were dispatched for it.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-deduplicate-product-recalculation-messages-in-tests.odin.shopsys.cloud
  - https://cz.mg-deduplicate-product-recalculation-messages-in-tests.odin.shopsys.cloud
  - https://mg-deduplicate-product-recalculation-messages-in-tests.odin.shopsys.cloud/sk
<!-- Replace -->
