### PR TITLE
Translate admin form labels that fell back to humanized field names

### DIFF
--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -200,6 +200,7 @@ final class CategoryFormType extends AbstractType
             ->add('descriptions', MultidomainType::class, [
                 'entry_type' => CKEditorType::class,
                 'required' => false,
+                'label' => false,
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -565,6 +565,7 @@ final class ProductFormType extends AbstractType
         if ($this->isProductMainVariant($product)) {
             $promotionGroup->add('promotionInfo', DisplayOnlyType::class, [
                 'data' => t('Promotion can be set on specific variant.'),
+                'label' => false,
             ]);
 
             return $promotionGroup;

--- a/packages/framework/src/Form/Admin/Store/StoreFormType.php
+++ b/packages/framework/src/Form/Admin/Store/StoreFormType.php
@@ -147,6 +147,7 @@ final class StoreFormType extends AbstractType
 
         $builderUserInformationGroup
             ->add('specialMessage', TextType::class, [
+                'label' => 'Special message',
                 'required' => false,
             ])
             ->add('phone', TextType::class, [
@@ -166,6 +167,7 @@ final class StoreFormType extends AbstractType
                 'required' => false,
             ])
             ->add('directions', CKEditorType::class, [
+                'label' => 'Directions',
                 'required' => false,
             ]);
 
@@ -180,6 +182,7 @@ final class StoreFormType extends AbstractType
 
         $builderMapGroup
             ->add('latitude', NumberType::class, [
+                'label' => 'Latitude',
                 'required' => false,
                 'scale' => 10,
                 'attr' => [
@@ -187,6 +190,7 @@ final class StoreFormType extends AbstractType
                 ],
             ])
             ->add('longitude', NumberType::class, [
+                'label' => 'Longitude',
                 'required' => false,
                 'scale' => 10,
                 'attr' => [

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1027,6 +1027,9 @@ msgstr "Popis můžete nastavit na kartě hlavní varianty."
 msgid "Description opacity"
 msgstr "Průhlednost popisu"
 
+msgid "Directions"
+msgstr "Jak se k nám dostanete"
+
 msgid "Disable two factor authentication"
 msgstr "Vypnout dvoufaktorové ověřování"
 
@@ -1975,6 +1978,9 @@ msgstr "Poslední spuštění"
 msgid "Last update"
 msgstr "Poslední aktualizace"
 
+msgid "Latitude"
+msgstr "Zeměpisná šířka"
+
 msgid "Legal conditions"
 msgstr "Právní podmínky"
 
@@ -2022,6 +2028,9 @@ msgstr "Přihlášení se nepodařilo."
 
 msgid "Login name"
 msgstr "Přihlašovací jméno"
+
+msgid "Longitude"
+msgstr "Zeměpisná délka"
 
 msgid "Main URL"
 msgstr "Hlavní URL"
@@ -3222,6 +3231,9 @@ msgstr "Některé položky nebyly naimportovány kvůli chybám:"
 
 msgid "Sorting priority"
 msgstr "Priorita řazení"
+
+msgid "Special message"
+msgstr "Speciální sdělení"
 
 msgid "Standard"
 msgstr "Standardní"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1027,6 +1027,9 @@ msgstr ""
 msgid "Description opacity"
 msgstr ""
 
+msgid "Directions"
+msgstr ""
+
 msgid "Disable two factor authentication"
 msgstr ""
 
@@ -1975,6 +1978,9 @@ msgstr ""
 msgid "Last update"
 msgstr ""
 
+msgid "Latitude"
+msgstr ""
+
 msgid "Legal conditions"
 msgstr ""
 
@@ -2021,6 +2027,9 @@ msgid "Log in failed."
 msgstr ""
 
 msgid "Login name"
+msgstr ""
+
+msgid "Longitude"
 msgstr ""
 
 msgid "Main URL"
@@ -3221,6 +3230,9 @@ msgid "Some items cannot be imported due to errors:"
 msgstr ""
 
 msgid "Sorting priority"
+msgstr ""
+
+msgid "Special message"
 msgstr ""
 
 msgid "Standard"

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -1027,6 +1027,9 @@ msgstr "Popis možno nastaviť v detaile produktu hlavného produktu."
 msgid "Description opacity"
 msgstr "Priehladnoť popisu"
 
+msgid "Directions"
+msgstr "Ako sa k nám dostanete"
+
 msgid "Disable two factor authentication"
 msgstr "Zakázať dvojfaktorové overenie"
 
@@ -1975,6 +1978,9 @@ msgstr "Posledné spustenie"
 msgid "Last update"
 msgstr "Posledná aktualizácia"
 
+msgid "Latitude"
+msgstr "Zemepisná šírka"
+
 msgid "Legal conditions"
 msgstr "Právne podmienky"
 
@@ -2022,6 +2028,9 @@ msgstr "Prihlásenie zlyhalo."
 
 msgid "Login name"
 msgstr "Prihlasovacie meno"
+
+msgid "Longitude"
+msgstr "Zemepisná dĺžka"
 
 msgid "Main URL"
 msgstr "Hlavné URL"
@@ -3222,6 +3231,9 @@ msgstr "Niečé položky nemôžu byť importované kvôli chybám:"
 
 msgid "Sorting priority"
 msgstr "Priorita triedenia"
+
+msgid "Special message"
+msgstr "Špeciálne oznámenie"
 
 msgid "Standard"
 msgstr "Štandardný"


### PR DESCRIPTION
#### Description, the reason for the PR

Several fields in the admin were displayed in English even with the Czech (or Slovak) admin locale — reported for **Store detail** (`Special message`, `Directions`, `Latitude`, `Longitude`) and **Category detail** (`Descriptions`).

The cause is not a missing translation but a missing label. When a form field is added without an explicit `label`, Symfony falls back to the humanized field name (`specialMessage` → `Special message`). That string exists only at runtime — the JMS extractor never sees it, so it can never reach `messages.*.po` and always renders in English.

An audit of every form type in `packages/` and `project-base/` for this pattern found six fields that actually render such a label; all other hits turned out to be fields whose form theme renders only the widget, so no label is ever shown. The `t()` / `|trans` catalogues themselves were also checked against `cs`/`sk` and are complete.

**What changed**

- `StoreFormType` — `specialMessage`, `directions`, `latitude` and `longitude` got explicit labels, added to the `cs`, `en` and `sk` catalogues.
- `CategoryFormType` — the `descriptions` field only repeated its own group heading (*Description*), so its label is hidden, consistent with the same field in `ProductFormType`.
- `ProductFormType` — `promotionInfo` is an informational message, not an input; its label is hidden like the sibling `shortDescriptions`, `descriptions` and `productStockDataMessage` fields in the same form.

No behaviour beyond the rendered labels changes.

#### Fixes issues

...

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pk-translate-missing-admin-form-labels.odin.shopsys.cloud
  - https://cz.pk-translate-missing-admin-form-labels.odin.shopsys.cloud
  - https://pk-translate-missing-admin-form-labels.odin.shopsys.cloud/sk
<!-- Replace -->
