### PR TITLE
PHPStan now understands Webmozart Assert calls in CRUD handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -222,6 +222,7 @@
         "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-symfony": "^2.0.6",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^12.5",
         "psr/event-dispatcher": "^1.0.0",
         "shipmonk/dead-code-detector": "^1.3",

--- a/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
+++ b/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\DeleteHandlerInterface;
+use Webmozart\Assert\Assert;
 
 class OrderDeleteHandler implements DeleteHandlerInterface
 {
@@ -31,10 +32,20 @@ class OrderDeleteHandler implements DeleteHandlerInterface
 
     public function delete(object $entity): void
     {
+        Assert::isInstanceOf($entity, Order::class);
+
         $this->orderFacade->deleteById($entity->getId());
     }
 }
 ```
+
+!!! tip "Narrow the `object` parameters with `Assert::isInstanceOf()`"
+
+    Handler interfaces declare entities and data objects as plain `object`, because the interfaces are shared by all CRUD controllers.
+    Start every method that receives an entity or a data object with `Assert::isInstanceOf()` (from `webmozart/assert`).
+    The assert fails fast with a clear message when the handler is registered for a wrong entity, and thanks to
+    the `phpstan/phpstan-webmozart-assert` extension PHPStan narrows the type, so calls like `$entity->getId()`
+    or passing `$data` to a typed facade method are analysed properly instead of being reported as errors.
 
 ## 2. Register the Handler in Your Controller
 
@@ -77,6 +88,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
+use Webmozart\Assert\Assert;
 
 class OrderEditHandler implements EditHandlerInterface
 {
@@ -93,11 +105,16 @@ class OrderEditHandler implements EditHandlerInterface
 
     public function createDataFromEntity(object $entity): object
     {
+        Assert::isInstanceOf($entity, Order::class);
+
         return $this->orderDataFactory->createFromOrder($entity);
     }
 
     public function edit(object $entity, object $data): void
     {
+        Assert::isInstanceOf($entity, Order::class);
+        Assert::isInstanceOf($data, OrderData::class);
+
         $this->orderFacade->edit($entity->getId(), $data);
     }
 }
@@ -115,6 +132,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface;
+use Webmozart\Assert\Assert;
 
 class OrderCreateHandler implements CreateHandlerInterface
 {
@@ -136,6 +154,8 @@ class OrderCreateHandler implements CreateHandlerInterface
 
     public function create(object $data): object
     {
+        Assert::isInstanceOf($data, OrderData::class);
+
         return $this->orderFacade->create($data);
     }
 }
@@ -153,6 +173,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\CrudHandlerInterface;
+use Webmozart\Assert\Assert;
 
 class OrderCrudHandler implements CrudHandlerInterface
 {
@@ -169,16 +190,23 @@ class OrderCrudHandler implements CrudHandlerInterface
 
     public function delete(object $entity): void
     {
+        Assert::isInstanceOf($entity, Order::class);
+
         $this->orderFacade->deleteById($entity->getId());
     }
 
     public function createDataFromEntity(object $entity): object
     {
+        Assert::isInstanceOf($entity, Order::class);
+
         return $this->orderDataFactory->createFromOrder($entity);
     }
 
     public function edit(object $entity, object $data): void
     {
+        Assert::isInstanceOf($entity, Order::class);
+        Assert::isInstanceOf($data, OrderData::class);
+
         $this->orderFacade->edit($entity->getId(), $data);
     }
 
@@ -189,6 +217,8 @@ class OrderCrudHandler implements CrudHandlerInterface
 
     public function create(object $data): object
     {
+        Assert::isInstanceOf($data, OrderData::class);
+
         return $this->orderFacade->create($data);
     }
 }

--- a/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
+++ b/docs/administration/crud-controller/getting-started/adding-create-edit-and-delete-actions.md
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\DeleteHandlerInterface;
+use Shopsys\FrameworkBundle\Component\Utils\Presentable;
 use Webmozart\Assert\Assert;
 
 class OrderDeleteHandler implements DeleteHandlerInterface
@@ -25,12 +26,12 @@ class OrderDeleteHandler implements DeleteHandlerInterface
     ) {
     }
 
-    public function getById(int $id): object
+    public function getById(int $id): Presentable
     {
         return $this->orderFacade->getById($id);
     }
 
-    public function delete(object $entity): void
+    public function delete(Presentable $entity): void
     {
         Assert::isInstanceOf($entity, Order::class);
 
@@ -41,7 +42,7 @@ class OrderDeleteHandler implements DeleteHandlerInterface
 
 !!! tip "Narrow the `object` parameters with `Assert::isInstanceOf()`"
 
-    Handler interfaces declare entities and data objects as plain `object`, because the interfaces are shared by all CRUD controllers.
+    Handler interfaces declare data objects as plain `object` and entities as the generic `Presentable` (or `object`), because the interfaces are shared by all CRUD controllers.
     Start every method that receives an entity or a data object with `Assert::isInstanceOf()` (from `webmozart/assert`).
     The assert fails fast with a clear message when the handler is registered for a wrong entity, and thanks to
     the `phpstan/phpstan-webmozart-assert` extension PHPStan narrows the type, so calls like `$entity->getId()`
@@ -88,6 +89,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\EditHandlerInterface;
+use Shopsys\FrameworkBundle\Component\Utils\Presentable;
 use Webmozart\Assert\Assert;
 
 class OrderEditHandler implements EditHandlerInterface
@@ -98,7 +100,7 @@ class OrderEditHandler implements EditHandlerInterface
     ) {
     }
 
-    public function getById(int $id): object
+    public function getById(int $id): Presentable
     {
         return $this->orderFacade->getById($id);
     }
@@ -132,6 +134,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\CreateHandlerInterface;
+use Shopsys\FrameworkBundle\Component\Utils\Presentable;
 use Webmozart\Assert\Assert;
 
 class OrderCreateHandler implements CreateHandlerInterface
@@ -142,7 +145,7 @@ class OrderCreateHandler implements CreateHandlerInterface
     ) {
     }
 
-    public function getById(int $id): object
+    public function getById(int $id): Presentable
     {
         return $this->orderFacade->getById($id);
     }
@@ -152,7 +155,7 @@ class OrderCreateHandler implements CreateHandlerInterface
         return $this->orderDataFactory->create();
     }
 
-    public function create(object $data): object
+    public function create(object $data): Presentable
     {
         Assert::isInstanceOf($data, OrderData::class);
 
@@ -173,6 +176,7 @@ declare(strict_types=1);
 namespace App\Model\Order;
 
 use Shopsys\AdministrationBundle\Component\Crud\Handler\CrudHandlerInterface;
+use Shopsys\FrameworkBundle\Component\Utils\Presentable;
 use Webmozart\Assert\Assert;
 
 class OrderCrudHandler implements CrudHandlerInterface
@@ -183,12 +187,12 @@ class OrderCrudHandler implements CrudHandlerInterface
     ) {
     }
 
-    public function getById(int $id): object
+    public function getById(int $id): Presentable
     {
         return $this->orderFacade->getById($id);
     }
 
-    public function delete(object $entity): void
+    public function delete(Presentable $entity): void
     {
         Assert::isInstanceOf($entity, Order::class);
 
@@ -215,7 +219,7 @@ class OrderCrudHandler implements CrudHandlerInterface
         return $this->orderDataFactory->create();
     }
 
-    public function create(object $data): object
+    public function create(object $data): Presentable
     {
         Assert::isInstanceOf($data, OrderData::class);
 

--- a/docs/administration/crud-controller/reference/handlers.md
+++ b/docs/administration/crud-controller/reference/handlers.md
@@ -41,6 +41,29 @@ Implement only the interface that matches your needs:
 
     `HandlerInterface` is a base marker interface used only for automatic service registration. Do not implement it directly - it provides no functionality. Always implement one of the specific handler interfaces instead.
 
+### Narrowing `object` Parameters
+
+The handler interfaces declare entities and data objects as plain `object` (or `Presentable`), because they are shared by every CRUD controller. Your handler, however, works with one concrete entity and its data object, so narrow the type at the start of every method that receives them:
+
+```php
+use Webmozart\Assert\Assert;
+
+public function edit(object $entity, object $data): void
+{
+    Assert::isInstanceOf($entity, Order::class);
+    Assert::isInstanceOf($data, OrderData::class);
+
+    $this->orderFacade->edit($entity->getId(), $data);
+}
+```
+
+The assert has two purposes:
+
+- **Fail fast** - a handler registered for a wrong entity throws an `InvalidArgumentException` with a clear message instead of failing somewhere deep in the facade
+- **Static analysis** - PHPStan understands `Assert::isInstanceOf()` thanks to the `phpstan/phpstan-webmozart-assert` extension (enabled in `phpstan.neon`), so the following code is analysed with the concrete type and calls like `$entity->getId()` or passing `$data` to a typed facade method are not reported as errors
+
+Do not skip the assert just because the method "only" forwards the object to the facade - the facade methods are typed, and without the narrowing PHPStan reports the call as passing `object` where the concrete class is expected.
+
 ### Registering Handlers
 
 After creating your handler, register it in your CRUD controller's `configure()` method:

--- a/packages/administration/composer.json
+++ b/packages/administration/composer.json
@@ -52,6 +52,7 @@
         "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-symfony": "^2.0.6",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^12.5",
         "shopsys/biome-config": "20.0.x-dev",
         "shopsys/coding-standards": "20.0.x-dev"

--- a/packages/administration/phpstan.neon
+++ b/packages/administration/phpstan.neon
@@ -7,4 +7,5 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/shopsys/coding-standards/extension.neon

--- a/packages/administration/src/Model/Blog/Author/BlogArticleAuthorCrudHandler.php
+++ b/packages/administration/src/Model/Blog/Author/BlogArticleAuthorCrudHandler.php
@@ -8,6 +8,7 @@ use Override;
 use Shopsys\AdministrationBundle\Component\Crud\Handler\CrudHandlerInterface;
 use Shopsys\FrameworkBundle\Component\Utils\Presentable;
 use Shopsys\FrameworkBundle\Model\Blog\Author\BlogArticleAuthor;
+use Shopsys\FrameworkBundle\Model\Blog\Author\BlogArticleAuthorData;
 use Shopsys\FrameworkBundle\Model\Blog\Author\BlogArticleAuthorDataFactory;
 use Shopsys\FrameworkBundle\Model\Blog\Author\BlogArticleAuthorFacade;
 use Webmozart\Assert\Assert;
@@ -35,18 +36,25 @@ class BlogArticleAuthorCrudHandler implements CrudHandlerInterface
     #[Override]
     public function create(object $data): Presentable
     {
+        Assert::isInstanceOf($data, BlogArticleAuthorData::class);
+
         return $this->blogArticleAuthorFacade->create($data);
     }
 
     #[Override]
     public function createDataFromEntity(object $entity): object
     {
+        Assert::isInstanceOf($entity, BlogArticleAuthor::class);
+
         return $this->blogArticleAuthorDataFactory->createFromBlogArticleAuthor($entity);
     }
 
     #[Override]
     public function edit(object $entity, object $data): void
     {
+        Assert::isInstanceOf($entity, BlogArticleAuthor::class);
+        Assert::isInstanceOf($data, BlogArticleAuthorData::class);
+
         $this->blogArticleAuthorFacade->edit($entity->getId(), $data);
     }
 

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -134,6 +134,7 @@
         "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-symfony": "^2.0.6",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^12.5",
         "psr/event-dispatcher": "^1.0.0",
         "shopsys/biome-config": "20.0.x-dev",

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -24,4 +24,5 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/shopsys/coding-standards/extension.neon

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -254,10 +254,11 @@ class OrderFacade
             $orderItemData->totalPriceWithVat = null;
             $orderItemData->totalPriceWithoutVat = null;
         } else {
-            Assert::allNotNull(
-                [$orderItemData->unitPriceWithVat, $orderItemData->unitPriceWithoutVat, $orderItemData->totalPriceWithVat, $orderItemData->totalPriceWithoutVat],
-                'When not using price calculation for an order item, all prices must be filled.',
-            );
+            $message = 'When not using price calculation for an order item, all prices must be filled.';
+            Assert::notNull($orderItemData->unitPriceWithVat, $message);
+            Assert::notNull($orderItemData->unitPriceWithoutVat, $message);
+            Assert::notNull($orderItemData->totalPriceWithVat, $message);
+            Assert::notNull($orderItemData->totalPriceWithoutVat, $message);
         }
     }
 

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -55,6 +55,7 @@
         "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-symfony": "^2.0.6",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^12.5",
         "shopsys/coding-standards": "20.0.x-dev"
     },

--- a/packages/frontend-api/phpstan.neon
+++ b/packages/frontend-api/phpstan.neon
@@ -9,4 +9,5 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/shopsys/coding-standards/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -75,6 +75,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/shipmonk/dead-code-detector/rules.neon
     - %currentWorkingDirectory%/packages/coding-standards/dead-code-detection.neon
     - %currentWorkingDirectory%/packages/coding-standards/extension.neon

--- a/project-base/.agents/skills/coding-conventions/SKILL.md
+++ b/project-base/.agents/skills/coding-conventions/SKILL.md
@@ -23,6 +23,13 @@ Follow these whenever you write or modify code in this project.
 - Leverage tested, proven functionality; build complex behavior from simple existing blocks.
 - Use framework conventions; prefer composition over inheritance or duplication.
 
+### Validation & guard clauses
+- Prefer the `Webmozart\Assert\Assert` package over hand-written `if (...) { throw new ... }` guards for argument and state validation. It is already a dependency, keeps the guard on one line, and makes the intent obvious (`Assert::notSame()`, `Assert::isEmpty()`, `Assert::allInstanceOf()`, `Assert::keyExists()`, …).
+- Narrow `object` or interface-typed parameters with `Assert::isInstanceOf($entity, Order::class)` instead of a `/** @var */` docblock or a manual `instanceof` check. PHPStan understands the assert (`phpstan/phpstan-webmozart-assert` is enabled in `phpstan.neon`), so the following code is analysed with the concrete type, and a wrong instance fails fast at runtime with a clear message.
+- Pass the message as a closure when building it is not trivial — `Assert::isEmpty($keys, fn (): string => sprintf(...))` — so it is only built when the assertion actually fails.
+- The message is passed through `sprintf()` by the library, so avoid a literal `%` in it.
+- Write a dedicated exception class instead when callers need to catch that specific failure — `Assert` always throws `\InvalidArgumentException`.
+
 ### Maintainability first
 - Write code that's easy to understand, modify, and debug; change things in the fewest places.
 - Follow existing conventions; favor long-term maintainability over short-term convenience.

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -120,6 +120,7 @@
         "phpstan/phpstan-doctrine": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.6",
         "phpstan/phpstan-symfony": "^2.0.6",
+        "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^12.5",
         "psr/event-dispatcher": "^1.0.0",
         "shipmonk/dead-code-detector": "^1.3",

--- a/project-base/app/phpstan.neon
+++ b/project-base/app/phpstan.neon
@@ -41,6 +41,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/shipmonk/dead-code-detector/rules.neon
     - vendor/shopsys/coding-standards/dead-code-detection.neon
     - vendor/shopsys/coding-standards/extension.neon

--- a/upgrade-notes/backend_20260909_200104.md
+++ b/upgrade-notes/backend_20260909_200104.md
@@ -1,0 +1,6 @@
+#### PHPStan now understands `Webmozart\Assert\Assert` calls ([#4842](https://github.com/shopsys/shopsys/pull/4842))
+
+- `phpstan/phpstan-webmozart-assert` was added as a dev dependency and enabled in `phpstan.neon`, so PHPStan narrows types after `Assert::isInstanceOf()` and similar calls
+- run `composer update phpstan/phpstan-webmozart-assert` in your project
+- the extension may report `Assert::*()` calls that always evaluate to true - fix or remove such asserts in your project (e.g. `Assert::allNotNull()` on untyped data object properties was replaced by separate `Assert::notNull()` calls in `OrderFacade`)
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

PHPStan now understands `Webmozart\Assert\Assert` calls. CRUD handlers (and other code) narrow generic `object` parameters with `Assert::isInstanceOf()`, but PHPStan so far ignored those asserts, so the following calls were analysed against a plain `object` and typed facade calls were either reported as errors or had to be worked around. The `phpstan/phpstan-webmozart-assert` extension is added as a dev dependency and enabled in every `phpstan.neon` (monorepo, project-base, framework, administration, frontend-api), so the type after an assert is known to static analysis the same way it is at runtime.

`BlogArticleAuthorCrudHandler` now asserts the entity and data object types in all methods that receive them (`create()`, `createDataFromEntity()`, `edit()`), matching `TransportGroupCrudHandler`. A wrongly registered handler therefore fails fast with a clear message instead of somewhere deep in the facade.

The CRUD handler documentation (getting-started examples and the handlers reference) now shows and explains the `Assert::isInstanceOf()` narrowing, so new handlers do not forget it. The `coding-conventions` skill gets a new *Validation & guard clauses* section: prefer `Webmozart\Assert\Assert` over hand-written guards, narrow `object` parameters with `Assert::isInstanceOf()` instead of `/** @var */` docblocks, pass non-trivial messages as closures, and use a dedicated exception class when callers need to catch the failure. As a side effect of the new extension, `Assert::allNotNull()` on untyped data object properties in `OrderFacade` was reported as always true and was replaced by separate `Assert::notNull()` calls with the same behaviour.

#### Fixes issues

N/A

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)









----
:globe_with_meridians: Live Preview:
  - https://jg-phpstan-webmozart-assert.odin.shopsys.cloud
  - https://cz.jg-phpstan-webmozart-assert.odin.shopsys.cloud
  - https://jg-phpstan-webmozart-assert.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1789145270.511609 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-phpstan-webmozart-assert.odin.shopsys.cloud
  - https://cz.jg-phpstan-webmozart-assert.odin.shopsys.cloud
  - https://jg-phpstan-webmozart-assert.odin.shopsys.cloud/sk
<!-- Replace -->
