### PR TITLE
Prevent category submenu flicker on quick click

### DIFF
--- a/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
@@ -37,6 +37,7 @@ export const NavigationItem: FC<NavigationItemProps> = ({
 }) => {
     const { url } = useDomainConfig();
     const triggerRef = useRef<HTMLButtonElement>(null);
+    const isPointerInteractionRef = useRef(false);
     const [catalogUrl] = getInternationalizedStaticUrls(['/catalog'], url);
     const skeletonType = getNavigationItemSkeletonType(navigationItem, catalogUrl);
     const isLink = isNavigationItemLink(navigationItem);
@@ -89,6 +90,10 @@ export const NavigationItem: FC<NavigationItemProps> = ({
             className="group"
             ref={itemRef}
             onFocus={() => {
+                if (isPointerInteractionRef.current) {
+                    return;
+                }
+
                 if (isDropdownTrigger) {
                     onMenuOpenImmediately();
                 } else {
@@ -97,6 +102,18 @@ export const NavigationItem: FC<NavigationItemProps> = ({
             }}
             onKeyDown={handleKeyDown}
             onMouseEnter={handleMouseEnter}
+            onPointerCancel={() => {
+                isPointerInteractionRef.current = false;
+            }}
+            onPointerDown={() => {
+                isPointerInteractionRef.current = true;
+            }}
+            onPointerLeave={() => {
+                isPointerInteractionRef.current = false;
+            }}
+            onPointerUp={() => {
+                isPointerInteractionRef.current = false;
+            }}
         >
             {isLink && link !== null ? (
                 <ExtendedNextLink

--- a/project-base/storefront/vitest/components/Layout/Header/Navigation/Navigation.test.tsx
+++ b/project-base/storefront/vitest/components/Layout/Header/Navigation/Navigation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Navigation } from 'components/Layout/Header/Navigation/Navigation';
 import { DomainConfigProvider } from 'components/providers/DomainConfigProvider';
@@ -94,6 +94,43 @@ const renderNavigation = () =>
     );
 
 describe('Navigation', () => {
+    test('keeps a category submenu open after an immediate pointer click following hover', () => {
+        vi.useFakeTimers();
+
+        try {
+            renderNavigation();
+            const categoryButton = screen.getByRole('button', { name: 'Electronics' });
+
+            fireEvent.mouseEnter(categoryButton);
+            fireEvent.pointerDown(categoryButton, { pointerType: 'mouse' });
+            fireEvent.focus(categoryButton);
+            act(() => {
+                vi.advanceTimersByTime(0);
+            });
+            fireEvent.pointerUp(categoryButton, { pointerType: 'mouse' });
+            fireEvent.click(categoryButton);
+            act(() => {
+                vi.advanceTimersByTime(0);
+            });
+
+            expect(categoryButton).toHaveAttribute('aria-expanded', 'true');
+            expect(screen.getByRole('link', { name: 'Televisions' })).toBeVisible();
+
+            fireEvent.pointerDown(categoryButton, { pointerType: 'mouse' });
+            fireEvent.pointerUp(categoryButton, { pointerType: 'mouse' });
+            fireEvent.click(categoryButton);
+            act(() => {
+                vi.advanceTimersByTime(0);
+            });
+
+            expect(categoryButton).toHaveAttribute('aria-expanded', 'false');
+            expect(screen.queryByRole('link', { name: 'Televisions' })).not.toBeInTheDocument();
+        } finally {
+            vi.clearAllTimers();
+            vi.useRealTimers();
+        }
+    });
+
     test('renders a category submenu at full width inside the centered menu container', async () => {
         const user = userEvent.setup();
         renderNavigation();
@@ -102,12 +139,13 @@ describe('Navigation', () => {
 
         const categoryLink = await screen.findByRole('link', { name: 'Televisions' });
         const categoryGrid = categoryLink.closest('ul');
-        const overlay = document.querySelector('.fixed.bg-overlay-default');
 
         expect(categoryGrid).toHaveClass('grid-cols-4');
         expect(categoryGrid?.parentElement).toHaveClass('w-full', 'vl:max-w-default-max-width');
         expect(categoryGrid?.parentElement?.parentElement).not.toHaveClass('grid-cols-4');
-        expect(overlay).toHaveClass('z-overlay');
+        await waitFor(() => {
+            expect(document.querySelector('.fixed.bg-overlay-default')).toHaveClass('z-overlay');
+        });
     });
 
     test('closes an opened submenu when keyboard focus moves to an item without children', async () => {

--- a/upgrade-notes/storefront_20260909_135028.md
+++ b/upgrade-notes/storefront_20260909_135028.md
@@ -1,0 +1,3 @@
+#### Prevent category submenu flicker on quick click ([#4837](https://github.com/shopsys/shopsys/pull/4837))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Quickly clicking a category navigation item immediately after hovering over it could briefly open and then close its submenu, creating a visible flicker.

The submenu now remains open after this interaction. Keyboard navigation and the existing explicit click-to-close behavior remain unchanged.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4276-fix-navigation-dropdown-flicker.odin.shopsys.cloud
  - https://cz.tc-ssp-4276-fix-navigation-dropdown-flicker.odin.shopsys.cloud
  - https://tc-ssp-4276-fix-navigation-dropdown-flicker.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1789039376.781419 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4276-fix-navigation-dropdown-flicker.odin.shopsys.cloud
  - https://cz.tc-ssp-4276-fix-navigation-dropdown-flicker.odin.shopsys.cloud
  - https://tc-ssp-4276-fix-navigation-dropdown-flicker.odin.shopsys.cloud/sk
<!-- Replace -->
