### PR TITLE
Disable Luigi's Box for local Cypress storefront

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -68,6 +68,7 @@ services:
             - build
         environment:
             - CYPRESS_KEEP_TID=1
+            - LUIGIS_BOX_ENABLED_DOMAIN_IDS=
         volumes:
             - storefront:/home/node/app
         healthcheck:

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -73,6 +73,7 @@ services:
             - build
         environment:
             - CYPRESS_KEEP_TID=1
+            - LUIGIS_BOX_ENABLED_DOMAIN_IDS=
         volumes:
             - ./project-base/storefront:/home/node/app
         healthcheck:

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -71,6 +71,7 @@ services:
             - build
         environment:
             - CYPRESS_KEEP_TID=1
+            - LUIGIS_BOX_ENABLED_DOMAIN_IDS=
         volumes:
             - storefront:/home/node/app
         healthcheck:

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -76,6 +76,7 @@ services:
             - build
         environment:
             - CYPRESS_KEEP_TID=1
+            - LUIGIS_BOX_ENABLED_DOMAIN_IDS=
         volumes:
             - ./storefront:/home/node/app
         healthcheck:

--- a/project-base/storefront/cypress/smokeTests/smokeTests.cy.ts
+++ b/project-base/storefront/cypress/smokeTests/smokeTests.cy.ts
@@ -1,5 +1,6 @@
 import { staticData } from 'fixtures/demodata';
 import { checktHeadlineText } from 'support';
+import { formatConsoleArguments } from 'support/formatConsoleArguments';
 import { visitEntityByUuid } from 'support/navigation';
 import { TIDs } from 'tids';
 
@@ -337,17 +338,7 @@ context('Smoke tests', () => {
                     win.console.error = (...args) => {
                         // log the error so we can still see it in test output
                         originalConsoleError.apply(win.console, args);
-                        const serializedArgs = args.map((arg) => {
-                            if (typeof arg === 'object' && arg !== null) {
-                                try {
-                                    return JSON.stringify(arg, null, 2);
-                                } catch {
-                                    return String(arg);
-                                }
-                            }
-                            return String(arg);
-                        });
-                        consoleErrors.push(serializedArgs.join(' '));
+                        consoleErrors.push(formatConsoleArguments(args));
                     };
 
                     // intercept unhandled errors

--- a/project-base/storefront/cypress/support/formatConsoleArguments.ts
+++ b/project-base/storefront/cypress/support/formatConsoleArguments.ts
@@ -1,0 +1,37 @@
+const serializeConsoleArgument = (argument: unknown): string => {
+    if (typeof argument === 'object' && argument !== null) {
+        try {
+            return JSON.stringify(argument, null, 2) ?? String(argument);
+        } catch {
+            return String(argument);
+        }
+    }
+
+    return String(argument);
+};
+
+export const formatConsoleArguments = (args: unknown[]): string => {
+    const [format, ...values] = args;
+
+    if (typeof format !== 'string') {
+        return args.map(serializeConsoleArgument).join(' ');
+    }
+
+    let valueIndex = 0;
+    const formattedMessage = format.replace(/%[cdfioOs%]/g, (placeholder) => {
+        if (placeholder === '%%') {
+            return '%';
+        }
+
+        if (valueIndex >= values.length) {
+            return placeholder;
+        }
+
+        const value = values[valueIndex++];
+
+        return placeholder === '%c' ? '' : serializeConsoleArgument(value);
+    });
+    const remainingValues = values.slice(valueIndex).map(serializeConsoleArgument);
+
+    return [formattedMessage, ...remainingValues].join(' ');
+};

--- a/project-base/storefront/vitest/cypress/formatConsoleArguments.test.ts
+++ b/project-base/storefront/vitest/cypress/formatConsoleArguments.test.ts
@@ -1,0 +1,25 @@
+import { formatConsoleArguments } from 'cypress/support/formatConsoleArguments';
+import { describe, expect, test } from 'vitest';
+
+describe('formatConsoleArguments', () => {
+    test('replaces console format specifiers with their argument values', () => {
+        const formattedMessage = formatConsoleArguments([
+            'Suppressed GraphQL error during redirect handling: %s',
+            'Customer is not authorized.',
+        ]);
+
+        expect(formattedMessage).toBe('Suppressed GraphQL error during redirect handling: Customer is not authorized.');
+    });
+
+    test('serializes objects and appends arguments without a format specifier', () => {
+        const formattedMessage = formatConsoleArguments(['Request failed: %o', { status: 500 }, 'retry disabled']);
+
+        expect(formattedMessage).toBe('Request failed: {\n  "status": 500\n} retry disabled');
+    });
+
+    test('preserves format specifiers without a matching argument', () => {
+        const formattedMessage = formatConsoleArguments(['Progress: 50%%, detail: %s']);
+
+        expect(formattedMessage).toBe('Progress: 50%, detail: %s');
+    });
+});

--- a/upgrade-notes/storefront_20260909_131608.md
+++ b/upgrade-notes/storefront_20260909_131608.md
@@ -1,0 +1,3 @@
+#### Disable Luigi's Box for local Cypress storefront ([#4836](https://github.com/shopsys/shopsys/pull/4836))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Local Cypress runs now use a storefront configuration that matches the test backend, regardless of a developer's local Luigi's Box settings. This prevents smoke and acceptance tests from failing when the storefront attempts to request recommendations from a backend where Luigi's Box is intentionally disabled.

The behavior is consistent across monorepo and project-base Docker templates on Linux and macOS.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement-for-contributions).








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4233-fix-local-smoke-tests.odin.shopsys.cloud
  - https://cz.tc-ssp-4233-fix-local-smoke-tests.odin.shopsys.cloud
  - https://tc-ssp-4233-fix-local-smoke-tests.odin.shopsys.cloud/sk
<!-- Replace -->
