### PR TITLE
Stop reporting third-party browser script errors as storefront errors

### DIFF
--- a/docs/storefront/error-handling.md
+++ b/docs/storefront/error-handling.md
@@ -238,6 +238,45 @@ If your verbosity is set to `toast-and-console`, the error page for 500 errors a
 
 This function will be your friend while logging exceptions anywhere in the app. It checks the current environment and based on it logs it to the console (development) and sends the error to Sentry. You should use it to make sure the errors are correctly displayed both in the console and in Sentry.
 
+## Errors from third-party browser scripts
+
+Scripts injected into the page by someone else — a chat widget, an analytics tag, anything added through Google Tag Manager — run in the same browser context as our own code. When they throw, Sentry captures the error, and by default it is indistinguishable from ours: `@sentry/nextjs` rewrites every stack frame's origin to `app:///`, whatever host the file actually came from. The result is a Sentry issue that looks like a storefront bug and, in production, an auto-created Jira ticket for code we do not ship.
+
+Two independent mechanisms in `instrumentation-client.ts` deal with this.
+
+### Suppressing a known vendor with `denyUrls`
+
+`denyUrls` drops an event outright when its stack points at a matching URL:
+
+```ts
+denyUrls: [/^https?:\/\/([a-z0-9-]+\.)*(smartsupp\.com|smartsuppchat\.com|smartsuppcdn\.com)\//],
+```
+
+Use this for a specific vendor you have identified and decided not to hear from. Anchor the pattern to the vendor's own origins so it can never match a first-party file or route that merely contains the vendor's name in its path. Match the vendor's **real hostname**, not the rewritten `app:///…` path — `denyUrls` is applied by the event-filters integration, which is first in the browser SDK's default integration list, while the frame-rewriting integration is appended last. Event processors run in registration order, so the filter still sees the original URL. Enabling `_experimental.thirdPartyOriginStackFrames` changes that rewriting, so re-check any deny pattern if it is ever turned on.
+
+Note the tradeoff: these events are discarded and cannot be recovered later. Diagnosing a future problem with a suppressed vendor means temporarily narrowing or removing its pattern.
+
+### Tagging everything else with `third_party_code`
+
+For scripts nobody has identified yet, we mark our own code instead of blocklisting theirs. At build time the Sentry bundler plugin stamps every first-party module with an application key, and `thirdPartyErrorFilterIntegration` tags any event whose frames carry none of it:
+
+```ts
+Sentry.thirdPartyErrorFilterIntegration({
+    filterKeys: [SENTRY_APPLICATION_KEY],
+    behaviour: 'apply-tag-if-exclusively-contains-third-party-frames',
+}),
+```
+
+`sentryApplicationKey.js` in the storefront root is the single source of truth for the key. It is a CommonJS module precisely so that `next.config.js` (which passes it to the bundler plugin as `applicationKey`) and `instrumentation-client.ts` (which filters on it) cannot drift apart.
+
+This layer **tags and never drops**, deliberately. A frame without the key reads as third-party, so if key injection ever stopped, every frame would look foreign — under a `drop-*` behaviour that would silently discard all browser errors with no signal. Tagging can only mislabel. Filter the issue stream with `!third_party_code:True`, and note that the production Jira auto-create alert rule excludes tagged events.
+
+The tag only appears in builds where the plugin actually ran, which needs `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT` present and `APP_ENV` other than `development`. To confirm a build is instrumented, look for the key in the output:
+
+```sh
+grep -rl '_sentryBundlerPluginAppKey:shopsys-storefront' .next/static/chunks
+```
+
 ## Run-time error on the server (`getServerSideProps` or `getInitialProps`)
 
 - **In production** - The error is propagated to the `_error.tsx` page with a status code **500**. We do not need to handle the error inside `getServerSideProps` or `getInitialProps`as it is handled inside the error page, where it is available inside `context.err`. The user is only shown `<Error500Content />`, the status code is **500**. A default error message (`500 - Internal Server Error`) is logged into the console, meaning the underlying error is unknown to the user.

--- a/project-base/storefront/instrumentation-client.ts
+++ b/project-base/storefront/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import { getPublicConfigProperty } from 'envConfig';
+import { SENTRY_APPLICATION_KEY } from 'sentryApplicationKey';
 import * as Sentry from '@sentry/nextjs';
 import { getTracePropagationTargetsFromPublicGraphqlEndpoints as getPublicGraphqlTracePropagationTargets } from 'utils/sentry/tracePropagationTargets';
 
@@ -18,7 +19,14 @@ if (isSentryEnabled) {
         environment: environment,
         release: release,
         tracesSampleRate: 0.1,
-        integrations: [Sentry.browserTracingIntegration()],
+        denyUrls: [/^https?:\/\/([a-z0-9-]+\.)*(smartsupp\.com|smartsuppchat\.com|smartsuppcdn\.com)\//],
+        integrations: [
+            Sentry.browserTracingIntegration(),
+            Sentry.thirdPartyErrorFilterIntegration({
+                filterKeys: [SENTRY_APPLICATION_KEY],
+                behaviour: 'apply-tag-if-exclusively-contains-third-party-frames',
+            }),
+        ],
         tracePropagationTargets: tracePropagationTargets,
         replaysSessionSampleRate: enableReplays ? 0.1 : 0,
         replaysOnErrorSampleRate: enableReplays ? 1.0 : 0,

--- a/project-base/storefront/next.config.js
+++ b/project-base/storefront/next.config.js
@@ -3,6 +3,7 @@ const nextTranslate = require('next-translate-plugin');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
     enabled: process.env.ANALYZE === 'true',
 });
+const { SENTRY_APPLICATION_KEY } = require('./sentryApplicationKey');
 
 // Sentry feature flags
 const isSentryReplaysEnabled = process.env.SENTRY_REPLAYS_ENABLE === '1';
@@ -79,6 +80,7 @@ const sentryConfig = {
     project: process.env.SENTRY_PROJECT,
     authToken: process.env.SENTRY_AUTH_TOKEN,
     sentryUrl: process.env.SENTRY_URL,
+    applicationKey: SENTRY_APPLICATION_KEY,
     telemetry: false,
     release: {
         name: process.env.SENTRY_RELEASE,

--- a/project-base/storefront/sentryApplicationKey.js
+++ b/project-base/storefront/sentryApplicationKey.js
@@ -1,0 +1,3 @@
+const SENTRY_APPLICATION_KEY = 'shopsys-storefront';
+
+module.exports = { SENTRY_APPLICATION_KEY };

--- a/upgrade-notes/storefront_20260824_152443.md
+++ b/upgrade-notes/storefront_20260824_152443.md
@@ -1,0 +1,3 @@
+#### Errors from third-party browser scripts are no longer reported as storefront errors ([#4798](https://github.com/shopsys/shopsys/pull/4798))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Production Sentry has been reporting a JavaScript crash as a storefront bug, and the alert rule has been auto-creating a Jira `FE bug` for each new variant of it (SSP-4169, and SSP-4234 as a duplicate). The crash is not in code we ship: it comes from the Smartsupp live-chat widget, which is added to the site through Google Tag Manager. Their script dereferences `window.parent.document` without checking that the parent frame still exists, so it throws once the widget's frame is detached.

The reason it looked like ours is that the Sentry SDK rewrites every stack frame's origin to `app:///`, whatever host the file actually came from. A third-party file therefore becomes indistinguishable from first-party code in the Sentry UI, and gets flagged as in-app. So the developer-facing problem is not the crash itself — we cannot fix someone else's CDN bundle — but that our error reporting cannot tell our code apart from other people's.

This is addressed in two layers. Errors originating in the Smartsupp widget are no longer sent to Sentry at all, so they stop creating issues and tickets while the widget keeps working exactly as before. Separately, our own bundles are now marked with a Sentry application key, so any *other* third-party script that starts throwing is tagged `third_party_code` instead of being mistaken for ours — which means the next unrecognised vendor does not have to be diagnosed from scratch before the noise can be stopped. That second layer only tags and never discards: a frame missing the key reads as third-party, so dropping on that basis would silently throw away every browser error if key injection ever regressed.

To complete the second layer, the production alert rule needs a filter so tagged events do not open Jira issues (`third_party_code` is not equal to `true`). That is Sentry-side configuration and is not part of this PR.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-sentry-do-not-report-external-errors.odin.shopsys.cloud
  - https://cz.tl-sentry-do-not-report-external-errors.odin.shopsys.cloud
  - https://tl-sentry-do-not-report-external-errors.odin.shopsys.cloud/sk
<!-- Replace -->
