### PR TITLE
VAT selects in admin now show the rate percentage

### DIFF
--- a/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
@@ -32,7 +32,7 @@ final class ProductPricesWithVatSelectType extends AbstractType
             ->add('vat', ChoiceType::class, [
                 'block_prefix' => 'prices_select_vat_input',
                 'required' => true,
-                'choices' => $this->vatFacade->getAllForDomainIncludingMarkedForDeletion($options['domain_id']),
+                'choices' => $this->vatFacade->getAllForDomain($options['domain_id']),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [

--- a/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
+++ b/packages/framework/src/Form/Admin/Product/Price/ProductPricesWithVatSelectType.php
@@ -5,23 +5,16 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Admin\Product\Price;
 
 use Override;
-use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
+use Shopsys\FrameworkBundle\Form\VatChoiceType;
 use Shopsys\FrameworkBundle\Model\Product\ProductInputPriceData;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints;
 
 final class ProductPricesWithVatSelectType extends AbstractType
 {
-    public function __construct(
-        protected readonly VatFacade $vatFacade,
-    ) {
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -29,16 +22,9 @@ final class ProductPricesWithVatSelectType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('vat', ChoiceType::class, [
+            ->add('vat', VatChoiceType::class, [
                 'block_prefix' => 'prices_select_vat_input',
-                'required' => true,
-                'choices' => $this->vatFacade->getAllForDomain($options['domain_id']),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
-                'constraints' => [
-                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
-                ],
-                'label' => 'VAT',
+                'domain_id' => $options['domain_id'],
             ])
             ->add(
                 'manualInputPricesByPricingGroupId',

--- a/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
@@ -6,9 +6,8 @@ namespace Shopsys\FrameworkBundle\Form\Admin\Vat;
 
 use Override;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
-use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
+use Shopsys\FrameworkBundle\Form\VatChoiceType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -17,7 +16,6 @@ use Symfony\Component\Validator\Constraints;
 final class VatSettingsFormType extends AbstractType
 {
     public function __construct(
-        private readonly VatFacade $vatFacade,
         private readonly AdminDomainTabsFacade $adminDomainTabsFacade,
     ) {
     }
@@ -26,11 +24,8 @@ final class VatSettingsFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('defaultVat', ChoiceType::class, [
-                'required' => true,
-                'choices' => $this->vatFacade->getAllForDomain($this->adminDomainTabsFacade->getSelectedDomainId()),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
+            ->add('defaultVat', VatChoiceType::class, [
+                'domain_id' => $this->adminDomainTabsFacade->getSelectedDomainId(),
                 'constraints' => [
                     new Constraints\NotBlank(message: 'Please enter default VAT'),
                 ],

--- a/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
+++ b/packages/framework/src/Form/PriceAndVatTableByDomainsType.php
@@ -7,9 +7,7 @@ namespace Shopsys\FrameworkBundle\Form;
 use Override;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Form\Constraints\NotNegativeMoneyAmount;
-use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -20,7 +18,7 @@ use Symfony\Component\Validator\Constraints;
 
 final class PriceAndVatTableByDomainsType extends AbstractType
 {
-    public function __construct(private readonly Domain $domain, private readonly VatFacade $vatFacade)
+    public function __construct(private readonly Domain $domain)
     {
     }
 
@@ -57,15 +55,8 @@ final class PriceAndVatTableByDomainsType extends AbstractType
         ]);
 
         foreach ($this->domain->getAdminEnabledDomains() as $domainConfig) {
-            $vatsIndexedByDomainId->add((string)$domainConfig->getId(), ChoiceType::class, [
-                'required' => true,
-                'choices' => $this->vatFacade->getAllForDomain($domainConfig->getId()),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
-                'constraints' => [
-                    new Constraints\NotBlank(message: 'Please enter VAT rate'),
-                ],
-                'label' => 'VAT',
+            $vatsIndexedByDomainId->add((string)$domainConfig->getId(), VatChoiceType::class, [
+                'domain_id' => $domainConfig->getId(),
             ]);
 
             $entityPricesByDomainId->add((string)$domainConfig->getId(), MoneyType::class, [

--- a/packages/framework/src/Form/TransportInputPricesType.php
+++ b/packages/framework/src/Form/TransportInputPricesType.php
@@ -32,7 +32,7 @@ final class TransportInputPricesType extends AbstractType
             ->add('vat', ChoiceType::class, [
                 'block_prefix' => 'prices_select_vat_input',
                 'required' => true,
-                'choices' => $this->vatFacade->getAllForDomainIncludingMarkedForDeletion($options['domain_id']),
+                'choices' => $this->vatFacade->getAllForDomain($options['domain_id']),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
                 'constraints' => [

--- a/packages/framework/src/Form/TransportInputPricesType.php
+++ b/packages/framework/src/Form/TransportInputPricesType.php
@@ -6,22 +6,14 @@ namespace Shopsys\FrameworkBundle\Form;
 
 use Override;
 use Shopsys\FrameworkBundle\Form\Admin\Transport\Price\PriceWithLimitType;
-use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Shopsys\FrameworkBundle\Model\Transport\TransportInputPricesData;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 final class TransportInputPricesType extends AbstractType
 {
-    public function __construct(
-        protected readonly VatFacade $vatFacade,
-    ) {
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -29,16 +21,9 @@ final class TransportInputPricesType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('vat', ChoiceType::class, [
+            ->add('vat', VatChoiceType::class, [
                 'block_prefix' => 'prices_select_vat_input',
-                'required' => true,
-                'choices' => $this->vatFacade->getAllForDomain($options['domain_id']),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
-                'constraints' => [
-                    new NotBlank(message: 'Please enter VAT rate'),
-                ],
-                'label' => 'VAT',
+                'domain_id' => $options['domain_id'],
             ])
             ->add(
                 'pricesWithLimits',

--- a/packages/framework/src/Form/VatChoiceType.php
+++ b/packages/framework/src/Form/VatChoiceType.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form;
 
 use Override;
+use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
+use Shopsys\FrameworkBundle\Twig\NumberFormatterExtension;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -13,12 +15,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
 /**
- * Select of VAT rates available on the given domain
+ * Select of VAT rates available on the given domain, labeled with the rate name and its percentage
  */
 final class VatChoiceType extends AbstractType
 {
     public function __construct(
         private readonly VatFacade $vatFacade,
+        private readonly NumberFormatterExtension $numberFormatterExtension,
     ) {
     }
 
@@ -30,7 +33,11 @@ final class VatChoiceType extends AbstractType
             ->setAllowedTypes('domain_id', 'int')
             ->setDefaults([
                 'choices' => fn (Options $options): array => $this->vatFacade->getAllForDomain($options['domain_id']),
-                'choice_label' => 'name',
+                'choice_label' => fn (Vat $vat): string => sprintf(
+                    '%s (%s)',
+                    $vat->getName(),
+                    $this->numberFormatterExtension->formatPercent($vat->getPercent()),
+                ),
                 'choice_value' => 'id',
                 'choice_translation_domain' => false,
                 'label' => 'VAT',

--- a/packages/framework/src/Form/VatChoiceType.php
+++ b/packages/framework/src/Form/VatChoiceType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form;
+
+use Override;
+use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints;
+
+/**
+ * Select of VAT rates available on the given domain
+ */
+final class VatChoiceType extends AbstractType
+{
+    public function __construct(
+        private readonly VatFacade $vatFacade,
+    ) {
+    }
+
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setRequired('domain_id')
+            ->setAllowedTypes('domain_id', 'int')
+            ->setDefaults([
+                'choices' => fn (Options $options): array => $this->vatFacade->getAllForDomain($options['domain_id']),
+                'choice_label' => 'name',
+                'choice_value' => 'id',
+                'choice_translation_domain' => false,
+                'label' => 'VAT',
+                'required' => true,
+                'constraints' => fn (Options $options): array => $options['required']
+                    ? [new Constraints\NotBlank(message: 'Please enter VAT rate')]
+                    : [],
+            ]);
+    }
+
+    #[Override]
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/packages/framework/src/Model/Pricing/Vat/VatFacade.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatFacade.php
@@ -135,12 +135,4 @@ class VatFacade
 
         return $this->vatRepository->isVatUsed($vat);
     }
-
-    /**
-     * @return \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat[]
-     */
-    public function getAllForDomainIncludingMarkedForDeletion(int $domainId): array
-    {
-        return $this->vatRepository->getAllForDomainIncludingMarkedForDeletion($domainId);
-    }
 }

--- a/packages/framework/src/Model/Pricing/Vat/VatRepository.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatRepository.php
@@ -32,14 +32,6 @@ class VatRepository
             ->orderBy($vatAlias . '.percent');
     }
 
-    /**
-     * @return \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat[]
-     */
-    public function getAllForDomainIncludingMarkedForDeletion(int $domainId): array
-    {
-        return $this->getVatRepository()->findBy(['domainId' => $domainId]);
-    }
-
     public function findById(int $vatId): ?Vat
     {
         return $this->getVatRepository()->find($vatId);

--- a/upgrade-notes/backend_20260901_142721.md
+++ b/upgrade-notes/backend_20260901_142721.md
@@ -1,0 +1,5 @@
+#### VAT selects in admin now show the rate percentage ([#4813](https://github.com/shopsys/shopsys/pull/4813))
+
+- `VatFacade::getAllForDomainIncludingMarkedForDeletion()` and `VatRepository::getAllForDomainIncludingMarkedForDeletion()` were removed
+    - their implementation has been identical to `getAllForDomain()`, so use `getAllForDomain()` instead, or implement the distinction yourself if your project needs it
+- for VAT selection in the admin, new `VatChoiceType` was introduced. Check your custom forms for such selections and replace them with `VatChoiceType` to keep the UX uniformity.


### PR DESCRIPTION
#### Description, the reason for the PR

Administrators choose a VAT rate in several admin forms (product prices, transport prices, payment prices, default VAT setting), but the select only showed the rate name (e.g. "Standard rate"), so they had to remember or look up how much each rate actually is.

Every VAT select now shows the percentage next to the name, e.g. **Standard rate (21 %)**, formatted according to the admin locale.

To make this a single change, the four hand-written `ChoiceType` configurations were first unified into a new reusable `VatChoiceType` (`domain_id` option, `NotBlank` validation derived from `required`). Any future change to how VAT rates are offered in admin is done in one place.

Along the way we removed `VatFacade::getAllForDomainIncludingMarkedForDeletion()` (and its `VatRepository` counterpart): its implementation has been identical to `getAllForDomain()` since #1498 made the VAT rates domain-scoped (2019) — the VATs marked for deletion have not been filtered out since then, so the distinction only pretended to exist. This is the only BC break, covered by an upgrade note.

#### Fixes issues
...

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


----
:globe_with_meridians: Live Preview:
  - https://rv-vat-choice-type.odin.shopsys.cloud
  - https://cz.rv-vat-choice-type.odin.shopsys.cloud
  - https://rv-vat-choice-type.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1788776625.673979 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-vat-choice-type.odin.shopsys.cloud
  - https://cz.rv-vat-choice-type.odin.shopsys.cloud
  - https://rv-vat-choice-type.odin.shopsys.cloud/sk
<!-- Replace -->
