### PR TITLE
Default pricing group can no longer be deleted without a replacement

### DIFF
--- a/packages/framework/src/Controller/Admin/PricingGroupController.php
+++ b/packages/framework/src/Controller/Admin/PricingGroupController.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Component\ConfirmDelete\ConfirmDeleteResponseFactory;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
@@ -14,6 +15,8 @@ use Shopsys\FrameworkBundle\Component\Security\Attribute\CanView;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\ForRole;
 use Shopsys\FrameworkBundle\Component\Security\Role\AdminRoleConstant;
 use Shopsys\FrameworkBundle\Form\Admin\Pricing\Group\PricingGroupSettingsFormType;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\InvalidPricingGroupReplacementException;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupIsUsedException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupNotFoundException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Grid\PricingGroupInlineEdit;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
@@ -31,6 +34,7 @@ class PricingGroupController extends AdminBaseController
         protected readonly PricingGroupInlineEdit $pricingGroupInlineEdit,
         protected readonly ConfirmDeleteResponseFactory $confirmDeleteResponseFactory,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
+        protected readonly Domain $domain,
     ) {
     }
 
@@ -75,8 +79,12 @@ class PricingGroupController extends AdminBaseController
                     ],
                 );
             }
-        } catch (PricingGroupNotFoundException $ex) {
+        } catch (PricingGroupNotFoundException) {
             $this->addErrorFlash(t('Selected pricing group doesn\'t exist.'));
+        } catch (PricingGroupIsUsedException) {
+            $this->addErrorFlash(t('Pricing group is used and cannot be deleted without choosing a replacement.'));
+        } catch (InvalidPricingGroupReplacementException) {
+            $this->addErrorFlash(t('Selected replacement pricing group must be a different pricing group from the same domain.'));
         }
 
         return $this->redirectToRoute('admin_pricinggroup_list');
@@ -90,16 +98,16 @@ class PricingGroupController extends AdminBaseController
         try {
             $pricingGroup = $this->pricingGroupFacade->getById($id);
 
-            $selectedDomain = $this->adminDomainTabsFacade->getSelectedDomainConfig();
+            $domainConfig = $this->domain->getDomainConfigById($pricingGroup->getDomainId());
 
-            if ($this->pricingGroupSettingFacade->isPricingGroupUsedOnDomain($pricingGroup, $selectedDomain)) {
+            if ($this->pricingGroupSettingFacade->isPricingGroupUsedOnDomain($pricingGroup, $domainConfig)) {
                 $message = t(
                     'For removing pricing group "%name%" you have to choose other one to be set everywhere where the existing one is used. '
                     . 'Which pricing group you want to set instead?',
                     ['%name%' => $pricingGroup->getName()],
                 );
 
-                if ($this->pricingGroupSettingFacade->isPricingGroupDefaultOnDomain($pricingGroup, $selectedDomain)) {
+                if ($this->pricingGroupSettingFacade->isPricingGroupDefaultOnDomain($pricingGroup, $domainConfig)) {
                     $message = t(
                         'Pricing group "%name%" set as default. For deleting it you have to choose other one to be set everywhere '
                         . 'where the existing one is used. Which pricing group you want to set instead?',

--- a/packages/framework/src/Controller/Admin/PricingGroupController.php
+++ b/packages/framework/src/Controller/Admin/PricingGroupController.php
@@ -6,7 +6,6 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Component\ConfirmDelete\ConfirmDeleteResponseFactory;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\HttpMethod;
 use Shopsys\FrameworkBundle\Component\Router\Security\Attribute\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Security\Attribute\CanDelete;
@@ -34,7 +33,6 @@ class PricingGroupController extends AdminBaseController
         protected readonly PricingGroupInlineEdit $pricingGroupInlineEdit,
         protected readonly ConfirmDeleteResponseFactory $confirmDeleteResponseFactory,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
-        protected readonly Domain $domain,
     ) {
     }
 
@@ -98,16 +96,14 @@ class PricingGroupController extends AdminBaseController
         try {
             $pricingGroup = $this->pricingGroupFacade->getById($id);
 
-            $domainConfig = $this->domain->getDomainConfigById($pricingGroup->getDomainId());
-
-            if ($this->pricingGroupSettingFacade->isPricingGroupUsedOnDomain($pricingGroup, $domainConfig)) {
+            if ($this->pricingGroupSettingFacade->isPricingGroupUsed($pricingGroup)) {
                 $message = t(
                     'For removing pricing group "%name%" you have to choose other one to be set everywhere where the existing one is used. '
                     . 'Which pricing group you want to set instead?',
                     ['%name%' => $pricingGroup->getName()],
                 );
 
-                if ($this->pricingGroupSettingFacade->isPricingGroupDefaultOnDomain($pricingGroup, $domainConfig)) {
+                if ($this->pricingGroupSettingFacade->isPricingGroupSetAsDefault($pricingGroup)) {
                     $message = t(
                         'Pricing group "%name%" set as default. For deleting it you have to choose other one to be set everywhere '
                         . 'where the existing one is used. Which pricing group you want to set instead?',
@@ -132,7 +128,7 @@ class PricingGroupController extends AdminBaseController
                 'admin_pricinggroup_delete',
                 $id,
             );
-        } catch (PricingGroupNotFoundException $ex) {
+        } catch (PricingGroupNotFoundException) {
             return new Response(t('Selected pricing group doesn\'t exist.'));
         }
     }
@@ -154,9 +150,8 @@ class PricingGroupController extends AdminBaseController
         if ($form->isSubmitted() && $form->isValid()) {
             $pricingGroupSettingsFormData = $form->getData();
 
-            $this->pricingGroupSettingFacade->setDefaultPricingGroupForDomain(
+            $this->pricingGroupSettingFacade->setPricingGroupAsDefault(
                 $pricingGroupSettingsFormData['defaultPricingGroup'],
-                $this->adminDomainTabsFacade->getSelectedDomainConfig(),
             );
 
             $this->addSuccessFlash(t('Default pricing group settings modified'));

--- a/packages/framework/src/Model/Pricing/Group/Exception/InvalidPricingGroupReplacementException.php
+++ b/packages/framework/src/Model/Pricing/Group/Exception/InvalidPricingGroupReplacementException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Pricing\Group\Exception;
+
+use Exception;
+
+class InvalidPricingGroupReplacementException extends Exception
+{
+}

--- a/packages/framework/src/Model/Pricing/Group/Exception/PricingGroupIsUsedException.php
+++ b/packages/framework/src/Model/Pricing/Group/Exception/PricingGroupIsUsedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Pricing\Group\Exception;
+
+use Exception;
+
+class PricingGroupIsUsedException extends Exception
+{
+}

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupFacade.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupFacade.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRepository;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\InvalidPricingGroupReplacementException;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupIsUsedException;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -20,6 +22,7 @@ class PricingGroupFacade
         protected readonly CustomerUserRepository $customerUserRepository,
         protected readonly PricingGroupFactory $pricingGroupFactory,
         protected readonly EventDispatcherInterface $eventDispatcher,
+        protected readonly Domain $domain,
     ) {
     }
 
@@ -64,23 +67,30 @@ class PricingGroupFacade
     public function delete(
         int $oldPricingGroupId,
         ?int $newPricingGroupId = null,
-        ?DomainConfig $selectedDomain = null,
     ): void {
         $oldPricingGroup = $this->pricingGroupRepository->getById($oldPricingGroupId);
+        $domainConfig = $this->domain->getDomainConfigById($oldPricingGroup->getDomainId());
 
-        if ($newPricingGroupId !== null) {
-            $newPricingGroup = $this->pricingGroupRepository->getById($newPricingGroupId);
-            $this->customerUserRepository->replaceCustomerUsersPricingGroup($oldPricingGroup, $newPricingGroup);
+        if ($newPricingGroupId === null) {
+            if ($this->pricingGroupSettingFacade->isPricingGroupUsedOnDomain($oldPricingGroup, $domainConfig)) {
+                throw new PricingGroupIsUsedException(
+                    sprintf('Pricing group with ID %d is used and cannot be deleted without a replacement.', $oldPricingGroupId),
+                );
+            }
         } else {
-            $newPricingGroup = null;
-        }
+            $newPricingGroup = $this->pricingGroupRepository->getById($newPricingGroupId);
 
-        if (
-            $newPricingGroup !== null
-            && $selectedDomain !== null
-            && $this->pricingGroupSettingFacade->isPricingGroupDefaultOnDomain($oldPricingGroup, $selectedDomain)
-        ) {
-            $this->pricingGroupSettingFacade->setDefaultPricingGroupForDomain($newPricingGroup, $selectedDomain);
+            if ($newPricingGroup === $oldPricingGroup || $newPricingGroup->getDomainId() !== $oldPricingGroup->getDomainId()) {
+                throw new InvalidPricingGroupReplacementException(
+                    sprintf('Pricing group with ID %d cannot replace pricing group with ID %d.', $newPricingGroupId, $oldPricingGroupId),
+                );
+            }
+
+            $this->customerUserRepository->replaceCustomerUsersPricingGroup($oldPricingGroup, $newPricingGroup);
+
+            if ($this->pricingGroupSettingFacade->isPricingGroupDefaultOnDomain($oldPricingGroup, $domainConfig)) {
+                $this->pricingGroupSettingFacade->setDefaultPricingGroupForDomain($newPricingGroup, $domainConfig);
+            }
         }
 
         $this->em->remove($oldPricingGroup);

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupFacade.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupFacade.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRepository;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\InvalidPricingGroupReplacementException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupIsUsedException;
@@ -22,7 +21,6 @@ class PricingGroupFacade
         protected readonly CustomerUserRepository $customerUserRepository,
         protected readonly PricingGroupFactory $pricingGroupFactory,
         protected readonly EventDispatcherInterface $eventDispatcher,
-        protected readonly Domain $domain,
     ) {
     }
 
@@ -69,10 +67,9 @@ class PricingGroupFacade
         ?int $newPricingGroupId = null,
     ): void {
         $oldPricingGroup = $this->pricingGroupRepository->getById($oldPricingGroupId);
-        $domainConfig = $this->domain->getDomainConfigById($oldPricingGroup->getDomainId());
 
         if ($newPricingGroupId === null) {
-            if ($this->pricingGroupSettingFacade->isPricingGroupUsedOnDomain($oldPricingGroup, $domainConfig)) {
+            if ($this->pricingGroupSettingFacade->isPricingGroupUsed($oldPricingGroup)) {
                 throw new PricingGroupIsUsedException(
                     sprintf('Pricing group with ID %d is used and cannot be deleted without a replacement.', $oldPricingGroupId),
                 );
@@ -88,8 +85,8 @@ class PricingGroupFacade
 
             $this->customerUserRepository->replaceCustomerUsersPricingGroup($oldPricingGroup, $newPricingGroup);
 
-            if ($this->pricingGroupSettingFacade->isPricingGroupDefaultOnDomain($oldPricingGroup, $domainConfig)) {
-                $this->pricingGroupSettingFacade->setDefaultPricingGroupForDomain($newPricingGroup, $domainConfig);
+            if ($this->pricingGroupSettingFacade->isPricingGroupSetAsDefault($oldPricingGroup)) {
+                $this->pricingGroupSettingFacade->setPricingGroupAsDefault($newPricingGroup);
             }
         }
 

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupSettingFacade.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupSettingFacade.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
 
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
@@ -47,11 +46,6 @@ class PricingGroupSettingFacade
     public function getDefaultPricingGroupByCurrentDomain(): PricingGroup
     {
         return $this->getDefaultPricingGroupByDomainId($this->domain->getId());
-    }
-
-    public function getDefaultPricingGroupByDomain(DomainConfig $domainConfig): PricingGroup
-    {
-        return $this->getDefaultPricingGroupByDomainId($domainConfig->getId());
     }
 
     public function setPricingGroupAsDefault(PricingGroup $pricingGroup): void

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupSettingFacade.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupSettingFacade.php
@@ -17,10 +17,10 @@ class PricingGroupSettingFacade
     ) {
     }
 
-    public function isPricingGroupUsedOnDomain(PricingGroup $pricingGroup, DomainConfig $domainConfig): bool
+    public function isPricingGroupUsed(PricingGroup $pricingGroup): bool
     {
         return $this->pricingGroupRepository->existsCustomerUserWithPricingGroup($pricingGroup)
-            || $this->isPricingGroupDefaultOnDomain($pricingGroup, $domainConfig);
+            || $this->isPricingGroupSetAsDefault($pricingGroup);
     }
 
     public function getDefaultPricingGroupByDomainId(int $domainId): PricingGroup
@@ -54,17 +54,17 @@ class PricingGroupSettingFacade
         return $this->getDefaultPricingGroupByDomainId($domainConfig->getId());
     }
 
-    public function setDefaultPricingGroupForDomain(PricingGroup $pricingGroup, DomainConfig $domainConfig): void
+    public function setPricingGroupAsDefault(PricingGroup $pricingGroup): void
     {
         $this->setting->setForDomain(
             Setting::DEFAULT_PRICING_GROUP,
             $pricingGroup->getId(),
-            $domainConfig->getId(),
+            $pricingGroup->getDomainId(),
         );
     }
 
-    public function isPricingGroupDefaultOnDomain(PricingGroup $pricingGroup, DomainConfig $domainConfig): bool
+    public function isPricingGroupSetAsDefault(PricingGroup $pricingGroup): bool
     {
-        return $pricingGroup === $this->getDefaultPricingGroupByDomain($domainConfig);
+        return $pricingGroup === $this->getDefaultPricingGroupByDomainId($pricingGroup->getDomainId());
     }
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2851,6 +2851,9 @@ msgstr "Cenová skupina <strong>{{ name }}</strong> byla smazána"
 msgid "Pricing group <strong>{{ name }}</strong> deleted and replaced by group <strong>{{ newName }}</strong>."
 msgstr "Cenová skupina <strong>{{ name }}</strong> byla smazána a byla nahrazena skupinou <strong>{{ newName }}</strong>."
 
+msgid "Pricing group is used and cannot be deleted without choosing a replacement."
+msgstr "Cenová skupina je používána a nelze ji smazat bez zvolení náhrady."
+
 msgid "Pricing groups"
 msgstr "Cenové skupiny"
 
@@ -3315,6 +3318,9 @@ msgstr "Zvolený produkt neexistuje."
 
 msgid "Selected promo code doesn't exist."
 msgstr "Zvolený slevový kupón neexistuje."
+
+msgid "Selected replacement pricing group must be a different pricing group from the same domain."
+msgstr "Zvolená náhradní cenová skupina musí být jiná cenová skupina ze stejné domény."
 
 msgid "Selected sales representative doesn't exist."
 msgstr "Zvolený obchodní zástupce neexistuje."

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2851,6 +2851,9 @@ msgstr ""
 msgid "Pricing group <strong>{{ name }}</strong> deleted and replaced by group <strong>{{ newName }}</strong>."
 msgstr ""
 
+msgid "Pricing group is used and cannot be deleted without choosing a replacement."
+msgstr ""
+
 msgid "Pricing groups"
 msgstr ""
 
@@ -3314,6 +3317,9 @@ msgid "Selected product doesn't exist."
 msgstr ""
 
 msgid "Selected promo code doesn't exist."
+msgstr ""
+
+msgid "Selected replacement pricing group must be a different pricing group from the same domain."
 msgstr ""
 
 msgid "Selected sales representative doesn't exist."

--- a/packages/framework/src/Resources/translations/messages.sk.po
+++ b/packages/framework/src/Resources/translations/messages.sk.po
@@ -2851,6 +2851,9 @@ msgstr "Cenová skupina <strong>{{ name }}</strong> odstránená"
 msgid "Pricing group <strong>{{ name }}</strong> deleted and replaced by group <strong>{{ newName }}</strong>."
 msgstr "Cenová skupina <strong>{{ name }}</strong> bola zmazaná a bola nahradená skupinou <strong>{{ newName }}</strong>."
 
+msgid "Pricing group is used and cannot be deleted without choosing a replacement."
+msgstr "Cenová skupina je používaná a nemôže byť odstránená bez zvolenia náhrady."
+
 msgid "Pricing groups"
 msgstr "Cenové skupiny"
 
@@ -3315,6 +3318,9 @@ msgstr "Zvolený produkt neexistuje."
 
 msgid "Selected promo code doesn't exist."
 msgstr "Zvolený zľavový kupón neexistuje."
+
+msgid "Selected replacement pricing group must be a different pricing group from the same domain."
+msgstr "Zvolená náhradná cenová skupina musí byť iná cenová skupina z tej istej domény."
 
 msgid "Selected sales representative doesn't exist."
 msgstr "Zvolený obchodný zástupca neexistuje."

--- a/project-base/app/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -10,6 +10,7 @@ use App\Model\Customer\User\CustomerUserDataFactory;
 use App\Model\Customer\User\CustomerUserFacade;
 use App\Model\Customer\User\CustomerUserUpdateDataFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\InvalidPricingGroupReplacementException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupIsUsedException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupNotFoundException;
@@ -62,19 +63,7 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
             PricingGroup::class,
         );
         $customerUser = $this->customerUserFacade->getCustomerUserById(1);
-
-        $customerUserData = $this->customerUserDataFactory->createFromCustomerUser($customerUser);
-        $customerUserData->pricingGroup = $pricingGroupToDelete;
-
-        /** @var \App\Model\Customer\BillingAddress $billingAddress */
-        $billingAddress = $customerUser->getCustomer()->getBillingAddress();
-        $billingAddressData = $this->billingAddressDataFactory->createFromBillingAddress($billingAddress);
-
-        $customerUserUpdateData = $this->customerUserUpdateDataFactory->create();
-        $customerUserUpdateData->customerUserData = $customerUserData;
-        $customerUserUpdateData->billingAddressData = $billingAddressData;
-
-        $this->customerUserFacade->editByAdmin($customerUser->getId(), $customerUserUpdateData);
+        $this->assignPricingGroupToCustomerUser($customerUser, $pricingGroupToDelete);
 
         $this->pricingGroupFacade->delete($pricingGroupToDelete->getId(), $pricingGroupToReplaceWith->getId());
 
@@ -109,6 +98,19 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
         $this->expectException(PricingGroupIsUsedException::class);
 
         $this->pricingGroupFacade->delete($defaultPricingGroup->getId());
+    }
+
+    public function testDeletePricingGroupAssignedToCustomerWithoutReplacementThrowsException(): void
+    {
+        $pricingGroupData = new PricingGroupData();
+        $pricingGroupData->name = 'assigned to customer';
+        $pricingGroupAssignedToCustomer = $this->pricingGroupFacade->create($pricingGroupData, Domain::FIRST_DOMAIN_ID);
+        $customerUser = $this->customerUserFacade->getCustomerUserById(1);
+        $this->assignPricingGroupToCustomerUser($customerUser, $pricingGroupAssignedToCustomer);
+
+        $this->expectException(PricingGroupIsUsedException::class);
+
+        $this->pricingGroupFacade->delete($pricingGroupAssignedToCustomer->getId());
     }
 
     public function testDeleteUnusedPricingGroupWithoutReplacement(): void
@@ -158,5 +160,21 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
         $this->expectException(InvalidPricingGroupReplacementException::class);
 
         $this->pricingGroupFacade->delete($pricingGroup->getId(), $pricingGroup->getId());
+    }
+
+    private function assignPricingGroupToCustomerUser(CustomerUser $customerUser, PricingGroup $pricingGroup): void
+    {
+        $customerUserData = $this->customerUserDataFactory->createFromCustomerUser($customerUser);
+        $customerUserData->pricingGroup = $pricingGroup;
+
+        /** @var \App\Model\Customer\BillingAddress $billingAddress */
+        $billingAddress = $customerUser->getCustomer()->getBillingAddress();
+        $billingAddressData = $this->billingAddressDataFactory->createFromBillingAddress($billingAddress);
+
+        $customerUserUpdateData = $this->customerUserUpdateDataFactory->create();
+        $customerUserUpdateData->customerUserData = $customerUserData;
+        $customerUserUpdateData->billingAddressData = $billingAddressData;
+
+        $this->customerUserFacade->editByAdmin($customerUser->getId(), $customerUserUpdateData);
     }
 }

--- a/project-base/app/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -6,11 +6,11 @@ namespace Tests\App\Functional\Model\Pricing\Group;
 
 use App\DataFixtures\Demo\PricingGroupDataFixture;
 use App\Model\Customer\BillingAddressDataFactory;
+use App\Model\Customer\User\CustomerUser;
 use App\Model\Customer\User\CustomerUserDataFactory;
 use App\Model\Customer\User\CustomerUserFacade;
 use App\Model\Customer\User\CustomerUserUpdateDataFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\InvalidPricingGroupReplacementException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupIsUsedException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupNotFoundException;
@@ -54,12 +54,14 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
 
     public function testDeleteAndReplace(): void
     {
+        $domainId = Domain::FIRST_DOMAIN_ID;
+
         $pricingGroupData = new PricingGroupData();
         $pricingGroupData->name = 'name';
-        $pricingGroupToDelete = $this->pricingGroupFacade->create($pricingGroupData, Domain::FIRST_DOMAIN_ID);
+        $pricingGroupToDelete = $this->pricingGroupFacade->create($pricingGroupData, $domainId);
         $pricingGroupToReplaceWith = $this->getReferenceForDomain(
             PricingGroupDataFixture::PRICING_GROUP_ORDINARY,
-            Domain::FIRST_DOMAIN_ID,
+            $domainId,
             PricingGroup::class,
         );
         $customerUser = $this->customerUserFacade->getCustomerUserById(1);
@@ -74,11 +76,12 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
 
     public function testDeleteDefaultPricingGroupSetsReplacementAsDefault(): void
     {
-        $domainConfig = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID);
-        $defaultPricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomain($domainConfig);
+        $domainId = Domain::FIRST_DOMAIN_ID;
+
+        $defaultPricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($domainId);
         $pricingGroupToReplaceWith = $this->getReferenceForDomain(
             PricingGroupDataFixture::PRICING_GROUP_VIP,
-            Domain::FIRST_DOMAIN_ID,
+            $domainId,
             PricingGroup::class,
         );
 
@@ -86,14 +89,13 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
 
         $this->assertSame(
             $pricingGroupToReplaceWith,
-            $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomain($domainConfig),
+            $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($domainId),
         );
     }
 
     public function testDeleteDefaultPricingGroupWithoutReplacementThrowsException(): void
     {
-        $domainConfig = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID);
-        $defaultPricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomain($domainConfig);
+        $defaultPricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId(Domain::FIRST_DOMAIN_ID);
 
         $this->expectException(PricingGroupIsUsedException::class);
 

--- a/project-base/app/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -10,9 +10,13 @@ use App\Model\Customer\User\CustomerUserDataFactory;
 use App\Model\Customer\User\CustomerUserFacade;
 use App\Model\Customer\User\CustomerUserUpdateDataFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\InvalidPricingGroupReplacementException;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupIsUsedException;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\Exception\PricingGroupNotFoundException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade;
 use Tests\App\Test\TransactionFunctionalTestCase;
 
 class PricingGroupFacadeTest extends TransactionFunctionalTestCase
@@ -21,6 +25,11 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
      * @inject
      */
     private PricingGroupFacade $pricingGroupFacade;
+
+    /**
+     * @inject
+     */
+    private PricingGroupSettingFacade $pricingGroupSettingFacade;
 
     /**
      * @inject
@@ -72,5 +81,82 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
         $this->em->refresh($customerUser);
 
         $this->assertEquals($pricingGroupToReplaceWith, $customerUser->getPricingGroup());
+    }
+
+    public function testDeleteDefaultPricingGroupSetsReplacementAsDefault(): void
+    {
+        $domainConfig = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID);
+        $defaultPricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomain($domainConfig);
+        $pricingGroupToReplaceWith = $this->getReferenceForDomain(
+            PricingGroupDataFixture::PRICING_GROUP_VIP,
+            Domain::FIRST_DOMAIN_ID,
+            PricingGroup::class,
+        );
+
+        $this->pricingGroupFacade->delete($defaultPricingGroup->getId(), $pricingGroupToReplaceWith->getId());
+
+        $this->assertSame(
+            $pricingGroupToReplaceWith,
+            $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomain($domainConfig),
+        );
+    }
+
+    public function testDeleteDefaultPricingGroupWithoutReplacementThrowsException(): void
+    {
+        $domainConfig = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID);
+        $defaultPricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomain($domainConfig);
+
+        $this->expectException(PricingGroupIsUsedException::class);
+
+        $this->pricingGroupFacade->delete($defaultPricingGroup->getId());
+    }
+
+    public function testDeleteUnusedPricingGroupWithoutReplacement(): void
+    {
+        $pricingGroupData = new PricingGroupData();
+        $pricingGroupData->name = 'unused';
+        $pricingGroup = $this->pricingGroupFacade->create($pricingGroupData, Domain::FIRST_DOMAIN_ID);
+        $pricingGroupId = $pricingGroup->getId();
+
+        $this->pricingGroupFacade->delete($pricingGroupId);
+
+        $this->expectException(PricingGroupNotFoundException::class);
+
+        $this->pricingGroupFacade->getById($pricingGroupId);
+    }
+
+    public function testDeleteWithReplacementFromAnotherDomainThrowsException(): void
+    {
+        if (!$this->domain->isMultidomain()) {
+            $this->markTestSkipped('Test requires at least two domains.');
+        }
+
+        $pricingGroupToDelete = $this->getReferenceForDomain(
+            PricingGroupDataFixture::PRICING_GROUP_ORDINARY,
+            Domain::FIRST_DOMAIN_ID,
+            PricingGroup::class,
+        );
+        $pricingGroupFromAnotherDomain = $this->getReferenceForDomain(
+            PricingGroupDataFixture::PRICING_GROUP_ORDINARY,
+            Domain::SECOND_DOMAIN_ID,
+            PricingGroup::class,
+        );
+
+        $this->expectException(InvalidPricingGroupReplacementException::class);
+
+        $this->pricingGroupFacade->delete($pricingGroupToDelete->getId(), $pricingGroupFromAnotherDomain->getId());
+    }
+
+    public function testDeleteWithItselfAsReplacementThrowsException(): void
+    {
+        $pricingGroup = $this->getReferenceForDomain(
+            PricingGroupDataFixture::PRICING_GROUP_ORDINARY,
+            Domain::FIRST_DOMAIN_ID,
+            PricingGroup::class,
+        );
+
+        $this->expectException(InvalidPricingGroupReplacementException::class);
+
+        $this->pricingGroupFacade->delete($pricingGroup->getId(), $pricingGroup->getId());
     }
 }

--- a/upgrade-notes/backend_20260909_111145.md
+++ b/upgrade-notes/backend_20260909_111145.md
@@ -1,0 +1,5 @@
+#### Default pricing group can no longer be deleted without a replacement ([#4833](https://github.com/shopsys/shopsys/pull/4833))
+
+- `PricingGroupFacade::delete()` no longer accepts the third `$selectedDomain` argument, the domain is now taken from the deleted pricing group itself
+    - the method throws `PricingGroupIsUsedException` when the pricing group is used (default on its domain or assigned to customers) and no replacement is given
+    - the method throws `InvalidPricingGroupReplacementException` when the replacement is the deleted pricing group itself or belongs to another domain

--- a/upgrade-notes/backend_20260909_111145.md
+++ b/upgrade-notes/backend_20260909_111145.md
@@ -3,3 +3,7 @@
 - `PricingGroupFacade::delete()` no longer accepts the third `$selectedDomain` argument, the domain is now taken from the deleted pricing group itself
     - the method throws `PricingGroupIsUsedException` when the pricing group is used (default on its domain or assigned to customers) and no replacement is given
     - the method throws `InvalidPricingGroupReplacementException` when the replacement is the deleted pricing group itself or belongs to another domain
+- methods in `PricingGroupSettingFacade` no longer accept the `DomainConfig` argument, the domain is now taken from the pricing group itself
+    - `isPricingGroupUsedOnDomain()` was renamed to `isPricingGroupUsed()`
+    - `isPricingGroupDefaultOnDomain()` was renamed to `isPricingGroupSetAsDefault()`
+    - `setDefaultPricingGroupForDomain()` was renamed to `setPricingGroupAsDefault()`


### PR DESCRIPTION
#### Description, the reason for the PR

Administrators could delete the default pricing group of a domain without the replacement ever becoming the new default. The confirmation dialog asked for a replacement group, but only customers were moved to it – the "default pricing group" setting of the domain kept pointing to the deleted group, which breaks pricing and product visibility for anonymous visitors on that domain. This was a regression from an earlier refactoring where the domain stopped being passed into the delete operation.

Now the replacement pricing group is also set as the domain default whenever the deleted group was the default. In addition, the delete operation validates its input on the server: a pricing group that is in use (default on its domain or assigned to customers) cannot be deleted without a replacement, and the replacement must be a different pricing group from the same domain. Previously these cases were only prevented by the browser form and could lead to a corrupted default setting or a database error.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-pricing-group.odin.shopsys.cloud
  - https://cz.mg-fix-pricing-group.odin.shopsys.cloud
  - https://mg-fix-pricing-group.odin.shopsys.cloud/sk
<!-- Replace -->
