### PR TITLE
Fix hydration mismatches in storefront links

### DIFF
--- a/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
+++ b/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
@@ -28,6 +28,7 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
     href,
     queryParams,
     as,
+    locale,
     onClick,
     type,
     skeletonType,
@@ -42,6 +43,11 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
     const { url } = useDomainConfig();
 
     const isDynamic = type && FriendlyPagesTypesKeys.includes(type as any);
+    const localHref = getLocalHref(href, url);
+    const originalAs = isDynamic ? href : as;
+    const localAs = getLocalHref(originalAs, url);
+    // Absolute URLs already specify their locale; Next.js must not prepend the current one after conversion.
+    const isAbsoluteTargetConverted = (originalAs ?? href) !== (localAs ?? localHref);
     const urlHref = isDynamic
         ? {
               pathname: FriendlyPagesDestinations[type as FriendlyPagesTypesKey],
@@ -50,7 +56,7 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
                   ...queryParams,
               },
           }
-        : href;
+        : localHref;
 
     const handleOnClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
         const mouseWheelClick = e.button === 1;
@@ -77,10 +83,11 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
 
     return (
         <NextLink
-            as={isDynamic ? href : as}
+            as={localAs}
             className={className}
             data-tid={tid}
             href={urlHref}
+            locale={locale ?? (isAbsoluteTargetConverted ? false : undefined)}
             prefetch={false}
             rel={addRelNoopenerWhenTargetIsBlank(rel, target)}
             tabIndex={0}
@@ -91,6 +98,29 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
             {children}
         </NextLink>
     );
+};
+
+// Next.js normalizes absolute local URLs differently during SSR and hydration.
+const getLocalHref = <T extends string | UrlObject | undefined>(href: T, baseUrl: string): T | string => {
+    if (typeof href !== 'string') {
+        return href;
+    }
+
+    try {
+        const parsedUrl = new URL(href);
+
+        if (
+            parsedUrl.origin === new URL(baseUrl).origin &&
+            parsedUrl.pathname.startsWith('/') &&
+            !parsedUrl.pathname.startsWith('//')
+        ) {
+            return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+        }
+    } catch {
+        return href;
+    }
+
+    return href;
 };
 
 const isHrefExternal = (href: string | UrlObject, baseUrl: string) => {

--- a/project-base/storefront/vitest/components/ExtendedNextLink/ExtendedNextLink.hydration.test.tsx
+++ b/project-base/storefront/vitest/components/ExtendedNextLink/ExtendedNextLink.hydration.test.tsx
@@ -1,0 +1,220 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { ExtendedNextLink, ExtendedNextLinkProps } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
+import { DomainConfigProvider } from 'components/providers/DomainConfigProvider';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import { NextRouter } from 'next/router';
+import { renderToString } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { defaultTestDomainConfig } from 'vitest/helpers/mockPublicConfig';
+
+const origin = window.location.origin;
+const anotherPortUrl = new URL('/blog/', origin);
+anotherPortUrl.port = '8443';
+const anotherProtocolUrl = new URL('/blog/', origin);
+anotherProtocolUrl.protocol = anotherProtocolUrl.protocol === 'http:' ? 'https:' : 'http:';
+
+const cases: {
+    name: string;
+    props: ExtendedNextLinkProps;
+    expectedHref: string;
+    currentLocale?: string;
+    expectedNavigation?: { as: string; locale: ExtendedNextLinkProps['locale'] };
+}[] = [
+    { name: 'absolute blog URL', props: { href: `${origin}/blog/`, type: 'blogCategory' }, expectedHref: '/blog' },
+    {
+        name: 'blog query and anchor',
+        props: { href: `${origin}/blog/?page=2#articles`, type: 'blogCategory' },
+        expectedHref: '/blog?page=2#articles',
+    },
+    { name: 'ordinary absolute URL', props: { href: `${origin}/contact/` }, expectedHref: '/contact' },
+    {
+        name: 'explicit absolute as',
+        props: { href: '/contact', as: `${origin}/contact/` },
+        expectedHref: '/contact',
+    },
+    { name: 'relative URL', props: { href: '/blog/' }, expectedHref: '/blog' },
+    { name: 'homepage', props: { href: `${origin}/` }, expectedHref: '/' },
+    {
+        name: 'URL object',
+        props: { href: { pathname: '/blog', query: { page: '2' }, hash: 'articles' } },
+        expectedHref: '/blog?page=2#articles',
+    },
+    {
+        name: 'another domain',
+        props: { href: 'https://other.example.com/blog/' },
+        expectedHref: 'https://other.example.com/blog/',
+    },
+    {
+        name: 'friendly URL on another domain',
+        props: { href: 'https://other.example.com/blog/', type: 'blogCategory' },
+        expectedHref: 'https://other.example.com/blog/',
+    },
+    {
+        name: 'another port',
+        props: { href: anotherPortUrl.href, type: 'blogCategory' },
+        expectedHref: anotherPortUrl.href,
+    },
+    {
+        name: 'another protocol',
+        props: { href: anotherProtocolUrl.href, type: 'blogCategory' },
+        expectedHref: anotherProtocolUrl.href,
+    },
+    { name: 'email', props: { href: 'mailto:info@example.com' }, expectedHref: 'mailto:info@example.com' },
+    { name: 'telephone', props: { href: 'tel:+420123456789' }, expectedHref: 'tel:+420123456789' },
+    {
+        name: 'absolute link to root domain',
+        props: { href: `${origin}/contact` },
+        currentLocale: 'sk',
+        expectedHref: '/contact',
+        expectedNavigation: { as: '/contact', locale: false },
+    },
+    {
+        name: 'absolute link to another language',
+        props: { href: `${origin}/en/contact` },
+        currentLocale: 'sk',
+        expectedHref: '/en/contact',
+        expectedNavigation: { as: '/en/contact', locale: false },
+    },
+    {
+        name: 'absolute link within current language',
+        props: { href: `${origin}/sk/contact` },
+        currentLocale: 'sk',
+        expectedHref: '/sk/contact',
+        expectedNavigation: { as: '/sk/contact', locale: false },
+    },
+    {
+        name: 'friendly URL to root domain',
+        props: { href: `${origin}/blog/?page=2#articles`, type: 'blogCategory' },
+        currentLocale: 'sk',
+        expectedHref: '/blog?page=2#articles',
+        expectedNavigation: { as: '/blog?page=2#articles', locale: false },
+    },
+    {
+        name: 'friendly URL to another language',
+        props: { href: `${origin}/en/blog/`, type: 'blogCategory' },
+        currentLocale: 'sk',
+        expectedHref: '/en/blog',
+        expectedNavigation: { as: '/en/blog', locale: false },
+    },
+    {
+        name: 'explicit absolute as to another language',
+        props: { href: '/contact', as: `${origin}/en/contact` },
+        currentLocale: 'sk',
+        expectedHref: '/en/contact',
+        expectedNavigation: { as: '/en/contact', locale: false },
+    },
+    {
+        name: 'relative link keeps current language',
+        props: { href: '/contact' },
+        currentLocale: 'sk',
+        expectedHref: '/sk/contact',
+        expectedNavigation: { as: '/contact', locale: undefined },
+    },
+    {
+        name: 'relative as keeps current language',
+        props: { href: `${origin}/contact`, as: '/contact' },
+        currentLocale: 'sk',
+        expectedHref: '/sk/contact',
+        expectedNavigation: { as: '/contact', locale: undefined },
+    },
+    {
+        name: 'explicit locale overrides converted URL default',
+        props: { href: `${origin}/contact`, locale: 'en' },
+        currentLocale: 'sk',
+        expectedHref: '/en/contact',
+        expectedNavigation: { as: '/contact', locale: 'en' },
+    },
+    {
+        name: 'explicit false locale on relative link',
+        props: { href: '/contact', locale: false },
+        currentLocale: 'sk',
+        expectedHref: '/contact',
+        expectedNavigation: { as: '/contact', locale: false },
+    },
+];
+
+describe('ExtendedNextLink SSR and hydration', () => {
+    beforeEach(() => {
+        vi.stubEnv('__NEXT_I18N_SUPPORT', '1');
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    test.each(cases)('$name produces matching server and client links', async ({
+        props,
+        expectedHref,
+        currentLocale = 'default',
+        expectedNavigation,
+    }) => {
+        const router: NextRouter = {
+            basePath: '',
+            locale: currentLocale,
+            defaultLocale: 'default',
+            locales: ['default', 'en', 'cs', 'sk'],
+            pathname: '/',
+            route: '/',
+            query: {},
+            asPath: '/',
+            isFallback: false,
+            isReady: true,
+            isPreview: false,
+            isLocaleDomain: false,
+            push: vi.fn().mockResolvedValue(true),
+            replace: vi.fn().mockResolvedValue(true),
+            reload: vi.fn(),
+            back: vi.fn(),
+            forward: vi.fn(),
+            prefetch: vi.fn().mockResolvedValue(undefined),
+            beforePopState: vi.fn(),
+            events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        };
+        const element = (
+            <RouterContext.Provider value={router}>
+                <DomainConfigProvider
+                    domainConfig={{
+                        ...defaultTestDomainConfig,
+                        url: `${origin}/${currentLocale === 'default' ? '' : `${currentLocale}/`}`,
+                    }}
+                >
+                    <ExtendedNextLink {...props}>Link</ExtendedNextLink>
+                </DomainConfigProvider>
+            </RouterContext.Provider>
+        );
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const onRecoverableError = vi.fn();
+        let html: string;
+
+        vi.stubGlobal('window', undefined);
+        try {
+            html = renderToString(element);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+
+        const container = document.createElement('div');
+        container.innerHTML = html;
+        document.body.append(container);
+        const serverHref = container.querySelector('a')?.getAttribute('href');
+
+        await act(async () => {
+            render(element, { container, hydrate: true, onRecoverableError });
+        });
+
+        expect(consoleError).not.toHaveBeenCalled();
+        expect(onRecoverableError).not.toHaveBeenCalled();
+        expect(serverHref).toBe(expectedHref);
+        expect(container.querySelector('a')).toHaveAttribute('href', expectedHref);
+
+        if (expectedNavigation) {
+            fireEvent.click(container.querySelector('a')!);
+
+            expect(router.push).toHaveBeenCalledWith(
+                expect.any(String),
+                expectedNavigation.as,
+                expect.objectContaining({ locale: expectedNavigation.locale }),
+            );
+        }
+    });
+});

--- a/upgrade-notes/storefront_20260907_105355.md
+++ b/upgrade-notes/storefront_20260907_105355.md
@@ -1,0 +1,3 @@
+#### Fix hydration mismatches in storefront links ([#4824](https://github.com/shopsys/shopsys/pull/4824))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

On a fresh storefront page load, the homepage's “All articles” link could produce a React hydration warning: the server rendered an absolute URL ending in `/blog/`, while the browser expected `/blog` without the trailing slash. The link could still work, making the mismatch easy to miss during normal navigation.

Links to the current storefront origin now use relative addresses so that the server and browser normalize them consistently. Query parameters and anchors are preserved, and links using another domain, port, or protocol keep their original destination.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4372-fix-link-hydration.odin.shopsys.cloud
  - https://cz.tc-ssp-4372-fix-link-hydration.odin.shopsys.cloud
  - https://tc-ssp-4372-fix-link-hydration.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1789132555.444549 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4372-fix-link-hydration.odin.shopsys.cloud
  - https://cz.tc-ssp-4372-fix-link-hydration.odin.shopsys.cloud
  - https://tc-ssp-4372-fix-link-hydration.odin.shopsys.cloud/sk
<!-- Replace -->
