### PR TITLE
Settings query no longer fails on domains without a product review policy article

### DIFF
--- a/packages/frontend-api/src/Model/Resolver/Article/ArticleQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticleQuery.php
@@ -54,9 +54,13 @@ class ArticleQuery extends AbstractQuery
         return '/' . $this->getSpecialArticle(Setting::USER_CONSENT_POLICY_ARTICLE_ID, 'user-consent-policy')['mainSlug'];
     }
 
-    public function productReviewPolicyArticleUrlQuery(): string
+    public function productReviewPolicyArticleUrlQuery(): ?string
     {
-        return '/' . $this->getSpecialArticle(Setting::PRODUCT_REVIEW_POLICY_ARTICLE_ID, 'product-review-policy')['mainSlug'];
+        try {
+            return '/' . $this->getSpecialArticle(Setting::PRODUCT_REVIEW_POLICY_ARTICLE_ID, 'product-review-policy')['mainSlug'];
+        } catch (ArticleNotFoundUserError) {
+            return null;
+        }
     }
 
     protected function getSpecialArticle(string $settingName, string $articleIdentifier): array
@@ -69,7 +73,7 @@ class ArticleQuery extends AbstractQuery
             }
 
             return $this->articleElasticsearchFacade->getById($specialArticleId);
-        } catch (ArticleNotFoundException | SettingValueNotFoundException $exception) {
+        } catch (ArticleNotFoundException|SettingValueNotFoundException $exception) {
             throw new ArticleNotFoundUserError($exception->getMessage(), $articleIdentifier);
         }
     }


### PR DESCRIPTION
#### Description, the reason for the PR

The storefront settings query failed with a GraphQL error on every page render for any domain that has no product review policy article assigned. This is the normal state for domains where product reviews are disabled, and also for every existing project right after upgrading, before an administrator assigns the article. The error surfaced in Sentry on each cache miss and left the review policy link permanently missing for the whole cache lifetime.

The `productReviewPolicyArticleUrl` field is now `null` when no article is set, matching its already-nullable schema type. The storefront already hides the policy link in that case, so nothing changes for customers on configured domains, and unconfigured domains stop producing errors.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-review-policy-article-fix.odin.shopsys.cloud
  - https://cz.mg-review-policy-article-fix.odin.shopsys.cloud
  - https://mg-review-policy-article-fix.odin.shopsys.cloud/sk
<!-- Replace -->
