### PR TITLE
Fix standalone PHPStan builds of framework and project-base

### DIFF
--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -8,6 +8,9 @@ parameters:
         -
             message: '#^Unsafe usage of new static\(\).#'
             path: %currentWorkingDirectory%/src/*
+        -
+            identifier: trait.unused
+            path: %currentWorkingDirectory%/src/DependencyInjection/SetterInjectionTrait.php
     excludePaths:
         # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:annotations" command
         - %currentWorkingDirectory%/tests/Unit/Component/ClassExtension/Source/*

--- a/phpstan-dead-code.neon
+++ b/phpstan-dead-code.neon
@@ -335,6 +335,10 @@ parameters:
             path: packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
         -
             identifier: shipmonk.deadMethod
+            message: '#^Unused\ App\\Model\\LegalConditions\\LegalConditionsFacade::getTermsAndConditionsDownloadFilename$#'
+            path: project-base/app/src/Model/LegalConditions/LegalConditionsFacade.php
+        -
+            identifier: shipmonk.deadMethod
             message: '#^Unused\ Shopsys\\FrameworkBundle\\Model\\Mail\\Exception\\MailTemplateAlreadyExistsException::getMailTemplate$#'
             path: packages/framework/src/Model/Mail/Exception/MailTemplateAlreadyExistsException.php
         -
@@ -387,6 +391,10 @@ parameters:
             identifier: shipmonk.deadMethod
             message: '#^Unused\ Shopsys\\FrameworkBundle\\Model\\Product\\Filter\\FlagFilterChoiceRepository::getFlagFilterChoicesInCategory$#'
             path: packages/framework/src/Model/Product/Filter/FlagFilterChoiceRepository.php
+        -
+            identifier: shipmonk.deadMethod
+            message: '#^Unused\ App\\Model\\Product\\Filter\\FlagFilterChoiceRepository::getFlagFilterChoicesInCategory\ \(all\ usages\ excluded\ by\ tests\ excluder\)$#'
+            path: project-base/app/src/Model/Product/Filter/FlagFilterChoiceRepository.php
         -
             identifier: shipmonk.deadMethod
             message: '#^Unused\ Shopsys\\FrameworkBundle\\Model\\Product\\Parameter\\ParameterFacade::getParameterValueByUuid$#'

--- a/project-base/app/phpstan-dead-code.neon
+++ b/project-base/app/phpstan-dead-code.neon
@@ -29,11 +29,3 @@ parameters:
             identifier: shipmonk.deadMethod
             message: '#^Unused\ App\\Kernel::configureRoutesAdministration$#'
             path: src/Kernel.php
-        -
-            identifier: shipmonk.deadMethod
-            message: '#^Unused\ App\\Model\\LegalConditions\\LegalConditionsFacade::getTermsAndConditionsDownloadFilename$#'
-            path: src/Model/LegalConditions/LegalConditionsFacade.php
-        -
-            identifier: shipmonk.deadMethod
-            message: '#^Unused\ App\\Model\\Product\\Filter\\FlagFilterChoiceRepository::getFlagFilterChoicesInCategory\ \(all\ usages\ excluded\ by\ tests\ excluder\)$#'
-            path: src/Model/Product/Filter/FlagFilterChoiceRepository.php

--- a/upgrade-notes/backend_20260831_085141.md
+++ b/upgrade-notes/backend_20260831_085141.md
@@ -1,0 +1,3 @@
+#### Fix standalone PHPStan builds of framework and project-base ([#4811](https://github.com/shopsys/shopsys/pull/4811))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
<!-- fix-set: d3b45007c6c0eb2393cf3c3a976c9a716ec808a1 -->

#### Description, the reason for the PR

Nightly verification of `12c6225e91` failed the standalone (split) PHPStan checks of the `framework` and `project-base` packages, while the monorepo check passed. Both regressions come from #4744, which enabled dead code detection and tuned the exemptions for the monorepo analysis but did not account for the split builds, where each package is analysed on its own with the rest of the platform living in `vendor`.

- **framework** — the unused `SetterInjectionTrait` was already exempted from `trait.unused` in the root monorepo config, but that config does not ship to the split repository. The same exemption is now in the package's own `phpstan.neon`. Deleting the trait would be the cleaner fix, but it is public API of the package and would need an upgrade note, so that decision is left to a human.
- **project-base** — two dead-code exemptions for `App` overrides of framework methods lived in the config shared by both builds. In the split build the framework parent class sits in `vendor`, so the override is considered alive and the exemptions were reported as unmatched. They are moved to the monorepo-only config, where they still match.

The remaining nightly failure (`main-build`, Cypress `cartLogin.cy.ts` merge-cart toast timeout) is a timing flake with no related application change and is not addressed here.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
