### PR TITLE
Link order number to order detail in the payment failed text

### DIFF
--- a/packages/framework/src/Migrations/Version20231101182132.php
+++ b/packages/framework/src/Migrations/Version20231101182132.php
@@ -35,7 +35,7 @@ final class Version20231101182132 extends AbstractMigration implements DomainAwa
                 'paymentFailedText',
                 t(
                     '
-                <p>Payment for order number {number} has failed. <br />
+                <p>Payment for order number <a href="{order_detail_url}" tabindex="0">{number}</a> has failed. <br />
                 Please contact us to resolve the issue.</p>',
                     [],
                     Translator::DATA_FIXTURES_TRANSLATION_DOMAIN,

--- a/packages/framework/src/Resources/translations/dataFixtures.cs.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.cs.po
@@ -37,11 +37,11 @@ msgstr "<p>Dobrý den {customerName},</p> <p>Děkujeme za Váš dotaz k produktu
 msgid "<p>Order number {number} has been sent, thank you for your purchase. We will contact you about next order status. <br /><br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions} <br /> {payment_instructions} <br /></p>"
 msgstr "<p>Objednávka číslo {number} byla úspěšně odeslána, děkujeme za Váš nákup. O dalším stavu objednávky Vás budeme informovat. <br /><br /> Stav Vaší objednávky můžete sledovat <a href=\"{order_detail_url}\" tabindex=\"0\">zde.</a> <br /> {transport_instructions} <br /> {payment_instructions} <br /></p>"
 
+msgid "<p>Payment for order number <a href=\"{order_detail_url}\" tabindex=\"0\">{number}</a> has failed. <br /> Please contact us to resolve the issue.</p>"
+msgstr "<p>Platba pro objednávku číslo <a href=\"{order_detail_url}\" tabindex=\"0\">{number}</a> nebyla úspěšná. <br /> Prosím kontaktujte nás pro vyřešení problému.</p>"
+
 msgid "<p>Payment for order number {number} has been successful. <br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions}</p>"
 msgstr "<p>Platba pro objednávku číslo {number} proběhla úspěšně. <br /> Stav Vaší objednávky můžete sledovat <a href=\"{order_detail_url}\" tabindex=\"0\">zde.</a> <br /> {transport_instructions}</p>"
-
-msgid "<p>Payment for order number {number} has failed. <br /> Please contact us to resolve the issue.</p>"
-msgstr "<p>Platba pro objednávku číslo {number} nebyla úspěšná. <br /> Prosím kontaktujte nás pro vyřešení problému.</p>"
 
 msgid "<p>We acknowledge your withdrawal from the contract for order number <b>{order_number}</b>.</p> <p>We will contact you in the following days regarding the next steps, including the return of the goods.</p> <p><a href=\"{order_detail_url}\" tabindex=\"0\">Show order detail</a></p>"
 msgstr "<p>Evidujeme vaše odstoupení od smlouvy u objednávky číslo <b>{order_number}</b>.</p> <p>V následujících dnech Vás budeme kontaktovat ohledně dalšího postupu včetně vrácení daného zboží.</p> <p><a href=\"{order_detail_url}\" tabindex=\"0\">Zobrazit detail objednávky</a></p>"

--- a/packages/framework/src/Resources/translations/dataFixtures.en.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.en.po
@@ -37,10 +37,10 @@ msgstr ""
 msgid "<p>Order number {number} has been sent, thank you for your purchase. We will contact you about next order status. <br /><br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions} <br /> {payment_instructions} <br /></p>"
 msgstr ""
 
-msgid "<p>Payment for order number {number} has been successful. <br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions}</p>"
+msgid "<p>Payment for order number <a href=\"{order_detail_url}\" tabindex=\"0\">{number}</a> has failed. <br /> Please contact us to resolve the issue.</p>"
 msgstr ""
 
-msgid "<p>Payment for order number {number} has failed. <br /> Please contact us to resolve the issue.</p>"
+msgid "<p>Payment for order number {number} has been successful. <br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions}</p>"
 msgstr ""
 
 msgid "<p>We acknowledge your withdrawal from the contract for order number <b>{order_number}</b>.</p> <p>We will contact you in the following days regarding the next steps, including the return of the goods.</p> <p><a href=\"{order_detail_url}\" tabindex=\"0\">Show order detail</a></p>"

--- a/packages/framework/src/Resources/translations/dataFixtures.sk.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.sk.po
@@ -37,11 +37,11 @@ msgstr "<p>Dobrý deň {customerName},</p> <p>Ďakujeme za Vašu otázku k produ
 msgid "<p>Order number {number} has been sent, thank you for your purchase. We will contact you about next order status. <br /><br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions} <br /> {payment_instructions} <br /></p>"
 msgstr "<p>Objednávka číslo {number} bola odoslaná, ďakujeme za váš nákup. Budeme vás kontaktovať ohľadom ďalšieho stavu objednávky. <br /><br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Sledovať</a> stav vašej objednávky. <br /> {transport_instructions} <br /> {payment_instructions} <br /></p>"
 
+msgid "<p>Payment for order number <a href=\"{order_detail_url}\" tabindex=\"0\">{number}</a> has failed. <br /> Please contact us to resolve the issue.</p>"
+msgstr "<p>Platba za objednávku číslo <a href=\"{order_detail_url}\" tabindex=\"0\">{number}</a> nebola úspešná. <br /> Prosím, kontaktujte nás pre vyriešenie problému.</p>"
+
 msgid "<p>Payment for order number {number} has been successful. <br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Track</a> the status of your order. <br /> {transport_instructions}</p>"
 msgstr "<p>Platba za objednávku číslo {number} bola úspešná. <br /> <a href=\"{order_detail_url}\" tabindex=\"0\">Sledovať</a> stav vašej objednávky. <br /> {transport_instructions}</p>"
-
-msgid "<p>Payment for order number {number} has failed. <br /> Please contact us to resolve the issue.</p>"
-msgstr "<p>Platba za objednávku číslo {number} nebola úspešná. <br /> Prosím, kontaktujte nás pre vyriešenie problému.</p>"
 
 msgid "<p>We acknowledge your withdrawal from the contract for order number <b>{order_number}</b>.</p> <p>We will contact you in the following days regarding the next steps, including the return of the goods.</p> <p><a href=\"{order_detail_url}\" tabindex=\"0\">Show order detail</a></p>"
 msgstr "<p>Potvrdzujeme vaše odstúpenie od zmluvy u objednávky číslo <b>{order_number}</b>. </p> <p> V nasledujúcich dňoch vás budeme kontaktovať ohľadom ďalších krokov, vrátane vrátenia tovaru.</p> <p> <a href=\"{order_detail_url}\" tabindex=\"0\">Zobraziť detail objednávky</a> </p>"


### PR DESCRIPTION
#### Description, the reason for the PR

When a customer's payment fails, the "payment failed" page tells them to contact us, but unlike the "payment successful" page it offered no way to get to the order itself. The customer had to find the order manually to retry the payment or check its details.

The order number in the default "payment failed" text is now a link to the order detail (with the same keyboard accessibility as the link on the "payment successful" page), so the customer can get back to their order with one click. The Czech and Slovak translations of the default text were updated accordingly.

Note: the default text is only inserted on installations where the "payment failed" text has not been set yet — on existing installations the text is managed by the administrator in *Customer communication* and stays untouched.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-payment-failed-order-number-link.odin.shopsys.cloud
  - https://cz.rv-payment-failed-order-number-link.odin.shopsys.cloud
  - https://rv-payment-failed-order-number-link.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1787835372.811519 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-payment-failed-order-number-link.odin.shopsys.cloud
  - https://cz.rv-payment-failed-order-number-link.odin.shopsys.cloud
  - https://rv-payment-failed-order-number-link.odin.shopsys.cloud/sk
<!-- Replace -->
