### PR TITLE
Fix AI checks failing on bot-triggered pull request runs

### DIFF
--- a/.github/workflows/ai-acceptance-criteria.yaml
+++ b/.github/workflows/ai-acceptance-criteria.yaml
@@ -186,6 +186,9 @@ jobs:
                 with:
                     github_token: ${{ github.token }}
                     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                    # The run is re-triggered with the github-actions actor when CI pushes the regenerated
+                    # Cypress snapshots commit, and the action refuses bot actors unless listed here.
+                    allowed_bots: github-actions
                     # The agent's own output would otherwise land in this repository's world-readable Actions log,
                     # and it holds credentials it could be talked into printing. Turn it on temporarily when a
                     # failure needs diagnosing, and accept that the whole session becomes public while it is on.

--- a/.github/workflows/ai-security-review.yaml
+++ b/.github/workflows/ai-security-review.yaml
@@ -38,6 +38,9 @@ jobs:
                 with:
                     github_token: ${{ github.token }}
                     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                    # the run is re-triggered with the github-actions actor when CI pushes the regenerated
+                    # Cypress snapshots commit, and the action refuses bot actors unless listed here
+                    allowed_bots: github-actions
                     prompt: "/security-audit ${{ github.repository }}#${{ github.event.pull_request.number }}"
                     claude_args: |
                         --model claude-opus-5


### PR DESCRIPTION
#### Description, the reason for the PR

Both AI checks on pull requests (the acceptance criteria check and the security audit) failed as soon as the workflow run was attributed to the `github-actions` bot instead of a person. That happens every time CI pushes the `regenerate all screenshots` commit after the `regenerate screenshots` label is used: the run actor becomes the bot, `claude-code-action` refuses bot actors by default, and the step dies before doing any work. Re-running the job from the UI does not help because a re-run keeps the original actor.

Both steps now list `github-actions` in the action's `allowed_bots` input, so the checks run and post their reports on these pull requests too. Nothing else changes: the jobs keep their read-only permissions and secret scans, and no other bot is allowed.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-ai-checks-allow-bot-actor.odin.shopsys.cloud
  - https://cz.tl-ai-checks-allow-bot-actor.odin.shopsys.cloud
  - https://tl-ai-checks-allow-bot-actor.odin.shopsys.cloud/sk
<!-- Replace -->
