### PR TITLE
Link type articles no longer get a friendly URL

### DIFF
--- a/packages/framework/src/Model/Article/Article.php
+++ b/packages/framework/src/Model/Article/Article.php
@@ -306,6 +306,14 @@ class Article implements OrderableEntityInterface, DomainSeparatedEntityInterfac
     }
 
     /**
+     * @return bool
+     */
+    public function isSiteType()
+    {
+        return $this->type === self::TYPE_SITE;
+    }
+
+    /**
      * @return int
      */
     public function getPosition()

--- a/packages/framework/src/Model/Article/ArticleDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Article/ArticleDetailFriendlyUrlDataProvider.php
@@ -40,7 +40,9 @@ class ArticleDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInt
             )
             ->setParameter('routeName', static::ROUTE_NAME)
             ->where('f.entityId IS NULL AND a.domainId = :domainId')
-            ->setParameter('domainId', $domainConfig->getId());
+            ->setParameter('domainId', $domainConfig->getId())
+            ->andWhere('a.type = :type')
+            ->setParameter('type', Article::TYPE_SITE);
         $scalarData = $queryBuilder->getQuery()->getScalarResult();
 
         $friendlyUrlsData = [];

--- a/packages/framework/src/Model/Article/ArticleFacade.php
+++ b/packages/framework/src/Model/Article/ArticleFacade.php
@@ -50,13 +50,16 @@ class ArticleFacade
 
         $this->em->persist($article);
         $this->em->flush();
-        $this->friendlyUrlFacade->createFriendlyUrlForDomain(
-            'front_article_detail',
-            $article->getId(),
-            $article->getName(),
-            $article->getDomainId(),
-        );
-        $this->em->flush();
+
+        if (!$article->isLinkType()) {
+            $this->friendlyUrlFacade->createFriendlyUrlForDomain(
+                'front_article_detail',
+                $article->getId(),
+                $article->getName(),
+                $article->getDomainId(),
+            );
+            $this->em->flush();
+        }
 
         $this->articleExportMessageDispatcher->dispatchArticleExportMessage($article->getId(), $article->getDomainId());
         $this->cleanStorefrontCacheFacade->cleanStorefrontGraphqlQueryCache(CleanStorefrontCacheFacade::ARTICLES_QUERY_KEY_PART);
@@ -69,14 +72,16 @@ class ArticleFacade
         $article = $this->articleRepository->getById($articleId);
 
         $article->edit($articleData);
-        $this->friendlyUrlFacade->saveUrlListFormData('front_article_detail', $article->getId(), $articleData->urls);
 
-        $this->friendlyUrlFacade->createFriendlyUrlForDomain(
-            'front_article_detail',
-            $article->getId(),
-            $article->getName(),
-            $article->getDomainId(),
-        );
+        if (!$article->isLinkType()) {
+            $this->friendlyUrlFacade->saveUrlListFormData('front_article_detail', $article->getId(), $articleData->urls);
+            $this->friendlyUrlFacade->createFriendlyUrlForDomain(
+                'front_article_detail',
+                $article->getId(),
+                $article->getName(),
+                $article->getDomainId(),
+            );
+        }
         $this->em->flush();
 
         $this->articleExportMessageDispatcher->dispatchArticleExportMessage($article->getId(), $article->getDomainId());

--- a/packages/framework/src/Model/Article/Elasticsearch/ArticleElasticsearchFacade.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/ArticleElasticsearchFacade.php
@@ -16,9 +16,9 @@ class ArticleElasticsearchFacade
         return $this->articleElasticsearchRepository->getByUuid($uuid);
     }
 
-    public function getBySlug(string $slug): array
+    public function getSiteArticleBySlug(string $slug): array
     {
-        return $this->articleElasticsearchRepository->getBySlug($slug);
+        return $this->articleElasticsearchRepository->getSiteArticleBySlug($slug);
     }
 
     /**

--- a/packages/framework/src/Model/Article/Elasticsearch/ArticleElasticsearchRepository.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/ArticleElasticsearchRepository.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Article\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchNoResultException;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
+use Shopsys\FrameworkBundle\Model\Article\Article;
 use Shopsys\FrameworkBundle\Model\Article\Exception\ArticleNotFoundException;
 
 class ArticleElasticsearchRepository
@@ -67,12 +68,12 @@ class ArticleElasticsearchRepository
         return $this->articleElasticsearchDataFetcher->getAllResults($filterQuery);
     }
 
-    public function getBySlug(string $slug): array
+    public function getSiteArticleBySlug(string $slug): array
     {
-        $article = $this->findBySlug($slug);
+        $article = $this->findSiteArticleBySlug($slug);
 
         if ($article === null) {
-            $article = $this->findBySlug($this->transformStringHelper->addOrRemoveTrailingSlashFromString($slug));
+            $article = $this->findSiteArticleBySlug($this->transformStringHelper->addOrRemoveTrailingSlashFromString($slug));
         }
 
         if ($article === null) {
@@ -82,9 +83,9 @@ class ArticleElasticsearchRepository
         return $article;
     }
 
-    protected function findBySlug(string $slug): ?array
+    protected function findSiteArticleBySlug(string $slug): ?array
     {
-        $filterQuery = $this->filterQueryFactory->createFilteredBySlug($slug);
+        $filterQuery = $this->filterQueryFactory->createFilteredBySlug($slug)->filterByType(Article::TYPE_SITE);
 
         try {
             return $this->articleElasticsearchDataFetcher->getSingleResult($filterQuery);

--- a/packages/framework/src/Model/Article/Elasticsearch/ArticleExportRepository.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/ArticleExportRepository.php
@@ -20,19 +20,17 @@ class ArticleExportRepository
     ) {
     }
 
-    public function getVisibleArticleSitesCountByDomainId(int $domainId): int
+    public function getVisibleArticlesCountByDomainId(int $domainId): int
     {
         return (int)($this->articleRepository->getVisibleArticlesByDomainIdQueryBuilder($domainId)
             ->select('COUNT(a)')
-            ->andWhere('a.type = :type')
-            ->setParameter('type', Article::TYPE_SITE)
             ->getQuery()->getSingleScalarResult());
     }
 
     /**
      * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
      */
-    public function getAllVisibleArticleSitesByDomainId(int $domainId, int $limit, int $lastProcessedId): array
+    public function getAllVisibleArticlesByDomainId(int $domainId, int $limit, int $lastProcessedId): array
     {
         return $this->articleRepository->getVisibleArticlesByDomainIdQueryBuilder($domainId)
             ->andWhere('a.id > :lastProcessedId')
@@ -47,7 +45,7 @@ class ArticleExportRepository
      * @param int[] $articleIds
      * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
      */
-    public function getVisibleArticleSitesByDomainIdAndArticleIds(int $domainId, array $articleIds): array
+    public function getVisibleArticlesByDomainIdAndArticleIds(int $domainId, array $articleIds): array
     {
         return $this->articleRepository->getVisibleArticlesByDomainIdQueryBuilder($domainId)
             ->andWhere('a.id IN (:articleIds)')
@@ -60,9 +58,8 @@ class ArticleExportRepository
     {
         $domainId = $article->getDomainId();
         $articleId = $article->getId();
-        $mainFriendlyUrl = $this->friendlyUrlFacade->getMainFriendlyUrl($domainId, 'front_article_detail', $articleId);
 
-        return [
+        $extractedArticle = [
             'name' => $article->getName(),
             'text' => $this->grapesJsParser->parse($article->getText()),
             'url' => $article->getUrl(),
@@ -71,13 +68,23 @@ class ArticleExportRepository
             'seoH1' => $article->getSeoH1(),
             'seoTitle' => $article->getSeoTitle(),
             'seoMetaDescription' => $article->getSeoMetaDescription(),
-            'slug' => $this->friendlyUrlFacade->getAllSlugsByRouteNameAndEntityId($domainId, 'front_article_detail', $articleId),
-            'mainSlug' => $mainFriendlyUrl->getSlug(),
             'position' => $article->getPosition(),
-            'breadcrumb' => $this->breadcrumbFacade->getBreadcrumbOnDomain($articleId, 'front_article_detail', $domainId),
             'external' => $article->isExternal(),
             'createdAt' => $article->getCreatedAt()->format('Y-m-d H:i:s'),
             'type' => $article->getType(),
+            'slug' => [],
+            'mainSlug' => null,
+            'breadcrumb' => [],
         ];
+
+        if ($article->isSiteType()) {
+            $mainFriendlyUrl = $this->friendlyUrlFacade->getMainFriendlyUrl($domainId, 'front_article_detail', $articleId);
+
+            $extractedArticle['slug'] = $this->friendlyUrlFacade->getAllSlugsByRouteNameAndEntityId($domainId, 'front_article_detail', $articleId);
+            $extractedArticle['mainSlug'] = $mainFriendlyUrl->getSlug();
+            $extractedArticle['breadcrumb'] = $this->breadcrumbFacade->getBreadcrumbOnDomain($articleId, 'front_article_detail', $domainId);
+        }
+
+        return $extractedArticle;
     }
 }

--- a/packages/framework/src/Model/Article/Elasticsearch/ArticleIndex.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/ArticleIndex.php
@@ -18,7 +18,7 @@ class ArticleIndex extends AbstractIndex
     #[Override]
     public function getTotalCount(int $domainId): int
     {
-        return $this->articleExportRepository->getVisibleArticleSitesCountByDomainId($domainId);
+        return $this->articleExportRepository->getVisibleArticlesCountByDomainId($domainId);
     }
 
     /**
@@ -36,7 +36,7 @@ class ArticleIndex extends AbstractIndex
         }
         $results = [];
 
-        foreach ($this->articleExportRepository->getAllVisibleArticleSitesByDomainId($domainId, $batchSize, $lastProcessedId) as $article) {
+        foreach ($this->articleExportRepository->getAllVisibleArticlesByDomainId($domainId, $batchSize, $lastProcessedId) as $article) {
             $results[$article->getId()] = $this->articleExportRepository->extractArticle($article);
         }
 
@@ -57,7 +57,7 @@ class ArticleIndex extends AbstractIndex
         }
         $results = [];
 
-        foreach ($this->articleExportRepository->getVisibleArticleSitesByDomainIdAndArticleIds($domainId, $restrictToIds) as $article) {
+        foreach ($this->articleExportRepository->getVisibleArticlesByDomainIdAndArticleIds($domainId, $restrictToIds) as $article) {
             $results[$article->getId()] = $this->articleExportRepository->extractArticle($article);
         }
 

--- a/packages/framework/src/Model/Article/Elasticsearch/FilterQuery.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/FilterQuery.php
@@ -42,6 +42,18 @@ class FilterQuery extends AbstractFilterQuery
         return $clone;
     }
 
+    public function filterByType(string $type): static
+    {
+        $clone = clone $this;
+        $clone->filters[] = [
+            'match' => [
+                'type' => $type,
+            ],
+        ];
+
+        return $clone;
+    }
+
     /**
      * @param string[] $placements
      */

--- a/packages/framework/src/Model/Sitemap/SitemapRepository.php
+++ b/packages/framework/src/Model/Sitemap/SitemapRepository.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
+use Shopsys\FrameworkBundle\Model\Article\Article;
 use Shopsys\FrameworkBundle\Model\Article\ArticleRepository;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleRepository;
 use Shopsys\FrameworkBundle\Model\Category\CategoryRepository;
@@ -92,6 +93,8 @@ class SitemapRepository
                 AND fu.domainId = :domainId
                 AND fu.main = TRUE',
             )
+            ->andWhere('a.type = :articleType')
+            ->setParameter('articleType', Article::TYPE_SITE)
             ->setParameter('articleDetailRouteName', 'front_article_detail')
             ->setParameter('domainId', $domainConfig->getId());
 

--- a/packages/framework/tests/Unit/Model/Article/Elasticsearch/ArticleExportRepositoryTest.php
+++ b/packages/framework/tests/Unit/Model/Article/Elasticsearch/ArticleExportRepositoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Article\Elasticsearch;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\GrapesJs\GrapesJsParser;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\Model\Article\Article;
+use Shopsys\FrameworkBundle\Model\Article\ArticleData;
+use Shopsys\FrameworkBundle\Model\Article\ArticleRepository;
+use Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleExportRepository;
+
+class ArticleExportRepositoryTest extends TestCase
+{
+    private const int ARTICLE_ID = 1;
+    private const string ARTICLE_SLUG = 'article';
+    private const array ARTICLE_BREADCRUMB = [['name' => 'Article', 'slug' => 'article']];
+
+    public function testExtractedLinkTypeArticleHasNoUrlData(): void
+    {
+        /** @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade|\PHPUnit\Framework\MockObject\Stub $friendlyUrlFacadeStub */
+        $friendlyUrlFacadeStub = $this->createStub(FriendlyUrlFacade::class);
+        $friendlyUrlFacadeStub->method('getMainFriendlyUrl')
+            ->willThrowException(new FriendlyUrlNotFoundException());
+        $friendlyUrlFacadeStub->method('getAllSlugsByRouteNameAndEntityId')->willReturn([self::ARTICLE_SLUG]);
+
+        $extractedArticle = $this->createArticleExportRepository($friendlyUrlFacadeStub)
+            ->extractArticle($this->createArticle(Article::TYPE_LINK));
+
+        $this->assertSame([], $extractedArticle['slug']);
+        $this->assertNull($extractedArticle['mainSlug']);
+        $this->assertSame([], $extractedArticle['breadcrumb']);
+        $this->assertSame('https://www.shopsys.com', $extractedArticle['url']);
+    }
+
+    public function testExtractedSiteTypeArticleHasUrlData(): void
+    {
+        /** @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade|\PHPUnit\Framework\MockObject\Stub $friendlyUrlFacadeStub */
+        $friendlyUrlFacadeStub = $this->createStub(FriendlyUrlFacade::class);
+        $friendlyUrlFacadeStub->method('getMainFriendlyUrl')->willReturn(
+            new FriendlyUrl('front_article_detail', self::ARTICLE_ID, Domain::FIRST_DOMAIN_ID, self::ARTICLE_SLUG),
+        );
+        $friendlyUrlFacadeStub->method('getAllSlugsByRouteNameAndEntityId')->willReturn([self::ARTICLE_SLUG]);
+
+        $extractedArticle = $this->createArticleExportRepository($friendlyUrlFacadeStub)
+            ->extractArticle($this->createArticle(Article::TYPE_SITE));
+
+        $this->assertSame([self::ARTICLE_SLUG], $extractedArticle['slug']);
+        $this->assertSame(self::ARTICLE_SLUG, $extractedArticle['mainSlug']);
+        $this->assertSame(self::ARTICLE_BREADCRUMB, $extractedArticle['breadcrumb']);
+    }
+
+    private function createArticleExportRepository(FriendlyUrlFacade $friendlyUrlFacade): ArticleExportRepository
+    {
+        /** @var \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbFacade|\PHPUnit\Framework\MockObject\Stub $breadcrumbFacadeStub */
+        $breadcrumbFacadeStub = $this->createStub(BreadcrumbFacade::class);
+        $breadcrumbFacadeStub->method('getBreadcrumbOnDomain')->willReturn(self::ARTICLE_BREADCRUMB);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Article\ArticleRepository|\PHPUnit\Framework\MockObject\Stub $articleRepositoryStub */
+        $articleRepositoryStub = $this->createStub(ArticleRepository::class);
+
+        return new ArticleExportRepository(
+            $articleRepositoryStub,
+            $friendlyUrlFacade,
+            $breadcrumbFacadeStub,
+            new GrapesJsParser(),
+        );
+    }
+
+    private function createArticle(string $type): Article
+    {
+        $articleData = new ArticleData();
+        $articleData->domainId = Domain::FIRST_DOMAIN_ID;
+        $articleData->name = 'Article';
+        $articleData->placement = Article::PLACEMENT_FOOTER_1;
+        $articleData->type = $type;
+
+        if ($type === Article::TYPE_LINK) {
+            $articleData->url = 'https://www.shopsys.com';
+        }
+
+        $article = new Article($articleData);
+        (new ReflectionClass($article))->getProperty('id')->setValue($article, self::ARTICLE_ID);
+
+        return $article;
+    }
+}

--- a/packages/framework/tests/Unit/Model/Article/Elasticsearch/FilterQueryTest.php
+++ b/packages/framework/tests/Unit/Model/Article/Elasticsearch/FilterQueryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Article\Elasticsearch;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Model\Article\Article;
+use Shopsys\FrameworkBundle\Model\Article\Elasticsearch\FilterQuery;
+use stdClass;
+
+class FilterQueryTest extends TestCase
+{
+    public function testFilterBySlugAndType(): void
+    {
+        $filterQuery = new FilterQuery('article');
+
+        $actualQuery = $filterQuery->filterBySlug('article-slug')->filterByType(Article::TYPE_SITE)->getQuery();
+
+        $expectedQuery = [
+            'index' => 'article',
+            'body' => [
+                'from' => 0,
+                'size' => 1000,
+                'sort' => [
+                    'placement' => 'asc',
+                    'position' => 'asc',
+                ],
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            'match_all' => new stdClass(),
+                        ],
+                        'filter' => [
+                            [
+                                'term' => [
+                                    'slug' => 'article-slug',
+                                ],
+                            ],
+                            [
+                                'match' => [
+                                    'type' => Article::TYPE_SITE,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expectedQuery, $actualQuery);
+    }
+}

--- a/packages/frontend-api/src/Model/Resolver/Article/ArticleQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticleQuery.php
@@ -28,7 +28,7 @@ class ArticleQuery extends AbstractQuery
             if ($uuid !== null) {
                 $articleData = $this->articleElasticsearchFacade->getByUuid($uuid);
             } elseif ($urlSlug !== null) {
-                $articleData = $this->articleElasticsearchFacade->getBySlug(ltrim($urlSlug, '/'));
+                $articleData = $this->articleElasticsearchFacade->getSiteArticleBySlug(ltrim($urlSlug, '/'));
             } else {
                 throw new InvalidArgumentUserError('You need to provide argument \'uuid\' or \'urlSlug\'.');
             }

--- a/project-base/app/tests/App/Functional/Model/Article/ArticleFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Article/ArticleFacadeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Model\Article;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\Model\Article\Article;
+use Shopsys\FrameworkBundle\Model\Article\ArticleData;
+use Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory;
+use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
+use Tests\App\Test\TransactionFunctionalTestCase;
+
+final class ArticleFacadeTest extends TransactionFunctionalTestCase
+{
+    /**
+     * @inject
+     */
+    private ArticleFacade $articleFacade;
+
+    /**
+     * @inject
+     */
+    private ArticleDataFactory $articleDataFactory;
+
+    /**
+     * @inject
+     */
+    private FriendlyUrlFacade $friendlyUrlFacade;
+
+    public function testCreatedLinkTypeArticleHasNoFriendlyUrl(): void
+    {
+        $articleData = $this->createArticleData('Link type article');
+        $articleData->type = Article::TYPE_LINK;
+        $articleData->url = 'https://www.shopsys.com';
+
+        $article = $this->articleFacade->create($articleData);
+
+        $this->assertNull($this->findMainFriendlyUrlSlug($article));
+    }
+
+    public function testCreatedSiteTypeArticleHasFriendlyUrl(): void
+    {
+        $articleData = $this->createArticleData('Site type article');
+
+        $article = $this->articleFacade->create($articleData);
+
+        $this->assertSame('site-type-article', $this->findMainFriendlyUrlSlug($article));
+    }
+
+    public function testArticleSwitchedToLinkTypeKeepsItsFriendlyUrl(): void
+    {
+        $article = $this->articleFacade->create($this->createArticleData('Article switched to link'));
+
+        $articleData = $this->articleDataFactory->createFromArticle($article);
+        $articleData->type = Article::TYPE_LINK;
+        $articleData->url = 'https://www.shopsys.com';
+        $this->articleFacade->edit($article->getId(), $articleData);
+
+        $this->assertSame('article-switched-to-link', $this->findMainFriendlyUrlSlug($article));
+    }
+
+    public function testArticleSwitchedBackToSiteTypeGetsFriendlyUrl(): void
+    {
+        $articleData = $this->createArticleData('Article switched back to site');
+        $articleData->type = Article::TYPE_LINK;
+        $articleData->url = 'https://www.shopsys.com';
+        $article = $this->articleFacade->create($articleData);
+
+        $articleData = $this->articleDataFactory->createFromArticle($article);
+        $articleData->type = Article::TYPE_SITE;
+        $this->articleFacade->edit($article->getId(), $articleData);
+
+        $this->assertSame('article-switched-back-to-site', $this->findMainFriendlyUrlSlug($article));
+    }
+
+    private function createArticleData(string $name): ArticleData
+    {
+        $articleData = $this->articleDataFactory->create(Domain::FIRST_DOMAIN_ID);
+        $articleData->name = $name;
+        $articleData->placement = Article::PLACEMENT_FOOTER_1;
+
+        return $articleData;
+    }
+
+    private function findMainFriendlyUrlSlug(Article $article): ?string
+    {
+        return $this->friendlyUrlFacade->findMainFriendlyUrl(
+            $article->getDomainId(),
+            'front_article_detail',
+            $article->getId(),
+        )?->getSlug();
+    }
+}

--- a/upgrade-notes/backend_20260827_105428.md
+++ b/upgrade-notes/backend_20260827_105428.md
@@ -1,0 +1,16 @@
+#### Link type articles no longer get a friendly URL ([#4805](https://github.com/shopsys/shopsys/pull/4805))
+
+- these methods were renamed and now match only articles of the site type:
+    - `Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleElasticsearchFacade::getBySlug()` was renamed to `getSiteArticleBySlug()`
+    - `Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleElasticsearchRepository::getBySlug()` was renamed to `getSiteArticleBySlug()`
+    - `Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleElasticsearchRepository::findBySlug()` was renamed to `findSiteArticleBySlug()`
+- these methods of `Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleExportRepository` were renamed because they return visible articles of all types, articles of the link type included:
+    - `getVisibleArticleSitesCountByDomainId()` was renamed to `getVisibleArticlesCountByDomainId()` and no longer excludes articles of the link type, so the count matches the articles the other two methods return
+    - `getAllVisibleArticleSitesByDomainId()` was renamed to `getAllVisibleArticlesByDomainId()`
+    - `getVisibleArticleSitesByDomainIdAndArticleIds()` was renamed to `getVisibleArticlesByDomainIdAndArticleIds()`
+- friendly URLs of articles switched to the link type are kept in the database, but they no longer resolve
+    - if your project links to such articles by their friendly URL, link to the article target URL instead
+- if you override `Shopsys\FrameworkBundle\Model\Article\ArticleFacade::create()` or `::edit()`, keep them from creating a friendly URL for an article of the link type, and let an article switched back to the site type get its friendly URL created even when its name did not change
+- if you override `Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleExportRepository::extractArticle()`, do not read the main friendly URL for an article of the link type - it has none, export empty `slug`, `mainSlug` and `breadcrumb` for it instead
+- if you override `Shopsys\FrameworkBundle\Model\Article\ArticleDetailFriendlyUrlDataProvider` or `Shopsys\FrameworkBundle\Model\Sitemap\SitemapRepository`, filter out articles of the link type there as well
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

An article of the **link** type is only a pointer somewhere else — there is no content to serve. It was nevertheless given a friendly URL of its own, so the storefront had a URL that rendered an empty page instead of a 404.

**What changes for the administrator and the visitor**

- Creating a link type article no longer writes a row into `friendly_urls`.
- An existing article switched to the link type keeps its URL, but that URL now returns 404 instead of an empty page.
- Link type articles are left out of the sitemap, so a URL that now 404s is not advertised to search engines.

The first acceptance criterion — hiding the content field in the administration for link type articles — was **already implemented** (commit `8706b0e13b`); this PR only had to verify it.

**The trap this had to avoid**

Blog and article listings read from Elasticsearch, and link type articles must stay in the index — the footer lists them. But `ArticleExportRepository::extractArticle()` unconditionally demanded a main friendly URL and a breadcrumb for every article, so it would have started throwing the moment those URLs stopped existing. It now exports link type articles with **explicit empty** `slug`, `mainSlug` and `breadcrumb` rather than omitting the keys, because `IndexRepository::bulkUpdate()` does a partial `doc` merge — omitting them would leave a stale slug in the document of an article that has just been switched.

**Other notes**

- The type filter was unified between the counting and the listing export queries by **removing** it from the count — the other direction would drop link type articles from the index and break the footer. The three `ArticleExportRepository` methods were renamed from `...ArticleSites...` to `...Articles...` accordingly — the old names no longer described what they return.
- The ES `type` field is mapped as `text`, not `keyword`, so `filterByType()` uses `match`, consistent with `CombinedArticleElasticsearchRepository`. Changing the mapping would force a reindex.
- Existing orphaned URLs are deliberately **not** migrated away — the acceptance criteria ask for them to stay.
- No storefront change was needed: `pages/articles/[articleSlug].tsx` already routes the API error through `handleServerSideErrorResponseForFriendlyUrls`.

#### Fixes issues

https://shopsys.atlassian.net/browse/SSP-2253

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)













----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-2253-link-article-without-friendly-url.odin.shopsys.cloud
  - https://cz.vk-ssp-2253-link-article-without-friendly-url.odin.shopsys.cloud
  - https://vk-ssp-2253-link-article-without-friendly-url.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788880940.571059 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://vk-ssp-2253-link-article-without-friendly-url.odin.shopsys.cloud
  - https://cz.vk-ssp-2253-link-article-without-friendly-url.odin.shopsys.cloud
  - https://vk-ssp-2253-link-article-without-friendly-url.odin.shopsys.cloud/sk
<!-- Replace -->
