### PR TITLE
Keep mobile search visible above the virtual keyboard

### DIFF
--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
@@ -33,6 +33,7 @@ export type AutocompleteSearchProps = {
     shouldFocusOnMount?: boolean;
     shouldRenderResultsOverlay?: boolean;
     onClearEmpty?: () => void;
+    onSearchSubmit?: () => void;
 };
 
 export const AutocompleteSearch: FC<AutocompleteSearchProps> = ({
@@ -44,6 +45,7 @@ export const AutocompleteSearch: FC<AutocompleteSearchProps> = ({
     shouldOpenPopupOnMount,
     shouldRenderResultsOverlay = true,
     onClearEmpty,
+    onSearchSubmit,
 }) => {
     const { t } = useTranslation();
     const { url } = useDomainConfig();
@@ -99,6 +101,7 @@ export const AutocompleteSearch: FC<AutocompleteSearchProps> = ({
                 query: { q: searchQueryValue },
             });
             setSearchQueryValue('');
+            onSearchSubmit?.();
         }
     };
 
@@ -165,6 +168,7 @@ export const AutocompleteSearch: FC<AutocompleteSearchProps> = ({
                             popupClassName={popupClassName}
                             showFavorites={showFavorites}
                             onClosePopupCallback={handleClosePopup}
+                            onSearchSubmit={onSearchSubmit}
                         />
                     )}
                 </AnimatePresence>

--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup.tsx
@@ -29,6 +29,7 @@ type AutocompleteProps = {
     favoritesData: TypeAutocompleteFavoritesQuery | undefined;
     popupClassName?: string;
     showFavorites: boolean;
+    onSearchSubmit?: () => void;
 };
 
 export const AutocompleteSearchPopup: FC<AutocompleteProps> = ({
@@ -39,6 +40,7 @@ export const AutocompleteSearchPopup: FC<AutocompleteProps> = ({
     favoritesData,
     popupClassName,
     showFavorites,
+    onSearchSubmit,
 }) => {
     const router = useRouter();
     const { t } = useTranslation();
@@ -133,6 +135,7 @@ export const AutocompleteSearchPopup: FC<AutocompleteProps> = ({
                                 variant="secondary"
                                 onClick={() => {
                                     onClosePopupCallback();
+                                    onSearchSubmit?.();
                                     router.push({
                                         pathname: searchUrl,
                                         query: { q: autocompleteSearchQueryValue },

--- a/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomSearchWithOverlay.tsx
+++ b/project-base/storefront/components/Layout/Header/MobileBottomNavigation/MobileBottomSearchWithOverlay.tsx
@@ -1,5 +1,5 @@
 import { AutocompleteSearch } from 'components/Layout/Header/AutocompleteSearch/AutocompleteSearch';
-import { type RefObject } from 'react';
+import { type RefObject, useEffect, useState } from 'react';
 import useTranslation from 'utils/i18n/useTranslationWrapper';
 
 type MobileBottomSearchWithOverlayProps = {
@@ -9,6 +9,26 @@ type MobileBottomSearchWithOverlayProps = {
 
 export const MobileBottomSearchWithOverlay: FC<MobileBottomSearchWithOverlayProps> = ({ searchInputRef, onClose }) => {
     const { t } = useTranslation();
+    const [visualViewportOffsetTop, setVisualViewportOffsetTop] = useState(0);
+
+    useEffect(() => {
+        const visualViewport = window.visualViewport;
+
+        if (!visualViewport) {
+            return undefined;
+        }
+
+        const updateVisualViewportOffsetTop = () => setVisualViewportOffsetTop(visualViewport.offsetTop);
+
+        updateVisualViewportOffsetTop();
+        visualViewport.addEventListener('resize', updateVisualViewportOffsetTop);
+        visualViewport.addEventListener('scroll', updateVisualViewportOffsetTop);
+
+        return () => {
+            visualViewport.removeEventListener('resize', updateVisualViewportOffsetTop);
+            visualViewport.removeEventListener('scroll', updateVisualViewportOffsetTop);
+        };
+    }, []);
 
     return (
         <>
@@ -19,7 +39,10 @@ export const MobileBottomSearchWithOverlay: FC<MobileBottomSearchWithOverlayProp
                 onClick={onClose}
             />
 
-            <div className="pointer-events-none fixed inset-x-0 top-5 z-aboveOverlay flex justify-center px-5">
+            <div
+                className="pointer-events-none fixed inset-x-0 top-5 z-aboveOverlay flex justify-center px-5"
+                style={{ transform: `translateY(${visualViewportOffsetTop}px)` }}
+            >
                 <div className="pointer-events-auto w-full max-w-xl">
                     <AutocompleteSearch
                         inputRef={searchInputRef}
@@ -28,6 +51,7 @@ export const MobileBottomSearchWithOverlay: FC<MobileBottomSearchWithOverlayProp
                         shouldOpenPopupOnMount
                         shouldRenderResultsOverlay={false}
                         onClearEmpty={onClose}
+                        onSearchSubmit={onClose}
                     />
                 </div>
             </div>

--- a/project-base/storefront/vitest/components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup.test.tsx
+++ b/project-base/storefront/vitest/components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AutocompleteSearchPopup } from 'components/Layout/Header/AutocompleteSearch/AutocompleteSearchPopup';
+import { type TypeAutocompleteSearchQuery } from 'graphql/requests/search/queries/AutocompleteSearchQuery.generated';
+import { TypeProductOrderingModeEnum } from 'graphql/types';
+import { describe, expect, test, vi } from 'vitest';
+
+const mockRouterPush = vi.fn();
+
+vi.mock('next/router', () => ({
+    useRouter: () => ({ push: mockRouterPush }),
+}));
+
+vi.mock('next-translate/useTranslation', () => ({
+    __esModule: true,
+    default: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+vi.mock('components/providers/DomainConfigProvider', () => ({
+    useDomainConfig: () => ({ url: 'https://example.com' }),
+}));
+
+vi.mock('utils/staticUrls/getInternationalizedStaticUrls', () => ({
+    getInternationalizedStaticUrls: (urls: string[]) => urls,
+}));
+
+vi.mock('components/Layout/Header/AutocompleteSearch/AutocompleteSearchBrandsResult', () => ({
+    AutocompleteSearchBrandsResult: () => <div>Brand results</div>,
+}));
+
+const autocompleteSearchResults = {
+    articlesSearch: [],
+    brandSearch: [{ __typename: 'Brand', name: 'Apple', slug: '/apple' }],
+    categoriesSearch: { __typename: 'CategoryConnection', totalCount: 0, edges: [] },
+    productsSearch: {
+        __typename: 'ProductConnection',
+        defaultOrderingMode: null,
+        edges: [],
+        orderingMode: TypeProductOrderingModeEnum.Relevance,
+        pageInfo: { hasNextPage: false },
+        productFilterOptions: {
+            __typename: 'ProductFilterOptions',
+            brands: [],
+            flags: [],
+            inStock: 0,
+            maximalPrice: '0',
+            minimalPrice: '0',
+            parameters: [],
+        },
+        totalCount: 0,
+    },
+} satisfies TypeAutocompleteSearchQuery;
+
+describe('AutocompleteSearchPopup', () => {
+    test('closes the mobile search overlay when navigating to all results', async () => {
+        const user = userEvent.setup();
+        const onClosePopupCallback = vi.fn();
+        const onSearchSubmit = vi.fn();
+
+        render(
+            <AutocompleteSearchPopup
+                areAutocompleteSearchDataFetching={false}
+                autocompleteSearchQueryValue="apple"
+                autocompleteSearchResults={autocompleteSearchResults}
+                favoritesData={undefined}
+                showFavorites={false}
+                onClosePopupCallback={onClosePopupCallback}
+                onSearchSubmit={onSearchSubmit}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'View all results' }));
+
+        expect(onClosePopupCallback).toHaveBeenCalledOnce();
+        expect(onSearchSubmit).toHaveBeenCalledOnce();
+        expect(mockRouterPush).toHaveBeenCalledWith({ pathname: '/search', query: { q: 'apple' } });
+    });
+});

--- a/project-base/storefront/vitest/components/Layout/Header/MobileBottomNavigation.test.tsx
+++ b/project-base/storefront/vitest/components/Layout/Header/MobileBottomNavigation.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MobileBottomNavigation } from 'components/Layout/Header/MobileBottomNavigation/MobileBottomNavigation';
 import { type ReactNode } from 'react';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
 
 vi.mock('next-translate/useTranslation', () => ({
     __esModule: true,
@@ -58,11 +62,14 @@ vi.mock('components/Layout/Header/MobileBottomNavigation/MobileBottomAccountDraw
 }));
 
 vi.mock('components/Layout/Header/AutocompleteSearch/AutocompleteSearch', () => ({
-    AutocompleteSearch: ({ inputRef, onClearEmpty }: any) => (
+    AutocompleteSearch: ({ inputRef, onClearEmpty, onSearchSubmit }: any) => (
         <div>
             <input aria-label="Search input" ref={inputRef} />
             <button type="button" onClick={onClearEmpty}>
                 Close mocked search
+            </button>
+            <button type="button" onClick={onSearchSubmit}>
+                Submit mocked search
             </button>
         </div>
     ),
@@ -112,5 +119,45 @@ describe('MobileBottomNavigation', () => {
 
         await waitFor(() => expect(screen.queryByLabelText('Search input')).not.toBeInTheDocument());
         expect(searchButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('closes search overlay after submitting a search', async () => {
+        const user = userEvent.setup();
+
+        render(<MobileBottomNavigation />);
+
+        const searchButton = screen.getByRole('button', { name: 'Search' });
+        await user.click(searchButton);
+        await user.click(screen.getByRole('button', { name: 'Submit mocked search' }));
+
+        expect(screen.queryByLabelText('Search input')).not.toBeInTheDocument();
+        expect(searchButton).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('keeps search input aligned with the visual viewport', async () => {
+        const visualViewport = new EventTarget() as EventTarget & { offsetTop: number };
+        visualViewport.offsetTop = 40;
+        vi.stubGlobal('visualViewport', visualViewport);
+
+        render(<MobileBottomNavigation />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+        const searchContainer = screen.getByLabelText('Search input').closest('.fixed');
+
+        await waitFor(() => expect(searchContainer).toHaveStyle({ transform: 'translateY(40px)' }));
+
+        act(() => {
+            visualViewport.offsetTop = 120;
+            visualViewport.dispatchEvent(new Event('scroll'));
+        });
+
+        await waitFor(() => expect(searchContainer).toHaveStyle({ transform: 'translateY(120px)' }));
+
+        act(() => {
+            visualViewport.offsetTop = 0;
+            visualViewport.dispatchEvent(new Event('resize'));
+        });
+
+        await waitFor(() => expect(searchContainer).toHaveStyle({ transform: 'translateY(0px)' }));
     });
 });

--- a/upgrade-notes/storefront_20260909_141706.md
+++ b/upgrade-notes/storefront_20260909_141706.md
@@ -1,0 +1,3 @@
+#### Keep mobile search visible above the virtual keyboard ([#4838](https://github.com/shopsys/shopsys/pull/4838))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Mobile customers can now keep the search field visible while typing with the virtual keyboard open. The search overlay follows the visible portion of the browser viewport, preventing the field from being pushed off-screen on affected iPhones.

The regular search experience remains unchanged when the browser does not move the visible viewport.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-4287-fix-mobile-search-input.odin.shopsys.cloud
  - https://cz.tc-ssp-4287-fix-mobile-search-input.odin.shopsys.cloud
  - https://tc-ssp-4287-fix-mobile-search-input.odin.shopsys.cloud/sk
<!-- Replace -->
