### PR TITLE
Blog article breadcrumb now reflects a renamed blog category

### DIFF
--- a/packages/framework/src/Model/Blog/Article/BlogArticleFacade.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleFacade.php
@@ -166,6 +166,19 @@ class BlogArticleFacade
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[] $blogCategories
+     * @return int[]
+     */
+    public function getBlogArticleIdsByCategories(array $blogCategories, int $domainId, string $locale): array
+    {
+        return $this->blogArticleRepository->getBlogArticleIdsByCategories(
+            $blogCategories,
+            $domainId,
+            $locale,
+        );
+    }
+
+    /**
      * @return \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticle[]
      */
     public function getAllVisibleOnDomain(DomainConfig $domainConfig): array

--- a/packages/framework/src/Model/Blog/Article/BlogArticleRepository.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticleRepository.php
@@ -232,6 +232,27 @@ class BlogArticleRepository
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[] $blogCategories
+     * @return int[]
+     */
+    public function getBlogArticleIdsByCategories(array $blogCategories, int $domainId, string $locale): array
+    {
+        $result = $this->getBlogArticlesByDomainIdAndLocaleQueryBuilder($domainId, $locale)
+            ->resetDQLPart('select')
+            ->resetDQLPart('orderBy')
+            ->select('DISTINCT ba.id')
+            ->join('ba.blogArticleBlogCategoryDomains', 'babcd')
+            ->where('babcd.blogCategory IN (:blogCategories)')
+            ->andWhere('babcd.domainId = :domainId')
+            ->setParameter('blogCategories', $blogCategories)
+            ->setParameter('domainId', $domainId)
+            ->getQuery()
+            ->getResult();
+
+        return array_column($result, 'id');
+    }
+
+    /**
      * @return \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticle[]
      */
     public function getAllVisibleOnDomain(DomainConfig $domainConfig): array

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
@@ -231,9 +231,12 @@ class BlogCategoryFacade implements TreeSelectionDataProviderInterface
 
     protected function scheduleArticlesToExportByCategory(BlogCategory $blogCategory): void
     {
+        // articles are indexed with data derived from the whole path to the root, so descendants are affected as well
+        $blogCategoriesWithDescendants = $this->blogCategoryRepository->getBlogCategoryWithDescendants($blogCategory);
+
         foreach ($this->domain->getAll() as $domainConfig) {
-            $articleIds = $this->blogArticleFacade->getBlogArticleIdsByCategory(
-                $blogCategory,
+            $articleIds = $this->blogArticleFacade->getBlogArticleIdsByCategories(
+                $blogCategoriesWithDescendants,
                 $domainConfig->getId(),
                 $domainConfig->getLocale(),
             );

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -232,6 +232,14 @@ class BlogCategoryRepository extends NestedTreeRepository
     /**
      * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
      */
+    public function getBlogCategoryWithDescendants(BlogCategory $blogCategory): array
+    {
+        return $this->getChildren($blogCategory, false, null, 'ASC', true);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
+     */
     public function getVisibleBlogCategoriesInPathFromRootOnDomain(BlogCategory $blogCategory, int $domainId): array
     {
         $queryBuilder = $this->getAllVisibleByDomainIdQueryBuilder($domainId)

--- a/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Blog/Article/BlogArticleDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Blog/Article/BlogArticleDecorator.types.yaml
@@ -59,6 +59,7 @@ BlogArticleDecorator:
             breadcrumb:
                 type: "[Link!]!"
                 description: "Hierarchy of the current element in relation to the structure"
+                resolve: '@=query("breadcrumbQuery", value["id"], "front_blogarticle_detail")'
             images:
                 type: "[Image!]!"
                 description: "Blog article images"

--- a/project-base/app/tests/App/Functional/Model/Blog/Category/BlogCategoryFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Blog/Category/BlogCategoryFacadeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Model\Blog\Category;
+
+use App\DataFixtures\Demo\BlogArticleDataFixture;
+use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleFacade;
+use Shopsys\FrameworkBundle\Model\Blog\Article\Elasticsearch\BlogArticleExportQueueFacade;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryDataFactory;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade;
+use Tests\App\Test\TransactionFunctionalTestCase;
+
+class BlogCategoryFacadeTest extends TransactionFunctionalTestCase
+{
+    private const int EXPORT_QUEUE_READ_LIMIT = 10000;
+
+    /**
+     * @inject
+     */
+    private BlogCategoryFacade $blogCategoryFacade;
+
+    /**
+     * @inject
+     */
+    private BlogCategoryDataFactory $blogCategoryDataFactory;
+
+    /**
+     * @inject
+     */
+    private BlogArticleFacade $blogArticleFacade;
+
+    /**
+     * @inject
+     */
+    private BlogArticleExportQueueFacade $blogArticleExportQueueFacade;
+
+    public function testEditingBlogCategorySchedulesArticlesOfItsDescendantsToExportOnAllDomains(): void
+    {
+        $editedBlogCategory = $this->getReference(BlogArticleDataFixture::FIRST_DEMO_BLOG_SUBCATEGORY, BlogCategory::class);
+        $descendantBlogCategory = $this->getReference(BlogArticleDataFixture::BLOG_CATEGORY_SCREEN_TECHNOLOGIES, BlogCategory::class);
+
+        $expectedBlogArticleIdsByDomainId = [];
+
+        foreach ($this->domain->getAll() as $domainConfig) {
+            $expectedBlogArticleIdsByDomainId[$domainConfig->getId()] = $this->blogArticleFacade->getBlogArticleIdsByCategory(
+                $descendantBlogCategory,
+                $domainConfig->getId(),
+                $domainConfig->getLocale(),
+            );
+            $this->assertNotEmpty($expectedBlogArticleIdsByDomainId[$domainConfig->getId()]);
+
+            $this->blogArticleExportQueueFacade->getIds($domainConfig->getId(), self::EXPORT_QUEUE_READ_LIMIT);
+        }
+
+        $this->blogCategoryFacade->edit(
+            $editedBlogCategory->getId(),
+            $this->blogCategoryDataFactory->createFromBlogCategory($editedBlogCategory),
+        );
+
+        foreach ($this->domain->getAll() as $domainConfig) {
+            $scheduledBlogArticleIds = array_map(
+                'intval',
+                $this->blogArticleExportQueueFacade->getIds($domainConfig->getId(), self::EXPORT_QUEUE_READ_LIMIT),
+            );
+
+            foreach ($expectedBlogArticleIdsByDomainId[$domainConfig->getId()] as $expectedBlogArticleId) {
+                $this->assertContains(
+                    $expectedBlogArticleId,
+                    $scheduledBlogArticleIds,
+                    sprintf('Blog article ID %d from a descendant blog category was not scheduled to export on domain ID %d.', $expectedBlogArticleId, $domainConfig->getId()),
+                );
+            }
+        }
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/Blog/Article/BlogArticleTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Blog/Article/BlogArticleTest.php
@@ -11,16 +11,36 @@ use Shopsys\FrameworkBundle\Component\GrapesJs\GrapesJsParser;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticle;
+use Shopsys\FrameworkBundle\Model\Blog\Article\Elasticsearch\BlogArticleElasticsearchFacade;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryDataFactory;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class BlogArticleTest extends GraphQlTestCase
 {
+    private const string RENAMED_BLOG_CATEGORY_NAME = 'Renamed ancestor blog category';
+
     /**
      * @inject
      */
     private FriendlyUrlFacade $friendlyUrlFacade;
+
+    /**
+     * @inject
+     */
+    private BlogCategoryFacade $blogCategoryFacade;
+
+    /**
+     * @inject
+     */
+    private BlogCategoryDataFactory $blogCategoryDataFactory;
+
+    /**
+     * @inject
+     */
+    private BlogArticleElasticsearchFacade $blogArticleElasticsearchFacade;
 
     private BlogArticle $blogArticle;
 
@@ -249,6 +269,40 @@ class BlogArticleTest extends GraphQlTestCase
 
         $this->assertArrayHasKey('author', $responseData);
         $this->assertNull($responseData['author']);
+    }
+
+    public function testBlogArticleBreadcrumbReflectsRenamedAncestorBlogCategoryWithoutReexport(): void
+    {
+        $locale = $this->getFirstDomainLocale();
+        $rootBlogCategory = $this->getReference(BlogArticleDataFixture::FIRST_DEMO_BLOG_CATEGORY, BlogCategory::class);
+        $ancestorBlogCategory = $this->getReference(BlogArticleDataFixture::FIRST_DEMO_BLOG_SUBCATEGORY, BlogCategory::class);
+        $televisionsBlogCategory = $this->getReference(BlogArticleDataFixture::BLOG_CATEGORY_TELEVISIONS, BlogCategory::class);
+        $screenTechnologiesBlogCategory = $this->getReference(BlogArticleDataFixture::BLOG_CATEGORY_SCREEN_TECHNOLOGIES, BlogCategory::class);
+
+        $blogArticlesData = $this->blogArticleElasticsearchFacade->getByBlogCategory($screenTechnologiesBlogCategory, 0, 1);
+        $this->assertNotEmpty($blogArticlesData);
+        $blogArticleData = array_shift($blogArticlesData);
+
+        $blogCategoryData = $this->blogCategoryDataFactory->createFromBlogCategory($ancestorBlogCategory);
+        $blogCategoryData->names[$locale] = self::RENAMED_BLOG_CATEGORY_NAME;
+        $this->blogCategoryFacade->edit($ancestorBlogCategory->getId(), $blogCategoryData);
+
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/graphql/BlogArticleBreadcrumbQuery.graphql',
+            ['uuid' => $blogArticleData['uuid']],
+        );
+        $responseData = $this->getResponseDataForGraphQlType($response, 'blogArticle');
+
+        $this->assertSame(
+            [
+                $rootBlogCategory->getName($locale),
+                self::RENAMED_BLOG_CATEGORY_NAME,
+                $televisionsBlogCategory->getName($locale),
+                $screenTechnologiesBlogCategory->getName($locale),
+                $blogArticleData['name'],
+            ],
+            array_column($responseData['breadcrumb'], 'name'),
+        );
     }
 
     private function getExpectedBlogArticleArray(): array

--- a/project-base/app/tests/FrontendApiBundle/Functional/Blog/Article/graphql/BlogArticleBreadcrumbQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Blog/Article/graphql/BlogArticleBreadcrumbQuery.graphql
@@ -1,0 +1,8 @@
+query BlogArticleBreadcrumbQuery($uuid: Uuid!) {
+    blogArticle(uuid: $uuid) {
+        breadcrumb {
+            name
+            slug
+        }
+    }
+}

--- a/upgrade-notes/backend_20260826_095842.md
+++ b/upgrade-notes/backend_20260826_095842.md
@@ -1,0 +1,11 @@
+#### Blog article breadcrumb now reflects a renamed blog category ([#4802](https://github.com/shopsys/shopsys/pull/4802))
+
+- `BlogArticle.breadcrumb` is now resolved live via the shared `breadcrumbQuery` instead of being read from the Elasticsearch document
+    - if you override `BlogArticleDecorator.types.yaml` in your project, add the `resolve` expression to the `breadcrumb` field
+    - the `breadcrumb` field is still written into the blog article index, but nothing reads it any more
+- `BlogCategoryFacade::scheduleArticlesToExportByCategory()` now schedules the whole subtree of the edited blog category, not only the articles assigned to it directly
+    - if you override this method, adopt the same behavior, otherwise articles in descendant blog categories keep a stale breadcrumb
+- added `BlogCategoryRepository::getBlogCategoryWithDescendants()`
+- added `BlogArticleRepository::getBlogArticleIdsByCategories()` and `BlogArticleFacade::getBlogArticleIdsByCategories()`
+    - the singular `getBlogArticleIdsByCategory()` is kept and still works
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Renaming a blog category did not reach the breadcrumb on the blog article detail. The new name showed up everywhere else — in the administration, on the category detail and in the right-hand menu — but the article's breadcrumb kept the old one until every affected article was re-saved by hand.

The cause is that blog articles are served from Elasticsearch, and the breadcrumb was a copy baked into the indexed document at export time. Blog categories have no index and are read live, which is why every other place updated instantly.

**What changes for the user**

- Renaming a blog category is now reflected in the article breadcrumb immediately, with no manual re-saving and no waiting for a re-export.
- The same applies to the other ways the breadcrumb could go stale: changing a category slug, moving a category in the tree, or deleting one.

**How**

- `BlogArticle.breadcrumb` gets an explicit resolver calling the shared breadcrumb query that `BlogCategory.breadcrumb` already uses, so it is computed from the database instead of read from the frozen copy. This removes the whole class of bug rather than one case of it.
- Second, separable commit: `BlogCategoryFacade::scheduleArticlesToExportByCategory()` now schedules the category's whole subtree. It previously matched only articles assigned to the exact edited category, while the breadcrumb is built from the whole path to the root — so an article sitting in a grandchild category never heard that its grandparent had been renamed.

**Notes for the reviewer**

- The GraphQL schema is byte-identical with and without this change, so `schema.graphql` and the storefront generated types need no regeneration.
- The `breadcrumb` field is still written into the Elasticsearch document; nothing reads it any more. Removing it properly means an index-version bump plus upgrade notes, so it is left for a follow-up.
- The singular `getBlogArticleIdsByCategory()` is kept alongside the new plural one — it is public package API and removing it would be a BC break.
- Only the two blog article *detail* fragments request `breadcrumb`; no listing fragment does. So this is one breadcrumb computation per article detail view, not an N+1 on listings.
- Blog category visibility recalculation is not wired to the Elasticsearch export at all — a separate bug of the same family, deliberately left out and worth its own ticket.

#### Fixes issues

https://shopsys.atlassian.net/browse/SSP-4272

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4272-blog-breadcrumb-live-resolver.odin.shopsys.cloud
  - https://cz.vk-ssp-4272-blog-breadcrumb-live-resolver.odin.shopsys.cloud
  - https://vk-ssp-4272-blog-breadcrumb-live-resolver.odin.shopsys.cloud/sk
<!-- Replace -->
