### PR TITLE
Quick approval of pending product reviews in administration

### DIFF
--- a/packages/administration/src/Controller/ProductReviewController.php
+++ b/packages/administration/src/Controller/ProductReviewController.php
@@ -6,7 +6,10 @@ namespace Shopsys\AdministrationBundle\Controller;
 
 use Doctrine\ORM\QueryBuilder;
 use Override;
+use Shopsys\AdministrationBundle\Component\Action\Action;
 use Shopsys\AdministrationBundle\Component\Attributes\CrudController;
+use Shopsys\AdministrationBundle\Component\Config\ActionsConfig;
+use Shopsys\AdministrationBundle\Component\Config\ActionType;
 use Shopsys\AdministrationBundle\Component\Config\CrudConfig;
 use Shopsys\AdministrationBundle\Component\Config\CrudListDomainControl;
 use Shopsys\AdministrationBundle\Component\Crud\Form\CrudFormConfigurator;
@@ -14,12 +17,17 @@ use Shopsys\AdministrationBundle\Component\Datagrid\Datagrid;
 use Shopsys\AdministrationBundle\Component\Security\Role\AdminRoleSectionsProvider;
 use Shopsys\AdministrationBundle\Model\ProductReview\ProductReviewEditHandler;
 use Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogFacade;
+use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
+use Shopsys\FrameworkBundle\Component\Security\Attribute\CanEdit;
 use Shopsys\FrameworkBundle\Form\Admin\ProductReview\ProductReviewFormType;
 use Shopsys\FrameworkBundle\Model\AdminNavigation\SideMenuBuilder;
 use Shopsys\FrameworkBundle\Model\ProductReview\ProductReview;
 use Shopsys\FrameworkBundle\Model\ProductReview\ProductReviewEnabledChecker;
+use Shopsys\FrameworkBundle\Model\ProductReview\ProductReviewFacade;
 use Shopsys\FrameworkBundle\Model\ProductReview\ProductReviewStatusEnum;
 use SortDirection;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[CrudController(ProductReview::class)]
 class ProductReviewController extends AbstractCrudController
@@ -27,6 +35,7 @@ class ProductReviewController extends AbstractCrudController
     public function __construct(
         protected readonly EntityLogFacade $entityLogFacade,
         protected readonly ProductReviewEnabledChecker $productReviewEnabledChecker,
+        protected readonly ProductReviewFacade $productReviewFacade,
     ) {
     }
 
@@ -41,6 +50,21 @@ class ProductReviewController extends AbstractCrudController
             ->setCustomRoleSection(AdminRoleSectionsProvider::PRODUCTS_CATALOG)
             ->registerHandler(ProductReviewEditHandler::class)
             ->disable(!$this->productReviewEnabledChecker->isEnabledOnAnyDomain());
+    }
+
+    #[Override]
+    protected function configureActions(ActionsConfig $actions): void
+    {
+        $actions->add(
+            ActionType::EDIT,
+            Action::create('approveReview', t('Approve review'))
+                ->setIcon('checked')
+                ->setAttribute('class', 'btn-success', true)
+                ->displayIf(fn (ProductReview $productReview) => $productReview->getStatus() === ProductReviewStatusEnum::STATUS_PENDING)
+                ->linkToRoute('admin_crud_product_review_approve', fn (ProductReview $productReview) => [
+                    'id' => $productReview->getId(),
+                ]),
+        );
     }
 
     #[Override]
@@ -142,5 +166,39 @@ class ProductReviewController extends AbstractCrudController
             'entityLogEntityName' => $this->entityLogFacade->getEntityNameByEntity(ProductReview::class),
             'productReview' => $productReview,
         ];
+    }
+
+    #[Route(path: '/product-review/approve/{id}', name: 'admin_crud_product_review_approve', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[CanEdit]
+    #[CsrfProtection]
+    public function approveAction(int $id): Response
+    {
+        /** @var \Shopsys\AdministrationBundle\Model\ProductReview\ProductReviewEditHandler $handler */
+        $handler = $this->definition->getHandlerForAction(ActionType::EDIT);
+        $productReview = $handler->getById($id);
+
+        if ($productReview->getStatus() !== ProductReviewStatusEnum::STATUS_PENDING) {
+            $this->addErrorFlashTwig(
+                t('Review <strong><a href="{{ url }}">{{ reviewName }}</a></strong> is no longer pending, so it cannot be approved.'),
+                [
+                    'reviewName' => $productReview->toHumanReadable(),
+                    'url' => $this->generateUrl('admin_crud_product_review_edit', ['id' => $id]),
+                ],
+            );
+
+            return $this->redirectToRoute('admin_crud_product_review_list');
+        }
+
+        $this->productReviewFacade->approve($productReview);
+
+        $this->addSuccessFlashTwig(
+            t('Review <strong><a href="{{ url }}">{{ reviewName }}</a></strong> was approved.'),
+            [
+                'reviewName' => $productReview->toHumanReadable(),
+                'url' => $this->generateUrl('admin_crud_product_review_edit', ['id' => $id]),
+            ],
+        );
+
+        return $this->redirectToRoute('admin_crud_product_review_list');
     }
 }

--- a/packages/administration/src/Model/ProductReview/ProductReviewEditHandler.php
+++ b/packages/administration/src/Model/ProductReview/ProductReviewEditHandler.php
@@ -6,7 +6,6 @@ namespace Shopsys\AdministrationBundle\Model\ProductReview;
 
 use Override;
 use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
-use Shopsys\FrameworkBundle\Component\Utils\Presentable;
 use Shopsys\FrameworkBundle\Model\ProductReview\Exception\ProductReviewNotFoundException;
 use Shopsys\FrameworkBundle\Model\ProductReview\ProductReview;
 use Shopsys\FrameworkBundle\Model\ProductReview\ProductReviewData;
@@ -30,7 +29,7 @@ class ProductReviewEditHandler implements EditHandlerInterface
      * {@inheritdoc}
      */
     #[Override]
-    public function getById(int $id): Presentable
+    public function getById(int $id): ProductReview
     {
         $productReview = $this->productReviewFacade->getById($id);
 

--- a/packages/administration/translations/messages.cs.po
+++ b/packages/administration/translations/messages.cs.po
@@ -202,6 +202,9 @@ msgstr "Použitelné proměnné pro obsah"
 msgid "Applicable variables for Subject"
 msgstr "Použitelné proměnné pro předmět"
 
+msgid "Approve review"
+msgstr "Schválit recenzi"
+
 msgid "Approved"
 msgstr "Schváleno"
 
@@ -1995,6 +1998,12 @@ msgstr "Resetovat heslo"
 
 msgid "Return back"
 msgstr "Vrátit zpět"
+
+msgid "Review <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> is no longer pending, so it cannot be approved."
+msgstr "Recenze <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> již není ve stavu čeká na schválení, proto ji nelze schválit."
+
+msgid "Review <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> was approved."
+msgstr "Recenze <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> byla schválena."
 
 msgid "Reviewed product"
 msgstr "Recenzovaný produkt"

--- a/packages/administration/translations/messages.en.po
+++ b/packages/administration/translations/messages.en.po
@@ -202,6 +202,9 @@ msgstr ""
 msgid "Applicable variables for Subject"
 msgstr ""
 
+msgid "Approve review"
+msgstr ""
+
 msgid "Approved"
 msgstr ""
 
@@ -1994,6 +1997,12 @@ msgid "Reset password"
 msgstr ""
 
 msgid "Return back"
+msgstr ""
+
+msgid "Review <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> is no longer pending, so it cannot be approved."
+msgstr ""
+
+msgid "Review <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> was approved."
 msgstr ""
 
 msgid "Reviewed product"

--- a/packages/administration/translations/messages.sk.po
+++ b/packages/administration/translations/messages.sk.po
@@ -202,6 +202,9 @@ msgstr "Použiteľné premenné pre obsah"
 msgid "Applicable variables for Subject"
 msgstr "Použiteľné premenné pre predmet"
 
+msgid "Approve review"
+msgstr "Schváliť recenziu"
+
 msgid "Approved"
 msgstr "Schváleno"
 
@@ -1995,6 +1998,12 @@ msgstr "Resetovať heslo"
 
 msgid "Return back"
 msgstr "Vrátiť späť"
+
+msgid "Review <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> is no longer pending, so it cannot be approved."
+msgstr "Recenzia <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> už nie je v stave čaká na schválenie, preto ju nie je možné schváliť."
+
+msgid "Review <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> was approved."
+msgstr "Recenzia <strong><a href=\"{{ url }}\">{{ reviewName }}</a></strong> bola schválená."
 
 msgid "Reviewed product"
 msgstr "Recenzovaný produkt"

--- a/packages/framework/src/Model/ProductReview/ProductReview.php
+++ b/packages/framework/src/Model/ProductReview/ProductReview.php
@@ -244,6 +244,12 @@ class ProductReview implements Presentable, DomainSeparatedEntityInterface
         $this->setData($productReviewData);
     }
 
+    public function approve(): void
+    {
+        $this->status = ProductReviewStatusEnum::STATUS_APPROVED;
+        $this->rejectionReason = null;
+    }
+
     public function isContentEdited(ProductReviewData $productReviewData): bool
     {
         return $this->firstName !== $productReviewData->firstName

--- a/packages/framework/src/Model/ProductReview/ProductReviewFacade.php
+++ b/packages/framework/src/Model/ProductReview/ProductReviewFacade.php
@@ -24,6 +24,7 @@ class ProductReviewFacade
         protected readonly EntityManagerInterface $em,
         protected readonly ProductReviewRepository $productReviewRepository,
         protected readonly ProductReviewFactory $productReviewFactory,
+        protected readonly ProductReviewDataFactory $productReviewDataFactory,
         protected readonly ProductRecalculationDispatcher $productRecalculationDispatcher,
         protected readonly EntityLogNoteRegistry $entityLogNoteRegistry,
         protected readonly CleanStorefrontCacheFacade $cleanStorefrontCacheFacade,
@@ -132,6 +133,19 @@ class ProductReviewFacade
         $this->em->flush();
 
         $this->productReviewImagePublisher->refreshPublicationStatus($productReview);
+    }
+
+    public function approve(ProductReview $productReview): void
+    {
+        $productReviewData = $this->productReviewDataFactory->createFromProductReview($productReview);
+
+        $productReview->approve();
+
+        $this->em->flush();
+
+        $this->editImages($productReview, $productReviewData->images);
+
+        $this->dispatchReviewsExport($productReview);
     }
 
     protected function dispatchReviewsExport(ProductReview $productReview): void

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -6,6 +6,7 @@ namespace Tests\App\Smoke\Http;
 
 use App\DataFixtures\Demo\OrderDataFixture;
 use App\DataFixtures\Demo\OrderStatusDataFixture;
+use App\DataFixtures\Demo\ProductReviewDataFixture;
 use App\DataFixtures\Demo\ReadyCategorySeoDataFixture;
 use App\DataFixtures\Demo\UnitDataFixture;
 use App\DataFixtures\Demo\VatDataFixture;
@@ -19,6 +20,7 @@ use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMix;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule;
 use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;
+use Shopsys\FrameworkBundle\Model\ProductReview\ProductReview;
 use Shopsys\HttpSmokeTesting\Auth\BasicHttpAuth;
 use Shopsys\HttpSmokeTesting\Auth\NoAuth;
 use Shopsys\HttpSmokeTesting\RequestDataSet;
@@ -263,6 +265,14 @@ class RouteConfigCustomization
                 $config->changeDefaultRequestDataSet('Use valid order from fixtures and add CSRF token.')
                     ->setParameter('id', $order->getId())
                     ->addCallDuringTestExecution($this->createAddCsrfTokenDuringTestExecutionCallback())
+                    ->setExpectedStatusCode(302);
+            })
+            ->customizeByRouteName('admin_crud_product_review_approve', function (RouteConfig $config): void {
+                $review = $this->getPersistentReference(ProductReviewDataFixture::PRODUCT_REVIEW_PENDING_GUEST, domainId: 1, entityClassName: ProductReview::class);
+
+                $config->changeDefaultRequestDataSet('Approving a review needs a CSRF token and redirects back to the list.')
+                    ->addCallDuringTestExecution($this->createAddCsrfTokenDuringTestExecutionCallback())
+                    ->setParameter('id', $review->getId())
                     ->setExpectedStatusCode(302);
             })
             ->customizeByRouteName('admin_pricinggroup_delete', function (RouteConfig $config): void {


### PR DESCRIPTION
#### Description, the reason for the PR

Product reviews that are waiting for moderation can now be approved with a single click.

Until now the moderator had to open a pending review, change the status select in the form to "Approved" and save the form. For the most common moderation outcome that is needlessly long. The edit page of a pending review now offers an **Approve review** button in the header; clicking it approves the review, keeps any previously entered rejection reason out of the approved review, and returns the moderator to the review list with a confirmation message linking back to the review.

The approval triggers the same follow-up as saving the form (product export and storefront cache invalidation), so the approved review shows up on the storefront right away. The button is available only to administrators who may edit product reviews, and the link is CSRF-protected.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-quick-review-approve.odin.shopsys.cloud
  - https://cz.mg-quick-review-approve.odin.shopsys.cloud
  - https://mg-quick-review-approve.odin.shopsys.cloud/sk
<!-- Replace -->
