### PR TITLE
Add agent skill for creating admin CRUD controllers

### DIFF
--- a/.agents/skills/create-crud-controller/SKILL.md
+++ b/.agents/skills/create-crud-controller/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: create-crud-controller
+description: >
+  Create or extend an administration CRUD controller (list / detail / create / edit / delete
+  pages for an entity) built on Shopsys\AdministrationBundle\Controller\AbstractCrudController.
+  Use when the user asks for a new admin section, admin list, admin management page or
+  admin CRUD for an entity, or wants to change an existing CRUD controller (columns, form,
+  actions, hooks, role). Explains the pieces (controller, handler, form, datagrid, actions,
+  extension) and where each is documented and implemented.
+user_invocable: true
+version: 1.0.0
+---
+
+# create-crud-controller (monorepo)
+
+The canonical instructions for this skill are authored from the project perspective. **Read them first:**
+
+- `project-base/.agents/skills/create-crud-controller/SKILL.md`
+
+Then apply the monorepo delta (package-first + path/role remap):
+
+- `.agents/skills/monorepo-vs-project/SKILL.md`
+
+The method — controller → handler → datagrid → form → actions, the handler rules, the
+extension/hook mechanism, verification and the checklist — follows the canonical unchanged.
+What differs here is *where* the classes go, *which conventions* they follow, and that you
+are usually also the author of the docs and upgrade notes.
+
+## Where the code goes (package-first)
+
+A CRUD controller in the monorepo is framework code that every downstream project receives, so it lives in the administration bundle, not in `project-base/`:
+
+| Piece | Monorepo location | Namespace |
+|---|---|---|
+| Controller | `packages/administration/src/Controller/<Entity>Controller.php` | `Shopsys\AdministrationBundle\Controller` |
+| Handler | `packages/administration/src/Model/<Area>/<Entity>CrudHandler.php` | `Shopsys\AdministrationBundle\Model\<Area>` |
+| Entity, Facade, Data, DataFactory | `packages/framework/src/Model/<Area>/` (existing model layer) | `Shopsys\FrameworkBundle\Model\<Area>` |
+| Admin FormType | `packages/framework/src/Form/Admin/<Area>/<Entity>FormType.php` | `Shopsys\FrameworkBundle\Form\Admin\<Area>` |
+| Column / edit templates | `packages/administration/templates/content/<entity>/…` (`@ShopsysAdministration/content/<entity>/…`) | — |
+| Menu section constants | `packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php` | — |
+| Existing role constants | `packages/framework/src/Component/Security/Role/AdminRoleConstant.php` | — |
+
+`project-base/app/src/Controller/Admin/` is only for the rare project-specific case — typically a `#[CrudControllerExtension]` demonstrating how a project customises a bundle controller. The canonical's `vendor/shopsys/administration/src/…` and `vendor/shopsys/framework/src/…` paths are `packages/administration/src/…` and `packages/framework/src/…` here, and they are editable.
+
+Service registration needs nothing from you: `packages/administration/config/services.yaml` registers everything under `src/` (handlers included, regardless of the class-name suffix) and `src/Controller/` with `controller.service_arguments`. Keep the `…Handler` suffix anyway — downstream projects rely on it for their own service glob.
+
+## Conventions that replace the canonical's project rules
+
+Package code follows `.agents/skills/coding-conventions/SKILL.md`, which inverts the canonical's `final` / `private` / full-typehint rules:
+
+- Controller and handler classes are **not `final`**, constructor properties and helper methods are **`protected`** (`protected readonly Facade $facade`), so projects can extend them. The FormType stays `final` (Symfony requirement) — projects override it via `getExtendedTypes()` or the form-extension mechanism, and its option name follows the existing admin FormTypes (`'transportGroup' => $entity`).
+- Mark every overridden `configure*()`, `getEditTemplate()`, `getEditViewData()` and handler method with `#[Override]`; handler methods carry a `{@inheritdoc}` docblock plus a *why* line when the method does more than delegate (see `ProductReviewEditHandler`).
+- `Assert::isInstanceOf()` at the start of every handler method that receives `object` — the three shipped handlers are the pattern to copy.
+
+## Docs, translations, upgrade notes — you own them here
+
+- **Documentation is local** — `docs/administration/crud-controller/` (getting-started + reference), `docs/administration/datagrid/`, `docs/administration/admin-rights.md`, `docs/administration/administration-menu.md`. Search it with `.agents/skills/docs-researcher/SKILL.md` instead of docs.shopsys.com. When you change the CRUD component itself (`AbstractCrudController`, `CrudConfig`, handler or hook interfaces, `Datagrid`), update the matching reference page in the same PR.
+- **Translations**: `php phing translations-dump` (php-fpm container, `.agents/skills/shopsys-commands/SKILL.md`) writes the new `t()` keys and the auto-generated entity names into `packages/*/translations/*.po` — those `.po` changes are part of the package and belong in the commit (commit message conventions in `.agents/skills/commit-conventions/SKILL.md`).
+- **Upgrade notes** (`upgrade-notes/_template.md`, `/generate-upgrade-notes`) whenever a project has to react: a new CRUD controller that replaces a legacy `packages/framework/src/Controller/Admin/*Controller.php` (list the removed routes, templates and menu items; keep the old `AdminRoleConstant` role via `#[ForRole]` so administrator permissions survive), a new `ROLE_CRUD_*` role, or any signature change in the CRUD component. Note the `{pullRequestId}` placeholder is backfilled by `/adhoc-pr`.
+
+## Tests
+
+- Unit tests for CRUD-component code go to `packages/administration/tests/Unit/…` and run with `--configuration packages/administration/phpunit.xml` (`.agents/skills/test-writing/SKILL.md`).
+- The HTTP smoke test and functional tests still live in `project-base/app/tests/` — route customisation is `project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php`, and the entity with id `1` the smoke test requests comes from `project-base/app/src/DataFixtures/Demo/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Think: "Can other Shopsys projects reuse this?" → Yes = `/packages/`, No = `/p
 - **Find where code lives / how it works / example patterns** → `.agents/skills/codebase-locator`, `codebase-analyzer`, `codebase-pattern-finder`
 - **Deep research · plan · implement · tests** → `.agents/skills/research-codebase`, `create-plan`, `implement-plan`, `test-writing`
 - **Reading project-authored skills in the monorepo** (package-first + path remap) → `.agents/skills/monorepo-vs-project/SKILL.md`
+- **Admin CRUD controller for an entity** (controller, handler, datagrid, form, actions, extensions) → `.agents/skills/create-crud-controller/SKILL.md`
 - **Commit rules & interactive grouped commits** → `.agents/skills/commit-conventions/SKILL.md`, `.agents/skills/commit/SKILL.md`
 - **Upgrade notes**: when asked to generate them, use `/generate-upgrade-notes` instead of analyzing commits by hand.
 - **More** — the list above isn't exhaustive; browse `.agents/skills/` for the full set.

--- a/project-base/.agents/skills/create-crud-controller/SKILL.md
+++ b/project-base/.agents/skills/create-crud-controller/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: create-crud-controller
+description: >
+  Create or extend an administration CRUD controller (list / detail / create / edit / delete
+  pages for an entity) built on Shopsys\AdministrationBundle\Controller\AbstractCrudController.
+  Use when the user asks for a new admin section, admin list, admin management page or
+  admin CRUD for an entity, or wants to change an existing CRUD controller (columns, form,
+  actions, hooks, role). Explains the pieces (controller, handler, form, datagrid, actions,
+  extension) and where each is documented and implemented.
+user_invocable: true
+version: 1.0.0
+---
+
+# Create a CRUD controller for the administration
+
+A CRUD controller gives an entity a complete admin UI — a datagrid list page and, once a
+handler is registered, detail / create / edit / delete pages — from a single class with a
+few `configure*()` methods. It replaces the hand-written "controller + grid factory + form
+handling + flash messages + menu item + routes + role" boilerplate the older admin
+controllers still carry.
+
+**Use it** for any new admin section that manages one entity through its facade.
+**Don't use it** for pages that are not a record list (dashboards, settings forms,
+wizards) or where the edit page is a bespoke multi-tab workflow (e.g. the order detail) —
+those stay plain `AdminBaseController` controllers.
+
+Assumption: the entity already has the standard model layer — `Facade` (`getById`,
+`create`, `edit`, `delete`), `Data` object + `DataFactory` (`create`, `createFrom<Entity>`)
+and an admin `FormType`. If it doesn't, build that first (`shopsys-architecture` skill,
+model architecture docs) — the CRUD controller only wires it together.
+
+## Where to read more
+
+Read the source first — the docblocks are complete and the code is short. Docs second.
+
+| Topic | Source (read-only) | Docs |
+|---|---|---|
+| Base controller: `configure*()` hooks, actions, list-domain helpers | `vendor/shopsys/administration/src/Controller/AbstractCrudController.php` | [Configuration reference](https://docs.shopsys.com/en/latest/administration/crud-controller/reference/crud-controller/) |
+| `CrudConfig` — every configurable option | `vendor/shopsys/administration/src/Component/Config/CrudConfig.php` | same page, section *CRUD Config* |
+| Handler interfaces | `vendor/shopsys/administration/src/Component/Crud/Handler/` | [Handlers](https://docs.shopsys.com/en/latest/administration/crud-controller/reference/handlers/) |
+| Hook interfaces (before/after/onError) | `vendor/shopsys/administration/src/Component/Crud/Extension/` | same page, section *Hooks System* |
+| Form configurator (FormType vs builder) | `vendor/shopsys/administration/src/Component/Crud/Form/CrudFormConfigurator.php` | *configureForm* section of the configuration reference |
+| Datagrid, fields, row actions | `vendor/shopsys/administration/src/Component/Datagrid/` | [Datagrid](https://docs.shopsys.com/en/latest/administration/datagrid/), [Fields](https://docs.shopsys.com/en/latest/administration/datagrid/fields/), [Row actions](https://docs.shopsys.com/en/latest/administration/datagrid/row-actions/) |
+| Top actions (`Action`, `ActionsConfig`) | `vendor/shopsys/administration/src/Component/Action/`, `.../Component/Config/ActionsConfig.php` | [Actions](https://docs.shopsys.com/en/latest/administration/crud-controller/reference/actions/) |
+| Extending an existing CRUD controller | `vendor/shopsys/administration/src/Controller/AbstractCrudControllerExtension.php` | [Extending](https://docs.shopsys.com/en/latest/administration/crud-controller/getting-started/extending-existing-crud-controller/) |
+| Roles, `#[ForRole]`, `#[CanView]`… | `vendor/shopsys/framework/src/Component/Security/Attribute/` | [Admin rights](https://docs.shopsys.com/en/latest/administration/admin-rights/) |
+| Menu sections and positioning | `vendor/shopsys/framework/src/Model/AdminNavigation/SideMenuBuilder.php` (constants) | [Administration menu](https://docs.shopsys.com/en/latest/administration/administration-menu/#positioning-menu-items) |
+| Page templates you can override | `vendor/shopsys/administration/templates/crud/{list,detail,new,edit}.html.twig` | — |
+
+Working examples shipped with the platform (`vendor/shopsys/administration/src/`):
+
+- `Controller/TransportGroupController.php` + `Model/Transport/TransportGroupCrudHandler.php` — the minimal full CRUD: FormType, one column, drag-and-drop ordering, `#[ForRole]`, menu positioning.
+- `Controller/BlogArticleAuthorController.php` — full CRUD plus a custom edit template with an extra grid (`getEditTemplate()` / `getEditViewData()`).
+- `Controller/ProductReviewController.php` + `Model/ProductReview/ProductReviewEditHandler.php` — edit-only handler, `configureQuery()` with computed columns, templates per column, domain quick filter, `disable()` by feature flag.
+
+## What you get and how it fits together
+
+```
+#[CrudController(Entity::class)]  Controller  ── configure(CrudConfig)         menu, names, route prefix, role section, handlers, domain control
+                                              ── configureDatagrid(Datagrid)  list columns, ordering, drag&drop, row actions
+                                              ── configureQuery(QueryBuilder) list DQL (root alias is `o`)
+                                              ── configureForm(...)           create/edit form: useFormType() OR useBuilder()
+                                              ── configureActions(...)        top buttons per page (ActionType::LIST/EDIT/…)
+                                              ── getEditTemplate()/getEditViewData()  custom edit page
+Handler (implements *HandlerInterface)        ── getById / createData / create / createDataFromEntity / edit / delete → delegates to the Facade
+Entity implements Presentable                 ── toHumanReadable() used in titles, breadcrumbs, flash messages
+Extension (#[CrudControllerExtension])        ── same configure*() methods + before/after/onError hooks, for controllers you don't own
+```
+
+- **Routes** are generated from the controller class name with the `Controller` / `CrudController`
+  suffix stripped: `PriceListController` → `/admin/price-list/`, route names
+  `admin_crud_price_list_{list|detail|create|edit|delete}` (`{entityId}` param). `setRoutePrefix()` adds a segment in front.
+- **Role** `ROLE_CRUD_<CONTROLLER_NAME>` is generated and registered in the role matrix
+  automatically. Put `#[ForRole(AdminRoleConstant::ROLE_X)]` on the class to reuse an
+  existing role instead — then no own role is registered.
+- **Menu item** and **page titles / breadcrumbs** are derived from the entity class name
+  (singular/plural inflection, auto-registered translation keys). Override only when the
+  inflection is wrong or the label should differ (`setEntityNameSingular/Plural`, `setMenuTitle`).
+- **Actions are enabled by handlers.** Only List is on by default; registering a handler
+  enables the actions its interface covers. `enableAction()` / `disableAction()` only work
+  for actions that have a handler.
+- **Default row actions** (edit, delete) and the **New** top button appear automatically
+  when the matching action is enabled — you don't add them.
+
+## Workflow
+
+### 1. Controller
+
+`app/src/Controller/Admin/<Entity>Controller.php`:
+
+```php
+#[CrudController(<Entity>::class)]
+// #[ForRole(AdminRoleConstant::ROLE_…)]  ← only to reuse an existing role
+final class <Entity>Controller extends AbstractCrudController
+{
+    #[Override]
+    public function configure(CrudConfig $config): void
+    {
+        $config
+            ->setMenuSection(SideMenuBuilder::ROOT_…, SideMenuBuilder::SECTION_…, ['after' => SideMenuBuilder::LIST_…])
+            ->registerHandler(<Entity>CrudHandler::class);
+    }
+}
+```
+
+Nothing else to register — `App\Controller\` is already a service resource in
+`app/config/services.yaml`, and `AbstractCrudController` carries the
+`shopsys.admin.crud_controllers` autoconfigure tag that the bundle's compiler passes and
+route loader pick up.
+
+`AbstractCrudController` receives its own dependencies through `#[Required]` setters, so
+your constructor is free for your services (see `BlogArticleAuthorController`).
+
+`CrudConfig` options (all fluent): `setEntityNameSingular/Plural`, `setMenuTitle`,
+`setMenuSection(section, submenu, position)`, `setMenuIcon` (root-level items only),
+`visibleInMenu`, `setRoutePrefix`, `setCustomRoleSection` (constants in
+`AdminRoleSectionsProvider`; default = menu section), `registerHandler` / `unregisterHandler`,
+`enableAction` / `disableAction`, `setListDomainControl`, `disable` (hide the whole controller,
+e.g. behind a feature flag).
+
+### 2. Handler
+
+`app/src/Model/<Entity>/<Entity>CrudHandler.php` (or `…EditHandler`, `…DeleteHandler` when
+narrower). Pick the narrowest interface from `Shopsys\AdministrationBundle\Component\Crud\Handler`:
+
+| Interface | Adds | Enables |
+|---|---|---|
+| `ReadHandlerInterface` | `getById(int): Presentable` | detail |
+| `DeleteHandlerInterface` | `delete(object)` | delete (+ detail) |
+| `EditHandlerInterface` | `createDataFromEntity(object): object`, `edit(object, object)` | edit (+ detail) |
+| `CreateHandlerInterface` | `createData(): object`, `create(object): Presentable` | create (+ detail) |
+| `CrudHandlerInterface` | all of the above | everything |
+
+Rules that bite:
+
+- Never implement the bare `HandlerInterface` — it's only a marker for service discovery.
+- `getById()` **must return a `Presentable`** — the entity has to implement
+  `Shopsys\FrameworkBundle\Component\Utils\Presentable` (`toHumanReadable()`), otherwise the
+  CRUD registry throws a `RuntimeException` the first time the controller is loaded. Let
+  `getById()` throw the facade's not-found exception (they extend `NotFoundHttpException`, so
+  the page is a 404).
+- One handler per action; `CrudHandlerInterface` claims all actions, so it cannot be mixed
+  with other handlers on the same controller. Replace a handler with
+  `unregisterHandler()` + `registerHandler()`.
+- Handlers are plain services. The `App\` resource glob in `app/config/services.yaml`
+  matches class names ending in `Handler` — keep that suffix or register the service by hand.
+- Start each method with `Assert::isInstanceOf($entity, <Entity>::class)` (see
+  `TransportGroupCrudHandler`) — the interface is typed `object`.
+- Handlers hold no business logic. Everything goes through the facade; a handler may only
+  add access filtering (see `ProductReviewEditHandler::getById()`).
+
+### 3. List page
+
+```php
+#[Override]
+protected function configureDatagrid(Datagrid $datagrid): void
+{
+    $datagrid
+        ->add('name', ['label' => t('Name')])
+        ->add('domainId', ['label' => t('Domain')])            // only if $this->domain->isMultidomain()
+        ->add('status', ['label' => t('Status'), 'virtual' => true, 'property' => 'computedStatus',
+                         'template' => '@ShopsysAdministration/content/…/grid/status.html.twig']);
+    $datagrid->setDefaultOrder('name', OrderingEnum::ASC);     // or enableDragAndDrop('position')
+    $datagrid->actions()->add(RowAction::create('publish', t('Publish'), 'eye')->linkToRoute(…));
+}
+
+#[Override]
+protected function configureQuery(QueryBuilder $queryBuilder): void
+{
+    // root entity alias is always `o`
+    $queryBuilder->addSelect('CASE … END AS computedStatus')->andWhere('o.deleted = false');
+}
+```
+
+Field options: `label`, `visible`, `sortable`, `virtual` (not selected from the entity —
+pair with `property` or `transform`), `property` (DQL path, e.g. `product.id`), `template`,
+`transform`, `help`. Datagrid methods: `add` / `update` / `remove` / `reorder`,
+`setDefaultOrder`, `setPagination`, `enableDragAndDrop(field)`, `actions()` (row actions:
+`add` / `update` / `delete` / `reorder`).
+
+**Multi-domain lists**: `setListDomainControl(CrudListDomainControl::QUICK_FILTER|SWITCHER, $allowedDomainIds)`
+in `configure()`. For entities implementing `DomainSeparatedEntityInterface` the domain
+condition is applied for you; otherwise use `addListDomainIdsCondition($qb, 'x.domainId')`,
+`getEffectiveListDomainIds()` or `getSelectedListDomainId()` in `configureQuery()` — the
+configuration reference has the join-vs-subselect guidance.
+
+### 4. Form
+
+```php
+#[Override]
+protected function configureForm(CrudFormConfigurator $formConfigurator, ?object $entity = null): void
+{
+    $formConfigurator->useFormType(<Entity>FormType::class, ['<entity>' => $entity]);   // $entity is null on create
+}
+```
+
+`useFormType()` and `useBuilder()` are mutually exclusive (`CrudFormAlreadyConfiguredException`).
+Prefer a FormType — it's reusable, testable and the option name (`'brand' => $entity`)
+follows the existing admin FormTypes. `useBuilder()` is for tiny forms and is the only mode
+extensions can add fields to. `setFormOption()` must be called before `useBuilder()`.
+
+### 5. Top actions, custom routes, templates (optional)
+
+- `configureActions(ActionsConfig $actions)`: `$actions->add(ActionType::EDIT, Action::create('name', t('Label'))->linkToRoute(...)->displayIf(...))`,
+  `update()`, `remove()`. `linkToRoute` / `displayIf` closures receive the edited entity on
+  EDIT and `null` elsewhere. `linkToCrud(OtherController::class, ActionType::LIST)` links between CRUDs.
+- Custom endpoints are ordinary `#[Route]` methods on the same controller; guard them with
+  `#[CanView]` / `#[CanEdit]` / `#[CanDelete]` (no role needed — they fall back to the
+  controller's role) and `#[CsrfProtection]` for state-changing GETs (the action link then
+  carries the token automatically).
+- Edit page with extra content: override `getEditTemplate()` (extend
+  `@ShopsysAdministration/crud/edit.html.twig`) and `getEditViewData()`.
+
+### 6. Extending a CRUD controller you don't own
+
+`app/src/Controller/Admin/<Entity>ControllerExtension.php`:
+
+```php
+#[CrudControllerExtension(crudController: \Shopsys\AdministrationBundle\Controller\<Entity>Controller::class)]
+final class <Entity>ControllerExtension extends AbstractCrudControllerExtension implements CrudEditHookExtensionInterface
+{
+    public function configureDatagrid(Datagrid $datagrid): void { $datagrid->remove('…')->add('…', […]); }
+    public function beforeEdit(object $entity, object $data): void {}
+    public function afterEdit(object $entity, object $data): void {}
+    public function onEditError(object $entity, object $data, Throwable $exception): void {}
+}
+```
+
+- Same `configure*()` methods as the controller; runs after the original (and after other
+  extensions in `priority` order — `App\` extensions without a priority run last).
+- Hooks: `CrudCreate|Edit|DeleteHookExtensionInterface` — run inside the same DB transaction;
+  an exception in a hook rolls everything back. Add your own flash message to replace the
+  default one; call `addErrorFlash()` in `on*Error` for a custom error text.
+- `#[ForRole]` on the extension overrides the extended controller's role.
+- Don't extend the controller class itself and don't re-register it — extensions are the
+  supported mechanism, and the admin CRUD controllers in `vendor/` are not `final` only
+  because of the framework's own conventions.
+
+## Verify
+
+1. Clear cache and open `/admin/<controller-name>/` — the item appears in the configured menu
+   section; open create, edit, detail, delete.
+2. New translation keys (`t()` in labels, `toHumanReadable()`, entity names): `php phing translations-dump`
+   in the php-fpm container and fill the `.po` files (`shopsys-commands` skill).
+3. Tests (`test-writing` skill): the HTTP smoke test discovers the new routes on its own —
+   `{entityId}` gets `1`, `_delete` routes get a CSRF token and expect a 302. Make sure demo
+   data contains the entity with id 1 or add a `customizeByRouteName()` entry in
+   `app/tests/App/Smoke/Http/RouteConfigCustomization.php`. Cover the handler's
+   non-trivial logic (filters, access rules) with a functional test; the facade is tested on
+   its own.
+4. `php phing standards-fix` and PHPStan; a new `#[ForRole]`-less controller adds a
+   `ROLE_CRUD_*` row to the administrator role matrix — check the role settings page renders.
+
+## Checklist
+
+- [ ] Entity implements `Presentable`; `toHumanReadable()` never throws and includes an identifier.
+- [ ] Controller has `#[CrudController(Entity::class)]`, extends `AbstractCrudController`, lives in `app/src/Controller/Admin/`.
+- [ ] Handler implements the narrowest sufficient interface, class name ends with `Handler`, asserts types, delegates to the facade.
+- [ ] `configure()`: menu section (+ position), handler registered, role section / `#[ForRole]` decided consciously.
+- [ ] Datagrid columns labelled with `t()`; default order or drag-and-drop set; domain column only in multidomain.
+- [ ] Form via an existing/new admin `FormType` (builder only for trivial forms).
+- [ ] Smoke test passes for all five routes; translations dumped; standards + PHPStan green.

--- a/project-base/AGENTS.md
+++ b/project-base/AGENTS.md
@@ -23,6 +23,7 @@ A project built on Shopsys Platform: Symfony/PHP backend (`app/`), Next.js/React
 ## Skills — the rest lives here
 
 - **Architecture & how to extend** (where code lives, Entity Extension, vendor overrides, Data/Factory/Facade, docs links) → `.agents/skills/shopsys-architecture/SKILL.md`
+- **Admin CRUD controller for an entity** (controller, handler, datagrid, form, actions, extending a bundle CRUD) → `.agents/skills/create-crud-controller/SKILL.md`
 - **Commands** (build, DB, tests, checks, schema) → `.agents/skills/shopsys-commands/SKILL.md`
 - **Coding conventions & docblocks** → `.agents/skills/coding-conventions/SKILL.md`
 - **Find where code lives** → `.agents/skills/codebase-locator/SKILL.md`


### PR DESCRIPTION
#### Description, the reason for the PR

:warning: **Stacked on #4842** (PHPStan support for `Webmozart\Assert` calls) - merge that PR first, then retarget this one to `20.0`. #4795 is stacked on top of this PR and updates the skill for the configurable CRUD templates.

Adds the `create-crud-controller` agent skill, so AI agents (and developers reading `.agents/skills/`) know how to build or extend an administration CRUD controller without piecing it together from the docs each time.

The skill is not a copy of the documentation. It explains how the pieces fit together — the controller with its `configure*()` methods, the handler interfaces and what each one enables, the datagrid and query, the two form modes, top and row actions, extensions and hooks — and points to the exact source files and documentation pages for the details. It also lists the rules that usually bite (entity must implement `Presentable`, one handler per action, `useFormType()` vs. `useBuilder()` exclusivity, handler service discovery), the shipped controllers to copy from, and how to verify the result (smoke test, translations, standards).

There are two copies, following the existing convention for shared skills: the canonical one in `project-base/.agents/skills/` is written from the perspective of a downstream project (`app/src/…`, read-only `vendor/shopsys/…`, docs.shopsys.com links) and ships with the project-base split; the monorepo copy in `.agents/skills/` is a stub that applies the package-first delta — where the classes go in `packages/administration`, the `protected`/non-`final` conventions, local docs, `.po` translations, upgrade notes and package tests. Both `AGENTS.md` files link the new skill.

#### Fixes issues
N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)









----
:globe_with_meridians: Live Preview:
  - https://jg-create-crud-controller-skill.odin.shopsys.cloud
  - https://cz.jg-create-crud-controller-skill.odin.shopsys.cloud
  - https://jg-create-crud-controller-skill.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1789147413.728669 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-create-crud-controller-skill.odin.shopsys.cloud
  - https://cz.jg-create-crud-controller-skill.odin.shopsys.cloud
  - https://jg-create-crud-controller-skill.odin.shopsys.cloud/sk
<!-- Replace -->
