### PR TITLE
Quick order status filters on the admin order list

### DIFF
--- a/packages/administration/assets/src/styles/main.scss
+++ b/packages/administration/assets/src/styles/main.scss
@@ -40,6 +40,16 @@
     white-space: nowrap;
 }
 
+.status-outline {
+    background: transparent;
+    border: 1px solid var(--tblr-border-color);
+
+    .status-dot {
+        background: transparent;
+        border: 2px solid currentColor;
+    }
+}
+
 .invalid-feedback {
     text-align: left;
 }
@@ -66,5 +76,39 @@
     .icon {
         width: 24px;
         height: 24px;
+    }
+}
+
+.quick-filter-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    > :first-child {
+        position: relative;
+        top: -1px;
+    }
+}
+
+.dropdown-toggle > .quick-filter-row {
+    min-width: 0;
+    margin-inline-start: -0.25rem;
+}
+
+.quick-filter-icon {
+    display: flex;
+    flex-shrink: 0;
+    justify-content: center;
+    width: 3em;
+    padding-inline: 0.25rem;
+
+    .icon {
+        margin: 0;
+    }
+
+    > .status {
+        width: 100%;
+        justify-content: center;
+        padding-inline: 0;
     }
 }

--- a/packages/administration/src/Controller/OrderListController.php
+++ b/packages/administration/src/Controller/OrderListController.php
@@ -24,6 +24,7 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade;
 use Shopsys\FrameworkBundle\Model\Order\AdvancedSearch\OrderAdvancedSearchFacade;
 use Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+use Shopsys\FrameworkBundle\Model\Order\Status\AdminOrderStatusFilterFacade;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -38,6 +39,7 @@ class OrderListController extends AdminBaseController
         protected readonly OrderAdvancedSearchFacade $orderAdvancedSearchFacade,
         protected readonly Domain $domain,
         protected readonly AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade,
+        protected readonly AdminOrderStatusFilterFacade $adminOrderStatusFilterFacade,
         protected readonly AdministratorGridFacade $administratorGridFacade,
         protected readonly GridFactory $gridFactory,
         protected readonly QueryBuilderWithRowManipulatorDataSourceFactory $queryBuilderWithRowManipulatorDataSourceFactory,
@@ -113,6 +115,14 @@ class OrderListController extends AdminBaseController
             $queryBuilder
                 ->andWhere('o.domainId IN (:domainIds)')
                 ->setParameter('domainIds', $this->domain->getAdminEnabledDomainIds());
+        }
+
+        $selectedOrderStatusId = $this->adminOrderStatusFilterFacade->getSelectedOrderStatusId();
+
+        if ($selectedOrderStatusId !== null) {
+            $queryBuilder
+                ->andWhere('o.status = :selectedOrderStatusId')
+                ->setParameter('selectedOrderStatusId', $selectedOrderStatusId);
         }
 
         $grid = $this->getOrdersGrid($queryBuilder);

--- a/packages/administration/templates/content/customer/list.html.twig
+++ b/packages/administration/templates/content/customer/list.html.twig
@@ -13,48 +13,60 @@
 {% endblock %}
 
 {% block main_content %}
-    <div class="card">
-        <div class="card-header">
-            <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs">
-                <li class="nav-item">
-                    <a href="#quick"
-                       class="nav-link{{ not isAdvancedSearchFormSubmitted ? ' active' }}"
-                       data-bs-toggle="tab"
-                    >
-                        {{ 'Quick search'|trans }}
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a href="#advanced"
-                       class="nav-link{{ isAdvancedSearchFormSubmitted ? ' active' }}"
-                       data-bs-toggle="tab"
-                    >
-                        {{ 'Advanced search'|trans }}
-                    </a>
-                </li>
-            </ul>
-        </div>
-        <div class="card-body">
-            <div class="tab-content">
-                <div class="tab-pane{{ not isAdvancedSearchFormSubmitted ? ' active show' }}" id="quick">
-                    {{ form_start(quickSearchForm) }}
-                    {% include '@ShopsysAdministration/partial/_quick_search_form.html.twig' with {
-                        form_input: quickSearchForm.text,
-                        form_submit: quickSearchForm.submit,
-                        placeholder: 'Search by name, email, phone, or UUID...'|trans,
-                        info_message: 'Searching searches in <ul><li>last name</li><li>company name</li><li>email</li><li>telephone</li><li>UUID</li></ul> It is possible to use wildcards * and ?.'|trans,
-                    } %}
-                    {{ form_end(quickSearchForm) }}
+    <div class="row row-deck row-cards mb-3">
+        <div class="col-12{% if showDomainSwitcher %} col-xl-8{% endif %}">
+            <div class="card">
+                <div class="card-header">
+                    <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs">
+                        <li class="nav-item">
+                            <a href="#quick"
+                               class="nav-link{{ not isAdvancedSearchFormSubmitted ? ' active' }}"
+                               data-bs-toggle="tab"
+                            >
+                                {{ 'Quick search'|trans }}
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#advanced"
+                               class="nav-link{{ isAdvancedSearchFormSubmitted ? ' active' }}"
+                               data-bs-toggle="tab"
+                            >
+                                {{ 'Advanced search'|trans }}
+                            </a>
+                        </li>
+                    </ul>
                 </div>
-                <div class="tab-pane{{ isAdvancedSearchFormSubmitted ? ' active show' }}" id="advanced">
-                    {% include '@ShopsysAdministration/content/advancedSearch/advancedSearch.html.twig'
-                        with {advancedSearchForm: advancedSearchForm} %}
+                <div class="card-body">
+                    <div class="tab-content">
+                        <div class="tab-pane{{ not isAdvancedSearchFormSubmitted ? ' active show' }}" id="quick">
+                            {{ form_start(quickSearchForm) }}
+                            {% include '@ShopsysAdministration/partial/_quick_search_form.html.twig' with {
+                                form_input: quickSearchForm.text,
+                                form_submit: quickSearchForm.submit,
+                                hide_title: true,
+                                placeholder: 'Search by name, email, phone, or UUID...'|trans,
+                                info_message: 'Searching searches in <ul><li>last name</li><li>company name</li><li>email</li><li>telephone</li><li>UUID</li></ul> It is possible to use wildcards * and ?.'|trans,
+                            } %}
+                            {{ form_end(quickSearchForm) }}
+                        </div>
+                        <div class="tab-pane{{ isAdvancedSearchFormSubmitted ? ' active show' }}" id="advanced">
+                            {% include '@ShopsysAdministration/content/advancedSearch/advancedSearch.html.twig'
+                                with {advancedSearchForm: advancedSearchForm} %}
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
+        {% if showDomainSwitcher %}
+            <div class="col-12 col-xl-4">
+                <div class="card">
+                    <div class="card-body d-grid align-items-center column-gap-3" style="grid-template-columns: auto minmax(0, 1fr)">
+                        {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainController::domainSelectAction')) }}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
     </div>
-
-    {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainController::domainTabsAction')) }}
 
     {{ gridView.render() }}
 {% endblock %}

--- a/packages/administration/templates/content/order/list.html.twig
+++ b/packages/administration/templates/content/order/list.html.twig
@@ -6,49 +6,60 @@
 {% block h1 %}{{ 'Orders'|trans }}{% endblock %}
 
 {% block main_content %}
-    <div class="card">
-        <div class="card-header">
-            <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs">
-                <li class="nav-item">
-                    <a href="#quick"
-                       class="nav-link{{ not isAdvancedSearchFormSubmitted ? ' active' }}"
-                       data-bs-toggle="tab"
-                    >
-                        {{ 'Quick search'|trans }}
-                    </a>
-                </li>
-                <li class="nav-item">
-                    <a href="#advanced"
-                       class="nav-link{{ isAdvancedSearchFormSubmitted ? ' active' }}"
-                       data-bs-toggle="tab"
-                    >
-                        {{ 'Advanced search'|trans }}
-                    </a>
-                </li>
-            </ul>
-        </div>
-        <div class="card-body">
-            <div class="tab-content">
-                <div class="tab-pane{{ not isAdvancedSearchFormSubmitted ? ' active show' }}" id="quick">
-                    {{ form_start(quickSearchForm) }}
-                    {% include '@ShopsysAdministration/partial/_quick_search_form.html.twig' with {
-                        form_input: quickSearchForm.text,
-                        form_submit: quickSearchForm.submit,
-                        hide_title: true,
-                        placeholder: 'Search by order number, email, name, or UUID...'|trans,
-                        info_message: 'Searching searches in <ul> <li>UUID</li><li>order number</li><li>registered customer email</li><li>customer\'s email in order</li><li>customer\'s last name</li><li>company name.'|trans,
-                    } %}
-                    {{ form_end(quickSearchForm) }}
+    <div class="row row-deck row-cards mb-3">
+        <div class="col-12 col-xl-8">
+            <div class="card">
+                <div class="card-header">
+                    <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs">
+                        <li class="nav-item">
+                            <a href="#quick"
+                               class="nav-link{{ not isAdvancedSearchFormSubmitted ? ' active' }}"
+                               data-bs-toggle="tab"
+                            >
+                                {{ 'Quick search'|trans }}
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#advanced"
+                               class="nav-link{{ isAdvancedSearchFormSubmitted ? ' active' }}"
+                               data-bs-toggle="tab"
+                            >
+                                {{ 'Advanced search'|trans }}
+                            </a>
+                        </li>
+                    </ul>
                 </div>
-                <div class="tab-pane{{ isAdvancedSearchFormSubmitted ? ' active show' }}" id="advanced">
-                    {% include '@ShopsysAdministration/content/order/advancedSearch/advancedSearch.html.twig'
-                        with {advancedSearchForm: advancedSearchForm} %}
+                <div class="card-body">
+                    <div class="tab-content">
+                        <div class="tab-pane{{ not isAdvancedSearchFormSubmitted ? ' active show' }}" id="quick">
+                            {{ form_start(quickSearchForm) }}
+                            {% include '@ShopsysAdministration/partial/_quick_search_form.html.twig' with {
+                                form_input: quickSearchForm.text,
+                                form_submit: quickSearchForm.submit,
+                                hide_title: true,
+                                placeholder: 'Search by order number, email, name, or UUID...'|trans,
+                                info_message: 'Searching searches in <ul> <li>UUID</li><li>order number</li><li>registered customer email</li><li>customer\'s email in order</li><li>customer\'s last name</li><li>company name.'|trans,
+                            } %}
+                            {{ form_end(quickSearchForm) }}
+                        </div>
+                        <div class="tab-pane{{ isAdvancedSearchFormSubmitted ? ' active show' }}" id="advanced">
+                            {% include '@ShopsysAdministration/content/order/advancedSearch/advancedSearch.html.twig'
+                                with {advancedSearchForm: advancedSearchForm} %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-4">
+            <div class="card">
+                <div class="card-body d-grid align-items-center row-gap-2 column-gap-3" style="grid-template-columns: auto minmax(0, 1fr)">
+                    {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainFilterController::domainFilterSelectAction', { namespace: domainFilterNamespace })) }}
+
+                    {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\OrderStatusFilterController::orderStatusFilterSelectAction')) }}
                 </div>
             </div>
         </div>
     </div>
-
-    {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\DomainFilterController::domainFilterTabsAction', { namespace: domainFilterNamespace })) }}
 
     {{ gridView.render() }}
 {% endblock %}

--- a/packages/administration/templates/partial/quick_domain_filter_select.html.twig
+++ b/packages/administration/templates/partial/quick_domain_filter_select.html.twig
@@ -1,0 +1,37 @@
+{% if domainConfigs|length > 1 %}
+    <div class="text-nowrap">{{ 'Domain'|trans }}</div>
+    <div class="dropdown">
+        <a href="#"
+           class="btn dropdown-toggle w-100 justify-content-between"
+           data-bs-toggle="dropdown"
+           role="button"
+        >
+            <span class="quick-filter-row">
+                {% if selectedDomainId is null %}
+                    <span class="quick-filter-icon">{{ ux_icon('world') }}</span>
+                    {{ 'All domains'|trans }}
+                {% else %}
+                    {{ domain_icon(selectedDomainId) }}
+                    {{ getDomainName(selectedDomainId) }}
+                {% endif %}
+            </span>
+        </a>
+        <div class="dropdown-menu">
+            <a class="dropdown-item quick-filter-row{% if selectedDomainId is null %} active{% endif %}"
+               href="{{ url('admin_domainfilter_selectdomain', { domainId: null, namespace: namespace }) }}"
+            >
+                <span class="quick-filter-icon">{{ ux_icon('world') }}</span>
+                {{ 'All domains'|trans }}
+            </a>
+
+            {% for domainConfig in domainConfigs %}
+                <a class="dropdown-item quick-filter-row{% if domainConfig.id == selectedDomainId %} active{% endif %}"
+                   href="{{ url('admin_domainfilter_selectdomain', { domainId: domainConfig.id, namespace: namespace }) }}"
+                >
+                    {{ domain_icon(domainConfig.id) }}
+                    {{ domainConfig.name }}
+                </a>
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}

--- a/packages/administration/templates/partial/quick_order_status_filter_select.html.twig
+++ b/packages/administration/templates/partial/quick_order_status_filter_select.html.twig
@@ -1,0 +1,53 @@
+{% set selectedOrderStatusId = selectedOrderStatus is null ? null : selectedOrderStatus.id %}
+
+<div class="text-nowrap">{{ 'Status'|trans }}</div>
+<div class="dropdown">
+    <a href="#"
+       class="btn dropdown-toggle w-100 justify-content-between"
+       data-bs-toggle="dropdown"
+       role="button"
+    >
+        <span class="quick-filter-row">
+            {% if selectedOrderStatus is null %}
+                <span class="quick-filter-icon">
+                    <span class="status status-outline">
+                        <span class="status-dot"></span>
+                    </span>
+                </span>
+                <span class="text-truncate">{{ 'All statuses'|trans }}</span>
+            {% else %}
+                <span class="quick-filter-icon">
+                    <span class="status status-{{ selectedOrderStatus.type|order_status_color }}">
+                        <span class="status-dot"></span>
+                    </span>
+                </span>
+                <span class="text-truncate">{{ selectedOrderStatus.name }}</span>
+            {% endif %}
+        </span>
+    </a>
+    <div class="dropdown-menu">
+        <a class="dropdown-item quick-filter-row{% if selectedOrderStatusId is null %} active{% endif %}"
+           href="{{ url('admin_orderstatusfilter_selectorderstatus') }}"
+        >
+            <span class="quick-filter-icon">
+                <span class="status status-outline">
+                    <span class="status-dot"></span>
+                </span>
+            </span>
+            {{ 'All statuses'|trans }}
+        </a>
+
+        {% for orderStatus in orderStatuses %}
+            <a class="dropdown-item quick-filter-row{% if orderStatus.id == selectedOrderStatusId %} active{% endif %}"
+               href="{{ url('admin_orderstatusfilter_selectorderstatus', { orderStatusId: orderStatus.id }) }}"
+            >
+                <span class="quick-filter-icon">
+                    <span class="status status-{{ orderStatus.type|order_status_color }}">
+                        <span class="status-dot"></span>
+                    </span>
+                </span>
+                {{ orderStatus.name }}
+            </a>
+        {% endfor %}
+    </div>
+</div>

--- a/packages/administration/templates/partial/select_domain.html.twig
+++ b/packages/administration/templates/partial/select_domain.html.twig
@@ -1,0 +1,23 @@
+<div class="text-nowrap">{{ 'Domain'|trans }}</div>
+<div class="dropdown">
+    <a href="#"
+       class="btn dropdown-toggle w-100 justify-content-between"
+       data-bs-toggle="dropdown"
+       role="button"
+    >
+        <span class="quick-filter-row">
+            {{ domain_icon(selectedDomainId) }}
+            <span class="text-truncate">{{ getDomainName(selectedDomainId) }}</span>
+        </span>
+    </a>
+    <div class="dropdown-menu">
+        {% for domainConfig in domainConfigs %}
+            <a class="dropdown-item quick-filter-row{% if domainConfig.id == selectedDomainId %} active{% endif %}"
+               href="{{ url('admin_domain_selectdomain', { id: domainConfig.id }) }}"
+            >
+                {{ domain_icon(domainConfig.id) }}
+                {{ domainConfig.name }}
+            </a>
+        {% endfor %}
+    </div>
+</div>

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -160,6 +160,9 @@ msgstr "Všechny domény"
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr "Pokud je zaškrtnuto, všechny ceny je třeba nastavovat ručně, jinak se jednotková cena bez DPH a celkové ceny pro tuto položku přepočítají automaticky."
 
+msgid "All statuses"
+msgstr "Všechny stavy"
+
 msgid "Alternate language"
 msgstr "Alternativní jazyky"
 

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -160,6 +160,9 @@ msgstr ""
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr ""
 
+msgid "All statuses"
+msgstr ""
+
 msgid "Alternate language"
 msgstr ""
 

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -160,6 +160,9 @@ msgstr "Všetky domény"
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr "Všetky ceny musia byť spracované manuálne ak je zaškrtnuté, inak bude jednotková cena bez DPH a celkové ceny pre túto položku prepočítané automaticky."
 
+msgid "All statuses"
+msgstr "Všetky stavy"
+
 msgid "Alternate language"
 msgstr "Alternatívny jazyk"
 

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -229,6 +229,7 @@ class CustomerController extends AdminBaseController
             'isAdvancedSearchFormSubmitted' => $this->customerUserAdvancedSearchFacade->isAdvancedSearchFormSubmitted(
                 $request,
             ),
+            'showDomainSwitcher' => count($this->domain->getAdminEnabledDomains()) > 1,
         ]);
     }
 

--- a/packages/framework/src/Controller/Admin/DomainController.php
+++ b/packages/framework/src/Controller/Admin/DomainController.php
@@ -44,6 +44,15 @@ class DomainController extends AdminBaseController
         ]);
     }
 
+    #[RequireRole(SystemRole::ADMIN)]
+    public function domainSelectAction(): Response
+    {
+        return $this->render('@ShopsysAdministration/partial/select_domain.html.twig', [
+            'domainConfigs' => $this->domain->getAdminEnabledDomains(),
+            'selectedDomainId' => $this->adminDomainTabsFacade->getSelectedDomainId(),
+        ]);
+    }
+
     #[Route(path: '/multidomain/select-domain/{id}', requirements: ['id' => '\d+'])]
     #[RequireRole(SystemRole::ADMIN)]
     public function selectDomainAction(Request $request, int $id): Response

--- a/packages/framework/src/Controller/Admin/DomainFilterController.php
+++ b/packages/framework/src/Controller/Admin/DomainFilterController.php
@@ -27,7 +27,31 @@ class DomainFilterController extends AdminBaseController
     #[RequireRole(SystemRole::ADMIN)]
     public function domainFilterTabsAction(string $namespace, ?array $domainIds = null): Response
     {
-        return $this->render('@ShopsysAdministration/partial/quick_domain_filter.html.twig', [
+        return $this->render(
+            '@ShopsysAdministration/partial/quick_domain_filter.html.twig',
+            $this->getQuickDomainFilterParameters($namespace, $domainIds),
+        );
+    }
+
+    /**
+     * @param int[]|null $domainIds
+     */
+    #[RequireRole(SystemRole::ADMIN)]
+    public function domainFilterSelectAction(string $namespace, ?array $domainIds = null): Response
+    {
+        return $this->render(
+            '@ShopsysAdministration/partial/quick_domain_filter_select.html.twig',
+            $this->getQuickDomainFilterParameters($namespace, $domainIds),
+        );
+    }
+
+    /**
+     * @param int[]|null $domainIds
+     * @return array<string, mixed>
+     */
+    protected function getQuickDomainFilterParameters(string $namespace, ?array $domainIds): array
+    {
+        return [
             'domainConfigs' => $domainIds === null
                 ? $this->domain->getAdminEnabledDomains()
                 : array_filter(
@@ -36,7 +60,7 @@ class DomainFilterController extends AdminBaseController
                 ),
             'namespace' => $namespace,
             'selectedDomainId' => $this->adminDomainFilterTabsFacade->getSelectedDomainId($namespace, $domainIds),
-        ]);
+        ];
     }
 
     #[Route(path: '/multidomain/filter-domain/{namespace}/{domainId}', requirements: ['domainId' => '\d+'])]

--- a/packages/framework/src/Controller/Admin/OrderStatusFilterController.php
+++ b/packages/framework/src/Controller/Admin/OrderStatusFilterController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Controller\Admin;
+
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\CanView;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
+use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
+use Shopsys\FrameworkBundle\Model\Order\Status\AdminOrderStatusFilterFacade;
+use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[ForRole(AdminRoleConstant::ROLE_ORDER)]
+class OrderStatusFilterController extends AdminBaseController
+{
+    public function __construct(
+        protected readonly AdminOrderStatusFilterFacade $adminOrderStatusFilterFacade,
+        protected readonly OrderStatusFacade $orderStatusFacade,
+    ) {
+    }
+
+    #[CanView]
+    public function orderStatusFilterSelectAction(): Response
+    {
+        return $this->render('@ShopsysAdministration/partial/quick_order_status_filter_select.html.twig', [
+            'orderStatuses' => $this->orderStatusFacade->getAll(),
+            'selectedOrderStatus' => $this->adminOrderStatusFilterFacade->getSelectedOrderStatus(),
+        ]);
+    }
+
+    #[Route(path: '/order/filter-status/{orderStatusId}', requirements: ['orderStatusId' => '\d+'])]
+    #[CanView]
+    public function selectOrderStatusAction(Request $request, ?int $orderStatusId = null): RedirectResponse
+    {
+        $this->adminOrderStatusFilterFacade->setSelectedOrderStatusId($orderStatusId);
+
+        $referer = $request->server->get('HTTP_REFERER');
+        $refererParts = $referer === null ? false : parse_url($referer);
+
+        if ($refererParts === false
+            || ($refererParts['host'] ?? null) !== $request->getHost()
+            || !$this->isSafeRefererPath($refererParts['path'] ?? '')
+        ) {
+            return $this->redirectToRoute('admin_order_list');
+        }
+
+        return $this->redirect($this->removeGridPagingFromUrl($referer));
+    }
+
+    protected function isSafeRefererPath(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            && !str_starts_with($path, '//')
+            && !str_starts_with($path, '/\\');
+    }
+
+    /**
+     * The grid clamps an out-of-range page itself, but the number kept from the referer would stay in the address bar.
+     */
+    protected function removeGridPagingFromUrl(string $url): string
+    {
+        $urlParts = parse_url($url);
+        parse_str($urlParts['query'] ?? '', $queryParameters);
+
+        $gridsParameters = $queryParameters[Grid::GET_PARAMETER] ?? null;
+
+        if (is_array($gridsParameters)) {
+            foreach ($gridsParameters as $gridId => $gridParameters) {
+                if (is_array($gridParameters)) {
+                    unset($gridParameters['page']);
+                    $queryParameters[Grid::GET_PARAMETER][$gridId] = $gridParameters;
+                }
+            }
+        }
+
+        $path = $urlParts['path'] ?? '/';
+        $query = http_build_query($queryParameters);
+
+        return $query === '' ? $path : $path . '?' . $query;
+    }
+}

--- a/packages/framework/src/Model/Order/Status/AdminOrderStatusFilterFacade.php
+++ b/packages/framework/src/Model/Order/Status/AdminOrderStatusFilterFacade.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Order\Status;
+
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class AdminOrderStatusFilterFacade
+{
+    protected const string SESSION_KEY = 'admin_order_status_filter';
+
+    public function __construct(
+        protected readonly RequestStack $requestStack,
+        protected readonly OrderStatusRepository $orderStatusRepository,
+    ) {
+    }
+
+    public function setSelectedOrderStatusId(?int $orderStatusId): void
+    {
+        $this->requestStack->getSession()->set(static::SESSION_KEY, $orderStatusId);
+    }
+
+    public function getSelectedOrderStatusId(): ?int
+    {
+        return $this->getSelectedOrderStatus()?->getId();
+    }
+
+    public function getSelectedOrderStatus(): ?OrderStatus
+    {
+        try {
+            $orderStatusId = $this->requestStack->getSession()->get(static::SESSION_KEY);
+        } catch (SessionNotFoundException) {
+            return null;
+        }
+
+        if ($orderStatusId === null) {
+            return null;
+        }
+
+        $orderStatus = $this->orderStatusRepository->findById((int)$orderStatusId);
+
+        if ($orderStatus === null) {
+            $this->setSelectedOrderStatusId(null);
+
+            return null;
+        }
+
+        return $orderStatus;
+    }
+}

--- a/packages/framework/tests/Unit/Model/Order/Status/AdminOrderStatusFilterFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Status/AdminOrderStatusFilterFacadeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Order\Status;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Model\Order\Status\AdminOrderStatusFilterFacade;
+use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus;
+use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+final class AdminOrderStatusFilterFacadeTest extends TestCase
+{
+    private const string SESSION_KEY = 'admin_order_status_filter';
+
+    public function testNoOrderStatusIsSelectedByDefault(): void
+    {
+        $adminOrderStatusFilterFacade = $this->createAdminOrderStatusFilterFacade($session, null);
+
+        $this->assertNull($adminOrderStatusFilterFacade->getSelectedOrderStatusId());
+        $this->assertNull($adminOrderStatusFilterFacade->getSelectedOrderStatus());
+    }
+
+    public function testSelectedOrderStatusIsReturned(): void
+    {
+        $orderStatus = $this->createOrderStatusStub(2);
+        $adminOrderStatusFilterFacade = $this->createAdminOrderStatusFilterFacade($session, $orderStatus);
+        $adminOrderStatusFilterFacade->setSelectedOrderStatusId(2);
+
+        $this->assertSame(2, $adminOrderStatusFilterFacade->getSelectedOrderStatusId());
+        $this->assertSame($orderStatus, $adminOrderStatusFilterFacade->getSelectedOrderStatus());
+    }
+
+    public function testSelectedOrderStatusIsClearedWhenItNoLongerExists(): void
+    {
+        $adminOrderStatusFilterFacade = $this->createAdminOrderStatusFilterFacade($session, null);
+        $adminOrderStatusFilterFacade->setSelectedOrderStatusId(2);
+
+        $this->assertNull($adminOrderStatusFilterFacade->getSelectedOrderStatusId());
+        $this->assertNull($session->get(self::SESSION_KEY));
+    }
+
+    public function testSelectedOrderStatusIsClearedByNull(): void
+    {
+        $adminOrderStatusFilterFacade = $this->createAdminOrderStatusFilterFacade($session, $this->createOrderStatusStub(2));
+        $adminOrderStatusFilterFacade->setSelectedOrderStatusId(2);
+        $adminOrderStatusFilterFacade->setSelectedOrderStatusId(null);
+
+        $this->assertNull($adminOrderStatusFilterFacade->getSelectedOrderStatusId());
+    }
+
+    /**
+     * @param-out \Symfony\Component\HttpFoundation\Session\SessionInterface $session
+     */
+    private function createAdminOrderStatusFilterFacade(
+        ?SessionInterface &$session,
+        ?OrderStatus $foundOrderStatus,
+    ): AdminOrderStatusFilterFacade {
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $orderStatusRepositoryStub = $this->createStub(OrderStatusRepository::class);
+        $orderStatusRepositoryStub->method('findById')->willReturn($foundOrderStatus);
+
+        return new AdminOrderStatusFilterFacade($requestStack, $orderStatusRepositoryStub);
+    }
+
+    private function createOrderStatusStub(int $orderStatusId): OrderStatus
+    {
+        $orderStatusStub = $this->createStub(OrderStatus::class);
+        $orderStatusStub->method('getId')->willReturn($orderStatusId);
+
+        return $orderStatusStub;
+    }
+}

--- a/project-base/app/assets/icons/tabler/world.svg
+++ b/project-base/app/assets/icons/tabler/world.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0-18 0m.6-3h16.8M3.6 15h16.8"/><path d="M11.5 3a17 17 0 0 0 0 18m1-18a17 17 0 0 1 0 18"/></g></svg>

--- a/project-base/app/config/packages/ux_icons.yaml
+++ b/project-base/app/config/packages/ux_icons.yaml
@@ -96,6 +96,7 @@ ux_icons:
         user-settings: 'tabler:user-cog'
         visible: 'tabler:eye'
         warning: 'tabler:alert-triangle'
+        world: 'tabler:world'
     default_icon_attributes:
         class: icon
         fill: currentColor

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -86,6 +86,9 @@ class RouteConfigCustomization
             ->customizeByRouteName('admin_domainfilter_selectdomain', function (RouteConfig $config): void {
                 $config->skipRoute('Used only for internal setting of selected domain by tab control in admin.');
             })
+            ->customizeByRouteName('admin_orderstatusfilter_selectorderstatus', function (RouteConfig $config): void {
+                $config->skipRoute('Used only for internal setting of selected order status by quick filter in admin.');
+            })
             ->customizeByRouteName('admin_feed_generate', function (RouteConfig $config): void {
                 $config->skipRoute('Do not rewrite XML feed by test products.');
             })

--- a/upgrade-notes/backend_20260826_100423.md
+++ b/upgrade-notes/backend_20260826_100423.md
@@ -1,0 +1,5 @@
+#### Quick order status filters on the admin order list ([#4803](https://github.com/shopsys/shopsys/pull/4803))
+
+- `@ShopsysAdministration/content/order/list.html.twig` renders both quick filters as dropdowns in one card next to the search card and no longer renders `DomainFilterController::domainFilterTabsAction`
+    - if you override this template, render `DomainFilterController::domainFilterSelectAction` and `OrderStatusFilterController::orderStatusFilterSelectAction` instead
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

To see only the orders in one state, an administrator had to open Advanced search and build a rule. This adds a row of one-click filters above the order list — the same control that already sits one row higher for the domain filter.

**What changes for the administrator**

- The order list shows links for every order status, plus "All" as the default.
- Clicking one narrows the listing to that status.
- The filter is respected and kept by **both** Quick search and Advanced search — narrowing by status and then searching gives the intersection, not one replacing the other.

**How, and two decisions worth reviewing**

- The condition is added to the query builder *shared* by the quick and advanced branches, right after the domain condition and after the branch — which is exactly how the existing Quick Domain Filter survives both searches.
- The choice lives in the **session**, not in the URL. Both search forms are GET forms without an `action`, so `?orderStatus=3` would be wiped from the URL on the first submit, and the advanced "Reset filter" link rebuilds its URL from route parameters only, dropping it a second time.
- The existing `OrderStatusFilter` advanced-search filter is deliberately **not** reused for these links: injecting an `as[…]` rule flips `isAdvancedSearchFormSubmitted()` to true, which makes the controller take the advanced branch and discard the quick-search data outright.

**Notes for the reviewer**

- Page number is stripped in the redirect rather than on the link, because it lives on the referer — a narrowed listing has fewer pages and would otherwise land on an empty one.
- The redirect targets a relative path rebuilt from the referer. As a side effect this avoids the open redirect via a forged `Referer` that `DomainFilterController` still has — worth its own ticket.
- The new facade has no namespace parameter (unlike `AdminDomainFilterTabsFacade`) because only one listing uses it.
- `AdminDomainFilterTabsFacade` calls `setSelectedDomainId()` from inside a `catch (SessionNotFoundException)`, which would rethrow. The new facade is structured to avoid that; the existing one was left untouched.
- Not verified: the click-through in a browser.

#### Fixes issues

https://shopsys.atlassian.net/browse/SSP-4104

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4104-quick-order-status-filter.odin.shopsys.cloud
  - https://cz.vk-ssp-4104-quick-order-status-filter.odin.shopsys.cloud
  - https://vk-ssp-4104-quick-order-status-filter.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788930828.235299 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-4104-quick-order-status-filter.odin.shopsys.cloud
  - https://cz.vk-ssp-4104-quick-order-status-filter.odin.shopsys.cloud
  - https://vk-ssp-4104-quick-order-status-filter.odin.shopsys.cloud/sk
<!-- Replace -->
