### PR TITLE
Main friendly URL is no longer changed when entity is renamed

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -65,6 +65,10 @@ class FriendlyUrlFacade
 
     protected function resolveUniquenessOfFriendlyUrl(FriendlyUrl $friendlyUrl, string $entityName): void
     {
+        if (!$this->shouldCreateFriendlyUrl($friendlyUrl)) {
+            return;
+        }
+
         $attempt = 0;
 
         do {
@@ -100,6 +104,17 @@ class FriendlyUrlFacade
 
         $this->em->persist($friendlyUrl);
         $this->setFriendlyUrlAsMain($friendlyUrl);
+    }
+
+    protected function shouldCreateFriendlyUrl(FriendlyUrl $friendlyUrl): bool
+    {
+        $mainFriendlyUrl = $this->findMainFriendlyUrl(
+            $friendlyUrl->getDomainId(),
+            $friendlyUrl->getRouteName(),
+            $friendlyUrl->getEntityId(),
+        );
+
+        return $mainFriendlyUrl === null;
     }
 
     /**

--- a/packages/framework/src/Model/Article/ArticleFacade.php
+++ b/packages/framework/src/Model/Article/ArticleFacade.php
@@ -67,19 +67,16 @@ class ArticleFacade
     public function edit(int $articleId, ArticleData $articleData): Article
     {
         $article = $this->articleRepository->getById($articleId);
-        $originalName = $article->getName();
 
         $article->edit($articleData);
         $this->friendlyUrlFacade->saveUrlListFormData('front_article_detail', $article->getId(), $articleData->urls);
 
-        if ($originalName !== $article->getName()) {
-            $this->friendlyUrlFacade->createFriendlyUrlForDomain(
-                'front_article_detail',
-                $article->getId(),
-                $article->getName(),
-                $article->getDomainId(),
-            );
-        }
+        $this->friendlyUrlFacade->createFriendlyUrlForDomain(
+            'front_article_detail',
+            $article->getId(),
+            $article->getName(),
+            $article->getDomainId(),
+        );
         $this->em->flush();
 
         $this->articleExportMessageDispatcher->dispatchArticleExportMessage($article->getId(), $article->getDomainId());

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -100,7 +100,6 @@ class CategoryFacade implements TreeSelectionDataProviderInterface
     {
         $rootCategory = $this->getRootCategory();
         $category = $this->categoryRepository->getById($categoryId);
-        $originalNames = $category->getNames();
 
         $category->edit($categoryData);
 
@@ -109,7 +108,7 @@ class CategoryFacade implements TreeSelectionDataProviderInterface
         }
         $this->em->flush();
         $this->friendlyUrlFacade->saveUrlListFormData('front_product_list', $category->getId(), $categoryData->urls);
-        $this->createFriendlyUrlsWhenRenamed($category, $originalNames);
+        $this->friendlyUrlFacade->createFriendlyUrls('front_product_list', $category->getId(), $category->getNames());
 
         $this->imageFacade->manageImages($category, $categoryData->image);
 
@@ -335,34 +334,6 @@ class CategoryFacade implements TreeSelectionDataProviderInterface
             $pricingGroup,
             $domainId,
         );
-    }
-
-    protected function createFriendlyUrlsWhenRenamed(Category $category, array $originalNames): void
-    {
-        $changedNames = $this->getChangedNamesByLocale($category, $originalNames);
-
-        if (count($changedNames) === 0) {
-            return;
-        }
-
-        $this->friendlyUrlFacade->createFriendlyUrls(
-            'front_product_list',
-            $category->getId(),
-            $changedNames,
-        );
-    }
-
-    protected function getChangedNamesByLocale(Category $category, array $originalNames): array
-    {
-        $changedCategoryNames = [];
-
-        foreach ($category->getNames() as $locale => $name) {
-            if ($name !== $originalNames[$locale]) {
-                $changedCategoryNames[$locale] = $name;
-            }
-        }
-
-        return $changedCategoryNames;
     }
 
     public function getProductMainCategoryOnCurrentDomain(Product $product): Category

--- a/packages/framework/src/Model/Product/Brand/BrandFacade.php
+++ b/packages/framework/src/Model/Product/Brand/BrandFacade.php
@@ -60,7 +60,6 @@ class BrandFacade
     {
         $domains = $this->domain->getAll();
         $brand = $this->brandRepository->getById($brandId);
-        $originalName = $brand->getName();
 
         $brand->edit($brandData);
         $this->imageFacade->manageImages($brand, $brandData->image);
@@ -68,15 +67,13 @@ class BrandFacade
 
         $this->friendlyUrlFacade->saveUrlListFormData('front_brand_detail', $brand->getId(), $brandData->urls);
 
-        if ($originalName !== $brand->getName()) {
-            foreach ($domains as $domain) {
-                $this->friendlyUrlFacade->createFriendlyUrlForDomain(
-                    'front_brand_detail',
-                    $brand->getId(),
-                    $brand->getName(),
-                    $domain->getId(),
-                );
-            }
+        foreach ($domains as $domain) {
+            $this->friendlyUrlFacade->createFriendlyUrlForDomain(
+                'front_brand_detail',
+                $brand->getId(),
+                $brand->getName(),
+                $domain->getId(),
+            );
         }
         $this->em->flush();
 

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -117,7 +117,6 @@ class ProductFacade
         string $priority = ProductRecalculationPriorityEnum::REGULAR,
     ): Product {
         $product = $this->productRepository->getById($productId);
-        $originalNames = $product->getFullNames();
 
         $productCategoryDomains = $this->productCategoryDomainFactory->createMultiple(
             $product,
@@ -145,7 +144,7 @@ class ProductFacade
         $this->uploadedFileFacade->manageFiles($product, $productData->files);
 
         $this->friendlyUrlFacade->saveUrlListFormData('front_product_detail', $product->getId(), $productData->urls);
-        $this->createFriendlyUrlsWhenRenamed($product, $originalNames);
+        $this->friendlyUrlFacade->createFriendlyUrls('front_product_detail', $product->getId(), $product->getFullNames());
 
         $this->pluginCrudExtensionFacade->saveAllData('product', $product->getId(), $productData->pluginData);
 
@@ -395,34 +394,6 @@ class ProductFacade
     public function getAllByIds(array $ids): array
     {
         return $this->productRepository->getAllByIds($ids);
-    }
-
-    protected function createFriendlyUrlsWhenRenamed(Product $product, array $originalNames): void
-    {
-        $changedNames = $this->getChangedNamesByLocale($product, $originalNames);
-
-        if (count($changedNames) === 0) {
-            return;
-        }
-
-        $this->friendlyUrlFacade->createFriendlyUrls(
-            'front_product_detail',
-            $product->getId(),
-            $changedNames,
-        );
-    }
-
-    protected function getChangedNamesByLocale(Product $product, array $originalNames): array
-    {
-        $changedProductNames = [];
-
-        foreach ($product->getFullNames() as $locale => $name) {
-            if ($name !== null && $name !== $originalNames[$locale]) {
-                $changedProductNames[$locale] = $name;
-            }
-        }
-
-        return $changedProductNames;
     }
 
     public function findByCatnum(string $catnum): ?Product

--- a/project-base/app/src/Model/Category/CategoryFacade.php
+++ b/project-base/app/src/Model/Category/CategoryFacade.php
@@ -26,8 +26,6 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade as BaseCategoryFacade;
  * @property \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
  * @method \App\Model\Category\Category[] getAllTranslated(string $locale)
  * @method \App\Model\Category\Category[] getAllTranslatedWithoutBranch(\App\Model\Category\Category $category, string $locale)
- * @method void createFriendlyUrlsWhenRenamed(\App\Model\Category\Category $category, array $originalNames)
- * @method array getChangedNamesByLocale(\App\Model\Category\Category $category, array $originalNames)
  * @method array<int, \App\Model\Category\Category> getByIds(int[] $categoryIds)
  * @method \App\Model\Category\Category getVisibleOnDomainByUuid(int $domainId, string $categoryUuid)
  * @method \App\Model\Category\Category getProductMainCategoryOnCurrentDomain(\App\Model\Product\Product $product)

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -20,8 +20,6 @@ use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
  * @method \App\Model\Product\Product getByUuid(string $uuid)
  * @method void editProductStockRelation(\App\Model\Product\ProductData $productData, \App\Model\Product\Product $product)
  * @method \App\Model\Product\Product[] getAllByIds(int[] $ids)
- * @method void createFriendlyUrlsWhenRenamed(\App\Model\Product\Product $product, array $originalNames)
- * @method array getChangedNamesByLocale(\App\Model\Product\Product $product, array $originalNames)
  * @method \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceInterface[][] getAllProductPricesIndexedByDomainId(\App\Model\Product\Product $product)
  * @method \App\Model\Product\Product|null findByCatnum(string $catnum)
  * @method \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceInterface getProductPriceForDefaultPricingGroup(\App\Model\Product\Product $product, int $domainId)

--- a/project-base/app/tests/App/Functional/Component/Router/FriendlyUrl/FriendlyUrlFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Component/Router/FriendlyUrl/FriendlyUrlFacadeTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Component\Router\FriendlyUrl;
+
+use App\DataFixtures\Demo\CategoryDataFixture;
+use App\Model\Category\Category;
+use App\Model\Category\CategoryDataFactory;
+use App\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\UrlListData;
+use Tests\App\Test\TransactionFunctionalTestCase;
+
+final class FriendlyUrlFacadeTest extends TransactionFunctionalTestCase
+{
+    private const string CATEGORY_ROUTE_NAME = 'front_product_list';
+
+    /**
+     * @inject
+     */
+    private FriendlyUrlFacade $friendlyUrlFacade;
+
+    /**
+     * @inject
+     */
+    private CategoryFacade $categoryFacade;
+
+    /**
+     * @inject
+     */
+    private CategoryDataFactory $categoryDataFactory;
+
+    public function testMainFriendlyUrlIsKeptWhenEntityIsRenamed(): void
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_ELECTRONICS, Category::class);
+        $mainFriendlyUrlSlugBeforeRename = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug();
+        $friendlyUrlCountBeforeRename = count($this->friendlyUrlFacade->getAllByRouteNameAndEntityId(self::CATEGORY_ROUTE_NAME, $category->getId()));
+        $categoryData = $this->categoryDataFactory->createFromCategory($category);
+        $categoryData->name[$this->getFirstDomainLocale()] = 'Renamed electronics';
+
+        $this->categoryFacade->edit($category->getId(), $categoryData);
+        $this->em->clear();
+
+        $mainFriendlyUrlAfterRename = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId());
+        $friendlyUrlCountAfterRename = count($this->friendlyUrlFacade->getAllByRouteNameAndEntityId(self::CATEGORY_ROUTE_NAME, $category->getId()));
+        $this->assertSame($mainFriendlyUrlSlugBeforeRename, $mainFriendlyUrlAfterRename->getSlug());
+        $this->assertSame($friendlyUrlCountBeforeRename, $friendlyUrlCountAfterRename);
+    }
+
+    public function testCreateFriendlyUrlsDoesNotCreateAnythingWhenMainFriendlyUrlExists(): void
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_ELECTRONICS, Category::class);
+        $mainFriendlyUrlSlugBefore = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug();
+        $friendlyUrlCountBefore = count($this->friendlyUrlFacade->getAllByRouteNameAndEntityId(self::CATEGORY_ROUTE_NAME, $category->getId()));
+
+        $this->friendlyUrlFacade->createFriendlyUrls(
+            self::CATEGORY_ROUTE_NAME,
+            $category->getId(),
+            [$this->getFirstDomainLocale() => 'Completely different category name'],
+        );
+        $this->em->clear();
+
+        $mainFriendlyUrlAfter = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId());
+        $friendlyUrlCountAfter = count($this->friendlyUrlFacade->getAllByRouteNameAndEntityId(self::CATEGORY_ROUTE_NAME, $category->getId()));
+        $this->assertSame($mainFriendlyUrlSlugBefore, $mainFriendlyUrlAfter->getSlug());
+        $this->assertSame($friendlyUrlCountBefore, $friendlyUrlCountAfter);
+    }
+
+    public function testMainFriendlyUrlsAreGeneratedForNewEntityAndKeptOnRename(): void
+    {
+        $categoryData = $this->categoryDataFactory->create();
+        $categoryData->name[$this->getFirstDomainLocale()] = 'Guarded test category';
+        $categoryData->name[$this->getSecondDomainLocale()] = 'Guarded test category second';
+
+        $category = $this->categoryFacade->create($categoryData);
+
+        $this->assertSame(
+            'guarded-test-category',
+            $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug(),
+        );
+        $this->assertSame(
+            'guarded-test-category-second',
+            $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::SECOND_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug(),
+        );
+
+        $friendlyUrlCountBeforeRename = count($this->friendlyUrlFacade->getAllByRouteNameAndEntityId(self::CATEGORY_ROUTE_NAME, $category->getId()));
+        $categoryDataForRename = $this->categoryDataFactory->createFromCategory($category);
+        $categoryDataForRename->name[$this->getFirstDomainLocale()] = 'Guarded test category renamed';
+
+        $this->categoryFacade->edit($category->getId(), $categoryDataForRename);
+        $this->em->clear();
+
+        $friendlyUrlCountAfterRename = count($this->friendlyUrlFacade->getAllByRouteNameAndEntityId(self::CATEGORY_ROUTE_NAME, $category->getId()));
+        $mainFriendlyUrlAfterRename = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId());
+        $this->assertSame('guarded-test-category', $mainFriendlyUrlAfterRename->getSlug());
+        $this->assertSame($friendlyUrlCountBeforeRename, $friendlyUrlCountAfterRename);
+    }
+
+    public function testMainFriendlyUrlIsGeneratedWhenNameIsFilledInPreviouslyEmptyLocale(): void
+    {
+        $categoryData = $this->categoryDataFactory->create();
+        $categoryData->name[$this->getFirstDomainLocale()] = 'First locale only category';
+
+        $category = $this->categoryFacade->create($categoryData);
+
+        $this->assertNull($this->friendlyUrlFacade->findMainFriendlyUrl(Domain::SECOND_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId()));
+
+        $categoryDataWithSecondLocaleName = $this->categoryDataFactory->createFromCategory($category);
+        $categoryDataWithSecondLocaleName->name[$this->getSecondDomainLocale()] = 'Second locale category name';
+
+        $this->categoryFacade->edit($category->getId(), $categoryDataWithSecondLocaleName);
+        $this->em->clear();
+
+        $this->assertSame(
+            'first-locale-only-category',
+            $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug(),
+        );
+        $this->assertSame(
+            'second-locale-category-name',
+            $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::SECOND_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug(),
+        );
+    }
+
+    public function testMainFriendlyUrlIsChangedByManualUrlManagement(): void
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_ELECTRONICS, Category::class);
+        $originalMainFriendlyUrlSlug = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId())->getSlug();
+        $urlListDataWithNewUrl = new UrlListData();
+        $urlListDataWithNewUrl->newUrls[] = [
+            UrlListData::FIELD_DOMAIN => Domain::FIRST_DOMAIN_ID,
+            UrlListData::FIELD_SLUG => 'manually-managed-category-url',
+        ];
+
+        $this->friendlyUrlFacade->saveUrlListFormData(self::CATEGORY_ROUTE_NAME, $category->getId(), $urlListDataWithNewUrl);
+        $newFriendlyUrl = $this->friendlyUrlFacade->findByDomainIdAndSlug(Domain::FIRST_DOMAIN_ID, 'manually-managed-category-url');
+        $this->assertNotNull($newFriendlyUrl);
+        $urlListDataWithNewMain = new UrlListData();
+        $urlListDataWithNewMain->mainFriendlyUrlsByDomainId[Domain::FIRST_DOMAIN_ID] = $newFriendlyUrl;
+        $this->friendlyUrlFacade->saveUrlListFormData(self::CATEGORY_ROUTE_NAME, $category->getId(), $urlListDataWithNewMain);
+        $this->em->clear();
+
+        $mainFriendlyUrlAfterManualChange = $this->friendlyUrlFacade->getMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, self::CATEGORY_ROUTE_NAME, $category->getId());
+        $originalFriendlyUrl = $this->friendlyUrlFacade->findByDomainIdAndSlug(Domain::FIRST_DOMAIN_ID, $originalMainFriendlyUrlSlug);
+        $this->assertSame('manually-managed-category-url', $mainFriendlyUrlAfterManualChange->getSlug());
+        $this->assertNotNull($originalFriendlyUrl);
+        $this->assertFalse($originalFriendlyUrl->isMain());
+    }
+
+    private function getSecondDomainLocale(): string
+    {
+        return $this->domain->getDomainConfigById(Domain::SECOND_DOMAIN_ID)->getLocale();
+    }
+}

--- a/upgrade-notes/backend_20260827_150047.md
+++ b/upgrade-notes/backend_20260827_150047.md
@@ -1,0 +1,7 @@
+#### Do not change the main friendly URL when an entity is renamed ([#4810](https://github.com/shopsys/shopsys/pull/4810))
+
+- `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade::createFriendlyUrls()` and `createFriendlyUrlForDomain()` no longer create anything for a domain where the entity already has a main friendly URL, so renaming an entity keeps its main URL unchanged
+    - if your project relies on the previous automatic regeneration of the main URL on rename, override the new protected method `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade::shouldCreateFriendlyUrl()` to return `true`
+- protected methods `createFriendlyUrlsWhenRenamed()` and `getChangedNamesByLocale()` were removed from `Shopsys\FrameworkBundle\Model\Product\ProductFacade` and `Shopsys\FrameworkBundle\Model\Category\CategoryFacade`
+    - if you call or override them, call `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade::createFriendlyUrls()` with the current entity names instead
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Until now, changing the name of anything with a friendly URL (product, category, brand, flag, article, blog article, blog category, SEO category, store) generated a new URL from the new name and made it the main one, demoting the previous URL to a redirect. From the SEO point of view this silently replaced established addresses and took control away from the administrator.

Now, once an entity has a main URL on a domain, renaming it leaves its URLs untouched — no new main URL and no new redirect record is created, so the main URL may intentionally differ from the current name. The only way to change the main URL is the manual URL management in administration. When an entity has no main URL for a domain yet (a newly created entity, a newly added domain, or a name filled in a language that was empty before), the URL is still generated from the name as before.

Downstream projects that rely on the previous automatic regeneration can restore it by overriding the new protected method `FriendlyUrlFacade::shouldCreateFriendlyUrl()`.

#### Fixes issues

[SSP-4275](https://shopsys.atlassian.net/browse/SSP-4275)

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-entity-url-does-not-change.odin.shopsys.cloud
  - https://cz.tl-entity-url-does-not-change.odin.shopsys.cloud
  - https://tl-entity-url-does-not-change.odin.shopsys.cloud/sk
<!-- Replace -->
