### PR TITLE
Webalize uploaded file names to prevent issues with special characters

### DIFF
--- a/packages/framework/src/Component/AbstractUploadedFile/AbstractUploadedFile.php
+++ b/packages/framework/src/Component/AbstractUploadedFile/AbstractUploadedFile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\AbstractUploadedFile;
 
 use Doctrine\ORM\Mapping as ORM;
+use Nette\Utils\Strings;
 use Override;
 use Shopsys\FrameworkBundle\Component\FileUpload\EntityFileUploadInterface;
 use Shopsys\FrameworkBundle\Component\FileUpload\Exception\InvalidFileKeyException;
@@ -40,7 +41,9 @@ abstract class AbstractUploadedFile implements EntityFileUploadInterface, Upload
      */
     #[AsMcpColumn]
     #[ORM\Column(type: 'string', length: 255)]
-    protected $name;
+    protected $name {
+        set => Strings::webalize($value, lower: false);
+    }
 
     /**
      * @var int

--- a/packages/framework/src/Component/AbstractUploadedFile/AbstractUploadedFile.php
+++ b/packages/framework/src/Component/AbstractUploadedFile/AbstractUploadedFile.php
@@ -42,7 +42,10 @@ abstract class AbstractUploadedFile implements EntityFileUploadInterface, Upload
     #[AsMcpColumn]
     #[ORM\Column(type: 'string', length: 255)]
     protected $name {
-        set => Strings::webalize($value, lower: false);
+        set {
+            $webalizedName = Strings::webalize($value, lower: false);
+            $this->name = $webalizedName === '' ? 'file' : $webalizedName;
+        }
     }
 
     /**

--- a/packages/framework/src/Component/PostDeploy/Task/WebalizeUploadedFileNamesTask.php
+++ b/packages/framework/src/Component/PostDeploy/Task/WebalizeUploadedFileNamesTask.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\PostDeploy\Task;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Nette\Utils\Strings;
+use Override;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class WebalizeUploadedFileNamesTask implements PostDeployTaskInterface
+{
+    protected const int BATCH_SIZE = 10000;
+
+    public function __construct(
+        protected readonly Connection $connection,
+    ) {
+    }
+
+    #[Override]
+    public function run(SymfonyStyle $style): void
+    {
+        $totalCount = 0;
+
+        foreach (['uploaded_files', 'customer_uploaded_files'] as $tableName) {
+            $style->section($tableName);
+            $totalCount += $this->webalizeNamesInTable($tableName, $style);
+        }
+
+        if ($totalCount === 0) {
+            $style->success('All uploaded file names are already webalized.');
+
+            return;
+        }
+
+        $style->success(sprintf('Webalized names of %d uploaded files.', $totalCount));
+    }
+
+    protected function webalizeNamesInTable(string $tableName, SymfonyStyle $style): int
+    {
+        $lastId = 0;
+        $processedCount = 0;
+
+        do {
+            $rows = $this->connection->fetchAllAssociative(
+                sprintf(
+                    "SELECT id, name FROM %s WHERE id > :lastId AND name !~ '^[A-Za-z0-9-]+$' ORDER BY id LIMIT :limit",
+                    $tableName,
+                ),
+                ['lastId' => $lastId, 'limit' => static::BATCH_SIZE],
+                ['lastId' => ParameterType::INTEGER, 'limit' => ParameterType::INTEGER],
+            );
+
+            if ($rows === []) {
+                break;
+            }
+
+            $sqlValues = [];
+            $parameters = [];
+
+            foreach ($rows as $index => $row) {
+                $lastId = $row['id'];
+                $webalizedName = Strings::webalize($row['name'], lower: false);
+
+                if ($webalizedName === '') {
+                    $webalizedName = 'file';
+                }
+
+                $sqlValues[] = sprintf('(:id%1$d::int, :name%1$d)', $index);
+                $parameters['id' . $index] = $row['id'];
+                $parameters['name' . $index] = $webalizedName;
+            }
+
+            $this->connection->executeStatement(
+                sprintf(
+                    'UPDATE %s AS t SET name = v.name FROM (VALUES %s) AS v(id, name) WHERE t.id = v.id',
+                    $tableName,
+                    implode(', ', $sqlValues),
+                ),
+                $parameters,
+            );
+
+            $rowsCount = count($rows);
+            $processedCount += $rowsCount;
+            $style->writeln(sprintf('Processed %d rows...', $processedCount));
+        } while ($rowsCount === static::BATCH_SIZE);
+
+        if ($processedCount === 0) {
+            $style->info('No file names to webalize.');
+        }
+
+        return $processedCount;
+    }
+}

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskConfig;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskDescriptor;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\PostDeployTaskRunEnum;
 use Shopsys\FrameworkBundle\Component\PostDeploy\Task\RecalculateFileSizesTask;
+use Shopsys\FrameworkBundle\Component\PostDeploy\Task\WebalizeUploadedFileNamesTask;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataProviderInterface;
 use Shopsys\FrameworkBundle\Model\Category\AutomatedFilter\CategoryAutomatedFilterInterface;
 use Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender\MailTemplateSenderInterface;
@@ -124,6 +125,11 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
                         'run' => PostDeployTaskRunEnum::ONE_TIME,
                         'priority' => 100,
                         'service' => RecalculateFileSizesTask::class,
+                    ],
+                    'webalize_uploaded_file_names' => [
+                        'run' => PostDeployTaskRunEnum::ONE_TIME,
+                        'priority' => 110,
+                        'service' => WebalizeUploadedFileNamesTask::class,
                     ],
                 ],
             ],

--- a/upgrade-notes/backend_20260901_124330.md
+++ b/upgrade-notes/backend_20260901_124330.md
@@ -1,0 +1,6 @@
+#### Webalize uploaded file names to prevent issues with special characters ([#4812](https://github.com/shopsys/shopsys/pull/4812))
+
+- the `$name` property of `Shopsys\FrameworkBundle\Component\AbstractUploadedFile\AbstractUploadedFile` is now sanitized by a PHP 8.4 property hook (`Nette\Utils\Strings::webalize()` with a `file` fallback for empty results) on every write, including direct `$this->name = ...` assignments in subclasses
+    - if you redeclare the `$name` property in your project entities, you will remove this sanitization — re-apply the hook in your redeclaration if you want to keep it
+- names of already existing uploaded files (`uploaded_files` and `customer_uploaded_files`) will be rewritten by the one-time post-deploy task `webalize_uploaded_file_names` on your next deploy
+    - if you need to keep the original names, disable the task in your `shopsys_framework.post_deploy.tasks` configuration by setting `run: never` before deploying


### PR DESCRIPTION
#### Description, the reason for the PR

Uploading a file whose name contained special characters (e.g. a customer complaint file named `Pozadí obrázku „generated-image“ bylo odstraněno.png`) caused problems, because the original file name is stored and later used as-is.

The name of an uploaded file is now webalized on assignment — diacritics and special characters (typographic quotes, etc.) are replaced with safe ASCII equivalents, while letter case is preserved. Customers can therefore attach files with any name to a complaint without breaking the upload.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-webalize-uploaded-file-name.odin.shopsys.cloud
  - https://cz.mg-webalize-uploaded-file-name.odin.shopsys.cloud
  - https://mg-webalize-uploaded-file-name.odin.shopsys.cloud/sk
<!-- Replace -->
